### PR TITLE
fix(paas-engine): clean base service on undeploy & block DB delete on K8s failure

### DIFF
--- a/apps/paas-engine/internal/adapter/http/release_handler.go
+++ b/apps/paas-engine/internal/adapter/http/release_handler.go
@@ -75,6 +75,24 @@ func (h *ReleaseHandler) Delete(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, map[string]string{"deleted": id})
 }
 
+func (h *ReleaseHandler) GetOrphans(w http.ResponseWriter, r *http.Request) {
+	report, err := h.svc.DetectOrphans(r.Context())
+	if err != nil {
+		writeError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, report)
+}
+
+func (h *ReleaseHandler) CleanupOrphans(w http.ResponseWriter, r *http.Request) {
+	report, err := h.svc.CleanupOrphans(r.Context())
+	if err != nil {
+		writeError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, report)
+}
+
 func (h *ReleaseHandler) DeleteByAppAndLane(w http.ResponseWriter, r *http.Request) {
 	appName := r.URL.Query().Get("app")
 	lane := r.URL.Query().Get("lane")

--- a/apps/paas-engine/internal/adapter/http/router.go
+++ b/apps/paas-engine/internal/adapter/http/router.go
@@ -57,6 +57,8 @@ func NewRouter(
 			r.Post("/", releaseH.Create)
 			r.Get("/", releaseH.List)
 			r.Delete("/", releaseH.DeleteByAppAndLane)
+			r.Get("/orphans", releaseH.GetOrphans)
+			r.Delete("/orphans", releaseH.CleanupOrphans)
 			r.Route("/{id}", func(r chi.Router) {
 				r.Get("/", releaseH.Get)
 				r.Put("/", releaseH.Update)

--- a/apps/paas-engine/internal/adapter/kubernetes/deployer.go
+++ b/apps/paas-engine/internal/adapter/kubernetes/deployer.go
@@ -50,7 +50,7 @@ func (d *K8sDeployer) Deploy(ctx context.Context, release *domain.Release, app *
 	return nil
 }
 
-func (d *K8sDeployer) Delete(ctx context.Context, release *domain.Release) error {
+func (d *K8sDeployer) Delete(ctx context.Context, release *domain.Release, hasOtherReleases bool) error {
 	name := release.ResourceName()
 	if err := d.client.AppsV1().Deployments(d.namespace).Delete(ctx, name, metav1.DeleteOptions{}); err != nil && !errors.IsNotFound(err) {
 		return fmt.Errorf("delete deployment %s: %w", name, err)
@@ -58,7 +58,66 @@ func (d *K8sDeployer) Delete(ctx context.Context, release *domain.Release) error
 	if err := d.client.CoreV1().Services(d.namespace).Delete(ctx, name, metav1.DeleteOptions{}); err != nil && !errors.IsNotFound(err) {
 		return fmt.Errorf("delete service %s: %w", name, err)
 	}
+	// 当该 app 没有其他 release 时，清理 base service
+	if !hasOtherReleases {
+		baseName := release.AppName
+		if err := d.client.CoreV1().Services(d.namespace).Delete(ctx, baseName, metav1.DeleteOptions{}); err != nil && !errors.IsNotFound(err) {
+			return fmt.Errorf("delete base service %s: %w", baseName, err)
+		}
+	}
 	return nil
+}
+
+func (d *K8sDeployer) DeleteResource(ctx context.Context, kind, name string) error {
+	switch kind {
+	case "Deployment":
+		if err := d.client.AppsV1().Deployments(d.namespace).Delete(ctx, name, metav1.DeleteOptions{}); err != nil && !errors.IsNotFound(err) {
+			return fmt.Errorf("delete deployment %s: %w", name, err)
+		}
+	case "Service":
+		if err := d.client.CoreV1().Services(d.namespace).Delete(ctx, name, metav1.DeleteOptions{}); err != nil && !errors.IsNotFound(err) {
+			return fmt.Errorf("delete service %s: %w", name, err)
+		}
+	default:
+		return fmt.Errorf("unsupported resource kind: %s", kind)
+	}
+	return nil
+}
+
+func (d *K8sDeployer) ListManagedResources(ctx context.Context) ([]port.ManagedResource, error) {
+	var resources []port.ManagedResource
+
+	deployments, err := d.client.AppsV1().Deployments(d.namespace).List(ctx, metav1.ListOptions{
+		LabelSelector: "app",
+	})
+	if err != nil {
+		return nil, fmt.Errorf("list deployments: %w", err)
+	}
+	for _, dep := range deployments.Items {
+		resources = append(resources, port.ManagedResource{
+			Kind:    "Deployment",
+			Name:    dep.Name,
+			AppName: dep.Labels["app"],
+			Lane:    dep.Labels["lane"],
+		})
+	}
+
+	services, err := d.client.CoreV1().Services(d.namespace).List(ctx, metav1.ListOptions{
+		LabelSelector: "app",
+	})
+	if err != nil {
+		return nil, fmt.Errorf("list services: %w", err)
+	}
+	for _, svc := range services.Items {
+		resources = append(resources, port.ManagedResource{
+			Kind:    "Service",
+			Name:    svc.Name,
+			AppName: svc.Labels["app"],
+			Lane:    svc.Labels["lane"],
+		})
+	}
+
+	return resources, nil
 }
 
 func (d *K8sDeployer) applyDeployment(ctx context.Context, release *domain.Release, app *domain.App) error {

--- a/apps/paas-engine/internal/port/kubernetes.go
+++ b/apps/paas-engine/internal/port/kubernetes.go
@@ -9,5 +9,17 @@ import (
 // Deployer 负责将 Release 翻译为 K8s Deployment + Service 并下发。
 type Deployer interface {
 	Deploy(ctx context.Context, release *domain.Release, app *domain.App) error
-	Delete(ctx context.Context, release *domain.Release) error
+	Delete(ctx context.Context, release *domain.Release, hasOtherReleases bool) error
+	// ListManagedResources 列出 namespace 中所有带 app label 的 Deployment 和 Service。
+	ListManagedResources(ctx context.Context) ([]ManagedResource, error)
+	// DeleteResource 删除指定的 K8s 资源（Deployment 或 Service）。
+	DeleteResource(ctx context.Context, kind, name string) error
+}
+
+// ManagedResource 表示一个由 paas-engine 管理的 K8s 资源。
+type ManagedResource struct {
+	Kind    string `json:"kind"`    // "Deployment" or "Service"
+	Name    string `json:"name"`    // 资源名称
+	AppName string `json:"app"`     // app label 值
+	Lane    string `json:"lane"`    // lane label 值（base service 无 lane）
 }

--- a/apps/paas-engine/internal/service/release_service.go
+++ b/apps/paas-engine/internal/service/release_service.go
@@ -3,7 +3,7 @@ package service
 import (
 	"context"
 	"errors"
-	"log/slog"
+	"fmt"
 	"time"
 
 	"github.com/chiwei-platform/paas-engine/internal/domain"
@@ -163,14 +163,106 @@ func (s *ReleaseService) DeleteRelease(ctx context.Context, id string) error {
 
 func (s *ReleaseService) deleteRelease(ctx context.Context, release *domain.Release) error {
 	if s.deployer != nil {
-		if err := s.deployer.Delete(ctx, release); err != nil {
-			slog.Warn("failed to delete K8s resources", "release_id", release.ID, "error", err)
+		// 查询该 app 是否还有其他 release
+		others, err := s.releaseRepo.FindAll(ctx, release.AppName, "")
+		if err != nil {
+			return err
+		}
+		hasOthers := false
+		for _, r := range others {
+			if r.ID != release.ID {
+				hasOthers = true
+				break
+			}
+		}
+		// K8s 删除失败直接返回错误，不删 DB
+		if err := s.deployer.Delete(ctx, release, hasOthers); err != nil {
+			return fmt.Errorf("delete k8s resources: %w", err)
 		}
 	}
 
-	if err := s.releaseRepo.Delete(ctx, release.ID); err != nil {
-		return err
+	return s.releaseRepo.Delete(ctx, release.ID)
+}
+
+// OrphanReport 包含 K8s 和 DB 中的孤儿资源。
+type OrphanReport struct {
+	K8sOrphans []port.ManagedResource `json:"k8s_orphans"` // K8s 存在但 DB 无记录
+	DBOrphans  []*domain.Release      `json:"db_orphans"`  // DB 存在但 K8s 无对应资源
+}
+
+// DetectOrphans 对比 K8s 资源和 DB release 记录，返回孤儿资源。
+func (s *ReleaseService) DetectOrphans(ctx context.Context) (*OrphanReport, error) {
+	if s.deployer == nil {
+		return &OrphanReport{}, nil
 	}
 
-	return nil
+	k8sResources, err := s.deployer.ListManagedResources(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("list managed resources: %w", err)
+	}
+
+	dbReleases, err := s.releaseRepo.FindAll(ctx, "", "")
+	if err != nil {
+		return nil, fmt.Errorf("list releases: %w", err)
+	}
+
+	// 构建 DB release 索引: resourceName -> release, appName -> true
+	dbResourceNames := make(map[string]bool)
+	dbAppNames := make(map[string]bool)
+	for _, r := range dbReleases {
+		dbResourceNames[r.ResourceName()] = true
+		dbAppNames[r.AppName] = true
+	}
+
+	// K8s 孤儿: K8s 中存在但 DB 无对应 release
+	var k8sOrphans []port.ManagedResource
+	for _, res := range k8sResources {
+		if res.Lane != "" {
+			// lane resource: 对应 {app}-{lane}
+			resourceName := res.AppName + "-" + res.Lane
+			if !dbResourceNames[resourceName] {
+				k8sOrphans = append(k8sOrphans, res)
+			}
+		} else {
+			// base service (无 lane): 只要该 app 在 DB 中还有任何 release 就不算孤儿
+			if !dbAppNames[res.AppName] {
+				k8sOrphans = append(k8sOrphans, res)
+			}
+		}
+	}
+
+	// DB 孤儿: DB 中存在但 K8s 无对应 Deployment
+	k8sDeployments := make(map[string]bool)
+	for _, res := range k8sResources {
+		if res.Kind == "Deployment" {
+			k8sDeployments[res.Name] = true
+		}
+	}
+	var dbOrphans []*domain.Release
+	for _, r := range dbReleases {
+		if !k8sDeployments[r.ResourceName()] {
+			dbOrphans = append(dbOrphans, r)
+		}
+	}
+
+	return &OrphanReport{
+		K8sOrphans: k8sOrphans,
+		DBOrphans:  dbOrphans,
+	}, nil
+}
+
+// CleanupOrphans 删除所有 K8s 孤儿资源。
+func (s *ReleaseService) CleanupOrphans(ctx context.Context) (*OrphanReport, error) {
+	report, err := s.DetectOrphans(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, res := range report.K8sOrphans {
+		if err := s.deployer.DeleteResource(ctx, res.Kind, res.Name); err != nil {
+			return nil, fmt.Errorf("delete orphan %s %s: %w", res.Kind, res.Name, err)
+		}
+	}
+
+	return report, nil
 }


### PR DESCRIPTION
## Summary
- Release 删除时，若该 app 无其他泳道 release，额外清理 base service (`{app}`)
- K8s 资源删除失败时阻断 DB 记录删除，避免产生孤儿资源（之前仅 warn 后继续删 DB）
- 新增 `GET /api/v1/releases/orphans` 检测孤儿资源（K8s↔DB 双向对比）
- 新增 `DELETE /api/v1/releases/orphans` 清理 K8s 孤儿资源

## Test plan
- [x] `make test` 全部通过
- [x] 部署 undeploy 测试泳道，验证孤儿检测 API 正常返回
- [x] 通过新代码 undeploy，确认 K8s Deployment + Service 被删除、base service 保留、DB 记录删除
- [x] 确认旧代码因 RBAC 缺 delete 权限导致 K8s 删除失败时只 warn 不阻断（bug 复现）
- [x] 修复 deploy-api ClusterRole 补充 deployments delete 和 replicasets list 权限

🤖 Generated with [Claude Code](https://claude.com/claude-code)