### PR TITLE
feat(monitor-dashboard): service status dashboard as homepage

### DIFF
--- a/apps/monitor-dashboard-web/src/App.tsx
+++ b/apps/monitor-dashboard-web/src/App.tsx
@@ -7,6 +7,7 @@ import {
   CloudServerOutlined,
   DashboardOutlined,
   DatabaseOutlined,
+  DollarOutlined,
   FileSearchOutlined,
   MessageOutlined,
   MonitorOutlined,
@@ -22,7 +23,8 @@ dayjs.locale('zh-cn');
 import AuthGuard from './components/AuthGuard';
 
 const Login = lazy(() => import('./pages/Login'));
-const Dashboard = lazy(() => import('./pages/Dashboard'));
+const ServiceStatus = lazy(() => import('./pages/ServiceStatus'));
+const TokenStats = lazy(() => import('./pages/TokenStats'));
 const Kibana = lazy(() => import('./pages/Kibana'));
 const Langfuse = lazy(() => import('./pages/Langfuse'));
 const Messages = lazy(() => import('./pages/Messages'));
@@ -43,7 +45,8 @@ interface MenuItem {
 }
 
 const menuItems: MenuItem[] = [
-  { key: '/', icon: <DashboardOutlined />, label: '概览' },
+  { key: '/', icon: <DashboardOutlined />, label: '服务状态' },
+  { key: '/token-stats', icon: <DollarOutlined />, label: '用量统计' },
   { key: '/messages', icon: <MessageOutlined />, label: '消息记录' },
   { key: '/providers', icon: <CloudServerOutlined />, label: '服务商' },
   { key: '/model-mappings', icon: <ApiOutlined />, label: '模型映射' },
@@ -188,7 +191,8 @@ export default function App() {
             <AuthGuard>
               <Suspense fallback={null}>
                 <Routes>
-                  <Route path="/" element={<Dashboard />} />
+                  <Route path="/" element={<ServiceStatus />} />
+                  <Route path="/token-stats" element={<TokenStats />} />
                   <Route path="/kibana" element={<Kibana />} />
                   <Route path="/langfuse" element={<Langfuse />} />
                   <Route path="/messages" element={<Messages />} />

--- a/apps/monitor-dashboard-web/src/pages/ServiceStatus.tsx
+++ b/apps/monitor-dashboard-web/src/pages/ServiceStatus.tsx
@@ -25,14 +25,20 @@ interface App {
 }
 
 interface Release {
-  id: number;
+  id: string;
   app_name: string;
   lane: string;
-  image_tag: string;
+  image: string;
   status: string;
   created_at: string;
   updated_at: string;
 }
+
+const getImageTag = (image?: string) => {
+  if (!image) return '';
+  const idx = image.lastIndexOf(':');
+  return idx >= 0 ? image.slice(idx + 1) : image;
+};
 
 interface ServiceRow {
   key: string;
@@ -122,9 +128,9 @@ export default function ServiceStatus() {
             <Tag color={cfg.color} icon={cfg.icon}>
               {rel.status}
             </Tag>
-            <Tooltip title={rel.image_tag}>
+            <Tooltip title={getImageTag(rel.image)}>
               <Text type="secondary" style={{ fontSize: 12 }}>
-                {rel.image_tag?.slice(0, 8)}
+                {getImageTag(rel.image)?.slice(0, 8)}
               </Text>
             </Tooltip>
           </Space>

--- a/apps/monitor-dashboard-web/src/pages/ServiceStatus.tsx
+++ b/apps/monitor-dashboard-web/src/pages/ServiceStatus.tsx
@@ -115,28 +115,47 @@ export default function ServiceStatus() {
       render: (port: number | string) =>
         port === 0 ? <Tag>Worker</Tag> : port,
     },
-    ...lanes.map((lane) => ({
-      title: lane,
-      key: `lane-${lane}`,
-      width: 160,
+    {
+      title: '部署泳道',
+      key: 'lanes',
       render: (_: unknown, row: ServiceRow) => {
-        const rel = row.releases.find((r) => r.lane === lane);
-        if (!rel) return <Text type="secondary">-</Text>;
-        const cfg = statusConfig[rel.status] || statusConfig.pending;
+        if (row.releases.length === 0) {
+          return <Text type="secondary">未部署</Text>;
+        }
         return (
-          <Space direction="vertical" size={0}>
-            <Tag color={cfg.color} icon={cfg.icon}>
-              {rel.status}
-            </Tag>
-            <Tooltip title={getImageTag(rel.image)}>
-              <Text type="secondary" style={{ fontSize: 12 }}>
-                {getImageTag(rel.image)?.slice(0, 8)}
-              </Text>
-            </Tooltip>
+          <Space size={[0, 6]} wrap>
+            {row.releases.map((rel) => {
+              const tag = getImageTag(rel.image);
+              const cfg = statusConfig[rel.status] || statusConfig.pending;
+              return (
+                <Tooltip key={rel.id} title={`${rel.status} · ${tag}`}>
+                  <Tag color={cfg.color} icon={cfg.icon} style={{ marginRight: 0 }}>
+                    {rel.lane}
+                  </Tag>
+                </Tooltip>
+              );
+            })}
           </Space>
         );
       },
-    })),
+    },
+    {
+      title: '镜像版本',
+      key: 'imageTag',
+      width: 120,
+      render: (_: unknown, row: ServiceRow) => {
+        const tags = [...new Set(row.releases.map((r) => getImageTag(r.image)))].filter(Boolean);
+        if (tags.length === 0) return '-';
+        if (tags.length === 1) return <Text copyable={{ text: tags[0] }}>{tags[0].slice(0, 8)}</Text>;
+        return (
+          <Space direction="vertical" size={0}>
+            {tags.map((t) => (
+              <Text key={t} copyable={{ text: t }} style={{ fontSize: 12 }}>{t.slice(0, 8)}</Text>
+            ))}
+          </Space>
+        );
+      },
+    },
     {
       title: '最后更新',
       key: 'updatedAt',

--- a/apps/monitor-dashboard-web/src/pages/ServiceStatus.tsx
+++ b/apps/monitor-dashboard-web/src/pages/ServiceStatus.tsx
@@ -1,0 +1,215 @@
+import { useEffect, useState, useCallback } from 'react';
+import { Card, Col, Row, Statistic, Table, Tag, Typography, Tooltip, Space } from 'antd';
+import dayjs from 'dayjs';
+import relativeTime from 'dayjs/plugin/relativeTime';
+import {
+  CheckCircleOutlined,
+  CloseCircleOutlined,
+  ClockCircleOutlined,
+  CloudServerOutlined,
+  DeploymentUnitOutlined,
+  ReloadOutlined,
+} from '@ant-design/icons';
+import { api } from '../api/client';
+
+dayjs.extend(relativeTime);
+
+const { Title, Text } = Typography;
+
+interface App {
+  name: string;
+  description?: string;
+  port?: number;
+  image_repo?: string;
+  command?: string;
+}
+
+interface Release {
+  id: number;
+  app_name: string;
+  lane: string;
+  image_tag: string;
+  status: string;
+  created_at: string;
+  updated_at: string;
+}
+
+interface ServiceRow {
+  key: string;
+  name: string;
+  description: string;
+  port: number | string;
+  releases: Release[];
+}
+
+const statusConfig: Record<string, { color: string; icon: React.ReactNode }> = {
+  deployed: { color: 'success', icon: <CheckCircleOutlined /> },
+  failed: { color: 'error', icon: <CloseCircleOutlined /> },
+  pending: { color: 'warning', icon: <ClockCircleOutlined /> },
+};
+
+export default function ServiceStatus() {
+  const [apps, setApps] = useState<App[]>([]);
+  const [releases, setReleases] = useState<Release[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  const fetchData = useCallback(async () => {
+    try {
+      const { data } = await api.get('/service-status');
+      setApps(data.apps || []);
+      setReleases(data.releases || []);
+    } catch (e) {
+      console.error('Failed to fetch service status:', e);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchData();
+    const timer = setInterval(fetchData, 30000);
+    return () => clearInterval(timer);
+  }, [fetchData]);
+
+  const lanes = [...new Set(releases.map((r) => r.lane))].sort();
+
+  const dataSource: ServiceRow[] = apps.map((app) => ({
+    key: app.name,
+    name: app.name,
+    description: app.description || '-',
+    port: app.port || '-',
+    releases: releases.filter((r) => r.app_name === app.name),
+  }));
+
+  const runningCount = new Set(
+    releases.filter((r) => r.status === 'deployed').map((r) => r.app_name),
+  ).size;
+  const failedCount = new Set(
+    releases.filter((r) => r.status === 'failed').map((r) => r.app_name),
+  ).size;
+
+  const columns = [
+    {
+      title: '服务名',
+      dataIndex: 'name',
+      key: 'name',
+      render: (name: string) => <Text strong>{name}</Text>,
+    },
+    {
+      title: '描述',
+      dataIndex: 'description',
+      key: 'description',
+      ellipsis: true,
+    },
+    {
+      title: '端口',
+      dataIndex: 'port',
+      key: 'port',
+      width: 80,
+      render: (port: number | string) =>
+        port === 0 ? <Tag>Worker</Tag> : port,
+    },
+    ...lanes.map((lane) => ({
+      title: lane,
+      key: `lane-${lane}`,
+      width: 160,
+      render: (_: unknown, row: ServiceRow) => {
+        const rel = row.releases.find((r) => r.lane === lane);
+        if (!rel) return <Text type="secondary">-</Text>;
+        const cfg = statusConfig[rel.status] || statusConfig.pending;
+        return (
+          <Space direction="vertical" size={0}>
+            <Tag color={cfg.color} icon={cfg.icon}>
+              {rel.status}
+            </Tag>
+            <Tooltip title={rel.image_tag}>
+              <Text type="secondary" style={{ fontSize: 12 }}>
+                {rel.image_tag?.slice(0, 8)}
+              </Text>
+            </Tooltip>
+          </Space>
+        );
+      },
+    })),
+    {
+      title: '最后更新',
+      key: 'updatedAt',
+      width: 140,
+      render: (_: unknown, row: ServiceRow) => {
+        const latest = row.releases
+          .map((r) => r.updated_at)
+          .filter(Boolean)
+          .sort()
+          .pop();
+        if (!latest) return '-';
+        return (
+          <Tooltip title={dayjs(latest).format('YYYY-MM-DD HH:mm:ss')}>
+            <Text type="secondary">{dayjs(latest).fromNow()}</Text>
+          </Tooltip>
+        );
+      },
+    },
+  ];
+
+  return (
+    <div className="page-container">
+      <div style={{ marginBottom: 24, display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+        <div>
+          <Title level={4} style={{ marginBottom: 4 }}>服务状态</Title>
+          <Text type="secondary">实时监控所有服务的部署状态</Text>
+        </div>
+        <Tooltip title="每 30 秒自动刷新">
+          <ReloadOutlined
+            spin={loading}
+            style={{ fontSize: 16, cursor: 'pointer', color: '#8c8c8c' }}
+            onClick={() => { setLoading(true); fetchData(); }}
+          />
+        </Tooltip>
+      </div>
+
+      <Row gutter={[24, 24]} style={{ marginBottom: 24 }}>
+        <Col xs={24} sm={8}>
+          <Card bordered={false}>
+            <Statistic
+              title="总服务数"
+              value={apps.length}
+              prefix={<CloudServerOutlined />}
+              valueStyle={{ fontWeight: 600 }}
+            />
+          </Card>
+        </Col>
+        <Col xs={24} sm={8}>
+          <Card bordered={false}>
+            <Statistic
+              title="运行中"
+              value={runningCount}
+              prefix={<CheckCircleOutlined style={{ color: '#52c41a' }} />}
+              valueStyle={{ fontWeight: 600, color: '#52c41a' }}
+              suffix={failedCount > 0 ? <Text type="danger" style={{ fontSize: 14 }}> / {failedCount} 异常</Text> : undefined}
+            />
+          </Card>
+        </Col>
+        <Col xs={24} sm={8}>
+          <Card bordered={false}>
+            <Statistic
+              title="活跃泳道"
+              value={lanes.length}
+              prefix={<DeploymentUnitOutlined />}
+              valueStyle={{ fontWeight: 600 }}
+            />
+          </Card>
+        </Col>
+      </Row>
+
+      <Card bordered={false}>
+        <Table
+          dataSource={dataSource}
+          columns={columns}
+          loading={loading}
+          pagination={false}
+          size="middle"
+        />
+      </Card>
+    </div>
+  );
+}

--- a/apps/monitor-dashboard-web/src/pages/ServiceStatus.tsx
+++ b/apps/monitor-dashboard-web/src/pages/ServiceStatus.tsx
@@ -123,7 +123,7 @@ export default function ServiceStatus() {
           return <Text type="secondary">未部署</Text>;
         }
         return (
-          <Space size={[0, 6]} wrap>
+          <Space size={[8, 6]} wrap>
             {row.releases.map((rel) => {
               const tag = getImageTag(rel.image);
               const cfg = statusConfig[rel.status] || statusConfig.pending;

--- a/apps/monitor-dashboard-web/src/pages/ServiceStatus.tsx
+++ b/apps/monitor-dashboard-web/src/pages/ServiceStatus.tsx
@@ -140,23 +140,6 @@ export default function ServiceStatus() {
       },
     },
     {
-      title: '镜像版本',
-      key: 'imageTag',
-      width: 120,
-      render: (_: unknown, row: ServiceRow) => {
-        const tags = [...new Set(row.releases.map((r) => getImageTag(r.image)))].filter(Boolean);
-        if (tags.length === 0) return '-';
-        if (tags.length === 1) return <Text copyable={{ text: tags[0] }}>{tags[0].slice(0, 8)}</Text>;
-        return (
-          <Space direction="vertical" size={0}>
-            {tags.map((t) => (
-              <Text key={t} copyable={{ text: t }} style={{ fontSize: 12 }}>{t.slice(0, 8)}</Text>
-            ))}
-          </Space>
-        );
-      },
-    },
-    {
       title: '最后更新',
       key: 'updatedAt',
       width: 140,

--- a/apps/monitor-dashboard-web/src/pages/TokenStats.tsx
+++ b/apps/monitor-dashboard-web/src/pages/TokenStats.tsx
@@ -80,7 +80,7 @@ const formatSeconds = (value?: number) => {
   return `${minutes}m ${total % 60}s`;
 };
 
-export default function Dashboard() {
+export default function TokenStats() {
   const [stats, setStats] = useState<TokenStatsResponse | null>(null);
   const [loading, setLoading] = useState(true);
 

--- a/apps/monitor-dashboard/src/index.ts
+++ b/apps/monitor-dashboard/src/index.ts
@@ -16,6 +16,7 @@ import providersRoutes from './routes/providers';
 import modelMappingsRoutes from './routes/model-mappings';
 import mongoRoutes from './routes/mongo';
 import migrationsRoutes from './routes/migrations';
+import serviceStatusRoutes from './routes/service-status';
 
 const PORT = Number(process.env.DASHBOARD_PORT || 3002);
 
@@ -47,6 +48,7 @@ const bootstrap = async () => {
   router.use(modelMappingsRoutes.routes());
   router.use(mongoRoutes.routes());
   router.use(migrationsRoutes.routes());
+  router.use(serviceStatusRoutes.routes());
 
   app.use(router.routes());
   app.use(router.allowedMethods());

--- a/apps/monitor-dashboard/src/routes/service-status.ts
+++ b/apps/monitor-dashboard/src/routes/service-status.ts
@@ -1,0 +1,30 @@
+import Router from '@koa/router';
+import axios from 'axios';
+
+const router = new Router();
+
+router.get('/api/service-status', async (ctx) => {
+  const paasApi = process.env.DASHBOARD_PAAS_API;
+  const paasToken = process.env.DASHBOARD_PAAS_TOKEN;
+
+  if (!paasApi || !paasToken) {
+    ctx.status = 500;
+    ctx.body = { message: 'DASHBOARD_PAAS_API or DASHBOARD_PAAS_TOKEN not configured' };
+    return;
+  }
+
+  const headers = { 'X-API-Key': paasToken };
+  const timeout = 10000;
+
+  const [appsRes, releasesRes] = await Promise.all([
+    axios.get(`${paasApi}/api/v1/apps/`, { headers, timeout }),
+    axios.get(`${paasApi}/api/v1/releases/`, { headers, timeout }),
+  ]);
+
+  ctx.body = {
+    apps: appsRes.data,
+    releases: releasesRes.data,
+  };
+});
+
+export default router;

--- a/apps/monitor-dashboard/src/routes/service-status.ts
+++ b/apps/monitor-dashboard/src/routes/service-status.ts
@@ -22,8 +22,8 @@ router.get('/api/service-status', async (ctx) => {
   ]);
 
   ctx.body = {
-    apps: appsRes.data,
-    releases: releasesRes.data,
+    apps: appsRes.data?.data ?? appsRes.data,
+    releases: releasesRes.data?.data ?? releasesRes.data,
   };
 });
 


### PR DESCRIPTION
## Summary
- Replace homepage with service status dashboard showing all apps and their deployment lanes
- Add backend route proxying paas-engine for apps/releases data
- Move token stats (formerly Dashboard) to /token-stats sub-page
- Update sidebar menu with new structure

## Test plan
- [x] Verified API returns apps + releases from paas-engine
- [x] Verified frontend displays service status table with lane tags
- [x] Verified token stats page still works at /token-stats
- [x] Tested on `token` lane, validated and undeployed

🤖 Generated with [Claude Code](https://claude.com/claude-code)