### PR TITLE
feat(agent): Google Search + Qwen3 Reranker + infra rules

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,9 +90,11 @@ make latest-build APP=<app>                # 最近成功构建
 
 ### 基础设施
 
+- **禁止使用 kubectl 修改线上资源（Secret、Deployment、ConfigMap 等）。** 所有配置变更必须通过 PaaS API 进行。kubectl 仅允许只读操作（get、logs、describe）用于排查问题。
 - **用户说怎么做就怎么做，不要自作主张换方案。**
 - **$PAAS_API 前面有反向代理，支持 x-lane 路由。** 测试用 `$PAAS_API` + `x-lane` header，不需要 port-forward。
 - **不要在没有充分验证的情况下否定用户的方案。**
+- **同一操作失败两次，必须停下来分析根因或问用户，禁止暴力重试。**
 
 ## 环境配置
 

--- a/apps/agent-service/app/agents/tools/search/reranker.py
+++ b/apps/agent-service/app/agents/tools/search/reranker.py
@@ -1,23 +1,21 @@
-"""切片 + Embedding 重排模块
+"""切片 + Rerank 模型重排模块
 
-将搜索结果的网页内容切片，通过 embedding cosine similarity 跨页面重排，
+将搜索结果的网页内容切片，通过 cross-encoder rerank 模型跨页面重排，
 返回与 query 最相关的 top-K chunks。
 """
 
-import asyncio
 import logging
 
-import numpy as np
+import httpx
 
-from app.agents.clients import create_client
-from app.agents.infra.embedding import InstructionBuilder, Modality
+from app.config import settings
 
 logger = logging.getLogger(__name__)
 
 CHUNK_SIZE = 2000
 CHUNK_OVERLAP = 200
 RESULT_TOP_K = 5
-MAX_CONCURRENT_EMBEDS = 10
+RERANK_MODEL = "Qwen/Qwen3-Reranker-4B"
 
 
 def chunk_text(text: str, chunk_size: int = CHUNK_SIZE, overlap: int = CHUNK_OVERLAP) -> list[str]:
@@ -64,11 +62,11 @@ async def rerank_chunks(
     results: list[dict],
     top_k: int = RESULT_TOP_K,
 ) -> list[dict]:
-    """对搜索结果做切片级 embedding 重排。
+    """对搜索结果做切片级 rerank 模型重排。
 
     1. 对每个 result 的 content 切片
-    2. 并发 embed query + 所有 chunks
-    3. cosine similarity 排序 → 取 top_k
+    2. 调用 SiliconFlow rerank API（cross-encoder）
+    3. 按 relevance_score 排序 → 取 top_k
     4. 异常时 fallback 到每页 content 的前 CHUNK_SIZE 字符
 
     Args:
@@ -79,6 +77,10 @@ async def rerank_chunks(
     Returns:
         [{title, link, content (=chunk), score}]
     """
+    if not settings.siliconflow_api_key:
+        logger.warning("SiliconFlow API key not configured, falling back to truncation")
+        return _fallback(results, top_k)
+
     # 构建所有 chunks
     all_chunks: list[dict] = []
     for r in results:
