### PR TITLE
feat: add forward proxy node for Google AI clients

### DIFF
--- a/apps/agent-service/app/agents/infra/model_builder.py
+++ b/apps/agent-service/app/agents/infra/model_builder.py
@@ -176,6 +176,8 @@ class ModelBuilder:
             elif client_type == "google":
                 from langchain_google_genai import ChatGoogleGenerativeAI
 
+                from app.config.config import settings
+
                 chat_params = {
                     "api_key": model_info["api_key"],
                     "base_url": model_info["base_url"],
@@ -183,6 +185,10 @@ class ModelBuilder:
                     "max_retries": max_retries,
                     **kwargs,
                 }
+                if settings.forward_proxy_url:
+                    chat_params["client_args"] = {
+                        "proxy": settings.forward_proxy_url
+                    }
 
                 logger.info(
                     f"为模型 {model_id} 构建ChatGoogleGenerativeAI实例，"

--- a/apps/agent-service/app/config/config.py
+++ b/apps/agent-service/app/config/config.py
@@ -34,6 +34,9 @@ class Settings(BaseSettings):
     langfuse_secret_key: str | None = None
     langfuse_host: str | None = None
 
+    # 正向代理（供 Google 等需要代理的供应商使用）
+    forward_proxy_url: str | None = None
+
     # 长期任务配置
     long_task_batch_size: int = 5
     long_task_lock_timeout: int = 1800  # 30分钟

--- a/infra/k8s/infra-services/forward-proxy/configmap.yaml
+++ b/infra/k8s/infra-services/forward-proxy/configmap.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: forward-proxy-config
+  namespace: prod
+  labels:
+    app: forward-proxy
+    tier: infra
+data:
+  tinyproxy.conf: |
+    Port 8888
+    Listen 0.0.0.0
+    Timeout 60
+    MaxClients 500
+
+    # Only allow CONNECT to standard HTTPS port
+    ConnectPort 443
+
+    # Allow K8s Pod/Service/Node CIDRs
+    Allow 10.42.0.0/16
+    Allow 10.43.0.0/16
+    Allow 10.37.0.0/16
+    Allow 10.251.0.0/16
+    Allow 127.0.0.1/8
+
+    # Logging
+    LogLevel Warning
+
+    # Disable Via header for cleaner requests
+    DisableViaHeader Yes

--- a/infra/k8s/infra-services/forward-proxy/deployment.yaml
+++ b/infra/k8s/infra-services/forward-proxy/deployment.yaml
@@ -1,0 +1,72 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: forward-proxy
+  namespace: prod
+  labels:
+    app: forward-proxy
+    tier: infra
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: forward-proxy
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: forward-proxy
+        tier: infra
+    spec:
+      nodeSelector:
+        node-role: proxy
+      tolerations:
+        - key: dedicated
+          operator: Equal
+          value: proxy
+          effect: NoSchedule
+      containers:
+        - name: tinyproxy
+          image: alpine:3.21
+          command:
+            - sh
+            - -c
+            - apk add --no-cache tinyproxy && exec tinyproxy -d -c /etc/tinyproxy/tinyproxy.conf
+          ports:
+            - containerPort: 8888
+          resources:
+            requests:
+              cpu: 50m
+              memory: 32Mi
+            limits:
+              cpu: 500m
+              memory: 128Mi
+          livenessProbe:
+            exec:
+              command:
+                - pgrep
+                - -x
+                - tinyproxy
+            initialDelaySeconds: 15
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            exec:
+              command:
+                - pgrep
+                - -x
+                - tinyproxy
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          volumeMounts:
+            - name: config
+              mountPath: /etc/tinyproxy/tinyproxy.conf
+              subPath: tinyproxy.conf
+      volumes:
+        - name: config
+          configMap:
+            name: forward-proxy-config

--- a/infra/k8s/infra-services/forward-proxy/kustomization.yaml
+++ b/infra/k8s/infra-services/forward-proxy/kustomization.yaml
@@ -4,10 +4,6 @@ kind: Kustomization
 namespace: prod
 
 resources:
-  - postgres/
-  - mongo/
-  - redis/
-  - qdrant/
-  - rabbitmq/
-  - meme/
-  - forward-proxy/
+  - configmap.yaml
+  - deployment.yaml
+  - service.yaml

--- a/infra/k8s/infra-services/forward-proxy/service.yaml
+++ b/infra/k8s/infra-services/forward-proxy/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: forward-proxy
+  namespace: prod
+  labels:
+    app: forward-proxy
+    tier: infra
+spec:
+  selector:
+    app: forward-proxy
+  ports:
+    - name: proxy
+      port: 8888
+      targetPort: 8888
+      protocol: TCP


### PR DESCRIPTION
## Summary
- 新增代理节点 n251-235-105（taint 隔离），部署 tinyproxy 正向代理
- agent-service Google 客户端通过 `FORWARD_PROXY_URL` 环境变量注入代理
- 新增 `infra/k8s/infra-services/forward-proxy/` manifests

## Test plan
- [x] forward-proxy Pod 运行正常，HTTP/HTTPS 代理功能验证通过
- [x] agent-service feat-forward-proxy 泳道端到端测试通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)