### PR TITLE
fix(monitoring): route InfoInhibitor to null receiver

### DIFF
--- a/infra/k8s/monitoring/kube-prometheus-stack-values.yaml
+++ b/infra/k8s/monitoring/kube-prometheus-stack-values.yaml
@@ -77,6 +77,10 @@ alertmanager:
       group_wait: 30s
       group_interval: 5m
       repeat_interval: 4h
+      routes:
+        - matchers:
+            - alertname = "InfoInhibitor"
+          receiver: "null"
     receivers:
       - name: feishu
         webhook_configs:


### PR DESCRIPTION
## Summary
- `InfoInhibitor` 是 kube-prometheus-stack 内置的元告警，仅用于抑制 info 级别告警的逻辑，不应触发真实通知
- 在 Alertmanager 路由中添加子路由，将 `InfoInhibitor` 导向 `null` receiver
- `null` receiver 已存在，只差这条路由规则

## Test plan
- [ ] 应用 helm upgrade 后，`InfoInhibitor` 不再发送飞书通知

🤖 Generated with [Claude Code](https://claude.com/claude-code)