### PR TITLE
feat(monitoring): enhance alerting with RabbitMQ consumer, health probes, outbound metrics

### DIFF
--- a/apps/agent-service/app/agents/tools/search/web.py
+++ b/apps/agent-service/app/agents/tools/search/web.py
@@ -2,15 +2,27 @@
 
 import asyncio
 import logging
+import time
 
 import httpx
 from langchain.tools import tool
+from prometheus_client import Counter, Histogram
 
 from app.agents.tools.search.reader import read_webpage
 from app.config import settings
 from app.utils.decorators import dict_serialize, log_io
 
 logger = logging.getLogger(__name__)
+
+YOU_SEARCH_REQUESTS_TOTAL = Counter(
+    "you_search_requests_total",
+    "Total You Search API requests",
+    ["status"],
+)
+YOU_SEARCH_DURATION = Histogram(
+    "you_search_duration_seconds",
+    "You Search API request duration in seconds",
+)
 
 
 async def _fetch_content(result: dict) -> dict:
@@ -66,20 +78,29 @@ async def search_web(
         "X-API-Key": settings.you_search_api_key,
     }
 
+    start = time.monotonic()
+    status = "error"
     try:
         async with httpx.AsyncClient(timeout=15) as client:
             response = await client.get(url, params=params, headers=headers)
             response.raise_for_status()
             data = response.json()
+        status = "ok"
     except httpx.TimeoutException:
+        status = "timeout"
         logger.error("Timeout during web search")
         return []
     except httpx.HTTPStatusError as e:
+        status = f"http_{e.response.status_code}"
         logger.error(f"HTTP error during web search: {e}")
         return []
     except Exception as e:
         logger.error(f"Unexpected error during web search: {e}")
         return []
+    finally:
+        duration = time.monotonic() - start
+        YOU_SEARCH_REQUESTS_TOTAL.labels(status=status).inc()
+        YOU_SEARCH_DURATION.observe(duration)
 
     # 转换响应结构
     web_results = data.get("results", {}).get("web", [])

--- a/apps/agent-service/app/clients/image_client.py
+++ b/apps/agent-service/app/clients/image_client.py
@@ -4,6 +4,7 @@ Main-server图片处理客户端
 
 import base64
 import logging
+import time
 
 import httpx
 
@@ -11,7 +12,23 @@ from app.clients.lane_router_instance import lane_router
 from app.config.config import settings  # for inner_http_secret, main_server_timeout
 from app.utils.middlewares.trace import get_app_name, get_trace_id
 
+try:
+    from inner_shared.lane_router import OUTBOUND_REQUESTS_TOTAL, OUTBOUND_REQUEST_DURATION, _HAS_METRICS
+except ImportError:
+    _HAS_METRICS = False
+
 logger = logging.getLogger(__name__)
+
+
+def _record_outbound(method: str, status: str, duration: float) -> None:
+    """Record outbound metrics for tool-service calls."""
+    if _HAS_METRICS:
+        OUTBOUND_REQUESTS_TOTAL.labels(
+            target_service="tool-service", method=method, status=status
+        ).inc()
+        OUTBOUND_REQUEST_DURATION.labels(
+            target_service="tool-service", method=method
+        ).observe(duration)
 
 
 class ImageProcessClient:
@@ -37,6 +54,8 @@ class ImageProcessClient:
         # 优先使用传入的 bot_name，否则从上下文获取
         app_name = bot_name or get_app_name() or ""
 
+        start = time.monotonic()
+        status = "network_error"
         try:
             request_data = {"message_id": message_id, "file_key": file_key}
 
@@ -54,6 +73,7 @@ class ImageProcessClient:
                     },
                 )
 
+                status = str(response.status_code)
                 response.raise_for_status()
                 data = response.json()
 
@@ -75,6 +95,8 @@ class ImageProcessClient:
         except Exception as e:
             logger.error(f"调用图片处理接口失败: {str(e)}")
             return None
