### PR TITLE
feat(lark-proxy): Koa to Hono migration + lane routing fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: deploy self-deploy release undeploy status latest-build
+.PHONY: deploy self-deploy release undeploy status latest-build lane-bind lane-unbind lane-bindings
 
 # 从 .env 加载配置（PAAS_API, PAAS_TOKEN, REGISTRY 等）
 -include .env
@@ -131,3 +131,36 @@ latest-build:
 	@curl -sf "$(PAAS_API)/api/paas/apps/$(APP)/builds/latest" \
 	  -H 'X-API-Key: $(PAAS_TOKEN)' \
 	  | python3 -m json.tool
+
+# ---------- 泳道绑定 ----------
+
+## 绑定 bot/chat 到泳道
+## 用法: make lane-bind TYPE=bot KEY=my-bot LANE=feat-test
+lane-bind:
+	$(if $(TYPE),,$(error TYPE 未指定（bot 或 chat）))
+	$(if $(KEY),,$(error KEY 未指定))
+	$(if $(LANE),,$(error LANE 未指定))
+	@echo ">>> 绑定 $(TYPE):$(KEY) -> $(LANE)"
+	@curl -sf -X POST $(PAAS_API)/api/lark/lane-bindings \
+	  -H 'Content-Type: application/json' \
+	  -H 'X-API-Key: $(PAAS_TOKEN)' \
+	  -d '{"route_type":"$(TYPE)","route_key":"$(KEY)","lane_name":"$(LANE)"}' \
+	  | python3 -m json.tool
+
+## 解绑 bot/chat 的泳道
+## 用法: make lane-unbind TYPE=bot KEY=my-bot
+lane-unbind:
+	$(if $(TYPE),,$(error TYPE 未指定（bot 或 chat）))
+	$(if $(KEY),,$(error KEY 未指定))
+	@echo ">>> 解绑 $(TYPE):$(KEY)"
+	@curl -sf -X DELETE "$(PAAS_API)/api/lark/lane-bindings?type=$(TYPE)&key=$(KEY)" \
+	  -H 'X-API-Key: $(PAAS_TOKEN)' \
+	  | python3 -m json.tool
+
+## 列出所有活跃泳道绑定
+## 用法: make lane-bindings
+lane-bindings:
+	@echo ">>> 活跃泳道绑定"
+	@curl -sf $(PAAS_API)/api/lark/lane-bindings \
+	  -H 'X-API-Key: $(PAAS_TOKEN)' \
+	  | python3 -c "import sys,json; [print(f\"  {r['route_type']:6s} | {r['route_key']:30s} | {r['lane_name']}\") for r in json.load(sys.stdin).get('data', [])]"

--- a/apps/api-gateway/config/routes.yaml
+++ b/apps/api-gateway/config/routes.yaml
@@ -6,6 +6,11 @@ routes:
     strip_prefix: /api/paas
     rewrite_prefix: /api/v1
 
+  # Lark 管理 API（泳道绑定等）
+  - prefix: /api/lark/
+    service: lark-proxy
+    port: 3003
+
   # Lark webhook 回调入口
   - prefix: /webhook/
     service: lark-proxy

--- a/apps/lark-proxy/package.json
+++ b/apps/lark-proxy/package.json
@@ -12,16 +12,13 @@
   },
   "dependencies": {
     "@inner/shared": "workspace:*",
-    "koa": "^2.15.0",
-    "@koa/router": "^12.0.1",
+    "hono": "^4.7.0",
     "@larksuiteoapi/node-sdk": "^1.23.0",
     "pg": "^8.11.5",
     "prom-client": "^15.1.0"
   },
   "devDependencies": {
     "typescript": "^5.4.0",
-    "@types/koa": "^2.15.0",
-    "@types/koa__router": "^12.0.4",
     "@types/pg": "^8.11.0",
     "@types/bun": "latest"
   }

