### PR TITLE
chore: add Claude Code ops skills

### DIFF
--- a/.claude/skills/ops-db/SKILL.md
+++ b/.claude/skills/ops-db/SKILL.md
@@ -1,0 +1,19 @@
+---
+description: 安全查询 PaaS Engine PostgreSQL 数据库
+user_invocable: true
+---
+
+# /ops-db
+
+安全查询 PaaS Engine 的 PostgreSQL 数据库。
+
+## 预处理数据
+
+```
+!`python3 .claude/skills/ops-db/query.py $ARGUMENTS`
+```
+
+## 指令
+
+1. 上面的预处理结果是 JSON 格式的查询结果（`columns` + `rows`），将其格式化为 markdown 表格输出
+2. 如果预处理报错，直接展示错误信息

--- a/.claude/skills/ops-db/query.py
+++ b/.claude/skills/ops-db/query.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""Safe read-only query against PaaS Engine PostgreSQL."""
+
+import json
+import re
+import subprocess
+import sys
+from urllib.parse import urlparse
+
+WRITE_KEYWORDS = re.compile(
+    r"\b(INSERT|UPDATE|DELETE|DROP|ALTER|TRUNCATE|CREATE|GRANT|REVOKE)\b",
+    re.IGNORECASE,
+)
+
+SCHEMA_SQL = (
+    "SELECT table_name FROM information_schema.tables "
+    "WHERE table_schema='public' ORDER BY table_name"
+)
+
+
+def get_secret_value(key: str) -> str:
+    raw = subprocess.check_output(
+        ["kubectl", "get", "secret", "paas-engine-secret", "-n", "prod",
+         "-o", f"jsonpath={{.data.{key}}}"],
+        text=True,
+    )
+    import base64
+    return base64.b64decode(raw).decode()
+
+
+def get_endpoint_ip() -> str:
+    return subprocess.check_output(
+        ["kubectl", "get", "endpoints", "postgres", "-n", "prod",
+         "-o", "jsonpath={.subsets[0].addresses[0].ip}"],
+        text=True, stderr=subprocess.DEVNULL,
+    ).strip()
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("用法: query.py <SQL | schema>", file=sys.stderr)
+        sys.exit(1)
+
+    sql = " ".join(sys.argv[1:]).strip()
+    if sql.lower() == "schema":
+        sql = SCHEMA_SQL
+
+    # Safety check
+    if WRITE_KEYWORDS.search(sql):
+        print(f"ERROR: 拒绝执行写操作: {sql}", file=sys.stderr)
+        sys.exit(1)
+
+    # Get connection info
+    db_url = get_secret_value("DATABASE_URL")
+    endpoint_ip = get_endpoint_ip()
+    parsed = urlparse(db_url)
+
+    import psycopg2
+    conn = psycopg2.connect(
+        host=endpoint_ip,
+        port=parsed.port or 5432,
+        user=parsed.username,
+        password=parsed.password,
+        dbname=parsed.path.lstrip("/"),
+    )
+    conn.set_session(readonly=True)
+
+    try:
+        cur = conn.cursor()
+        cur.execute(sql)
+        columns = [desc[0] for desc in cur.description]
+        rows = cur.fetchall()
+        # Output as JSON for easy parsing
+        print(json.dumps({"columns": columns, "rows": [list(r) for r in rows]},
+                         default=str, ensure_ascii=False))
+    finally:
+        conn.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/ops-health/SKILL.md
+++ b/.claude/skills/ops-health/SKILL.md
@@ -1,0 +1,26 @@
+---
+description: 一键检查所有服务健康端点
+user_invocable: true
+---
+
+# /ops-health
+
+检查所有业务服务的健康状态。
+
+## 预处理数据
+
+```
+!`bash .claude/skills/ops-health/check.sh`
+```
+
+## 指令
+
+1. 解析上面的健康检查结果，输出格式化的状态表：
+
+   | 服务 | 端口 | 状态 |
+   |------|------|------|
+   | xxx  | 8000 | OK / DOWN / TIMEOUT |
+
+2. 200 = OK，000 = TIMEOUT（无法连接），其他 = 异常（标注 HTTP 状态码）
+3. 如有异常服务，给出排查建议（如检查 pod 状态、查看日志等）
+4. 如果 `/healthz` 返回 404，提示该服务可能使用其他健康检查路径（如 `/health`、`/api/health`）

--- a/.claude/skills/ops-health/check.sh
+++ b/.claude/skills/ops-health/check.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Health check all services via kubectl exec into a cluster pod.
+# Output: one line per service: "<name> <port> <status>"
+# status: 200 = OK, 000 = TIMEOUT/unreachable
+
+SERVICES="agent-service:8000 lark-server:3000 lark-proxy:3003 api-gateway:8080 tool-service:8000 paas-engine:8080 lite-registry:8080 alert-webhook:8080 monitor-dashboard:3002"
+
+kubectl exec deploy/api-gateway-prod -n prod -- sh -c "
+for svc in $SERVICES; do
+  name=\${svc%%:*}
+  port=\${svc##*:}
+  if wget -q -O /dev/null --timeout=2 http://\${name}:\${port}/healthz 2>/dev/null; then
+    echo \"\${name} \${port} 200\"
+  else
+    echo \"\${name} \${port} 000\"
+  fi
+done
+" 2>&1

--- a/.claude/skills/ops-logs/SKILL.md
+++ b/.claude/skills/ops-logs/SKILL.md
@@ -1,0 +1,20 @@
+---
+description: 快速拉服务日志
+user_invocable: true
+---
+
+# /ops-logs
+
+拉取指定服务的运行日志。
+
+## 预处理数据
+
+```
+!`bash .claude/skills/ops-logs/logs.sh $ARGUMENTS`
+```
+
+## 指令
+
+1. 展示上面的日志输出
+2. 高亮标注 ERROR、WARN、Exception、Traceback 等关键信息
+3. 如有明显错误模式，给出简短分析

--- a/.claude/skills/ops-logs/logs.sh
+++ b/.claude/skills/ops-logs/logs.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Fetch logs for a service deployment.
+# Usage: logs.sh <app> [lane] [lines]
+#   app:   required, service name
+#   lane:  optional, default "prod"
+#   lines: optional, default 100
+
+APP="${1:?用法: logs.sh <app> [lane] [lines]}"
+LANE="${2:-prod}"
+LINES="${3:-100}"
+
+# Try {app}-{lane} first, fallback to {app}
+kubectl logs "deploy/${APP}-${LANE}" -n prod --tail="${LINES}" --timestamps 2>/dev/null \
+  || kubectl logs "deploy/${APP}" -n prod --tail="${LINES}" --timestamps 2>&1

--- a/.claude/skills/ops-status/SKILL.md
+++ b/.claude/skills/ops-status/SKILL.md
@@ -1,0 +1,28 @@
+---
+description: 快速查看集群健康状态，可指定 app 名称深入查看
+user_invocable: true
+---
+
+# /ops-status
+
+查看 K8s 集群 pod 状态和事件。
+
+## 预处理数据
+
+```
+!`kubectl get pods -n prod -o wide --sort-by=.metadata.name 2>&1`
+```
+
+```
+!`kubectl get events -n prod --sort-by='.lastTimestamp' --field-selector type!=Normal 2>&1 | tail -20`
+```
+
+## 指令
+
+1. 分析上面的 pod 状态和异常事件，输出格式化的健康摘要表
+2. 标注任何异常状态（CrashLoopBackOff、ImagePullBackOff、Pending、OOMKilled 等）
+3. 如果 `$ARGUMENTS` 指定了 app 名称，额外执行：
+   - `kubectl describe deployment {app}-prod -n prod`（如果不存在尝试 `{app}`）
+   - `kubectl top pods -n prod -l app={app}`
+   - 输出该 app 的详细状态、资源用量和最近事件
+4. 如果没有异常，简短确认"集群健康"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,40 +108,7 @@ make latest-build APP=<app>
 
 ### API
 
-```
-GET    /healthz                                        # 健康检查（无需认证）
-
-# Apps
-POST   /api/v1/apps/                                   # 创建应用
-GET    /api/v1/apps/                                    # 列出应用
-GET    /api/v1/apps/{app}/                              # 获取应用
-PUT    /api/v1/apps/{app}/                              # 更新应用
-DELETE /api/v1/apps/{app}/                              # 删除应用
-GET    /api/v1/apps/{app}/logs                          # 运行日志
-
-# Builds（挂在 App 下，内部通过 app.image_repo 关联）
-POST   /api/v1/apps/{app}/builds/                      # 触发构建
-GET    /api/v1/apps/{app}/builds/                       # 列出构建
-GET    /api/v1/apps/{app}/builds/latest                 # 最近成功构建
-GET    /api/v1/apps/{app}/builds/{id}/                  # 获取构建状态
-POST   /api/v1/apps/{app}/builds/{id}/cancel            # 取消构建
-GET    /api/v1/apps/{app}/builds/{id}/logs              # 构建日志
-
-# Image Repos（镜像构建配置）
-POST   /api/v1/image-repos/                             # 创建 ImageRepo
-GET    /api/v1/image-repos/                             # 列出 ImageRepo
-GET    /api/v1/image-repos/{repo}/                      # 获取 ImageRepo
-PUT    /api/v1/image-repos/{repo}/                      # 更新 ImageRepo
-DELETE /api/v1/image-repos/{repo}/                      # 删除 ImageRepo
-
-# Releases
-POST   /api/v1/releases/                                # 创建/更新 Release
-GET    /api/v1/releases/                                # 列出 Release
-DELETE /api/v1/releases/?app=xxx&lane=yyy               # 按 app+lane 删除 Release
-GET    /api/v1/releases/{id}/                           # 获取 Release
-PUT    /api/v1/releases/{id}/                           # 更新 Release
-DELETE /api/v1/releases/{id}/                           # 删除 Release
-```
+API 端点详见 `apps/paas-engine/internal/adapter/http/router.go`
 
 ### 泳道路由
 


### PR DESCRIPTION
## Summary
- Add `.claude/skills/` with 4 ops skills: health check, logs, status, DB query
- Simplify CLAUDE.md by replacing inline API endpoint list with source code reference
- All files verified: no hardcoded IPs, credentials, or sensitive information

## Test plan
- [ ] Verify `/ops-health` skill runs correctly
- [ ] Verify `/ops-logs` skill fetches logs
- [ ] Verify `/ops-status` skill shows pod status
- [ ] Verify `/ops-db` skill can query schema

🤖 Generated with [Claude Code](https://claude.com/claude-code)