+        finally:
+            _record_outbound("POST", status, time.monotonic() - start)
 
     async def upload_base64_image(
         self, base64_data: str, bot_name: str | None = None
@@ -92,6 +114,8 @@ class ImageProcessClient:
         # 优先使用传入的 bot_name，否则从上下文获取
         app_name = bot_name or get_app_name() or ""
 
+        start = time.monotonic()
+        status = "network_error"
         try:
             # logger.info(f"上传base64图片到飞书，base64_data: {base64_data}")
             request_data = {"base64_data": base64_data}
@@ -110,6 +134,7 @@ class ImageProcessClient:
                     },
                 )
 
+                status = str(response.status_code)
                 response.raise_for_status()
                 data = response.json()
 
@@ -135,6 +160,8 @@ class ImageProcessClient:
         except Exception as e:
             logger.error(f"调用base64图片上传接口失败: {str(e)}")
             return None
+        finally:
+            _record_outbound("POST", status, time.monotonic() - start)
 
     async def download_image_as_base64(
         self, file_key: str, message_id: str | None, bot_name: str | None = None

--- a/apps/lark-server/src/infrastructure/integrations/lark-client.ts
+++ b/apps/lark-server/src/infrastructure/integrations/lark-client.ts
@@ -1,8 +1,24 @@
 import * as lark from '@larksuiteoapi/node-sdk';
 import { multiBotManager } from '@core/services/bot/multi-bot-manager';
 import { context } from '@middleware/context';
+import { register } from '@middleware/metrics';
+import { Counter, Histogram } from 'prom-client';
 import { Readable } from 'node:stream';
 import { ReadStream } from 'node:fs';
+
+const larkApiRequestsTotal = new Counter({
+    name: 'lark_api_requests_total',
+    help: 'Total Lark API requests',
+    labelNames: ['operation', 'status'] as const,
+    registers: [register],
+});
+
+const larkApiDuration = new Histogram({
+    name: 'lark_api_duration_seconds',
+    help: 'Lark API request duration in seconds',
+    labelNames: ['operation'] as const,
+    registers: [register],
+});
 
 const errorMap: Record<number, string> = {
     41050: '无用户权限，请将当前操作的用户添加到应用或用户的权限范围内',
@@ -101,19 +117,28 @@ interface LarkResp<T> {
     data?: T;
 }
 
-async function handleResponse<T>(promise: Promise<LarkResp<T>>): Promise<T> {
+async function handleResponse<T>(promise: Promise<LarkResp<T>>, operation: string): Promise<T> {
+    const start = performance.now();
+    let status = 'error';
     try {
         const res = await promise;
         if (res.code !== 0) {
+            status = `lark_${res.code}`;
             throw new Error(res.msg);
         }
+        status = 'ok';
         return res.data!;
     } catch (e: any) {
         console.error(JSON.stringify(e.response?.data || e, null, 4));
         if (e.response?.data?.code) {
+            status = `lark_${e.response.data.code}`;
             throw new Error(errorMap[e.response?.data?.code] || e.response?.data?.msg);
         }
         throw e;
+    } finally {
+        const duration = (performance.now() - start) / 1000;
+        larkApiRequestsTotal.inc({ operation, status });
+        larkApiDuration.observe({ operation }, duration);
     }
 }
 
@@ -124,6 +149,7 @@ export async function getUserInfo(unionId: string) {
             path: { user_id: unionId },
             params: { user_id_type: 'union_id' },
         }),
+        'get_user_info',
     );
 }
 
@@ -138,6 +164,7 @@ export async function send(chat_id: string, content: any, msgType: string) {
                 msg_type: msgType,
             },
         }),
+        'send_message',
     );
 }
 
@@ -157,6 +184,7 @@ export async function reply(
                 reply_in_thread: replyInThread,
             },
         }),
+        'reply_message',
     );
 }
 
