### PR TITLE
feat(monitor-dashboard-web): add lane support with multi-tab isolation

### DIFF
--- a/apps/monitor-dashboard-web/src/App.tsx
+++ b/apps/monitor-dashboard-web/src/App.tsx
@@ -1,4 +1,4 @@
-import { Layout, Menu, ConfigProvider, Button, Dropdown, Avatar, Space, Typography } from 'antd';
+import { Layout, Menu, ConfigProvider, Button, Dropdown, Avatar, Space, Typography, Tag } from 'antd';
 import zhCN from 'antd/locale/zh_CN';
 import dayjs from 'dayjs';
 import 'dayjs/locale/zh-cn';
@@ -30,7 +30,7 @@ const Providers = lazy(() => import('./pages/Providers'));
 const ModelMappings = lazy(() => import('./pages/ModelMappings'));
 const MongoExplorer = lazy(() => import('./pages/MongoExplorer'));
 import { themeConfig } from './theme';
-import { clearToken } from './api/client';
+import { clearToken, getLane } from './api/client';
 
 const { Sider, Content, Header } = Layout;
 const { Text } = Typography;
@@ -172,6 +172,7 @@ export default function App() {
             </div>
 
             <Space size={16}>
+              {getLane() && <Tag color="blue">{getLane()}</Tag>}
               <Dropdown menu={userMenu} placement="bottomRight">
                 <Space style={{ cursor: 'pointer', padding: '4px 8px', borderRadius: 6 }} className="user-dropdown">
                   <Avatar icon={<UserOutlined />} style={{ backgroundColor: primaryColor }} size="small" />

--- a/apps/monitor-dashboard-web/src/api/client.ts
+++ b/apps/monitor-dashboard-web/src/api/client.ts
@@ -1,6 +1,34 @@
 import axios from 'axios';
 
 const TOKEN_KEY = 'monitor_dashboard_token';
+const LANE_KEY = 'x-lane';
+
+// 启动时调用：检测 URL query param，存入 sessionStorage + 同步 cookie
+export function initLane() {
+  const params = new URLSearchParams(window.location.search);
+  if (params.has(LANE_KEY)) {
+    const lane = params.get(LANE_KEY)!;
+    if (lane) {
+      sessionStorage.setItem(LANE_KEY, lane);
+      document.cookie = `${LANE_KEY}=${lane}; path=/`;
+    } else {
+      sessionStorage.removeItem(LANE_KEY);
+      document.cookie = `${LANE_KEY}=; path=/; max-age=0`;
+    }
+  }
+  // tab 获焦时同步 cookie（解决多 tab cookie 竞争）
+  document.addEventListener('visibilitychange', () => {
+    if (document.visibilityState === 'visible') {
+      const lane = sessionStorage.getItem(LANE_KEY);
+      if (lane) document.cookie = `${LANE_KEY}=${lane}; path=/`;
+      else document.cookie = `${LANE_KEY}=; path=/; max-age=0`;
+    }
+  });
+}
+
+export function getLane(): string | null {
+  return sessionStorage.getItem(LANE_KEY);
+}
 
 export const getToken = () => localStorage.getItem(TOKEN_KEY) || '';
 
@@ -21,6 +49,11 @@ api.interceptors.request.use((config) => {
   if (token) {
     config.headers = config.headers || {};
     config.headers.Authorization = `Bearer ${token}`;
+  }
+  const lane = getLane();
+  if (lane) {
+    config.headers = config.headers || {};
+    config.headers['x-lane'] = lane;
   }
   return config;
 });

--- a/apps/monitor-dashboard-web/src/main.tsx
+++ b/apps/monitor-dashboard-web/src/main.tsx
@@ -2,8 +2,11 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
 import App from './App';
+import { initLane } from './api/client';
 import 'antd/dist/reset.css';
 import './styles.css';
+
+initLane();
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>


### PR DESCRIPTION
## Summary
- `initLane()` 从 URL `?x-lane=` 读取泳道，存入 sessionStorage + cookie
- axios 拦截器注入 `x-lane` header（API 调用）
- `visibilitychange` 事件同步 cookie（多 tab 隔离）
- Header 右侧显示泳道 Tag

依赖 #21（api-gateway query param + cookie 读取，已合并）

## Test plan
- [x] 测试泳道 `test-lane-web` 部署验证
- [x] query param 路由到 test lane 前端（不同 JS bundle hash）
- [x] cookie 路由正确
- [x] 无 lane fallback 到 prod
- [x] JS bundle 包含 x-lane 逻辑

🤖 Generated with [Claude Code](https://claude.com/claude-code)