### PR TITLE
fix(monitoring): exclude completed Job pods from PodNotReady alert

### DIFF
--- a/infra/k8s/monitoring/alert-rules.yaml
+++ b/infra/k8s/monitoring/alert-rules.yaml
@@ -20,7 +20,10 @@ spec:
             description: "Pod {{ $labels.pod }} 在过去 15 分钟内重启了 {{ $value }} 次。"
 
         - alert: PodNotReady
-          expr: kube_pod_status_ready{namespace="prod", condition="true"} == 0
+          expr: |-
+            kube_pod_status_ready{namespace="prod", condition="true"} == 0
+            unless on(namespace, pod)
+            kube_pod_status_phase{namespace="prod", phase=~"Succeeded|Failed"} == 1
           for: 5m
           labels:
             severity: warning


### PR DESCRIPTION
## Summary
- CronJob 完成后 Pod 进入 Succeeded 状态，`kube_pod_status_ready` 为 0，触发 PodNotReady 误报
- 在 expr 中添加 `unless on(namespace, pod) kube_pod_status_phase{phase=~"Succeeded|Failed"} == 1`，排除已完成的 Job Pod

## Test plan
- [x] 已 `kubectl apply` 到集群，规则已生效（generation 3 → 4）
- [ ] 等待下次 CronJob `daily-report` 执行，确认不再误报

🤖 Generated with [Claude Code](https://claude.com/claude-code)