--- a/apps/lark-proxy/src/admin.ts
+++ b/apps/lark-proxy/src/admin.ts
@@ -1,0 +1,62 @@
+import { Hono } from 'hono';
+import type { Pool } from 'pg';
+import type { LaneResolver } from './lane-resolver';
+
+const PAAS_TOKEN = process.env.PAAS_TOKEN || '';
+
+export function createAdminApp(pool: Pool, laneResolver: LaneResolver): Hono {
+    const admin = new Hono().basePath('/api/lark');
+
+    // X-API-Key 认证
+    admin.use('*', async (c, next) => {
+        if (!PAAS_TOKEN || c.req.header('X-API-Key') !== PAAS_TOKEN) {
+            return c.json({ error: 'unauthorized' }, 401);
+        }
+        await next();
+    });
+
+    // 列出所有活跃绑定
+    admin.get('/lane-bindings', async (c) => {
+        const result = await pool.query(
+            'SELECT route_type, route_key, lane_name FROM lane_routing WHERE is_active = true ORDER BY route_type, route_key',
+        );
+        return c.json({ data: result.rows });
+    });
+
+    // 创建/更新绑定 (upsert)
+    admin.post('/lane-bindings', async (c) => {
+        const { route_type, route_key, lane_name } = await c.req.json<{
+            route_type: string;
+            route_key: string;
+            lane_name: string;
+        }>();
+        if (!route_type || !route_key || !lane_name) {
+            return c.json({ error: 'route_type, route_key, lane_name are required' }, 400);
+        }
+        await pool.query(
+            `INSERT INTO lane_routing (route_type, route_key, lane_name, is_active)
+             VALUES ($1, $2, $3, true)
+             ON CONFLICT (route_type, route_key) DO UPDATE SET lane_name = $3, is_active = true`,
+            [route_type, route_key, lane_name],
+        );
+        laneResolver.clearCache();
+        return c.json({ ok: true, route_type, route_key, lane_name });
+    });
+
+    // 删除绑定（软删除）
+    admin.delete('/lane-bindings', async (c) => {
+        const type = c.req.query('type');
+        const key = c.req.query('key');
+        if (!type || !key) {
+            return c.json({ error: 'type and key query params are required' }, 400);
+        }
+        await pool.query(
+            'UPDATE lane_routing SET is_active = false WHERE route_type = $1 AND route_key = $2',
+            [type, key],
+        );
+        laneResolver.clearCache();
+        return c.json({ ok: true });
+    });
+
+    return admin;
+}

--- a/apps/lark-proxy/src/bot-manager.ts
+++ b/apps/lark-proxy/src/bot-manager.ts
@@ -1,11 +1,9 @@
 import * as Lark from '@larksuiteoapi/node-sdk';
-import Router from '@koa/router';
+import type { Hono } from 'hono';
 import { Pool } from 'pg';
 import { EventForwarder } from './forwarder';
+import { adaptHono } from './lark-adapter';
 
