### PR TITLE
fix(worker): is_last default + ack safety + queue backlog alert

### DIFF
--- a/apps/lark-server/src/infrastructure/integrations/rabbitmq.ts
+++ b/apps/lark-server/src/infrastructure/integrations/rabbitmq.ts
@@ -179,11 +179,19 @@ class RabbitMQClient {
     }
 
     ack(msg: ConsumeMessage): void {
-        this.getChannel().ack(msg);
+        try {
+            this.getChannel().ack(msg);
+        } catch (e) {
+            console.warn('[RabbitMQ] ack failed (channel likely closed):', (e as Error).message);
+        }
     }
 
     nack(msg: ConsumeMessage, requeue = false): void {
-        this.getChannel().nack(msg, false, requeue);
+        try {
+            this.getChannel().nack(msg, false, requeue);
+        } catch (e) {
+            console.warn('[RabbitMQ] nack failed (channel likely closed):', (e as Error).message);
+        }
     }
 
     getChannel(): Channel {

--- a/apps/lark-server/src/workers/chat-response-worker.ts
+++ b/apps/lark-server/src/workers/chat-response-worker.ts
@@ -59,7 +59,15 @@ function sleep(ms: number): Promise<void> {
 }
 
 async function handleChatResponse(msg: ConsumeMessage): Promise<void> {
-    const payload: ChatResponsePayload = JSON.parse(msg.content.toString());
+    let payload: ChatResponsePayload;
+    try {
+        payload = JSON.parse(msg.content.toString());
+    } catch (e) {
+        console.error('[ChatResponseWorker] Malformed message, sending to DLQ:', msg.content.toString().slice(0, 200));
+        rabbitmqClient.nack(msg, false);
+        return;
+    }
+
     const {
         session_id,
         message_id,
@@ -82,9 +90,14 @@ async function handleChatResponse(msg: ConsumeMessage): Promise<void> {
 
     // 查询 agent_response 获取 bot_name
     const agentResponse = await repo.findOneBy({ session_id });
-    const botName = agentResponse?.bot_name;
+    if (!agentResponse) {
+        console.error(`[ChatResponseWorker] No agent_response found: session_id=${session_id}`);
+        rabbitmqClient.ack(msg);
+        return;
+    }
+    const botName = agentResponse.bot_name;
 
-    // 设置 bot context
+    // 设置 bot context — ack 统一在 context.run 之后，callback 内部禁止 ack/nack
     const contextData = context.createContext(botName || undefined, undefined, payload.lane);
 
     await context.run(contextData, async () => {
@@ -93,7 +106,6 @@ async function handleChatResponse(msg: ConsumeMessage): Promise<void> {
                 `[ChatResponseWorker] Agent failed: session_id=${session_id}, error=${error}`,
             );
             await repo.update({ session_id }, { status: 'failed' });
-            rabbitmqClient.ack(msg);
             return;
         }
 
@@ -102,7 +114,6 @@ async function handleChatResponse(msg: ConsumeMessage): Promise<void> {
             if (is_last) {
                 await repo.update({ session_id }, { status: 'completed' });
             }
-            rabbitmqClient.ack(msg);
             return;
         }
 
@@ -141,21 +152,22 @@ async function handleChatResponse(msg: ConsumeMessage): Promise<void> {
                 reply_message_id: message_id,
             });
 
-            // 每条消息追加到 agent_responses.replies jsonb 数组
-            const replyEntry = JSON.stringify([
+            // 每条消息追加到 agent_responses.replies jsonb 数组（参数化）
+            const replyEntry = [
                 {
                     message_id: effectiveMessageId,
                     content_type: 'post',
                     sent_at: new Date().toISOString(),
                 },
-            ]);
+            ];
             await repo
                 .createQueryBuilder()
                 .update(AgentResponse)
                 .set({
                     replies: () =>
-                        `COALESCE(replies, '[]'::jsonb) || '${replyEntry}'::jsonb`,
+                        `COALESCE(replies, '[]'::jsonb) || :replyEntry::jsonb`,
                 })
+                .setParameter('replyEntry', JSON.stringify(replyEntry))
                 .where('session_id = :sid', { sid: session_id })
                 .execute();
 
@@ -173,7 +185,11 @@ async function handleChatResponse(msg: ConsumeMessage): Promise<void> {
             console.info(`[ChatResponseWorker] Reply sent: session_id=${session_id}, part=${part_index}, ai_msg_id=${effectiveMessageId}`);
         } catch (e) {
             console.error(`[ChatResponseWorker] Failed to send reply: session_id=${session_id}, part=${part_index}`, e);
-            await repo.update({ session_id }, { status: 'failed' });
+            try {
+                await repo.update({ session_id }, { status: 'failed' });
+            } catch (dbErr) {
+                console.error(`[ChatResponseWorker] DB update also failed: session_id=${session_id}`, dbErr);
+            }
         }
     });
 

--- a/apps/lark-server/src/workers/chat-response-worker.ts
+++ b/apps/lark-server/src/workers/chat-response-worker.ts
@@ -79,7 +79,7 @@ async function handleChatResponse(msg: ConsumeMessage): Promise<void> {
         status,
         error,
         part_index = 0,
-        is_last = true,
+        is_last = false,
     } = payload;
 
     console.info(

--- a/infra/k8s/monitoring/alert-rules.yaml
+++ b/infra/k8s/monitoring/alert-rules.yaml
@@ -236,13 +236,23 @@ spec:
 
         # RabbitMQ - 已知业务队列 consumer 断开
         - alert: RabbitmqConsumerDown
-          expr: rabbitmq_queue_consumers{namespace="prod", queue=~"(recall|safety_check|vectorize).*"} == 0
+          expr: rabbitmq_queue_consumers{namespace="prod", queue=~"(recall|safety_check|vectorize|chat_response).*"} == 0
           for: 1m
           labels:
             severity: critical
           annotations:
             summary: "RabbitMQ 业务队列 {{ $labels.queue }} consumer 断开"
             description: "关键业务队列 {{ $labels.queue }} 的 consumer 已断开超过 1 分钟。"
+
+        # chat_response 队列积压超过 20s（10s 是泳道 fallback TTL，20s 说明 prod consumer 也没在消费）
+        - alert: ChatResponseQueueBacklog
+          expr: rabbitmq_queue_messages_ready{namespace="prod", queue="chat_response"} > 0
+          for: 20s
+          labels:
+            severity: critical
+          annotations:
+            summary: "chat_response 队列积压超过 20s"
+            description: "chat_response 队列有 {{ $value }} 条消息积压超过 20 秒，consumer 可能已崩溃或断连。"
 
     # --- Phase 4: 健康探针告警 ---
     - name: probe-alerts


### PR DESCRIPTION
## Summary
- `is_last` 默认值从 `true` 改为 `false`：agent-service 中间分段不带 is_last，旧默认值导致每个中间分段提前设 status=completed 和覆盖 response_text
- `ack()`/`nack()` 加 try-catch：重连后 handler 用新 channel ack 旧 delivery tag 会再次触发 PRECONDITION_FAILED，现在安全降级
- 新增 `ChatResponseQueueBacklog` 告警：chat_response 队列积压超过 20s 触发 critical 告警
- `RabbitmqConsumerDown` 补上 chat_response 队列监控（之前遗漏）

## Test plan
- [x] 部署到 double-ack-crash 泳道，绑定 dev bot 验证消息正常收发
- [x] 告警规则已 apply 到集群并确认加载

🤖 Generated with [Claude Code](https://claude.com/claude-code)