### PR TITLE
fix: 移除 .env 依赖，PaaS 变量改由 shell 环境加载

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,0 @@
-PAAS_API=http://<node-ip>:30080
-PAAS_TOKEN=<your-api-token>
-REGISTRY=<your-registry>

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,5 @@
 .PHONY: deploy self-deploy release undeploy status latest-build lane-bind lane-unbind lane-bindings
 
-# 从 .env 加载配置（PAAS_API, PAAS_TOKEN, REGISTRY 等）
--include .env
-
 # ---------- 参数 ----------
 # APP        — 应用名（必填），对应 apps/<APP> 和 PaaS 注册的应用名
 # TAG        — 镜像 tag，默认 git short hash

--- a/apps/lark-server/README.md
+++ b/apps/lark-server/README.md
@@ -81,7 +81,7 @@ sequenceDiagram
 
 ## 配置
 
-请将仓库根目录的 .env.example 复制为 .env 并按需填写。关键项：
+PaaS 相关变量（PAAS_API, PAAS_TOKEN）已通过 shell 环境加载（见 ~/.zshrc）。其他关键项：
 - 数据库：POSTGRES_* / MONGO_* / REDIS_*
 - AI 服务：AI_SERVER_HOST / AI_SERVER_PORT
 - 代理/日志：PROXY_* / LOG_LEVEL 等


### PR DESCRIPTION
## Summary
- Makefile 删除 `-include .env`，PaaS 变量（PAAS_API, PAAS_TOKEN）改从 shell 环境继承
- 删除 `.env.example`（不再需要）
- 更新 lark-server README 配置说明

## 背景
worktree 模式下 `.env` 文件不会跟过去，导致 `make deploy/status` 等命令失败。改为在 `~/.zshrc` 中 `export`，所有目录通用。

## Test plan
- [x] worktree 下 `make status` 正常返回

🤖 Generated with [Claude Code](https://claude.com/claude-code)