### PR TITLE
fix(api-gateway): Set-Cookie x-lane from query param

### DIFF
--- a/apps/api-gateway/internal/gateway/gateway.go
+++ b/apps/api-gateway/internal/gateway/gateway.go
@@ -66,6 +66,12 @@ func (g *Gateway) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	// Set cookie when lane comes from query param so subsequent
+	// browser requests (static assets) carry the lane automatically.
+	if lane != "" && r.Header.Get("x-lane") == "" {
+		http.SetCookie(w, &http.Cookie{Name: "x-lane", Value: lane, Path: "/"})
+	}
+
 	// Resolve upstream host:port via registry (with fallback)
 	host, port := g.registry.Resolve(rt.Service, lane, rt.Port)
 


### PR DESCRIPTION
## Summary
- api-gateway 读到 query param 的 x-lane 时主动 `Set-Cookie`
- 解决白屏问题：浏览器加载静态资源时 JS 尚未执行无法设 cookie，导致 fallback 到 prod，hash 不匹配 404

## Test plan
- [x] 单元测试通过
- [ ] 部署后配合 monitor-dashboard-web 测试泳道验证

🤖 Generated with [Claude Code](https://claude.com/claude-code)