### PR TITLE
refactor(agent-service): restructure chat context for p2p/group clarity

### DIFF
--- a/apps/agent-service/app/agents/domains/main/agent.py
+++ b/apps/agent-service/app/agents/domains/main/agent.py
@@ -4,8 +4,6 @@ import asyncio
 import logging
 import uuid
 from collections.abc import AsyncGenerator
-from datetime import datetime
-
 from langchain.messages import AIMessageChunk
 from langfuse import get_client as get_langfuse
 from langfuse import propagate_attributes
@@ -183,12 +181,9 @@ async def _build_and_stream(
 ) -> AsyncGenerator[str, None]:
     """构建 agent + 上下文，执行流式生成（两种模式共用）"""
     # 构建 prompt 变量（注入复杂度引导）
-    now = datetime.now()
     prompt_vars = {
         "complexity_hint": COMPLEXITY_HINTS.get(complexity, ""),
-        "curr_date": now.strftime("%Y-%m-%d"),
-        "curr_time": now.strftime("%H:%M"),
-        "user_info": "",
+        "user_context": "",
     }
 
     # 创建 agent
@@ -211,6 +206,7 @@ async def _build_and_stream(
         trigger_username,
         chat_type,
         trigger_user_id,
+        chat_name,
     ) = await build_chat_context(message_id)
 
     if not messages:
@@ -218,22 +214,34 @@ async def _build_and_stream(
         yield "抱歉，未找到相关消息记录"
         return
 
-    # 私聊时注入用户信息，帮助模型了解对话对象
-    if chat_type == "p2p" and trigger_username:
-        prompt_vars["user_info"] = f"你正在和 {trigger_username} 私聊。"
+    # 构建 user_context
+    context_lines: list[str] = []
+    if chat_type == "p2p":
+        if trigger_username:
+            context_lines.append(f"你正在和 {trigger_username} 私聊。")
+    else:  # group
+        if chat_name:
+            context_lines.append(f"你在群聊「{chat_name}」中。")
+        if trigger_username:
+            context_lines.append(
+                f"需要回复 {trigger_username} 的消息（消息中用 ⭐ 标记）。"
+            )
 
-    # 注入记忆上下文
+    # 注入记忆上下文（p2p 和 group 通用）
     if trigger_user_id:
         try:
             memory_text = await build_memory_context(
-                trigger_user_id, chat_id, chat_type
+                trigger_user_id, chat_id, chat_type, username=trigger_username or ""
             )
-            prompt_vars["memory_context"] = memory_text
+            if memory_text:
+                context_lines.append(
+                    f"你对 {trigger_username or '对方'} 的了解："
+                )
+                context_lines.append(memory_text)
         except Exception as e:
             logger.error(f"Failed to build memory context: {e}")
-            prompt_vars["memory_context"] = ""
-    else:
-        prompt_vars["memory_context"] = ""
+
+    prompt_vars["user_context"] = "\n".join(context_lines)
 
     full_content = ""
 

--- a/apps/agent-service/app/agents/domains/main/context_builder.py
+++ b/apps/agent-service/app/agents/domains/main/context_builder.py
@@ -5,7 +5,6 @@
 
 import asyncio
 import logging
-from dataclasses import dataclass
 
 from langchain.messages import AIMessage, HumanMessage
 
@@ -19,27 +18,25 @@ logger = logging.getLogger(__name__)
 
 async def build_chat_context(
     message_id: str, limit: int = 10
-) -> tuple[list[HumanMessage | AIMessage], list[str], str, str, str, str]:
+) -> tuple[list[HumanMessage | AIMessage], list[str], str, str, str, str, str]:
     """构建聊天上下文，支持私聊和群聊使用不同组装策略
 
-    群聊: 使用系统Prompt进行上下文组装成一条HumanMessage
+    群聊: 按回复链分组，组装成一条 HumanMessage
     私聊: 直接使用历史消息组装成 HumanMessage 和 AIMessage 列表
-
-    注意: banned_word 检测已移至 guard graph，此处不再检测
 
     Args:
         message_id: 触发消息的ID
         limit: 获取的历史消息数量限制
 
     Returns:
-        tuple: (消息列表, 图片URL列表, chat_id, 触发用户名, 聊天类型, 触发用户ID)
+        tuple: (消息列表, 图片URL列表, chat_id, 触发用户名, 聊天类型, 触发用户ID, 群聊名称)
     """
     # L1: 使用 quick_search 拉取近期历史
     l1_results = await quick_search(message_id=message_id, limit=limit)
 
     if not l1_results:
         logger.warning(f"No results found for message_id: {message_id}")
