### PR TITLE
fix(monitoring): suppress Watchdog alert notification

### DIFF
--- a/infra/k8s/monitoring/kube-prometheus-stack-values.yaml
+++ b/infra/k8s/monitoring/kube-prometheus-stack-values.yaml
@@ -79,7 +79,7 @@ alertmanager:
       repeat_interval: 4h
       routes:
         - matchers:
-            - alertname = "InfoInhibitor"
+            - alertname =~ "InfoInhibitor|Watchdog"
           receiver: "null"
     receivers:
       - name: feishu


### PR DESCRIPTION
## Summary
- `Watchdog` 是 kube-prometheus-stack 内置心跳告警，设计上永远触发，用于验证告警链路是否正常
- 不应该发通知给用户，路由到 `null` receiver
- 与上一个 PR 合并 `InfoInhibitor` 的路由规则为一条正则匹配

🤖 Generated with [Claude Code](https://claude.com/claude-code)