### PR TITLE
feat(makefile): add require_pushed guard for deploy safety

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,12 +15,21 @@ define require_app
 	$(if $(APP),,$(error APP 未指定。用法: make $@ APP=<应用名>))
 endef
 
+define require_main_for_prod
+	@if [ "$(LANE)" = "prod" ] && [ "$(GIT_REF)" != "main" ]; then \
+		echo ">>> 错误: 禁止将非 main 分支 ($(GIT_REF)) 部署到 prod 泳道"; \
+		echo ">>>   请先合并到 main，或指定 LANE=<泳道名> 部署到非 prod 泳道"; \
+		exit 1; \
+	fi
+endef
+
 # ---------- 命令 ----------
 
 ## 一键部署：构建 → 等待 → 发布到指定泳道
 ## 用法: make deploy APP=my-service [LANE=dev]
 deploy:
 	@$(call require_app)
+	$(call require_main_for_prod)
 	@echo ">>> 部署 $(APP): $(GIT_REF) -> $(TAG) -> $(LANE)"
 	@BUILD_ID=$$(curl -sf -X POST $(PAAS_API)/api/paas/apps/$(APP)/builds/ \
 		-H 'Content-Type: application/json' \
@@ -50,6 +59,7 @@ deploy:
 ## paas-engine 蓝绿自部署：构建 → 等待 → prod → blue
 ## 用法: make self-deploy
 self-deploy:
+	$(call require_main_for_prod)
 	@echo ">>> 蓝绿自部署 paas-engine: $(GIT_REF) -> $(TAG)"
 	@BUILD_ID=$$(curl -sf -X POST $(PAAS_API)/api/paas/apps/paas-engine/builds/ \
 		-H 'Content-Type: application/json' \

--- a/Makefile
+++ b/Makefile
@@ -7,8 +7,7 @@
 # LANE       — 部署泳道，默认 prod
 
 GIT_REF  ?= $(shell git rev-parse --abbrev-ref HEAD)
-GIT_SHORT := $(shell git rev-parse --short HEAD)
-TAG      ?= $(GIT_SHORT)
+TAG      ?= $(shell git rev-parse --short $(GIT_REF))
 LANE     ?= prod
 
 define require_app
@@ -23,6 +22,29 @@ define require_main_for_prod
 	fi
 endef
 
+define require_pushed
+	@if git show-ref --verify --quiet refs/heads/$(GIT_REF) 2>/dev/null; then \
+		if ! git show-ref --verify --quiet refs/remotes/origin/$(GIT_REF) 2>/dev/null; then \
+			echo ">>> 错误: 分支 $(GIT_REF) 未推送到远端，请先 git push"; \
+			exit 1; \
+		fi; \
+		LOCAL_SHA=$$(git rev-parse refs/heads/$(GIT_REF)); \
+		REMOTE_SHA=$$(git rev-parse refs/remotes/origin/$(GIT_REF)); \
+		if [ "$$LOCAL_SHA" != "$$REMOTE_SHA" ]; then \
+			echo ">>> 错误: 分支 $(GIT_REF) 有未推送的 commit，请先 git push"; \
+			echo ">>>   本地: $$LOCAL_SHA"; \
+			echo ">>>   远端: $$REMOTE_SHA"; \
+			exit 1; \
+		fi; \
+		CURRENT_BRANCH=$$(git rev-parse --abbrev-ref HEAD); \
+		if [ "$(GIT_REF)" = "$$CURRENT_BRANCH" ]; then \
+			if ! git diff --quiet HEAD 2>/dev/null || ! git diff --cached --quiet HEAD 2>/dev/null; then \
+				echo ">>> 警告: 工作区有未提交的改动，不会包含在构建中"; \
+			fi; \
+		fi; \
+	fi
+endef
+
 # ---------- 命令 ----------
 
 ## 一键部署：构建 → 等待 → 发布到指定泳道
@@ -30,6 +52,7 @@ endef
 deploy:
 	@$(call require_app)
 	$(call require_main_for_prod)
+	$(call require_pushed)
 	@echo ">>> 部署 $(APP): $(GIT_REF) -> $(TAG) -> $(LANE)"
 	@BUILD_ID=$$(curl -sf -X POST $(PAAS_API)/api/paas/apps/$(APP)/builds/ \
 		-H 'Content-Type: application/json' \
@@ -60,6 +83,7 @@ deploy:
 ## 用法: make self-deploy
 self-deploy:
 	$(call require_main_for_prod)
+	$(call require_pushed)
 	@echo ">>> 蓝绿自部署 paas-engine: $(GIT_REF) -> $(TAG)"
 	@BUILD_ID=$$(curl -sf -X POST $(PAAS_API)/api/paas/apps/paas-engine/builds/ \
 		-H 'Content-Type: application/json' \

--- a/apps/paas-engine/cmd/paas-engine/main.go
+++ b/apps/paas-engine/cmd/paas-engine/main.go
@@ -64,7 +64,7 @@ func main() {
 	appSvc := service.NewAppService(appRepo, imageRepoRepo, releaseRepo)
 	imageRepoSvc := service.NewImageRepoService(imageRepoRepo, appRepo)
 	buildSvc := service.NewBuildService(imageRepoRepo, buildRepo, buildExecutor, lokiClient)
-	releaseSvc := service.NewReleaseService(appRepo, imageRepoRepo, releaseRepo, deployer)
+	releaseSvc := service.NewReleaseService(appRepo, imageRepoRepo, buildRepo, releaseRepo, deployer)
 	logSvc := service.NewLogService(appRepo, lokiClient, cfg.DeployNamespace)
 
 	// 启动 Build Informer

--- a/apps/paas-engine/internal/adapter/repository/build_repo.go
+++ b/apps/paas-engine/internal/adapter/repository/build_repo.go
@@ -63,6 +63,21 @@ func (r *BuildRepo) FindLatestSuccessful(ctx context.Context, imageRepoName stri
 	return modelToBuild(&m), nil
 }
 
+func (r *BuildRepo) FindByImageTag(ctx context.Context, imageTag string) (*domain.Build, error) {
+	var m BuildModel
+	result := r.db.WithContext(ctx).
+		Where("image_tag = ?", imageTag).
+		Order("created_at desc").
+		First(&m)
+	if result.Error != nil {
+		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
+			return nil, domain.ErrBuildNotFound
+		}
+		return nil, result.Error
+	}
+	return modelToBuild(&m), nil
+}
+
 func (r *BuildRepo) Update(ctx context.Context, build *domain.Build) error {
 	m := buildToModel(build)
 	return r.db.WithContext(ctx).Save(m).Error

--- a/apps/paas-engine/internal/domain/errors.go
+++ b/apps/paas-engine/internal/domain/errors.go
@@ -12,8 +12,10 @@ var (
 	ErrCannotDelete  = errors.New("cannot delete")
 	ErrCannotCancel  = errors.New("cannot cancel")
 
-	ErrAppNotFound     = fmt.Errorf("app %w", ErrNotFound)
-	ErrBuildNotFound   = fmt.Errorf("build %w", ErrNotFound)
-	ErrReleaseNotFound  = fmt.Errorf("release %w", ErrNotFound)
+	ErrAppNotFound       = fmt.Errorf("app %w", ErrNotFound)
+	ErrBuildNotFound     = fmt.Errorf("build %w", ErrNotFound)
+	ErrReleaseNotFound   = fmt.Errorf("release %w", ErrNotFound)
 	ErrImageRepoNotFound = fmt.Errorf("image repo %w", ErrNotFound)
+
+	ErrNonMainProdDeploy = fmt.Errorf("%w: prod lane only accepts images built from main branch", ErrInvalidInput)
 )

--- a/apps/paas-engine/internal/port/repository.go
+++ b/apps/paas-engine/internal/port/repository.go
@@ -19,6 +19,7 @@ type BuildRepository interface {
 	FindByID(ctx context.Context, id string) (*domain.Build, error)
 	FindByImageRepo(ctx context.Context, imageRepoName string) ([]*domain.Build, error)
 	FindLatestSuccessful(ctx context.Context, imageRepoName string) (*domain.Build, error)
+	FindByImageTag(ctx context.Context, imageTag string) (*domain.Build, error)
 	Update(ctx context.Context, build *domain.Build) error
 }
 

--- a/apps/paas-engine/internal/service/build_service_test.go
+++ b/apps/paas-engine/internal/service/build_service_test.go
@@ -27,6 +27,9 @@ func (s *stubBuildRepo) FindByImageRepo(_ context.Context, _ string) ([]*domain.
 func (s *stubBuildRepo) FindLatestSuccessful(_ context.Context, _ string) (*domain.Build, error) {
 	return nil, domain.ErrBuildNotFound
 }
+func (s *stubBuildRepo) FindByImageTag(_ context.Context, _ string) (*domain.Build, error) {
+	return nil, domain.ErrBuildNotFound
+}
 func (s *stubBuildRepo) Update(_ context.Context, _ *domain.Build) error { return nil }
 
 func TestCreateBuild_UsesImageRepoConfig(t *testing.T) {

--- a/apps/paas-engine/internal/service/release_service.go
+++ b/apps/paas-engine/internal/service/release_service.go
@@ -16,6 +16,7 @@ import (
 type ReleaseService struct {
 	appRepo       port.AppRepository
 	imageRepoRepo port.ImageRepoRepository
+	buildRepo     port.BuildRepository
 	releaseRepo   port.ReleaseRepository
 	deployer      port.Deployer
 }
@@ -23,12 +24,14 @@ type ReleaseService struct {
 func NewReleaseService(
 	appRepo port.AppRepository,
 	imageRepoRepo port.ImageRepoRepository,
+	buildRepo port.BuildRepository,
 	releaseRepo port.ReleaseRepository,
 	deployer port.Deployer,
 ) *ReleaseService {
 	return &ReleaseService{
 		appRepo:       appRepo,
 		imageRepoRepo: imageRepoRepo,
+		buildRepo:     buildRepo,
 		releaseRepo:   releaseRepo,
 		deployer:      deployer,
 	}
@@ -62,6 +65,15 @@ func (s *ReleaseService) CreateOrUpdateRelease(ctx context.Context, req CreateRe
 	lane := req.Lane
 	if lane == "" {
 		lane = domain.DefaultLane
+	}
+
+	// prod 泳道只允许 main 分支构建的镜像
+	if lane == domain.DefaultLane && fullImage != "" {
+		build, err := s.buildRepo.FindByImageTag(ctx, fullImage)
+		if err == nil && build.GitRef != "main" {
+			return nil, fmt.Errorf("%w (got %q)", domain.ErrNonMainProdDeploy, build.GitRef)
+		}
+		// build not found → 外部镜像，放行
 	}
 
 	if req.Replicas <= 0 {


### PR DESCRIPTION
## Summary
- 新增 `require_pushed` 宏，在 `deploy` 和 `self-deploy` 构建前检查代码是否已推送到远端
- 分支未推送到远端 → 硬阻断
- 本地有未推送 commit → 硬阻断（显示本地/远端 SHA）
- 当前分支工作区脏 → 警告（不阻断）
- GIT_REF 为 commit hash / tag → 跳过检查
- 修复 TAG 变量：从 `HEAD` 改为基于 `GIT_REF` 计算，确保 TAG 与构建分支一致

## Test plan
- [ ] `make deploy APP=test GIT_REF=<未推送分支>` → 应报错 "分支未推送到远端"
- [ ] 本地 commit 未 push 后执行 deploy → 应报错 "有未推送的 commit"
- [ ] 工作区有未提交改动 → 应警告但不阻断
- [ ] `make deploy APP=test GIT_REF=7d03035` → 应跳过检查
- [ ] `make release` → 不受影响

🤖 Generated with [Claude Code](https://claude.com/claude-code)