### PR TITLE
fix: use Harbor mirror for all base images

### DIFF
--- a/apps/agent-service/Dockerfile
+++ b/apps/agent-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim
+FROM harbor.local:30002/library/python:3.11-slim
 
 RUN sed -i 's/deb.debian.org/mirrors.aliyun.com/g' /etc/apt/sources.list.d/debian.sources && \
     apt-get update && \

--- a/apps/alert-webhook/Dockerfile
+++ b/apps/alert-webhook/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25-alpine AS builder
+FROM harbor.local:30002/library/golang:1.25-alpine AS builder
 WORKDIR /app
 ENV GOPROXY=https://goproxy.cn,direct
 COPY go.mod ./
@@ -6,7 +6,7 @@ RUN go mod download
 COPY . .
 RUN CGO_ENABLED=0 go build -ldflags="-s -w" -o /bin/alert-webhook ./cmd/alert-webhook
 
-FROM alpine:3.21
+FROM harbor.local:30002/library/alpine:3.21
 RUN apk add --no-cache ca-certificates
 COPY --from=builder /bin/alert-webhook /usr/local/bin/alert-webhook
 EXPOSE 8080

--- a/apps/api-gateway/Dockerfile
+++ b/apps/api-gateway/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25-alpine AS builder
+FROM harbor.local:30002/library/golang:1.25-alpine AS builder
 WORKDIR /app
 ENV GOPROXY=https://goproxy.cn,direct
 COPY go.mod go.sum ./
@@ -6,7 +6,7 @@ RUN go mod download
 COPY . .
 RUN CGO_ENABLED=0 go build -ldflags="-s -w" -o /bin/api-gateway ./cmd/api-gateway
 
-FROM alpine:3.21
+FROM harbor.local:30002/library/alpine:3.21
 RUN apk add --no-cache ca-certificates
 COPY --from=builder /bin/api-gateway /usr/local/bin/api-gateway
 COPY config/routes.yaml /etc/api-gateway/routes.yaml

--- a/apps/lark-proxy/Dockerfile
+++ b/apps/lark-proxy/Dockerfile
@@ -1,4 +1,4 @@
-FROM oven/bun:1.3.9-alpine
+FROM harbor.local:30002/library/bun:1.3.9-alpine
 
 RUN apk add --no-cache tzdata
 ENV TZ=Asia/Shanghai

--- a/apps/lark-server/Dockerfile
+++ b/apps/lark-server/Dockerfile
@@ -1,4 +1,4 @@
-FROM oven/bun:1.3.9-slim AS builder
+FROM harbor.local:30002/library/bun:1.3.9-slim AS builder
 
 WORKDIR /repo
 
@@ -26,7 +26,7 @@ RUN bun build src/workers/recall-worker.ts --compile --outfile=recall-worker
 RUN bun build src/workers/chat-response-worker.ts --compile --outfile=chat-response-worker
 
 # --- Runtime（同样基于 Debian/glibc）---
-FROM debian:bookworm-slim
+FROM harbor.local:30002/library/debian:bookworm-slim
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates tzdata && rm -rf /var/lib/apt/lists/*

--- a/apps/lite-registry/Dockerfile
+++ b/apps/lite-registry/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25-alpine AS builder
+FROM harbor.local:30002/library/golang:1.25-alpine AS builder
 
 WORKDIR /app
 
@@ -10,7 +10,7 @@ RUN go mod download
 COPY . .
 RUN CGO_ENABLED=0 go build -ldflags="-s -w" -o lite-registry ./cmd/lite-registry
 
-FROM alpine:3.21
+FROM harbor.local:30002/library/alpine:3.21
 
 RUN apk add --no-cache ca-certificates
 

--- a/apps/monitor-dashboard-web/Dockerfile
+++ b/apps/monitor-dashboard-web/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Build frontend with Bun
-FROM oven/bun:1.3.9-alpine AS builder
+FROM harbor.local:30002/library/bun:1.3.9-alpine AS builder
 
 WORKDIR /app
 
@@ -12,7 +12,7 @@ COPY src ./src
 RUN bunx vite build
 
 # Stage 2: Serve with Nginx
-FROM nginx:alpine
+FROM harbor.local:30002/library/nginx:alpine
 
 RUN apk add --no-cache tzdata
 ENV TZ=Asia/Shanghai

--- a/apps/monitor-dashboard/Dockerfile
+++ b/apps/monitor-dashboard/Dockerfile
@@ -1,4 +1,4 @@
-FROM oven/bun:1.3.9-alpine
+FROM harbor.local:30002/library/bun:1.3.9-alpine
 
 RUN apk add --no-cache tzdata
 ENV TZ=Asia/Shanghai

--- a/apps/paas-engine/Dockerfile
+++ b/apps/paas-engine/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25-alpine AS builder
+FROM harbor.local:30002/library/golang:1.25-alpine AS builder
 WORKDIR /app
 ENV GOPROXY=https://goproxy.cn,direct
 COPY go.mod go.sum ./
@@ -6,7 +6,7 @@ RUN go mod download
 COPY . .
 RUN CGO_ENABLED=0 go build -ldflags="-s -w" -o /bin/paas-engine ./cmd/paas-engine
 
-FROM alpine:3.21
+FROM harbor.local:30002/library/alpine:3.21
 RUN apk add --no-cache ca-certificates
 COPY --from=builder /bin/paas-engine /usr/local/bin/paas-engine
 EXPOSE 8080

--- a/apps/tool-service/Dockerfile
+++ b/apps/tool-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim
+FROM harbor.local:30002/library/python:3.11-slim
 
 RUN sed -i 's/deb.debian.org/mirrors.aliyun.com/g' /etc/apt/sources.list.d/debian.sources && \
     apt-get update && \


### PR DESCRIPTION
## Summary
- 将所有服务的基础镜像从外部 registry 迁移到 Harbor 内网镜像
- 覆盖镜像：`golang:1.25-alpine`、`alpine:3.21`、`bun:1.3.9-alpine`、`bun:1.3.9-slim`、`debian:bookworm-slim`、`nginx:alpine`、`python:3.11-slim`
- 同步开启 lark-server 的 Kaniko layer cache（`no_cache: false`）

## 背景
lark-server 偶发极慢构建（最慢 1535s），根因是 Kaniko 拉取基础镜像时依赖外部镜像源 `docker.m.daocloud.io`，网络抖动时下载 layer 耗时极长。改走 Harbor 内网后构建稳定在 63s。

## Test plan
- [x] fix/lark-server-harbor-base-image 分支构建验证：63s 完成，日志确认走 harbor.local:30002