### PR TITLE
feat(agent): inject diary memory in group chat

### DIFF
--- a/apps/agent-service/app/agents/domains/main/agent.py
+++ b/apps/agent-service/app/agents/domains/main/agent.py
@@ -19,7 +19,7 @@ from app.agents.domains.main.context_builder import build_chat_context
 from app.agents.domains.main.tools import ALL_TOOLS
 from app.agents.graphs.pre import Complexity, run_pre
 from app.orm.crud import get_gray_config, get_message_content
-from app.services.memory_context import build_memory_context
+from app.services.memory_context import build_diary_context
 from app.utils.content_parser import parse_content
 
 logger = logging.getLogger(__name__)
@@ -271,19 +271,15 @@ async def _build_and_stream(
                 f"需要回复 {trigger_username} 的消息（消息中用 ⭐ 标记）。"
             )
 
-    # 注入记忆上下文（p2p 和 group 通用）
-    if trigger_user_id:
+    # 群聊注入日记记忆
+    if chat_type != "p2p":
         try:
-            memory_text = await build_memory_context(
-                trigger_user_id, chat_id, chat_type, username=trigger_username or ""
-            )
-            if memory_text:
-                context_lines.append(
-                    f"你对 {trigger_username or '对方'} 的了解："
-                )
-                context_lines.append(memory_text)
+            diary_text = await build_diary_context(chat_id)
+            if diary_text:
+                context_lines.append("你最近的日记：")
+                context_lines.append(diary_text)
         except Exception as e:
-            logger.error(f"Failed to build memory context: {e}")
+            logger.error(f"Failed to build diary context: {e}")
 
     prompt_vars["user_context"] = "\n".join(context_lines)
 

--- a/apps/agent-service/app/config/config.py
+++ b/apps/agent-service/app/config/config.py
@@ -41,6 +41,10 @@ class Settings(BaseSettings):
     long_task_batch_size: int = 5
     long_task_lock_timeout: int = 1800  # 30分钟
 
+    # 日记生成
+    diary_chat_ids: str = ""  # 逗号分隔的 chat_id 列表
+    diary_model: str = "diary-model"
+
     class Config:
         env_file = ".env"
         extra = "ignore"

--- a/apps/agent-service/app/orm/crud.py
+++ b/apps/agent-service/app/orm/crud.py
@@ -6,6 +6,7 @@ from sqlalchemy.future import select
 from .base import AsyncSessionLocal
 from .models import (
     ConversationMessage,
+    DiaryEntry,
     LarkBaseChatInfo,
     LarkUser,
     ModelMapping,
@@ -299,6 +300,74 @@ async def get_active_users_for_consolidation(
             }
             for row in result.all()
         ]
+
+
+
+# ==================== Diary CRUD ====================
+
+
+async def get_chat_messages_in_range(
+    chat_id: str, start_time: int, end_time: int, limit: int = 2000
+) -> list[ConversationMessage]:
+    """获取指定群在时间范围内的所有消息（user + assistant）"""
+    async with AsyncSessionLocal() as session:
+        result = await session.execute(
+            select(ConversationMessage)
+            .where(ConversationMessage.chat_id == chat_id)
+            .where(ConversationMessage.create_time >= start_time)
+            .where(ConversationMessage.create_time < end_time)
+            .order_by(ConversationMessage.create_time.asc())
+            .limit(limit)
+        )
+        return list(result.scalars().all())
+
+
+async def upsert_diary_entry(
+    chat_id: str,
+    diary_date: str,
+    content: str,
+    message_count: int,
+    model: str | None = None,
+) -> None:
+    """插入或更新日记（upsert by chat_id + diary_date）"""
+    async with AsyncSessionLocal() as session:
+        result = await session.execute(
+            select(DiaryEntry)
+            .where(DiaryEntry.chat_id == chat_id)
+            .where(DiaryEntry.diary_date == diary_date)
+        )
+        existing = result.scalar_one_or_none()
+
+        if existing:
+            existing.content = content
+            existing.message_count = message_count
+            existing.model = model
+        else:
+            session.add(
+                DiaryEntry(
+                    chat_id=chat_id,
+                    diary_date=diary_date,
+                    content=content,
+                    message_count=message_count,
+                    model=model,
+                )
+            )
+        await session.commit()
+
+
+async def get_recent_diaries(
+    chat_id: str, before_date: str, limit: int = 3
+) -> list[DiaryEntry]:
+    """查最近 N 篇日记（before_date 之前）"""
+    async with AsyncSessionLocal() as session:
+        result = await session.execute(
+            select(DiaryEntry)
+            .where(DiaryEntry.chat_id == chat_id)
+            .where(DiaryEntry.diary_date < before_date)
+            .order_by(DiaryEntry.diary_date.desc())
+            .limit(limit)
+        )
+        return list(result.scalars().all())
 
 
 async def get_username(user_id: str) -> str | None:

