### PR TITLE
fix: Redis连接池耗尽致P99飙升 + 告警标题UTF-8截断乱码

### DIFF
--- a/apps/alert-webhook/cmd/alert-webhook/main.go
+++ b/apps/alert-webhook/cmd/alert-webhook/main.go
@@ -181,8 +181,8 @@ func buildFeishuCard(alert Alert) map[string]interface{} {
 	}
 
 	title := fmt.Sprintf("[%s] %s", alertName, summary)
-	if len(title) > 80 {
-		title = title[:80]
+	if runes := []rune(title); len(runes) > 80 {
+		title = string(runes[:80])
 	}
 
 	return map[string]interface{}{

--- a/apps/tool-service/app/infrastructure/redis_client.py
+++ b/apps/tool-service/app/infrastructure/redis_client.py
@@ -17,7 +17,7 @@ async def init_redis() -> None:
         port=settings.redis_port,
         password=settings.redis_password,
         decode_responses=True,
-        max_connections=10,
+        max_connections=50,
     )
     _client = Redis(connection_pool=_pool)
     logger.info("Redis client initialized")


### PR DESCRIPTION
## Summary
- **tool-service**: Redis `max_connections` 10 → 50，解决 image-pipeline 并发请求打满连接池导致 lark-server → tool-service P99 延迟 9.88s 的问题
- **alert-webhook**: 标题截断从字节级 `title[:80]` 改为字符级 `[]rune(title)[:80]`，修复中文被从 UTF-8 字节中间截断产生乱码（如"延迟过�"）

## Test plan
- [ ] 部署 tool-service，观察 P99 延迟是否回落
- [ ] 部署 alert-webhook，触发告警验证中文标题不再乱码
- [ ] 检查 Redis 连接数监控确认无异常

🤖 Generated with [Claude Code](https://claude.com/claude-code)