### PR TITLE
fix(lark-proxy): match partial unique index in lane-binding upsert

### DIFF
--- a/apps/lark-proxy/src/admin.ts
+++ b/apps/lark-proxy/src/admin.ts
@@ -36,7 +36,7 @@ export function createAdminApp(pool: Pool, laneResolver: LaneResolver): Hono {
         await pool.query(
             `INSERT INTO lane_routing (route_type, route_key, lane_name, is_active)
              VALUES ($1, $2, $3, true)
-             ON CONFLICT (route_type, route_key) DO UPDATE SET lane_name = $3, is_active = true`,
+             ON CONFLICT (route_type, route_key) WHERE is_active = true DO UPDATE SET lane_name = $3`,
             [route_type, route_key, lane_name],
         );
         laneResolver.clearCache();


### PR DESCRIPTION
## Summary
- `ON CONFLICT (route_type, route_key)` fails with PostgreSQL 42P10 because the unique index is partial (`WHERE is_active = true`)
- Add `WHERE is_active = true` clause to match the index

## Test plan
- [x] Deployed to `fix-upsert` lane, tested upsert via `lane-bind` — succeeded
- [x] Restored original binding, removed test lane

🤖 Generated with [Claude Code](https://claude.com/claude-code)