### PR TITLE
fix(mq): use request-level lane for publish + TTL fallback for lane queues

### DIFF
--- a/apps/agent-service/app/clients/rabbitmq.py
+++ b/apps/agent-service/app/clients/rabbitmq.py
@@ -33,6 +33,7 @@ RK_CHAT_RESPONSE = "chat.response"
 
 # 非 prod 队列空闲自动删除（24h）
 _NON_PROD_EXPIRES_MS = 86_400_000
+_LANE_FALLBACK_TTL_MS = 10_000
 
 
 def _current_lane() -> str | None:
@@ -110,18 +111,25 @@ class RabbitMQClient:
             arguments={"x-delayed-type": "topic"},
         )
 
-        # 非 prod 队列额外参数
-        extra_args: dict[str, Any] = {}
-        if lane:
-            extra_args["x-expires"] = _NON_PROD_EXPIRES_MS
-
-        base_args = {"x-dead-letter-exchange": DLX_NAME, **extra_args}
+        # 队列参数：prod 队列用 DLX → DLQ；lane 队列用 TTL → 主 exchange fallback 到 prod
+        def queue_args(prod_rk: str) -> dict[str, Any]:
+            extra: dict[str, Any] = {}
+            if lane:
+                extra["x-expires"] = _NON_PROD_EXPIRES_MS
+            if not lane:
+                return {"x-dead-letter-exchange": DLX_NAME, **extra}
+            return {
+                "x-message-ttl": _LANE_FALLBACK_TTL_MS,
+                "x-dead-letter-exchange": EXCHANGE_NAME,
+                "x-dead-letter-routing-key": prod_rk,
+                **extra,
+            }
 
         # safety_check queue
         q_safety = await self._channel.declare_queue(
             _lane_queue(QUEUE_SAFETY_CHECK, lane),
             durable=True,
-            arguments=base_args,
+            arguments=queue_args(RK_SAFETY_CHECK),
         )
         await q_safety.bind(self._exchange, routing_key=_lane_rk(RK_SAFETY_CHECK, lane))
 
@@ -129,7 +137,7 @@ class RabbitMQClient:
         q_recall = await self._channel.declare_queue(
             _lane_queue(QUEUE_RECALL, lane),
             durable=True,
-            arguments=base_args,
+            arguments=queue_args(RK_RECALL),
         )
         await q_recall.bind(self._exchange, routing_key=_lane_rk(RK_RECALL, lane))
 