@@ -168,6 +196,7 @@ export async function sendReq<T>(url: string, data: any, method: string) {
             method,
             data,
         }),
+        'send_request',
     );
 }
 
@@ -177,6 +206,7 @@ export async function getChatList(page_token?: string) {
         client.im.chat.list({
             params: { page_size: 100, page_token, sort_type: 'ByCreateTimeAsc' },
         }),
+        'get_chat_list',
     );
 }
 
@@ -187,6 +217,7 @@ export async function getChatInfo(chat_id: string) {
             path: { chat_id },
             params: { user_id_type: 'union_id' },
         }),
+        'get_chat_info',
     );
 }
 
@@ -201,6 +232,7 @@ export async function searchAllMembers(
             path: { chat_id },
             params: { page_size: 50, page_token, member_id_type },
         }),
+        'search_members',
     );
 }
 
@@ -211,6 +243,7 @@ export async function getMessageInfo(message_id: string) {
             path: { message_id },
             params: { user_id_type: 'union_id' },
         }),
+        'get_message',
     );
 }
 
@@ -220,6 +253,7 @@ export async function deleteMessage(message_id: string) {
         client.im.message.delete({
             path: { message_id },
         }),
+        'delete_message',
     );
 }
 
@@ -242,6 +276,7 @@ export async function getMessageList(
                 sort_type: 'ByCreateTimeAsc',
             },
         }),
+        'get_message_list',
     );
 }
 
@@ -287,5 +322,6 @@ export async function addChatMember(chat_id: string, open_id: string) {
                 id_list: [open_id],
             },
         }),
+        'add_chat_member',
     );
 }

--- a/apps/lark-server/src/infrastructure/lane-router.ts
+++ b/apps/lark-server/src/infrastructure/lane-router.ts
@@ -1,5 +1,8 @@
 import { LaneRouter } from '@inner/shared';
+import { register } from '@middleware/metrics';
 
 export const laneRouter = new LaneRouter(
     process.env.REGISTRY_URL || 'http://lite-registry:8080',
+    30_000,
+    register,
 );

--- a/apps/lark-server/src/middleware/metrics.ts
+++ b/apps/lark-server/src/middleware/metrics.ts
@@ -2,7 +2,7 @@ import { Counter, Histogram, Gauge, Registry, collectDefaultMetrics } from 'prom
 import type { Context, Next } from 'koa';
 import Router from '@koa/router';
 
