### PR TITLE
feat(build): per-ImageRepo cache control & infra improvements

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+.git
+*.md
+docs/
+scripts/
+infra/
+.env
+.env.*
+**/__pycache__
+**/*.pyc
+**/node_modules
+**/.venv

--- a/apps/lark-proxy/Dockerfile
+++ b/apps/lark-proxy/Dockerfile
@@ -3,9 +3,6 @@ FROM oven/bun:1.3.9-alpine
 RUN apk add --no-cache tzdata
 ENV TZ=Asia/Shanghai
 
-ARG GIT_SHA=unknown
-ENV GIT_SHA=${GIT_SHA}
-
 WORKDIR /repo
 
 # 复制所有 workspace 元数据和共享包源码
@@ -26,6 +23,9 @@ RUN bun install --frozen-lockfile --backend=copyfile \
     && cp -rL packages/ts-shared node_modules/@inner/shared \
     && cp -rL packages/pixiv-client node_modules/@inner/pixiv-client \
     && cp -rL packages/lark-utils node_modules/@inner/lark-utils
+
+ARG GIT_SHA=unknown
+ENV GIT_SHA=${GIT_SHA}
 
 # 复制源码
 COPY apps/lark-proxy/tsconfig.json ./apps/lark-proxy/tsconfig.json

--- a/apps/monitor-dashboard/Dockerfile
+++ b/apps/monitor-dashboard/Dockerfile
@@ -3,9 +3,6 @@ FROM oven/bun:1.3.9-alpine
 RUN apk add --no-cache tzdata
 ENV TZ=Asia/Shanghai
 
-ARG GIT_SHA=unknown
-ENV GIT_SHA=${GIT_SHA}
-
 WORKDIR /repo
 
 # Copy all workspace metadata and shared packages
@@ -23,6 +20,9 @@ RUN bun install --frozen-lockfile --backend=copyfile \
     && mkdir -p node_modules/@inner \
     && rm -rf node_modules/@inner/shared \
     && cp -rL packages/ts-shared node_modules/@inner/shared
+
+ARG GIT_SHA=unknown
+ENV GIT_SHA=${GIT_SHA}
 
 # Copy app source
 COPY apps/monitor-dashboard/tsconfig.json ./apps/monitor-dashboard/tsconfig.json

--- a/apps/paas-engine/internal/adapter/kubernetes/kaniko.go
+++ b/apps/paas-engine/internal/adapter/kubernetes/kaniko.go
@@ -86,6 +86,7 @@ func (e *KanikoBuildExecutor) Submit(ctx context.Context, sub *port.BuildSubmiss
 	} else {
 		args = append(args, "--cache=false")
 	}