--- a/apps/agent-service/app/orm/models.py
+++ b/apps/agent-service/app/orm/models.py
@@ -9,6 +9,7 @@ from sqlalchemy import (
     Integer,
     String,
     Text,
+    UniqueConstraint,
     func,
 )
 from sqlalchemy.dialects.postgresql import JSONB
@@ -123,6 +124,26 @@ class UserKnowledge(Base):
     )
     updated_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), onupdate=func.now()
+    )
+
+
+class DiaryEntry(Base):
+    """赤尾日记"""
+
+    __tablename__ = "diary_entry"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    chat_id: Mapped[str] = mapped_column(String(100), nullable=False)
+    diary_date: Mapped[str] = mapped_column(String(10), nullable=False)  # "2026-03-10"
+    content: Mapped[str] = mapped_column(Text, nullable=False)
+    message_count: Mapped[int] = mapped_column(Integer, default=0)
+    model: Mapped[str | None] = mapped_column(String(100), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now()
+    )
+
+    __table_args__ = (
+        UniqueConstraint("chat_id", "diary_date"),
     )
 
 

--- a/apps/agent-service/app/services/memory_context.py
+++ b/apps/agent-service/app/services/memory_context.py
@@ -5,11 +5,33 @@
 
 import logging
 from collections import defaultdict
+from datetime import date
 
-from app.orm.crud import get_user_knowledge
+from app.orm.crud import get_recent_diaries, get_user_knowledge
 from app.orm.models import UserKnowledge
 
 logger = logging.getLogger(__name__)
+
+# 日记注入硬上限：约 2 篇日记
+MAX_DIARY_CHARS = 1500
+
+
+async def build_diary_context(chat_id: str) -> str:
+    """构建日记记忆文本，注入群聊 system prompt
+
+    查 today 之前最近 2 篇日记，时间正序拼接。
+    """
+    today = date.today().isoformat()
+    diaries = await get_recent_diaries(chat_id, today, limit=2)
+    if not diaries:
+        return ""
+    parts = []
+    for diary in reversed(diaries):  # DB 返回 desc，reversed 变正序（旧→新）
+        parts.append(f"--- {diary.diary_date} ---\n{diary.content}")
+    text = "\n\n".join(parts)
+    if len(text) > MAX_DIARY_CHARS:
+        text = text[:MAX_DIARY_CHARS] + "……"
+    return text
 
 # 硬上限：约 600 tokens，中文 ~1.5 token/字 → ~400 字
 MAX_CHARS = 400

