### PR TITLE
fix(agent): raise prompt injection confidence threshold to 0.85

### DIFF
--- a/apps/agent-service/app/agents/graphs/pre/nodes/safety.py
+++ b/apps/agent-service/app/agents/graphs/pre/nodes/safety.py
@@ -75,7 +75,7 @@ async def check_prompt_injection(state: PreState, config) -> dict:
             messages, config=config
         )
 
-        if result.is_injection and result.confidence >= 0.7:
+        if result.is_injection and result.confidence >= 0.85:
             logger.warning(f"检测到提示词注入: confidence={result.confidence}")
             return {
                 "safety_results": [


### PR DESCRIPTION
## Summary
- Raise prompt injection confidence threshold from 0.7 to 0.85 to reduce false positives on normal identity questions (e.g. "你是什么大模型")
- Langfuse prompt `guard_prompt_injection` v2 also updated with exclusion rules for identity questions

## Test plan
- [x] Deployed to `fix-injection` lane and verified via dev bot

🤖 Generated with [Claude Code](https://claude.com/claude-code)