-        return [], [], "", "", "p2p", ""
+        return [], [], "", "", "p2p", "", ""
 
     chat_type = l1_results[-1].chat_type or "p2p"  # 默认私聊
 
@@ -71,7 +68,7 @@ async def build_chat_context(
 
     # 2. 根据chat_type使用不同策略组装消息列表
     if chat_type == "group":
-        # 群聊：使用prompt模板组装成一条HumanMessage
+        # 群聊：按回复链分组，组装成一条HumanMessage
         messages = await _build_group_messages(l1_results, message_id, image_key_to_url)
     else:
         # 私聊：直接组装成HumanMessage和AIMessage列表
@@ -84,6 +81,9 @@ async def build_chat_context(
     trigger_username = l1_results[-1].username or ""
     trigger_user_id = l1_results[-1].user_id or ""
 
+    # 提取群聊名称
+    chat_name = l1_results[-1].chat_name or ""
+
     return (
         messages,
         image_urls,
@@ -91,7 +91,29 @@ async def build_chat_context(
         trigger_username,
         chat_type,
         trigger_user_id,
+        chat_name,
     )
+
+
+def _extract_reply_chain(
+    messages: list[QuickSearchResult], trigger_id: str
+) -> tuple[list[QuickSearchResult], list[QuickSearchResult]]:
+    """从触发消息向上追溯 reply_message_id，提取回复链
+
+    Returns:
+        (chain_messages, other_messages) - 均按时间升序
+    """
+    msg_map = {msg.message_id: msg for msg in messages}
+
+    chain_ids: set[str] = set()
+    current_id: str | None = trigger_id
+    while current_id and current_id in msg_map:
+        chain_ids.add(current_id)
+        current_id = msg_map[current_id].reply_message_id
+
+    chain = [m for m in messages if m.message_id in chain_ids]
+    other = [m for m in messages if m.message_id not in chain_ids]
+    return chain, other
 
 
 async def _build_group_messages(
@@ -101,7 +123,7 @@ async def _build_group_messages(
 ) -> list[HumanMessage | AIMessage]:
     """构建群聊消息列表
 
-    使用 prompt 模板将历史组装成一条 HumanMessage
+    按回复链分组：回复链内消息有序排列，其他消息作为背景上下文。
 
     Args:
         messages: 消息列表
@@ -111,21 +133,34 @@ async def _build_group_messages(
     Returns:
         包含一条 HumanMessage 的列表
     """
-    # 复用现有的 context 构建逻辑
-    context = await _build_context_from_messages(messages, trigger_id)
+    chain, other = _extract_reply_chain(messages, trigger_id)
 
-    # 使用 langfuse prompt 模板
+    # 格式化回复链消息（有序链，不需要编号和回复标记）
+    chain_lines = []
+    for msg in chain:
+        time_str = msg.create_time.strftime("%H:%M:%S")
+        username = msg.username or "未知用户"
+        parsed = parse_content(msg.content)
+        text = parsed.render()
+        marker = " ⭐" if msg.message_id == trigger_id else ""
+        chain_lines.append(f"[{time_str}] {username}: {text}{marker}")
+
+    # 格式化其他消息（简略背景）
+    other_lines = []
+    for msg in other:
+        time_str = msg.create_time.strftime("%H:%M:%S")
+        username = msg.username or "未知用户"
+        parsed = parse_content(msg.content)
+        text = parsed.render()
+        other_lines.append(f"[{time_str}] {username}: {text}")
+
+    # 用 context_builder 模板组装
     user_content = get_prompt("context_builder").compile(
-        group_name=context.chat_name,
-        chat_history=context.chat_history,
-        trigger_content=context.trigger_content,
-        trigger_username=context.trigger_username,
+        reply_chain="\n".join(chain_lines) if chain_lines else "（无回复链）",
+        other_messages="\n".join(other_lines) if other_lines else "（无其他消息）",
     )
 
-    # 构建多模态消息
     content_blocks: list = [{"type": "text", "text": user_content}]
-
-    # 追加所有成功获取的图片
     for url in image_key_to_url.values():
         content_blocks.append({"type": "image", "url": url})
 
@@ -183,139 +218,3 @@ async def _build_p2p_messages(
     return result
 
 
-def _extract_and_replace_images(
-    content: str, start_index: int
-) -> tuple[str, list[str]]:
-    """从消息内容中提取图片keys，替换为【图片N】标记
-
-    Args:
-        content: 原始消息内容（v2 JSON 格式）
-        start_index: 起始图片编号
-
-    Returns:
-        tuple[str, list[str]]: (处理后的文本, 图片keys列表)
-    """
-    parsed = parse_content(content)
-    rendered = parsed.render(image_fn=lambda i, _key: f"【图片{start_index + i + 1}】")
-    return rendered, parsed.image_keys
-
-
-@dataclass
-class ChatContext:
-    """聊天上下文数据类
-
-    Attributes:
-        chat_history: 格式化的聊天历史
-        trigger_content: 触发消息的格式化内容
-        trigger_username: 触发用户的用户名
-        chat_type: 聊天类型（p2p/group）
-        chat_name: 群聊名称（私聊时为None）
-    """
-
-    chat_history: str
-    trigger_content: str
-    trigger_username: str
-    chat_name: str | None
-
-
-def _build_message_id_map(messages: list[QuickSearchResult]) -> dict[str, int]:
-    """构建消息ID到编号的映射
-
-    Args:
-        messages: 消息列表
-
-    Returns:
-        dict[str, int]: 消息ID到编号的映射（从1开始）
-    """
-    return {msg.message_id: idx + 1 for idx, msg in enumerate(messages)}
-
-
-def _format_chat_message(
-    msg: QuickSearchResult,
-    image_counter: dict[str, int],
-    message_index: int,
-    message_id_map: dict[str, int],
-) -> tuple[str, list[str]]:
-    """格式化单条聊天消息，提取图片keys
-
-    Args:
-        msg: 消息对象
-        image_counter: 图片计数器字典，包含 "count" 键
-        message_index: 当前消息的编号
-        message_id_map: 消息ID到编号的映射
-
-    Returns:
-        tuple[str, list[str]]: (格式化后的消息字符串, 图片keys列表)
-    """
-    time_str = msg.create_time.strftime("%Y-%m-%d %H:%M:%S")
-    username = msg.username or "未知用户"
-
-    # 提取并替换图片标记
-    processed_content, image_keys = _extract_and_replace_images(
-        msg.content, image_counter["count"]
-    )
-
-    # 更新计数器
-    image_counter["count"] += len(image_keys)
-
-    # 构建回复标注
-    reply_tag = ""
-    if msg.reply_message_id:
-        if msg.reply_message_id in message_id_map:
-            # 回复的消息在上下文中
-            parent_index = message_id_map[msg.reply_message_id]
-            reply_tag = f" [↪️回复消息{parent_index}]"
-        else:
-            # 回复的消息不在上下文中
-            reply_tag = " [↪️回复(消息已不在上下文)]"
-
-    formatted_text = f"【消息{message_index}】[{time_str}] [User: {username}]{reply_tag}: {processed_content}"
-    return formatted_text, image_keys
-
-
-async def _build_context_from_messages(
-    messages: list[QuickSearchResult], trigger_id: str
-) -> ChatContext:
-    """从消息列表构建聊天上下文
-
-    Args:
-        messages: 消息列表
-        trigger_id: 触发消息的ID
-
-    Returns:
-        ChatContext对象
-    """
-    history_messages = []
-    trigger_username = "未知用户"
-    trigger_formatted = "（未找到触发消息）"
-    chat_name = None
-
-    # 初始化图片计数器（用于【图片N】标记）
-    image_counter = {"count": 0}
-
-    # 构建消息ID到编号的映射
-    message_id_map = _build_message_id_map(messages)
-
-    for idx, msg in enumerate(messages):
-        message_index = idx + 1
-        formatted_text, _ = _format_chat_message(
-            msg, image_counter, message_index, message_id_map
-        )
-
-        if msg.message_id == trigger_id:
-            trigger_username = msg.username or "未知用户"
-            chat_name = msg.chat_name
-            trigger_formatted = formatted_text
-        else:
-            history_messages.append(formatted_text)
-
-    chat_history = (
-        "\n".join(history_messages) if history_messages else "（暂无历史记录）"
-    )
-
-    return ChatContext(
-        chat_history=chat_history,
-        trigger_content=trigger_formatted,
-        trigger_username=trigger_username,
-        chat_name=chat_name,
-    )

--- a/apps/agent-service/app/services/memory_context.py
+++ b/apps/agent-service/app/services/memory_context.py
@@ -18,13 +18,16 @@ MAX_CHARS = 400
 _MIN_CONFIDENCE = 0.6
 
 
-async def build_memory_context(user_id: str, chat_id: str, chat_type: str) -> str:
+async def build_memory_context(
+    user_id: str, chat_id: str, chat_type: str, *, username: str = ""
+) -> str:
     """构建记忆上下文文本，注入 system prompt
 
     Args:
         user_id: 触发用户 ID
         chat_id: 聊天 ID（预留）
         chat_type: 聊天类型
+        username: 触发用户名，用于画像归属
 
     Returns:
         渲染后的记忆文本，或空字符串
@@ -33,10 +36,10 @@ async def build_memory_context(user_id: str, chat_id: str, chat_type: str) -> st
     if not knowledge:
         return ""
 
-    return _render_knowledge(knowledge)
+    return _render_knowledge(knowledge, username=username)
 
 
-def _render_knowledge(knowledge: UserKnowledge) -> str:
+def _render_knowledge(knowledge: UserKnowledge, *, username: str = "") -> str:
     """将 UserKnowledge 渲染为赤尾视角的自然语言描述"""
     parts: list[str] = []
 
@@ -77,7 +80,8 @@ def _render_knowledge(knowledge: UserKnowledge) -> str:
 
     # personality_note
     if knowledge.personality_note:
-        parts.append(f"你对这个人的印象：{knowledge.personality_note}")
+        label = f"你对 {username} 的印象" if username else "你的印象"
+        parts.append(f"{label}：{knowledge.personality_note}")
 
     # communication_style
     if knowledge.communication_style:


### PR DESCRIPTION
## Summary
- Replace `user_info` + `memory_context` with unified `user_context` in system prompt, clearly distinguishing p2p/group scenarios
- Group chat: split messages into reply-chain vs flat list, fixing the issue where trigger message was isolated from its conversation thread
- Add username attribution to user knowledge/personality notes, preventing model from misattributing user traits to itself
- Simplify `context_builder` Langfuse template from 5 vars to 2 (`reply_chain`, `other_messages`)
- Remove unused `ChatContext`, `_build_context_from_messages`, `_build_message_id_map`, `_format_chat_message`

## Test plan
- [x] Deploy to `resistance` test lane
- [x] P2P chat: verified user_context renders correctly with username attribution
- [x] Group chat: verified reply chain grouping and trigger message marking
- [x] Langfuse trace: confirmed prompt variables render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)