--- a/apps/agent-service/app/workers/diary_worker.py
+++ b/apps/agent-service/app/workers/diary_worker.py
@@ -1,0 +1,195 @@
+"""
+赤尾日记生成 Worker — ArQ cron job
+
+每天凌晨 3:00 CST（UTC 19:00）为指定群生成赤尾第一人称日记。
+核心原子函数 generate_diary_for_chat(chat_id, target_date) 可独立调用回溯。
+"""
+
+import logging
+from datetime import date, datetime, timedelta, timezone
+
+from langfuse import get_client as get_langfuse
+
+from app.agents.infra.langfuse_client import get_prompt
+from app.agents.infra.model_builder import ModelBuilder
+from app.config.config import settings
+from app.orm.crud import (
+    get_chat_messages_in_range,
+    get_recent_diaries,
+    get_username,
+    upsert_diary_entry,
+)
+from app.utils.content_parser import parse_content
+
+logger = logging.getLogger(__name__)
+
+CST = timezone(timedelta(hours=8))
+
+_WEEKDAY_CN = ["周一", "周二", "周三", "周四", "周五", "周六", "周日"]
+
+
+# ==================== ArQ cron 入口 ====================
+
+
+async def cron_generate_diaries(ctx) -> None:
+    """cron 入口：为所有配置的群生成昨天的日记"""
+    chat_ids = [
+        cid.strip() for cid in settings.diary_chat_ids.split(",") if cid.strip()
+    ]
+    if not chat_ids:
+        logger.info("No diary_chat_ids configured, skip")
+        return
+
+    yesterday = date.today() - timedelta(days=1)
+
+    for chat_id in chat_ids:
+        try:
+            await generate_diary_for_chat(chat_id, yesterday)
+        except Exception as e:
+            logger.error(f"Diary generation failed for {chat_id} on {yesterday}: {e}")
+
+
+# ==================== 核心原子函数 ====================
+
+
+async def generate_diary_for_chat(chat_id: str, target_date: date) -> str | None:
+    """为指定群生成指定日期的日记
+
+    Args:
+        chat_id: 群 ID
+        target_date: 目标日期
+
+    Returns:
+        生成的日记内容，无消息时返回 None
+    """
+    langfuse = get_langfuse()
+    date_str = target_date.isoformat()  # "2026-03-10"
+    weekday = _WEEKDAY_CN[target_date.weekday()]
+
+    trace = langfuse.trace(
+        name="diary-generation",
+        input={"chat_id": chat_id, "date": date_str},
+    )
+
+    try:
+        # 1. 收集当天消息（CST 00:00 ~ 次日 00:00）
+        day_start_cst = datetime(
+            target_date.year, target_date.month, target_date.day, tzinfo=CST
+        )
+        day_end_cst = day_start_cst + timedelta(days=1)
+        # 转为毫秒时间戳（create_time 是毫秒级 BigInteger）
+        start_ts = int(day_start_cst.timestamp() * 1000)
+        end_ts = int(day_end_cst.timestamp() * 1000)
+
+        messages = await get_chat_messages_in_range(chat_id, start_ts, end_ts)
+
+        # 2. 格式化消息时间线
+        timeline = await _format_messages_timeline(messages)
+
+        if not timeline:
+            logger.info(f"No messages for {chat_id} on {date_str}, skip")
+            trace.update(output={"status": "no_messages"})
+            return None
+
+        # 3. 查最近 3 篇日记
+        recent = await get_recent_diaries(chat_id, date_str, limit=3)
+        recent_diaries_text = _format_recent_diaries(recent)
+
+        # 4. 获取 Langfuse prompt 并编译
+        prompt_template = get_prompt("diary_generation")
+        compiled_prompt = prompt_template.compile(
+            date=date_str,
+            weekday=weekday,
+            messages=timeline,
+            recent_diaries=recent_diaries_text,
+        )
+
+        # 5. 调用 LLM
+        model = await ModelBuilder.build_chat_model(settings.diary_model)
+        response = await model.ainvoke(
+            [{"role": "user", "content": compiled_prompt}],
+        )
+
+        diary_content = response.content
+        if not diary_content:
+            logger.warning(f"LLM returned empty content for {chat_id} on {date_str}")
+            trace.update(output={"status": "empty_response"})
+            return None
+
+        # 6. 写入数据库（upsert）
+        await upsert_diary_entry(
+            chat_id=chat_id,
+            diary_date=date_str,
+            content=diary_content,
+            message_count=len(messages),
+            model=settings.diary_model,
+        )
+
+        logger.info(
+            f"Diary generated for {chat_id} on {date_str}: "
+            f"{len(messages)} messages, {len(diary_content)} chars"
+        )
+        trace.update(
+            output={
+                "status": "success",
+                "message_count": len(messages),
+                "diary_length": len(diary_content),
+            },
+        )
+        return diary_content
+
+    except Exception as e:
+        logger.error(f"generate_diary_for_chat failed: {e}")
+        trace.update(output={"status": "error", "error": str(e)})
+        raise
+
+
+# ==================== 辅助函数 ====================
+
+
+async def _format_messages_timeline(messages: list) -> str:
+    """将消息列表格式化为时间线文本
+
+    格式: [14:32] 群友A: 今天吃什么
+    跳过纯图片/表情包/空内容
+    """
+    # 批量收集 user_id 去重，一次查名字
+    user_ids = {msg.user_id for msg in messages}
+    user_names: dict[str, str] = {}
+    for uid in user_ids:
+        name = await get_username(uid)
+        user_names[uid] = name or uid[:8]
+
+    lines: list[str] = []
+    for msg in messages:
+        # 渲染内容（跳过图片）
+        rendered = parse_content(msg.content).render()
+        if not rendered or not rendered.strip():
+            continue
+
+        # 时间戳 → CST 时间
+        msg_time = datetime.fromtimestamp(msg.create_time / 1000, tz=CST)
+        time_str = msg_time.strftime("%H:%M")
+
+        # 发言者名称
+        if msg.role == "assistant":
+            speaker = "赤尾"
+        else:
+            speaker = user_names.get(msg.user_id, msg.user_id[:8])
+
+        lines.append(f"[{time_str}] {speaker}: {rendered}")
+
+    return "\n".join(lines)
+
+
+def _format_recent_diaries(diaries: list) -> str:
+    """格式化最近日记供 prompt 注入"""
+    if not diaries:
+        return "（这是第一篇日记，没有历史参考）"
+
+    # diaries 按 date desc 返回，反转为时间正序
+    parts: list[str] = []
+    for diary in reversed(diaries):
+        parts.append(f"--- {diary.diary_date} ---\n{diary.content}")
+
+    return "\n\n".join(parts)

