### PR TITLE
fix(monitor-dashboard): extend JWT expiry to 7d

### DIFF
--- a/apps/monitor-dashboard/src/routes/auth.ts
+++ b/apps/monitor-dashboard/src/routes/auth.ts
@@ -13,7 +13,7 @@ router.post('/api/auth/login', async (ctx) => {
   }
 
   const secret = process.env.DASHBOARD_JWT_SECRET!;
-  const token = jwt.sign({ role: 'admin' }, secret, { expiresIn: '24h' });
+  const token = jwt.sign({ role: 'admin' }, secret, { expiresIn: '365d' });
 
   ctx.body = { token };
 });

--- a/apps/monitor-dashboard/src/routes/auth.ts
+++ b/apps/monitor-dashboard/src/routes/auth.ts
@@ -13,7 +13,7 @@ router.post('/api/auth/login', async (ctx) => {
   }
 
   const secret = process.env.DASHBOARD_JWT_SECRET!;
-  const token = jwt.sign({ role: 'admin' }, secret, { expiresIn: '365d' });
+  const token = jwt.sign({ role: 'admin' }, secret, { expiresIn: '7d' });
 
   ctx.body = { token };
 });


### PR DESCRIPTION
## Summary
- JWT token 有效期从 24h 延长到 7d，减少重复登录

🤖 Generated with [Claude Code](https://claude.com/claude-code)