-/**
- * 从 DB 加载的 bot 配置（仅需 proxy 用到的字段）
- */
 interface BotConfig {
     bot_name: string;
     app_id: string;
@@ -17,9 +15,6 @@ interface BotConfig {
     is_dev: boolean;
 }
 
-/**
- * proxy 需要注册的固定事件列表（从 handlers.ts 提取）
- */
 const REGISTERED_EVENT_TYPES = [
     'im.message.receive_v1',
     'im.message.recalled_v1',
@@ -34,20 +29,13 @@ const REGISTERED_EVENT_TYPES = [
     'im.chat.updated_v1',
 ];
 
-/**
- * Bot 管理器
- * 从 DB 加载 bot_config，为每个 HTTP bot 创建 EventDispatcher + Koa 路由
- */
 export class BotManager {
     constructor(
         private pool: Pool,
         private forwarder: EventForwarder,
     ) {}
 
-    /**
-     * 从 DB 加载 bot 配置并注册到 router
-     */
-    async registerBots(router: Router): Promise<void> {
+    async registerBots(app: Hono): Promise<void> {
         const bots = await this.loadBotConfigs();
 
         const httpBots = bots.filter((b) => b.init_type === 'http');
@@ -57,7 +45,7 @@ export class BotManager {
         }
 
         for (const bot of httpBots) {
-            this.registerBot(router, bot);
+            this.registerBot(app, bot);
         }
 
         console.info(`Registered ${httpBots.length} HTTP bot(s)`);
@@ -75,8 +63,7 @@ export class BotManager {
         });
     }
 
-    private registerBot(router: Router, bot: BotConfig): void {
-        // 创建 EventDispatcher 并注册所有事件
+    private registerBot(app: Hono, bot: BotConfig): void {
         const handler = this.forwarder.createHandler(bot.bot_name);
         const eventHandlers: Record<string, (params: unknown) => Record<string, never>> = {};
         for (const eventType of REGISTERED_EVENT_TYPES) {
@@ -88,7 +75,6 @@ export class BotManager {
             encryptKey: bot.encrypt_key,
         }).register(eventHandlers);
 
-        // 创建 CardActionHandler
         const cardHandler = this.forwarder.createCardHandler(bot.bot_name);
         const cardActionHandler = new Lark.CardActionHandler(
             {
@@ -98,16 +84,11 @@ export class BotManager {
             cardHandler,
         );
 
-        // 转为 Koa 中间件
-        const eventMiddleware = Lark.adaptKoaRouter(eventDispatcher, { autoChallenge: true });
-        const cardMiddleware = Lark.adaptKoaRouter(cardActionHandler, { autoChallenge: true });
-
-        // 注册路由
         const eventPath = `/webhook/${bot.bot_name}/event`;
         const cardPath = `/webhook/${bot.bot_name}/card`;
 
-        router.post(eventPath, eventMiddleware);
-        router.post(cardPath, cardMiddleware);
+        app.post(eventPath, adaptHono(eventDispatcher));
+        app.post(cardPath, adaptHono(cardActionHandler));
 
         console.info(
             `Registered bot: ${bot.bot_name} (${bot.app_id}) → ${eventPath}, ${cardPath}`,

--- a/apps/lark-proxy/src/forwarder.ts
+++ b/apps/lark-proxy/src/forwarder.ts
@@ -30,7 +30,7 @@ export class EventForwarder {
 
     private async doForward(eventType: string, botName: string, params: unknown): Promise<void> {
         const lane = await this.laneResolver.resolve('bot', botName);
-        const url = this.laneRouter.resolveUrl('lark-server', '/api/internal/lark-event', lane || undefined);
+        const url = this.laneRouter.resolveUrl('lark-server', '/api/internal/lark-event', lane || 'prod');
         const traceId = randomUUID();
 
         console.info(

--- a/apps/lark-proxy/src/health.ts
+++ b/apps/lark-proxy/src/health.ts
@@ -1,14 +1,14 @@
-import Router from '@koa/router';
+import { Hono } from 'hono';
 
-const router = new Router();
+const health = new Hono();
 
-router.get('/api/health', (ctx) => {
-    ctx.body = {
+health.get('/api/health', (c) => {
+    return c.json({
         status: 'ok',
         service: 'lark-proxy',
         version: process.env.VERSION || process.env.GIT_SHA || 'unknown',
         timestamp: new Date().toISOString(),
-    };
+    });
 });
 
-export default router;
+export default health;

--- a/apps/lark-proxy/src/index.ts
+++ b/apps/lark-proxy/src/index.ts
@@ -1,54 +1,46 @@
-import Koa from 'koa';
-import Router from '@koa/router';
+import { Hono } from 'hono';
 import { Pool } from 'pg';
 import { LaneResolver } from './lane-resolver';
 import { EventForwarder } from './forwarder';
 import { BotManager } from './bot-manager';
-import healthRouter from './health';
+import healthApp from './health';
 import { laneRouter } from './lane-router-instance';
-import { metricsMiddleware, metricsRouter } from './metrics';
+import { metricsMiddleware, metricsApp } from './metrics';
+import { createAdminApp } from './admin';
 
 const PORT = parseInt(process.env.LARK_PROXY_PORT || '3003', 10);
 
-async function main(): Promise<void> {
-    const pool = new Pool({
-        host: process.env.POSTGRES_HOST,
-        port: parseInt(process.env.POSTGRES_PORT || '5432', 10),
-        user: process.env.POSTGRES_USER,
-        password: process.env.POSTGRES_PASSWORD,
-        database: process.env.POSTGRES_DB,
-    });
-
-    // 验证 DB 连接
-    await pool.query('SELECT 1');
-    console.info('PostgreSQL connected');
-
-    const laneResolver = new LaneResolver(pool);
-    const forwarder = new EventForwarder(laneResolver, laneRouter);
-    const botManager = new BotManager(pool, forwarder);
-
-    const app = new Koa();
-    const router = new Router();
-
-    // Prometheus metrics（最外层）
-    app.use(metricsMiddleware);
-    app.use(metricsRouter.routes());
-
-    // 注册 health check
-    app.use(healthRouter.routes());
-
-    // 注册所有 bot webhook 路由
-    await botManager.registerBots(router);
-
-    app.use(router.routes());
-    app.use(router.allowedMethods());
-
-    app.listen(PORT, () => {
-        console.info(`lark-proxy listening on port ${PORT}`);
-    });
-}
-
-main().catch((err) => {
-    console.error('lark-proxy failed to start:', err);
-    process.exit(1);
+const pool = new Pool({
+    host: process.env.POSTGRES_HOST,
+    port: parseInt(process.env.POSTGRES_PORT || '5432', 10),
+    user: process.env.POSTGRES_USER,
+    password: process.env.POSTGRES_PASSWORD,
+    database: process.env.POSTGRES_DB,
 });
+
+await pool.query('SELECT 1');
+console.info('PostgreSQL connected');
+
+const laneResolver = new LaneResolver(pool);
+const forwarder = new EventForwarder(laneResolver, laneRouter);
+const botManager = new BotManager(pool, forwarder);
+
+const app = new Hono();
+
+// Prometheus metrics
+app.use('*', metricsMiddleware);
+app.route('', metricsApp);
+
+// Health check
+app.route('', healthApp);
+
+// 管理 API（泳道绑定）
+const adminApp = createAdminApp(pool, laneResolver);
+app.route('', adminApp);
+
+// Bot webhook 路由
+await botManager.registerBots(app);
+
+console.info(`lark-proxy listening on port ${PORT}`);
+
+export default { port: PORT, fetch: app.fetch };

--- a/apps/lark-proxy/src/lark-adapter.ts
+++ b/apps/lark-proxy/src/lark-adapter.ts
@@ -1,0 +1,15 @@
+import type { Handler } from 'hono';
+import type * as Lark from '@larksuiteoapi/node-sdk';
+
+export function adaptHono(
+    dispatcher: Lark.EventDispatcher | Lark.CardActionHandler,
+): Handler {
+    return async (c) => {
+        const data = await c.req.json();
+        const headers = Object.fromEntries(c.req.raw.headers);
+        const result = await (dispatcher as any).invoke(
+            Object.assign(Object.create({ headers }), data),
+        );
+        return c.json(result);
+    };
+}

--- a/apps/lark-proxy/src/metrics.ts
+++ b/apps/lark-proxy/src/metrics.ts
@@ -1,6 +1,6 @@
 import { Counter, Histogram, Gauge, Registry, collectDefaultMetrics } from 'prom-client';
-import type { Context, Next } from 'koa';
-import Router from '@koa/router';
+import { Hono } from 'hono';
+import type { Context, Next } from 'hono';
 
 const register = new Registry();
 collectDefaultMetrics({ register });
@@ -25,10 +25,7 @@ const httpRequestsInFlight = new Gauge({
     registers: [register],
 });
 
-/**
- * Koa middleware that records Prometheus HTTP metrics.
- */
-export async function metricsMiddleware(ctx: Context, next: Next): Promise<void> {
+export async function metricsMiddleware(c: Context, next: Next): Promise<void | Response> {
     httpRequestsInFlight.inc();
     const start = performance.now();
     try {
@@ -36,16 +33,12 @@ export async function metricsMiddleware(ctx: Context, next: Next): Promise<void>
     } finally {
         const duration = (performance.now() - start) / 1000;
         httpRequestsInFlight.dec();
-        httpRequestsTotal.inc({ method: ctx.method, path: ctx.path, status: String(ctx.status) });
-        httpRequestDuration.observe({ method: ctx.method, path: ctx.path }, duration);
+        httpRequestsTotal.inc({ method: c.req.method, path: c.req.path, status: String(c.res.status) });
+        httpRequestDuration.observe({ method: c.req.method, path: c.req.path }, duration);
     }
 }
 
-/**
- * Router with /metrics endpoint.
- */
-export const metricsRouter = new Router();
-metricsRouter.get('/metrics', async (ctx) => {
-    ctx.set('Content-Type', register.contentType);
-    ctx.body = await register.metrics();
+export const metricsApp = new Hono();
+metricsApp.get('/metrics', async (c) => {
+    return c.text(await register.metrics(), 200, { 'Content-Type': register.contentType });
 });

--- a/bun.lock
+++ b/bun.lock
@@ -10,16 +10,13 @@
       "version": "1.0.0",
       "dependencies": {
         "@inner/shared": "workspace:*",
-        "@koa/router": "^12.0.1",
         "@larksuiteoapi/node-sdk": "^1.23.0",
-        "koa": "^2.15.0",
+        "hono": "^4.7.0",
         "pg": "^8.11.5",
         "prom-client": "^15.1.0",
       },
       "devDependencies": {
         "@types/bun": "latest",
-        "@types/koa": "^2.15.0",
-        "@types/koa__router": "^12.0.4",
         "@types/pg": "^8.11.0",
         "typescript": "^5.4.0",
       },
@@ -892,6 +889,8 @@
     "has-tostringtag": ["has-tostringtag@1.0.2", "https://bnpm.byted.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz", { "dependencies": { "has-symbols": "^1.0.3" } }, "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw=="],
 
     "hasown": ["hasown@2.0.2", "https://bnpm.byted.org/hasown/-/hasown-2.0.2.tgz", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ=="],
+
+    "hono": ["hono@4.12.5", "", {}, "sha512-3qq+FUBtlTHhtYxbxheZgY8NIFnkkC/MR8u5TTsr7YZ3wixryQ3cCwn3iZbg8p8B88iDBBAYSfZDS75t8MN7Vg=="],
 
     "http-assert": ["http-assert@1.5.0", "https://bnpm.byted.org/http-assert/-/http-assert-1.5.0.tgz", { "dependencies": { "deep-equal": "~1.0.1", "http-errors": "~1.8.0" } }, "sha512-uPpH7OKX4H25hBmU6G1jWNaqJGpTXxey+YOUizJUAgu0AjLUeC8D73hTrhvDS5D+GJN1DN1+hhc/eF/wpxtp0w=="],
 


### PR DESCRIPTION
## Summary
- Migrate lark-proxy from Koa to Hono (Bun-native, lighter, built-in body parsing)
- Add `adaptHono()` bridge for Lark SDK `dispatcher.invoke()`, replacing `Lark.adaptKoaRouter()`
- Add lane-binding admin API (`/api/lark/lane-bindings`) and Makefile commands
- Fix base service fallback: explicitly use `prod` lane when no `lane_routing` match, preventing cross-lane pod selection

## Test plan
- [x] `bun build` passes
- [x] Deployed to `feat-hono` lane, pod starts normally
- [x] Health, metrics, webhook endpoints verified
- [x] Real Lark messages forwarded successfully via temporary ingress hijack
- [x] Teardown: ingress deleted, lane undeployed

🤖 Generated with [Claude Code](https://claude.com/claude-code)