@@ -137,7 +145,7 @@ class RabbitMQClient:
         q_vectorize = await self._channel.declare_queue(
             _lane_queue(QUEUE_VECTORIZE, lane),
             durable=True,
-            arguments=base_args,
+            arguments=queue_args(RK_VECTORIZE),
         )
         await q_vectorize.bind(
             self._exchange, routing_key=_lane_rk(RK_VECTORIZE, lane)
@@ -147,7 +155,7 @@ class RabbitMQClient:
         q_chat_req = await self._channel.declare_queue(
             _lane_queue(QUEUE_CHAT_REQUEST, lane),
             durable=True,
-            arguments=base_args,
+            arguments=queue_args(RK_CHAT_REQUEST),
         )
         await q_chat_req.bind(
             self._exchange, routing_key=_lane_rk(RK_CHAT_REQUEST, lane)
@@ -157,7 +165,7 @@ class RabbitMQClient:
         q_chat_resp = await self._channel.declare_queue(
             _lane_queue(QUEUE_CHAT_RESPONSE, lane),
             durable=True,
-            arguments=base_args,
+            arguments=queue_args(RK_CHAT_RESPONSE),
         )
         await q_chat_resp.bind(
             self._exchange, routing_key=_lane_rk(RK_CHAT_RESPONSE, lane)

--- a/apps/agent-service/app/workers/post_consumer.py
+++ b/apps/agent-service/app/workers/post_consumer.py
@@ -59,6 +59,10 @@ async def handle_safety_check(message: AbstractIncomingMessage) -> None:
         chat_id = body.get("chat_id")
         trigger_message_id = body.get("trigger_message_id")
         lane = body.get("lane")  # 从消息 payload 中读取泳道
+        if lane:
+            from app.utils.middlewares.trace import header_vars
+
+            header_vars["lane"].set(lane)
 
         logger.info("Post safety check: session_id=%s, lane=%s", session_id, lane)
 

--- a/apps/lark-server/src/core/services/ai/reply.ts
+++ b/apps/lark-server/src/core/services/ai/reply.ts
@@ -27,7 +27,7 @@ export async function makeTextReply(message: Message): Promise<void> {
     }
 
     // 发布到 chat.request 队列
-    const lane = getLane();
+    const lane = context.getLane() || getLane() || undefined;
     await rabbitmqClient.publish(
         RK_CHAT_REQUEST,
         {

--- a/apps/lark-server/src/infrastructure/integrations/rabbitmq.ts
+++ b/apps/lark-server/src/infrastructure/integrations/rabbitmq.ts
@@ -14,6 +14,7 @@ export const RK_CHAT_REQUEST = 'chat.request';
 export const RK_CHAT_RESPONSE = 'chat.response';
 
 const NON_PROD_EXPIRES_MS = 86_400_000;
+const LANE_FALLBACK_TTL_MS = 10_000;
 
 export type MessageHandler = (msg: ConsumeMessage) => Promise<void>;
 
@@ -89,30 +90,40 @@ class RabbitMQClient {
             arguments: { 'x-delayed-type': 'topic' },
         });
 
-        // 非 prod 队列额外参数
-        const extraArgs: Record<string, unknown> = lane
-            ? { 'x-expires': NON_PROD_EXPIRES_MS }
-            : {};
-        const baseArgs = { 'x-dead-letter-exchange': DLX_NAME, ...extraArgs };
+        // 队列参数：prod 队列用 DLX → DLQ；lane 队列用 TTL → 主 exchange fallback 到 prod
+        function queueArgs(prodRK: string): Record<string, unknown> {
+            const extra: Record<string, unknown> = lane
+                ? { 'x-expires': NON_PROD_EXPIRES_MS }
+                : {};
+            if (!lane) {
+                return { 'x-dead-letter-exchange': DLX_NAME, ...extra };
+            }
+            return {
+                'x-message-ttl': LANE_FALLBACK_TTL_MS,
+                'x-dead-letter-exchange': EXCHANGE_NAME,
+                'x-dead-letter-routing-key': prodRK,
+                ...extra,
+            };
+        }
 
         // recall queue
         const recallQ = laneQueue(QUEUE_RECALL, lane);
-        await ch.assertQueue(recallQ, { durable: true, arguments: baseArgs });
+        await ch.assertQueue(recallQ, { durable: true, arguments: queueArgs(RK_RECALL) });
         await ch.bindQueue(recallQ, EXCHANGE_NAME, laneRK(RK_RECALL, lane));
 
         // vectorize queue
         const vectorizeQ = laneQueue(QUEUE_VECTORIZE, lane);
-        await ch.assertQueue(vectorizeQ, { durable: true, arguments: baseArgs });
+        await ch.assertQueue(vectorizeQ, { durable: true, arguments: queueArgs(RK_VECTORIZE) });
         await ch.bindQueue(vectorizeQ, EXCHANGE_NAME, laneRK(RK_VECTORIZE, lane));
 
         // chat_request queue
         const chatReqQ = laneQueue(QUEUE_CHAT_REQUEST, lane);
-        await ch.assertQueue(chatReqQ, { durable: true, arguments: baseArgs });
+        await ch.assertQueue(chatReqQ, { durable: true, arguments: queueArgs(RK_CHAT_REQUEST) });
         await ch.bindQueue(chatReqQ, EXCHANGE_NAME, laneRK(RK_CHAT_REQUEST, lane));
 
         // chat_response queue
         const chatRespQ = laneQueue(QUEUE_CHAT_RESPONSE, lane);
-        await ch.assertQueue(chatRespQ, { durable: true, arguments: baseArgs });
+        await ch.assertQueue(chatRespQ, { durable: true, arguments: queueArgs(RK_CHAT_RESPONSE) });
         await ch.bindQueue(chatRespQ, EXCHANGE_NAME, laneRK(RK_CHAT_RESPONSE, lane));
 
         console.info(`[RabbitMQ] topology declared (lane=${lane || 'prod'})`);

--- a/apps/lark-server/src/workers/chat-response-worker.ts
+++ b/apps/lark-server/src/workers/chat-response-worker.ts
@@ -84,7 +84,7 @@ async function handleChatResponse(msg: ConsumeMessage): Promise<void> {
     const botName = agentResponse?.bot_name;
 
     // 设置 bot context
-    const contextData = context.createContext(botName || undefined);
+    const contextData = context.createContext(botName || undefined, undefined, payload.lane);
 
     await context.run(contextData, async () => {
         if (status === 'failed') {

--- a/apps/lark-server/src/workers/recall-worker.ts
+++ b/apps/lark-server/src/workers/recall-worker.ts
@@ -81,7 +81,7 @@ async function handleRecall(msg: ConsumeMessage): Promise<void> {
 
     // 设置 bot context 以使用正确的 Lark client
     const botName = agentResponse.bot_name;
-    const contextData = context.createContext(botName || undefined);
+    const contextData = context.createContext(botName || undefined, undefined, payload.lane);
     let recalledCount = 0;
     let failedCount = 0;
 


### PR DESCRIPTION
## Summary
- 发布侧优先使用请求级 `context.getLane()` 而非部署级 `process.env.LANE`，修复 prod 实例转发 dev 请求时 lane 丢失
- 消费侧（chat-response-worker、recall-worker、post_consumer）从消息 payload 恢复 lane 到 AsyncLocalStorage/contextvars
- Lane 队列增加 TTL 10s + DLX 回主 exchange 的 fallback 机制：当 lane 队列无消费者时，消息自动回落到 prod 队列

## Test plan
- [x] 部署 fix-mq-lane 泳道（不含 agent-service），验证消息 TTL 10s 后 fallback 到 prod 队列（实测 ~13-14s = 10s TTL + agent 处理）
- [x] 加回 agent-service 后验证消息直接消费无额外延迟（实测 ~7s）

🤖 Generated with [Claude Code](https://claude.com/claude-code)