-const register = new Registry();
+export const register = new Registry();
 collectDefaultMetrics({ register });
 
 const httpRequestsTotal = new Counter({

--- a/infra/k8s/monitoring/alert-rules.yaml
+++ b/infra/k8s/monitoring/alert-rules.yaml
@@ -175,13 +175,13 @@ spec:
 
         # RabbitMQ
         - alert: RabbitmqQueueMessagesReady
-          expr: rabbitmq_queue_messages_ready{namespace="prod"} > 1000
-          for: 10m
+          expr: rabbitmq_queue_messages_ready{namespace="prod"} > 50
+          for: 5m
           labels:
             severity: warning
           annotations:
             summary: "RabbitMQ 队列 {{ $labels.queue }} 消息积压"
-            description: "队列 {{ $labels.queue }} 积压 {{ $value }} 条消息，持续超过 10 分钟。"
+            description: "队列 {{ $labels.queue }} 积压 {{ $value }} 条消息，持续超过 5 分钟。"
 
         - alert: RabbitmqNodeDown
           expr: rabbitmq_identity_info{namespace="prod"} < 1
@@ -210,3 +210,126 @@ spec:
           annotations:
             summary: "MongoDB 连接数过高"
             description: "MongoDB 当前连接数为 {{ $value }}，持续超过 5 分钟。"
+
+        # RabbitMQ - 队列消息持续增长（consumer 跟不上）
+        - alert: RabbitmqQueueGrowing
+          expr: deriv(rabbitmq_queue_messages_ready{namespace="prod"}[5m]) > 2
+          for: 5m
+          labels:
+            severity: warning
+          annotations:
+            summary: "RabbitMQ 队列 {{ $labels.queue }} 消息持续增长"
+            description: "队列 {{ $labels.queue }} 消息增长速率为 {{ $value }}/s，consumer 可能跟不上。"
+
+        # RabbitMQ - 有消息但无 consumer
+        - alert: RabbitmqQueueNoConsumers
+          expr: rabbitmq_queue_consumers{namespace="prod"} == 0 and rabbitmq_queue_messages_ready{namespace="prod"} > 0
+          for: 2m
+          labels:
+            severity: critical
+          annotations:
+            summary: "RabbitMQ 队列 {{ $labels.queue }} 无消费者"
+            description: "队列 {{ $labels.queue }} 有 {{ $value }} 条消息但没有消费者连接。"
+
+        # RabbitMQ - 已知业务队列 consumer 断开
+        - alert: RabbitmqConsumerDown
+          expr: rabbitmq_queue_consumers{namespace="prod", queue=~"(recall|safety_check|vectorize).*"} == 0
+          for: 1m
+          labels:
+            severity: critical
+          annotations:
+            summary: "RabbitMQ 业务队列 {{ $labels.queue }} consumer 断开"
+            description: "关键业务队列 {{ $labels.queue }} 的 consumer 已断开超过 1 分钟。"
+
+    # --- Phase 4: 健康探针告警 ---
+    - name: probe-alerts
+      rules:
+        - alert: ServiceHealthCheckDown
+          expr: probe_success == 0
+          for: 1m
+          labels:
+            severity: critical
+          annotations:
+            summary: "服务 {{ $labels.instance }} 健康检查失败"
+            description: "服务 {{ $labels.instance }} 健康探测失败，持续超过 1 分钟。"
+
+        - alert: ServiceHealthCheckSlow
+          expr: probe_duration_seconds > 3
+          for: 3m
+          labels:
+            severity: warning
+          annotations:
+            summary: "服务 {{ $labels.instance }} 健康检查响应慢"
+            description: "服务 {{ $labels.instance }} 健康探测响应时间为 {{ $value }}s，持续超过 3 分钟。"
+
+    # --- Phase 5: 服务间调用告警 ---
+    - name: outbound-alerts
+      rules:
+        - alert: OutboundHighErrorRate
+          expr: |
+            sum(rate(http_outbound_requests_total{status=~"5..|network_error"}[5m])) by (job, target_service)
+            /
+            sum(rate(http_outbound_requests_total[5m])) by (job, target_service)
+            > 0.1
+          for: 3m
+          labels:
+            severity: critical
+          annotations:
+            summary: "服务 {{ $labels.job }} → {{ $labels.target_service }} 调用错误率过高"
+            description: "出站调用错误率已达 {{ $value | humanizePercentage }}，持续超过 3 分钟。"
+
+        - alert: OutboundHighLatencyP99
+          expr: histogram_quantile(0.99, sum(rate(http_outbound_request_duration_seconds_bucket[5m])) by (job, target_service, le)) > 5
+          for: 3m
+          labels:
+            severity: warning
+          annotations:
+            summary: "服务 {{ $labels.job }} → {{ $labels.target_service }} P99 延迟过高"
+            description: "出站调用 P99 延迟已达 {{ $value }}s，持续超过 3 分钟。"
+
+    # --- Phase 6: 外部依赖告警 ---
+    - name: external-dependency-alerts
+      rules:
+        - alert: LarkApiHighErrorRate
+          expr: |
+            sum(rate(lark_api_requests_total{status!="ok"}[5m]))
+            /
+            sum(rate(lark_api_requests_total[5m]))
+            > 0.1
+          for: 3m
+          labels:
+            severity: critical
+          annotations:
+            summary: "飞书 API 错误率过高"
+            description: "飞书 API 错误率已达 {{ $value | humanizePercentage }}，持续超过 3 分钟。"
+
+        - alert: LarkApiHighLatency
+          expr: histogram_quantile(0.99, sum(rate(lark_api_duration_seconds_bucket[5m])) by (le)) > 5
+          for: 3m
+          labels:
+            severity: warning
+          annotations:
+            summary: "飞书 API P99 延迟过高"
+            description: "飞书 API P99 延迟已达 {{ $value }}s，持续超过 3 分钟。"
+
+        - alert: YouSearchHighErrorRate
+          expr: |
+            sum(rate(you_search_requests_total{status!="ok"}[10m]))
+            /
+            sum(rate(you_search_requests_total[10m]))
+            > 0.3
+          for: 5m
+          labels:
+            severity: warning
+          annotations:
+            summary: "You Search 错误率过高"
+            description: "You Search 错误率已达 {{ $value | humanizePercentage }}，持续超过 5 分钟。"
+
+        - alert: YouSearchHighLatency
+          expr: histogram_quantile(0.99, sum(rate(you_search_duration_seconds_bucket[5m])) by (le)) > 15
+          for: 5m
+          labels:
+            severity: warning
+          annotations:
+            summary: "You Search P99 延迟过高"
+            description: "You Search P99 延迟已达 {{ $value }}s，持续超过 5 分钟。"

--- a/infra/k8s/monitoring/blackbox-exporter.yaml
+++ b/infra/k8s/monitoring/blackbox-exporter.yaml
@@ -100,6 +100,6 @@ spec:
         - http://paas-engine.prod:8080/healthz
         - http://lite-registry.prod:8080/healthz
         - http://lark-server.prod:3000/api/health
-        - http://lark-proxy.prod:3000/api/health
-        - http://agent-service.prod:8000/api/health
+        - http://lark-proxy.prod:3003/api/health
+        - http://agent-service.prod:8000/health
         - http://tool-service.prod:8000/health

--- a/infra/k8s/monitoring/blackbox-exporter.yaml
+++ b/infra/k8s/monitoring/blackbox-exporter.yaml
@@ -1,0 +1,105 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: blackbox-exporter-config
+  namespace: monitoring
+data:
+  config.yml: |
+    modules:
+      http_2xx:
+        prober: http
+        timeout: 5s
+        http:
+          valid_http_versions: ["HTTP/1.1", "HTTP/2.0"]
+          valid_status_codes: [200]
+          method: GET
+          preferred_ip_protocol: ip4
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: blackbox-exporter
+  namespace: monitoring
+  labels:
+    app: blackbox-exporter
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: blackbox-exporter
+  template:
+    metadata:
+      labels:
+        app: blackbox-exporter
+    spec:
+      containers:
+        - name: blackbox-exporter
+          image: prom/blackbox-exporter:v0.25.0
+          args:
+            - --config.file=/config/config.yml
+          ports:
+            - containerPort: 9115
+              name: http
+          volumeMounts:
+            - name: config
+              mountPath: /config
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              cpu: 100m
+              memory: 64Mi
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 5
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 5
+      volumes:
+        - name: config
+          configMap:
+            name: blackbox-exporter-config
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: blackbox-exporter
+  namespace: monitoring
+  labels:
+    app: blackbox-exporter
+spec:
+  selector:
+    app: blackbox-exporter
+  ports:
+    - name: http
+      port: 9115
+      targetPort: http
+---
+apiVersion: monitoring.coreos.com/v1
+kind: Probe
+metadata:
+  name: app-health-probes
+  namespace: monitoring
+  labels:
+    release: kube-prometheus-stack
+spec:
+  jobName: blackbox-health
+  prober:
+    url: blackbox-exporter.monitoring:9115
+    path: /probe
+  module: http_2xx
+  targets:
+    staticConfig:
+      static:
+        - http://api-gateway.prod:8080/healthz
+        - http://paas-engine.prod:8080/healthz
+        - http://lite-registry.prod:8080/healthz
+        - http://lark-server.prod:3000/api/health
+        - http://lark-proxy.prod:3000/api/health
+        - http://agent-service.prod:8000/api/health
+        - http://tool-service.prod:8000/health

--- a/packages/py-shared/inner_shared/lane_router.py
+++ b/packages/py-shared/inner_shared/lane_router.py
@@ -6,12 +6,57 @@ LaneRouter - 泳道感知的服务路由器 (Python SDK)
 
 import logging
 import threading
+import time
 from collections.abc import Callable
 from typing import Any
 
 import httpx
 
 logger = logging.getLogger(__name__)
+
+# --- Outbound metrics (prometheus_client) ---
+try:
+    from prometheus_client import Counter, Histogram
+
+    OUTBOUND_REQUESTS_TOTAL = Counter(
+        "http_outbound_requests_total",
+        "Total outbound HTTP requests via LaneRouter",
+        ["target_service", "method", "status"],
+    )
+    OUTBOUND_REQUEST_DURATION = Histogram(
+        "http_outbound_request_duration_seconds",
+        "Outbound HTTP request duration in seconds",
+        ["target_service", "method"],
+    )
+    _HAS_METRICS = True
+except ImportError:
+    _HAS_METRICS = False
+
+
+class _MetricsTransport(httpx.AsyncBaseTransport):
+    """Async transport wrapper that records outbound HTTP metrics."""
+
+    def __init__(self, transport: httpx.AsyncBaseTransport, service: str):
+        self._transport = transport
+        self._service = service
+
+    async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+        method = request.method.upper()
+        status = "network_error"
+        start = time.monotonic()
+        try:
+            response = await self._transport.handle_async_request(request)
+            status = str(response.status_code)
+            return response
+        finally:
+            if _HAS_METRICS:
+                duration = time.monotonic() - start
+                OUTBOUND_REQUESTS_TOTAL.labels(
+                    target_service=self._service, method=method, status=status
+                ).inc()
+                OUTBOUND_REQUEST_DURATION.labels(
+                    target_service=self._service, method=method
+                ).observe(duration)
 
 
 class LaneRouter:
@@ -120,6 +165,36 @@ class LaneRouter:
         if lane:
             headers["x-lane"] = lane
         return headers
+
+    def create_client(
+        self,
+        service: str,
+        timeout: float = 30.0,
+        **kwargs: Any,
+    ) -> httpx.AsyncClient:
+        """
+        创建绑定到某服务的 httpx.AsyncClient，自动记录 outbound metrics。
+
+        Args:
+            service: 目标服务名
+            timeout: 请求超时（秒）
+            **kwargs: 传递给 httpx.AsyncClient 的额外参数
+        """
+        base_url = self.base_url(service)
+        transport = httpx.AsyncHTTPTransport()
+
+        if _HAS_METRICS:
+            transport_wrapper = _MetricsTransport(transport, service)
+        else:
+            transport_wrapper = transport  # type: ignore[assignment]
+
+        return httpx.AsyncClient(
+            base_url=base_url,
+            transport=transport_wrapper,
+            timeout=timeout,
+            headers=self.get_headers(),
+            **kwargs,
+        )
 
     def stop(self) -> None:
         """停止后台轮询。"""

--- a/packages/ts-shared/src/lane-router/index.ts
+++ b/packages/ts-shared/src/lane-router/index.ts
@@ -19,6 +19,45 @@ export interface LaneRouterOptions {
     pollInterval?: number;
 }
 
+// prom-client types (optional peer dependency)
+interface PromCounter {
+    inc(labels: Record<string, string>): void;
+}
+interface PromHistogram {
+    observe(labels: Record<string, string>, value: number): void;
+}
+interface PromRegistry {
+    registerMetric(metric: any): void;
+}
+
+// 模块级 metrics 实例（懒初始化，所有 LaneRouter 实例共享）
+let outboundRequestsTotal: PromCounter | null = null;
+let outboundRequestDuration: PromHistogram | null = null;
+let metricsInitialized = false;
+
+function initMetrics(registry: PromRegistry): void {
+    if (metricsInitialized) return;
+    try {
+        // 动态 require prom-client（optional peer dep）
+        const prom = require('prom-client');
+        outboundRequestsTotal = new prom.Counter({
+            name: 'http_outbound_requests_total',
+            help: 'Total outbound HTTP requests via LaneRouter',
+            labelNames: ['target_service', 'method', 'status'],
+            registers: [registry],
+        });
+        outboundRequestDuration = new prom.Histogram({
+            name: 'http_outbound_request_duration_seconds',
+            help: 'Outbound HTTP request duration in seconds',
+            labelNames: ['target_service', 'method'],
+            registers: [registry],
+        });
+        metricsInitialized = true;
+    } catch {
+        // prom-client not available, metrics disabled
+    }
+}
+
 /**
  * LaneRouter - 泳道感知的服务路由器
  *
@@ -32,9 +71,13 @@ export class LaneRouter {
     private registryUrl: string;
     private pollInterval: number;
 
-    constructor(registryUrl: string, pollInterval = 30_000) {
+    constructor(registryUrl: string, pollInterval = 30_000, promRegistry?: PromRegistry) {
         this.registryUrl = registryUrl.replace(/\/+$/, '');
         this.pollInterval = pollInterval;
+
+        if (promRegistry) {
+            initMetrics(promRegistry);
+        }
 
         // 立即拉取一次，然后启动轮询
         this.poll();
@@ -120,10 +163,22 @@ export class LaneRouter {
             ...(init?.headers as Record<string, string>),
         };
 
-        return fetch(url, {
-            ...init,
-            headers: mergedHeaders,
-        });
+        const method = init?.method?.toUpperCase() || 'GET';
+        const start = performance.now();
+        let status = 'network_error';
+
+        try {
+            const resp = await fetch(url, {
+                ...init,
+                headers: mergedHeaders,
+            });
+            status = String(resp.status);
+            return resp;
+        } finally {
+            const duration = (performance.now() - start) / 1000;
+            outboundRequestsTotal?.inc({ target_service: service, method, status });
+            outboundRequestDuration?.observe({ target_service: service, method }, duration);
+        }
     }
 
     /**
@@ -143,8 +198,36 @@ export class LaneRouter {
                     config.headers[key] = value;
                 }
             }
+            // Attach start time for duration tracking
+            (config as any).__startTime = performance.now();
             return config;
         });
+
+        // Response interceptor: record success metrics
+        client.interceptors.response.use(
+            (response) => {
+                const start = (response.config as any).__startTime;
+                if (start) {
+                    const duration = (performance.now() - start) / 1000;
+                    const method = (response.config.method || 'get').toUpperCase();
+                    outboundRequestsTotal?.inc({ target_service: service, method, status: String(response.status) });
+                    outboundRequestDuration?.observe({ target_service: service, method }, duration);
+                }
+                return response;
+            },
+            (error) => {
+                const config = error.config;
+                const start = config?.__startTime;
+                if (start) {
+                    const duration = (performance.now() - start) / 1000;
+                    const method = (config.method || 'get').toUpperCase();
+                    const status = error.response ? String(error.response.status) : 'network_error';
+                    outboundRequestsTotal?.inc({ target_service: service, method, status });
+                    outboundRequestDuration?.observe({ target_service: service, method }, duration);
+                }
+                return Promise.reject(error);
+            },
+        );
 
         return client;
     }


### PR DESCRIPTION
- Phase A: RabbitMQ 阈值调整 + Consumer 告警（3条新规则）
- Phase B: Blackbox Exporter 健康探针（探测7个服务端点）
- Phase C: LaneRouter SDK outbound HTTP metrics（TS/Py）
- Phase D: 飞书 API + You Search 外部依赖 metrics
- 共新增12条告警规则