+	args = append(args, "--snapshot-mode=redo")
 
 	// 构建上下文子目录
 	if sub.ContextDir != "" && sub.ContextDir != "." {

--- a/apps/paas-engine/internal/adapter/kubernetes/kaniko.go
+++ b/apps/paas-engine/internal/adapter/kubernetes/kaniko.go
@@ -81,7 +81,7 @@ func (e *KanikoBuildExecutor) Submit(ctx context.Context, sub *port.BuildSubmiss
 		fmt.Sprintf("--context=%s#%s", gitContext, gitRef),
 		fmt.Sprintf("--destination=%s", sub.ImageTag),
 	}
-	if e.cacheRepo != "" {
+	if !sub.NoCache && e.cacheRepo != "" {
 		args = append(args, "--cache=true", "--cache-repo="+e.cacheRepo)
 	} else {
 		args = append(args, "--cache=false")

--- a/apps/paas-engine/internal/adapter/repository/image_repo_repo.go
+++ b/apps/paas-engine/internal/adapter/repository/image_repo_repo.go
@@ -71,6 +71,7 @@ func imageRepoToModel(ir *domain.ImageRepo) *ImageRepoModel {
 		GitRepo:    ir.GitRepo,
 		ContextDir: ir.ContextDir,
 		Dockerfile: ir.Dockerfile,
+		NoCache:    ir.NoCache,
 		CreatedAt:  ir.CreatedAt,
 		UpdatedAt:  ir.UpdatedAt,
 	}
@@ -83,6 +84,7 @@ func modelToImageRepo(m *ImageRepoModel) *domain.ImageRepo {
 		GitRepo:    m.GitRepo,
 		ContextDir: m.ContextDir,
 		Dockerfile: m.Dockerfile,
+		NoCache:    m.NoCache,
 		CreatedAt:  m.CreatedAt,
 		UpdatedAt:  m.UpdatedAt,
 	}

--- a/apps/paas-engine/internal/adapter/repository/model.go
+++ b/apps/paas-engine/internal/adapter/repository/model.go
@@ -26,6 +26,7 @@ type ImageRepoModel struct {
 	GitRepo    string
 	ContextDir string
 	Dockerfile string
+	NoCache    bool
 	CreatedAt  time.Time
 	UpdatedAt  time.Time
 }

--- a/apps/paas-engine/internal/domain/image_repo.go
+++ b/apps/paas-engine/internal/domain/image_repo.go
@@ -13,6 +13,7 @@ type ImageRepo struct {
 	GitRepo    string    `json:"git_repo"`    // Git 仓库地址
 	ContextDir string    `json:"context_dir"` // 构建上下文子目录
 	Dockerfile string    `json:"dockerfile"`  // Dockerfile 路径（相对 context），空则使用默认 Dockerfile
+	NoCache    bool      `json:"no_cache"`    // true = 强制关闭构建缓存，忽略全局 cacheRepo 配置
 	CreatedAt  time.Time `json:"created_at"`
 	UpdatedAt  time.Time `json:"updated_at"`
 }

--- a/apps/paas-engine/internal/port/builder.go
+++ b/apps/paas-engine/internal/port/builder.go
@@ -24,6 +24,7 @@ type BuildSubmission struct {
 	ContextDir string
 	Dockerfile string // Dockerfile 路径（相对 context），空则使用默认
 	ImageTag   string // 完整镜像地址含 tag
+	NoCache    bool   // true = 强制关闭构建缓存
 }
 
 // BuildExecutor 负责驱动 Kaniko Job 的生命周期。

--- a/apps/paas-engine/internal/service/build_service.go
+++ b/apps/paas-engine/internal/service/build_service.go
@@ -79,6 +79,7 @@ func (s *BuildService) CreateBuild(ctx context.Context, imageRepoName string, re
 			ContextDir: imageRepo.ContextDir,
 			Dockerfile: imageRepo.Dockerfile,
 			ImageTag:   fullImageRef,
+			NoCache:    imageRepo.NoCache,
 		}
 		jobName, err := s.executor.Submit(ctx, sub)
 		if err != nil {

--- a/apps/paas-engine/internal/service/image_repo_service.go
+++ b/apps/paas-engine/internal/service/image_repo_service.go
@@ -23,6 +23,7 @@ type CreateImageRepoRequest struct {
 	GitRepo    string `json:"git_repo"`
 	ContextDir string `json:"context_dir"`
 	Dockerfile string `json:"dockerfile"`
+	NoCache    bool   `json:"no_cache"`
 }
 
 func (s *ImageRepoService) CreateImageRepo(ctx context.Context, req CreateImageRepoRequest) (*domain.ImageRepo, error) {
@@ -46,6 +47,7 @@ func (s *ImageRepoService) CreateImageRepo(ctx context.Context, req CreateImageR
 		GitRepo:    req.GitRepo,
 		ContextDir: req.ContextDir,
 		Dockerfile: req.Dockerfile,
+		NoCache:    req.NoCache,
 		CreatedAt:  now,
 		UpdatedAt:  now,
 	}
@@ -68,6 +70,7 @@ type UpdateImageRepoRequest struct {
 	GitRepo    string `json:"git_repo"`
 	ContextDir string `json:"context_dir"`
 	Dockerfile string `json:"dockerfile"`
+	NoCache    bool   `json:"no_cache"`
 }
 
 func (s *ImageRepoService) UpdateImageRepo(ctx context.Context, name string, req UpdateImageRepoRequest) (*domain.ImageRepo, error) {
@@ -89,6 +92,7 @@ func (s *ImageRepoService) UpdateImageRepo(ctx context.Context, name string, req
 	repo.GitRepo = req.GitRepo
 	repo.ContextDir = req.ContextDir
 	repo.Dockerfile = req.Dockerfile
+	repo.NoCache = req.NoCache
 	repo.UpdatedAt = time.Now()
 	if err := s.imageRepoRepo.Update(ctx, repo); err != nil {
 		return nil, err


### PR DESCRIPTION
## Summary
- **per-ImageRepo no_cache 开关**: bun/JS 应用的 Kaniko 远程层缓存适得其反（解压 3.7 万小文件 130~262s vs bun install 2s），支持按 ImageRepo 关闭缓存
- **Kaniko 构建缓存支持**: 全局层缓存配置（KANIKO_CACHE_REPO）
- **外部节点看门狗**: control plane 监控脚本
- **基础设施迁移**: postgres 迁移到 host docker, Redis/Qdrant 监控修复
- **Prometheus metrics**: 应用服务和中间件 exporter

## Test plan
- [x] 部署到 test-nocache 泳道验证
- [x] 确认 no_cache=true 时 Kaniko args 为 --cache=false
- [x] 确认 no_cache=false 时保持全局缓存配置
- [x] 确认 DB AutoMigrate 向后兼容
- [x] 所有测试通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)