### PR TITLE
feat: resolve @mentions in AI replies to <at> tags

### DIFF
--- a/apps/lark-server/src/core/services/message/resolve-mentions.ts
+++ b/apps/lark-server/src/core/services/message/resolve-mentions.ts
@@ -1,0 +1,49 @@
+import AppDataSource from 'ormconfig';
+import { LarkGroupMember } from '@entities/lark-group-member';
+import { LarkUser } from '@entities/lark-user';
+
+interface GroupMemberInfo {
+    union_id: string;
+    name: string;
+}
+
+const cache = new Map<string, { members: GroupMemberInfo[]; ts: number }>();
+const CACHE_TTL_MS = 60_000;
+
+async function getGroupMembers(chatId: string): Promise<GroupMemberInfo[]> {
+    const cached = cache.get(chatId);
+    if (cached && Date.now() - cached.ts < CACHE_TTL_MS) {
+        return cached.members;
+    }
+
+    const members = await AppDataSource.getRepository(LarkGroupMember)
+        .createQueryBuilder('m')
+        .innerJoin(LarkUser, 'u', 'u.union_id = m.union_id')
+        .select(['m.union_id AS union_id', 'u.name AS name'])
+        .where('m.chat_id = :chatId', { chatId })
+        .andWhere('m.is_leave = false')
+        .getRawMany<GroupMemberInfo>();
+
+    // 按 name 长度降序，避免短名误匹配长名子串
+    members.sort((a, b) => b.name.length - a.name.length);
+
+    cache.set(chatId, { members, ts: Date.now() });
+    return members;
+}
+
+/**
+ * 将 AI 回复中的 @用户名 替换为 <at union_id="xxx">用户名</at>
+ */
+export async function resolveMentionsForGroup(
+    content: string,
+    chatId: string,
+): Promise<string> {
+    const members = await getGroupMembers(chatId);
+    if (members.length === 0) return content;
+
+    let result = content;
+    for (const { union_id, name } of members) {
+        result = result.replaceAll(`@${name}`, `<at union_id="${union_id}">${name}</at>`);
+    }
+    return result;
+}

--- a/apps/lark-server/src/core/services/message/resolve-mentions.ts
+++ b/apps/lark-server/src/core/services/message/resolve-mentions.ts
@@ -43,7 +43,7 @@ export async function resolveMentionsForGroup(
 
     let result = content;
     for (const { union_id, name } of members) {
-        result = result.replaceAll(`@${name}`, `<at union_id="${union_id}">${name}</at>`);
+        result = result.replaceAll(`@${name}`, `<at user_id="${union_id}">${name}</at>`);
     }
     return result;
 }

--- a/apps/lark-server/src/workers/chat-response-worker.ts
+++ b/apps/lark-server/src/workers/chat-response-worker.ts
@@ -30,6 +30,7 @@ import { context } from '@middleware/context';
 import { storeMessage } from '@integrations/memory';
 import { replyPost, sendPost } from '@lark/basic/message';
 import { markdownToPostContent } from 'core/services/message/post-content-processor';
+import { resolveMentionsForGroup } from 'core/services/message/resolve-mentions';
 import { getBotUnionId } from '@core/services/bot/bot-var';
 import { MessageContentUtils } from 'core/models/message-content';
 import dayjs from 'dayjs';
@@ -106,7 +107,11 @@ async function handleChatResponse(msg: ConsumeMessage): Promise<void> {
         }
 
         try {
-            const postContent = markdownToPostContent(content);
+            // 群聊中将 @用户名 替换为 <at union_id="xxx">用户名</at>
+            const resolvedContent = is_p2p
+                ? content
+                : await resolveMentionsForGroup(content, chat_id);
+            const postContent = markdownToPostContent(resolvedContent);
 
             // 发送消息并捕获 AI 消息 ID
             let aiMessageId: string | undefined;


### PR DESCRIPTION
## Summary
- AI 回复中 @用户名 自动匹配群成员，替换为飞书 `<at user_id="union_id">用户名</at>` 格式
- 按名称长度降序匹配，避免短名误匹配
- 60s 内存缓存，群聊专用（P2P 跳过）

## Test plan
- [x] dev bot 泳道测试通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)