--- a/apps/agent-service/app/workers/diary_worker.py
+++ b/apps/agent-service/app/workers/diary_worker.py
@@ -8,8 +8,6 @@
 import logging
 from datetime import date, datetime, timedelta, timezone
 
-from langfuse import get_client as get_langfuse
-
 from app.agents.infra.langfuse_client import get_prompt
 from app.agents.infra.model_builder import ModelBuilder
 from app.config.config import settings
@@ -62,86 +60,65 @@ async def generate_diary_for_chat(chat_id: str, target_date: date) -> str | None
     Returns:
         生成的日记内容，无消息时返回 None
     """
-    langfuse = get_langfuse()
     date_str = target_date.isoformat()  # "2026-03-10"
     weekday = _WEEKDAY_CN[target_date.weekday()]
 
-    trace = langfuse.trace(
-        name="diary-generation",
-        input={"chat_id": chat_id, "date": date_str},
+    # 1. 收集当天消息（CST 00:00 ~ 次日 00:00）
+    day_start_cst = datetime(
+        target_date.year, target_date.month, target_date.day, tzinfo=CST
+    )
+    day_end_cst = day_start_cst + timedelta(days=1)
+    # 转为毫秒时间戳（create_time 是毫秒级 BigInteger）
+    start_ts = int(day_start_cst.timestamp() * 1000)
+    end_ts = int(day_end_cst.timestamp() * 1000)
+
+    messages = await get_chat_messages_in_range(chat_id, start_ts, end_ts)
+
+    # 2. 格式化消息时间线
+    timeline = await _format_messages_timeline(messages)
+
+    if not timeline:
+        logger.info(f"No messages for {chat_id} on {date_str}, skip")
+        return None
+
+    # 3. 查最近 3 篇日记
+    recent = await get_recent_diaries(chat_id, date_str, limit=3)
+    recent_diaries_text = _format_recent_diaries(recent)
+
+    # 4. 获取 Langfuse prompt 并编译
+    prompt_template = get_prompt("diary_generation")
+    compiled_prompt = prompt_template.compile(
+        date=date_str,
+        weekday=weekday,
+        messages=timeline,
+        recent_diaries=recent_diaries_text,
     )
 
-    try:
-        # 1. 收集当天消息（CST 00:00 ~ 次日 00:00）
-        day_start_cst = datetime(
-            target_date.year, target_date.month, target_date.day, tzinfo=CST
-        )
-        day_end_cst = day_start_cst + timedelta(days=1)
-        # 转为毫秒时间戳（create_time 是毫秒级 BigInteger）
-        start_ts = int(day_start_cst.timestamp() * 1000)
-        end_ts = int(day_end_cst.timestamp() * 1000)
+    # 5. 调用 LLM
+    model = await ModelBuilder.build_chat_model(settings.diary_model)
+    response = await model.ainvoke(
+        [{"role": "user", "content": compiled_prompt}],
+    )
 
-        messages = await get_chat_messages_in_range(chat_id, start_ts, end_ts)
+    diary_content = response.content
+    if not diary_content:
+        logger.warning(f"LLM returned empty content for {chat_id} on {date_str}")
+        return None
 
-        # 2. 格式化消息时间线
-        timeline = await _format_messages_timeline(messages)
+    # 6. 写入数据库（upsert）
+    await upsert_diary_entry(
+        chat_id=chat_id,
+        diary_date=date_str,
+        content=diary_content,
+        message_count=len(messages),
+        model=settings.diary_model,
+    )
 
-        if not timeline:
-            logger.info(f"No messages for {chat_id} on {date_str}, skip")
-            trace.update(output={"status": "no_messages"})
-            return None
-
-        # 3. 查最近 3 篇日记
-        recent = await get_recent_diaries(chat_id, date_str, limit=3)
-        recent_diaries_text = _format_recent_diaries(recent)
-
-        # 4. 获取 Langfuse prompt 并编译
-        prompt_template = get_prompt("diary_generation")
-        compiled_prompt = prompt_template.compile(
-            date=date_str,
-            weekday=weekday,
-            messages=timeline,
-            recent_diaries=recent_diaries_text,
-        )
-
-        # 5. 调用 LLM
-        model = await ModelBuilder.build_chat_model(settings.diary_model)
-        response = await model.ainvoke(
-            [{"role": "user", "content": compiled_prompt}],
-        )
-
-        diary_content = response.content
-        if not diary_content:
-            logger.warning(f"LLM returned empty content for {chat_id} on {date_str}")
-            trace.update(output={"status": "empty_response"})
-            return None
-
-        # 6. 写入数据库（upsert）
-        await upsert_diary_entry(
-            chat_id=chat_id,
-            diary_date=date_str,
-            content=diary_content,
-            message_count=len(messages),
-            model=settings.diary_model,
-        )
-
-        logger.info(
-            f"Diary generated for {chat_id} on {date_str}: "
-            f"{len(messages)} messages, {len(diary_content)} chars"
-        )
-        trace.update(
-            output={
-                "status": "success",
-                "message_count": len(messages),
-                "diary_length": len(diary_content),
-            },
-        )
-        return diary_content
-
-    except Exception as e:
-        logger.error(f"generate_diary_for_chat failed: {e}")
-        trace.update(output={"status": "error", "error": str(e)})
-        raise
+    logger.info(
+        f"Diary generated for {chat_id} on {date_str}: "
+        f"{len(messages)} messages, {len(diary_content)} chars"
+    )
+    return diary_content
 
 
 # ==================== 辅助函数 ====================

--- a/apps/agent-service/app/workers/diary_worker.py
+++ b/apps/agent-service/app/workers/diary_worker.py
@@ -101,6 +101,12 @@ async def generate_diary_for_chat(chat_id: str, target_date: date) -> str | None
     )
 
     diary_content = response.content
+    # Gemini 返回 list[dict]，提取文本
+    if isinstance(diary_content, list):
+        diary_content = "".join(
+            part.get("text", "") if isinstance(part, dict) else str(part)
+            for part in diary_content
+        )
     if not diary_content:
         logger.warning(f"LLM returned empty content for {chat_id} on {date_str}")
         return None

--- a/apps/agent-service/app/workers/unified_worker.py
+++ b/apps/agent-service/app/workers/unified_worker.py
@@ -14,6 +14,7 @@ from inner_shared.logger import setup_logging
 
 from app.config.config import settings
 from app.long_tasks.executor import poll_and_execute_tasks
+from app.workers.diary_worker import cron_generate_diaries
 from app.workers.memory_worker import cron_consolidate_profiles
 from app.workers.vectorize_worker import cron_scan_pending_messages
 
@@ -64,4 +65,6 @@ class UnifiedWorkerSettings:
             hour={2, 6, 10, 14, 18, 22},
             minute={15},
         ),
+        # 4. 日记生成：每天 UTC 19:00（CST 03:00）
+        cron(cron_generate_diaries, hour={19}, minute={0}),
     ]


### PR DESCRIPTION
## Summary
- 群聊注入最近 2 篇日记作为赤尾记忆，替代 user_knowledge 注入
- 私聊不再注入 user_knowledge
- Langfuse main prompt v44 同步更新引导文字

## Test plan
- [x] 部署 feat-diary 泳道验证

🤖 Generated with [Claude Code](https://claude.com/claude-code)