@@ -98,48 +100,34 @@ async def rerank_chunks(
         return _fallback(results, top_k)
 
     try:
-        # 构建 embedding instructions
-        query_instructions = InstructionBuilder.for_query(
-            target_modality=Modality.TEXT,
-            instruction="为这个搜索查询生成表示以用于检索相关网页内容片段",
-        )
-        corpus_instructions = InstructionBuilder.for_corpus(modality=Modality.TEXT)
+        documents = [c["chunk"] for c in all_chunks]
 
-        sem = asyncio.Semaphore(MAX_CONCURRENT_EMBEDS)
-
-        async def _embed(text: str, instructions: str) -> list[float]:
-            async with sem:
-                async with await create_client("embedding-model") as client:
-                    return await client.embed(text=text, instructions=instructions)
-
-        # 并发 embed query + 所有 chunks
-        tasks = [_embed(query, query_instructions)]
-        for c in all_chunks:
-            tasks.append(_embed(c["chunk"], corpus_instructions))
-
-        embeddings = await asyncio.gather(*tasks)
-
-        query_vec = np.array(embeddings[0])
-        chunk_vecs = np.array(embeddings[1:])
-
-        # cosine similarity
-        query_norm = np.linalg.norm(query_vec)
-        chunk_norms = np.linalg.norm(chunk_vecs, axis=1)
-        # 避免除零
-        chunk_norms = np.where(chunk_norms == 0, 1e-10, chunk_norms)
-        similarities = chunk_vecs @ query_vec / (chunk_norms * query_norm)
-
-        # 排序取 top_k
-        top_indices = np.argsort(similarities)[::-1][:top_k]
+        async with httpx.AsyncClient(timeout=30) as client:
+            resp = await client.post(
+                f"{settings.siliconflow_base_url}/rerank",
+                headers={
+                    "Authorization": f"Bearer {settings.siliconflow_api_key}",
+                    "Content-Type": "application/json",
+                },
+                json={
+                    "model": RERANK_MODEL,
+                    "query": query,
+                    "documents": documents,
+                    "top_n": top_k,
+                },
+            )
+            resp.raise_for_status()
+            data = resp.json()
 
         ranked = []
-        for idx in top_indices:
+        for item in data.get("results", []):
+            idx = item["index"]
             c = all_chunks[idx]
             ranked.append({
                 "title": c["title"],
                 "link": c["link"],
                 "content": c["chunk"],
-                "score": float(similarities[idx]),
+                "score": item.get("relevance_score", 0),
             })
 
         return ranked

--- a/apps/agent-service/app/agents/tools/search/web.py
+++ b/apps/agent-service/app/agents/tools/search/web.py
@@ -15,18 +15,18 @@ from app.utils.decorators import dict_serialize, log_io
 
 logger = logging.getLogger(__name__)
 
-YOU_SEARCH_REQUESTS_TOTAL = Counter(
-    "you_search_requests_total",
-    "Total You Search API requests",
+WEB_SEARCH_REQUESTS_TOTAL = Counter(
+    "web_search_requests_total",
+    "Total web search API requests",
     ["status"],
 )
-YOU_SEARCH_DURATION = Histogram(
-    "you_search_duration_seconds",
-    "You Search API request duration in seconds",
+WEB_SEARCH_DURATION = Histogram(
+    "web_search_duration_seconds",
+    "Web search API request duration in seconds",
 )
 RERANK_DURATION = Histogram(
     "search_rerank_duration_seconds",
-    "Search rerank (chunk embedding) duration in seconds",
+    "Search rerank duration in seconds",
 )
 
 PAGE_MAX_CHARS = 16000
@@ -46,6 +46,58 @@ async def _fetch_content(result: dict) -> dict:
         result["content"] = result.get("snippet", "")
 
     return result
+
+
+async def _google_search(query: str, num: int) -> list[dict]:
+    """通过 Google Custom Search 代理搜索。"""
+    params = {
+        "q": query,
+        "ak": settings.google_search_api_key,
+        "cx": settings.google_search_cx,
+        "num": num,
+    }
+
+    async with httpx.AsyncClient(timeout=15) as client:
+        url = f"{settings.google_search_host}/gpt/openapi/online/v2/crawl/google/custom_search"
+        response = await client.get(url, params=params)
+        response.raise_for_status()
+        data = response.json()
+
+    return [
+        {
+            "link": r.get("link", ""),
+            "title": r.get("title", ""),
+            "snippet": r.get("snippet", ""),
+        }
+        for r in data.get("items", [])
+    ]
+
+
+async def _you_search(query: str, num: int, gl: str, hl: str) -> list[dict]:
+    """通过 You Search API 搜索（fallback）。"""
+    params: dict[str, str | int] = {
+        "query": query,
+        "count": num,
+        "country": gl,
+        "language": hl,
+    }
+    headers = {"X-API-Key": settings.you_search_api_key or ""}
+
+    async with httpx.AsyncClient(timeout=15) as client:
+        url = f"{settings.you_search_host}/v1/search"
+        response = await client.get(url, params=params, headers=headers)
+        response.raise_for_status()
+        data = response.json()
+
+    web_results = data.get("results", {}).get("web", [])
+    return [
+        {
+            "link": r.get("url", ""),
+            "title": r.get("title", ""),
+            "snippet": r.get("description", ""),
+        }
+        for r in web_results
+    ]
 
 
 @tool
@@ -68,30 +120,17 @@ async def search_web(
     Returns:
         搜索结果列表，每个结果包含 title, link, snippet, content。
     """
-    if not settings.you_search_host or not settings.you_search_api_key:
-        logger.error("You Search not configured")
-        return []
-
-    url = f"{settings.you_search_host}/v1/search"
-
-    params: dict[str, str | int] = {
-        "query": query,
-        "count": num,
-        "country": gl,
-        "language": hl,
-    }
-
-    headers = {
-        "X-API-Key": settings.you_search_api_key,
-    }
-
     start = time.monotonic()
     status = "error"
     try:
-        async with httpx.AsyncClient(timeout=15) as client:
-            response = await client.get(url, params=params, headers=headers)
-            response.raise_for_status()
-            data = response.json()
+        # 优先 Google Custom Search，fallback You Search
+        if settings.google_search_host and settings.google_search_api_key:
+            organic_results = await _google_search(query, num)
+        elif settings.you_search_host and settings.you_search_api_key:
+            organic_results = await _you_search(query, num, gl, hl)
+        else:
+            logger.error("No search provider configured")
+            return []
         status = "ok"
     except httpx.TimeoutException:
         status = "timeout"
@@ -106,25 +145,14 @@ async def search_web(
         return []
     finally:
         duration = time.monotonic() - start
-        YOU_SEARCH_REQUESTS_TOTAL.labels(status=status).inc()
-        YOU_SEARCH_DURATION.observe(duration)
-
-    # 转换响应结构
-    web_results = data.get("results", {}).get("web", [])
-    organic_results = [
-        {
-            "link": r.get("url", ""),
-            "title": r.get("title", ""),
-            "snippet": r.get("description", ""),
-        }
-        for r in web_results
-    ]
+        WEB_SEARCH_REQUESTS_TOTAL.labels(status=status).inc()
+        WEB_SEARCH_DURATION.observe(duration)
 
     # 并发抓取每个结果的网页内容
     tasks = [_fetch_content(result) for result in organic_results]
     results = await asyncio.gather(*tasks)
 
-    # 切片级 embedding 重排
+    # 切片级 rerank 重排
     rerank_start = time.monotonic()
     try:
         ranked = await rerank_chunks(query, list(results))

--- a/apps/agent-service/app/agents/tools/search/web.py
+++ b/apps/agent-service/app/agents/tools/search/web.py
@@ -62,6 +62,8 @@ async def _google_search(query: str, num: int) -> list[dict]:
         response.raise_for_status()
         data = response.json()
 
+    items = data.get("items", [])
+    logger.info("Google Custom Search returned %d items", len(items))
     return [
         {
             "link": item.get("link", ""),
@@ -69,7 +71,7 @@ async def _google_search(query: str, num: int) -> list[dict]:
             "snippet": item.get("snippet", ""),
             "displayLink": item.get("displayLink", ""),
         }
-        for item in data.get("items", [])
+        for item in items
     ]
 
 
@@ -90,6 +92,7 @@ async def _you_search(query: str, num: int, gl: str, hl: str) -> list[dict]:
         data = response.json()
 
     web_results = data.get("results", {}).get("web", [])
+    logger.info("You Search returned %d results", len(web_results))
     return [
         {
             "link": r.get("url", ""),

--- a/apps/agent-service/app/agents/tools/search/web.py
+++ b/apps/agent-service/app/agents/tools/search/web.py
@@ -58,18 +58,18 @@ async def _google_search(query: str, num: int) -> list[dict]:
     }
 
     async with httpx.AsyncClient(timeout=15) as client:
-        url = f"{settings.google_search_host}/gpt/openapi/online/v2/crawl/google/custom_search"
-        response = await client.get(url, params=params)
+        response = await client.get(settings.google_search_host, params=params)
         response.raise_for_status()
         data = response.json()
 
     return [
         {
-            "link": r.get("link", ""),
-            "title": r.get("title", ""),
-            "snippet": r.get("snippet", ""),
+            "link": item.get("link", ""),
+            "title": item.get("title", ""),
+            "snippet": item.get("snippet", ""),
+            "displayLink": item.get("displayLink", ""),
         }
-        for r in data.get("items", [])
+        for item in data.get("items", [])
     ]
 
 

--- a/apps/agent-service/app/config/config.py
+++ b/apps/agent-service/app/config/config.py
@@ -21,8 +21,8 @@ class Settings(BaseSettings):
     you_search_host: str | None = None
     you_search_api_key: str | None = None
 
-    # Google Custom Search（via proxy）
-    google_search_host: str | None = None
+    # Google Custom Search
+    google_search_host: str | None = None  # 完整 endpoint URL
     google_search_api_key: str | None = None
     google_search_cx: str | None = None
 

--- a/apps/agent-service/app/config/config.py
+++ b/apps/agent-service/app/config/config.py
@@ -34,6 +34,10 @@ class Settings(BaseSettings):
     langfuse_secret_key: str | None = None
     langfuse_host: str | None = None
 
+    # SiliconFlow（rerank 模型）
+    siliconflow_base_url: str = "https://api.siliconflow.cn/v1"
+    siliconflow_api_key: str | None = None
+
     # 正向代理（供 Google 等需要代理的供应商使用）
     forward_proxy_url: str | None = None
 

--- a/apps/agent-service/app/config/config.py
+++ b/apps/agent-service/app/config/config.py
@@ -17,9 +17,14 @@ class Settings(BaseSettings):
     qdrant_service_port: int = 6333
     qdrant_service_api_key: str | None = None
 
-    # You Search 配置
+    # You Search 配置（已弃用，保留兼容）
     you_search_host: str | None = None
     you_search_api_key: str | None = None
+
+    # Google Custom Search（via proxy）
+    google_search_host: str | None = None
+    google_search_api_key: str | None = None
+    google_search_cx: str | None = None
 
     bangumi_access_token: str | None = None
 


### PR DESCRIPTION
## Summary
- 搜索引擎从 You Search 切换到 Google Custom Search（优先 Google，fallback You Search）
- Reranker 从 embedding cosine similarity 替换为 Qwen3-Reranker-4B（SiliconFlow cross-encoder）
- 网页内容截断 16K + 切片 2K chunks + rerank top 5
- CLAUDE.md 新增 kubectl 禁写规则和重试禁令
- 所有敏感配置（endpoint URL、API key、cx）通过 PaaS API env 管理，代码中不含密钥

## Test plan
- [x] 部署 `feat-rerank-model` 泳道，dev bot 绑定测试
- [x] 日志确认 `Google Custom Search returned N items`
- [x] Langfuse trace 确认 rerank score 存在

🤖 Generated with [Claude Code](https://claude.com/claude-code)