### PR TITLE
fix(lark-server): double-ack crash + consumer lost on reconnect

### DIFF
--- a/apps/lark-server/src/infrastructure/integrations/rabbitmq.ts
+++ b/apps/lark-server/src/infrastructure/integrations/rabbitmq.ts
@@ -40,6 +40,7 @@ class RabbitMQClient {
     private conn: ChannelModel | null = null;
     private channel: Channel | null = null;
     private reconnecting = false;
+    private consumers: { queue: string; handler: MessageHandler }[] = [];
 
     private constructor() {}
 
@@ -156,6 +157,10 @@ class RabbitMQClient {
     }
 
     async consume(queueName: string, handler: MessageHandler): Promise<void> {
+        // 记录 consumer 以便重连后恢复
+        if (!this.consumers.find((c) => c.queue === queueName)) {
+            this.consumers.push({ queue: queueName, handler });
+        }
         const ch = this.getChannel();
         await ch.consume(queueName, async (msg) => {
             if (!msg) return;
@@ -203,6 +208,10 @@ class RabbitMQClient {
             try {
                 await this.connect();
                 await this.declareTopology();
+                // 恢复所有 consumer
+                for (const { queue, handler } of this.consumers) {
+                    await this.consume(queue, handler);
+                }
                 console.info('[RabbitMQ] reconnected');
             } catch (err) {
                 console.error('[RabbitMQ] reconnect failed:', err);

--- a/apps/lark-server/src/workers/chat-response-worker.ts
+++ b/apps/lark-server/src/workers/chat-response-worker.ts
@@ -92,7 +92,6 @@ async function handleChatResponse(msg: ConsumeMessage): Promise<void> {
                 `[ChatResponseWorker] Agent failed: session_id=${session_id}, error=${error}`,
             );
             await repo.update({ session_id }, { status: 'failed' });
-            rabbitmqClient.ack(msg);
             return;
         }
 
@@ -101,7 +100,6 @@ async function handleChatResponse(msg: ConsumeMessage): Promise<void> {
             if (is_last) {
                 await repo.update({ session_id }, { status: 'completed' });
             }
-            rabbitmqClient.ack(msg);
             return;
         }
 


### PR DESCRIPTION
## Summary
- Remove duplicate `rabbitmqClient.ack()` inside `context.run` early-return paths (failed/empty content) — the outer ack already covers all cases. Double-ack triggered `PRECONDITION_FAILED - unknown delivery tag` which killed the RabbitMQ channel.
- Store consumer registrations and re-subscribe after reconnect so the worker resumes consuming instead of sitting idle.

## Test plan
- [x] Restarted prod worker, 2 stuck messages (`c7d3591e`, `ff1970f2`) delivered successfully
- [x] Deployed fix to prod, worker running normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)