### PR TITLE
fix(agent-service): upgrade Azure OpenAI API version for json_schema support

### DIFF
--- a/apps/agent-service/app/agents/infra/model_builder.py
+++ b/apps/agent-service/app/agents/infra/model_builder.py
@@ -159,7 +159,7 @@ class ModelBuilder:
                 # 使用 AzureChatOpenAI
                 chat_params = {
                     "openai_api_type": "azure",
-                    "openai_api_version": "2024-03-01-preview",
+                    "openai_api_version": "2024-08-01-preview",
                     "azure_endpoint": model_info["base_url"],
                     "openai_api_key": model_info["api_key"],
                     "deployment_name": model_info["model_name"],


### PR DESCRIPTION
## Summary
- 将 Azure OpenAI API 版本从 `2024-03-01-preview` 升级到 `2024-08-01-preview`
- 修复 `response_format: json_schema` 不被支持的问题

## 注意
- 部署时 GIT_REF 需手动填 `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)