### PR TITLE
fix(rabbitmq): restore consumers after reconnection

### DIFF
--- a/apps/lark-server/src/infrastructure/integrations/rabbitmq.ts
+++ b/apps/lark-server/src/infrastructure/integrations/rabbitmq.ts
@@ -40,6 +40,7 @@ class RabbitMQClient {
     private conn: ChannelModel | null = null;
     private channel: Channel | null = null;
     private reconnecting = false;
+    private consumers: Array<{ queue: string; handler: MessageHandler }> = [];
 
     private constructor() {}
 
@@ -156,6 +157,14 @@ class RabbitMQClient {
     }
 
     async consume(queueName: string, handler: MessageHandler): Promise<void> {
+        // 记录 consumer 以便重连后恢复
+        if (!this.consumers.some((c) => c.queue === queueName)) {
+            this.consumers.push({ queue: queueName, handler });
+        }
+        await this.registerConsumer(queueName, handler);
+    }
+
+    private async registerConsumer(queueName: string, handler: MessageHandler): Promise<void> {
         const ch = this.getChannel();
         await ch.consume(queueName, async (msg) => {
             if (!msg) return;
@@ -203,6 +212,9 @@ class RabbitMQClient {
             try {
                 await this.connect();
                 await this.declareTopology();
+                for (const { queue, handler } of this.consumers) {
+                    await this.registerConsumer(queue, handler);
+                }
                 console.info('[RabbitMQ] reconnected');
             } catch (err) {
                 console.error('[RabbitMQ] reconnect failed:', err);


### PR DESCRIPTION
## Summary
- RabbitMQ 重连后只恢复了连接和拓扑声明，但漏掉了重新注册 consumer
- 导致 chat-response-worker（以及 recall-worker、lark-server）在连接断开重连后变成"假活"——进程 Running 但不再消费消息
- 修复：记录已注册的 consumer，`scheduleReconnect()` 成功后自动恢复

## Test plan
- [x] 部署到 `fix-rmq` 泳道，pod 启动正常，consumer 注册成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)