### PR TITLE
feat(agent): impression phase 2 - expand injection + load_memory tool

### DIFF
--- a/apps/agent-service/app/agents/domains/main/agent.py
+++ b/apps/agent-service/app/agents/domains/main/agent.py
@@ -251,6 +251,7 @@ async def _build_and_stream(
         chat_type,
         trigger_user_id,
         chat_name,
+        chain_user_ids,
     ) = await build_chat_context(message_id)
 
     if not messages:
@@ -283,7 +284,7 @@ async def _build_and_stream(
 
         try:
             impression_text = await build_impression_context(
-                chat_id, [trigger_user_id] if trigger_user_id else []
+                chat_id, chain_user_ids
             )
             if impression_text:
                 context_lines.append(impression_text)

--- a/apps/agent-service/app/agents/domains/main/agent.py
+++ b/apps/agent-service/app/agents/domains/main/agent.py
@@ -19,7 +19,7 @@ from app.agents.domains.main.context_builder import build_chat_context
 from app.agents.domains.main.tools import ALL_TOOLS
 from app.agents.graphs.pre import Complexity, run_pre
 from app.orm.crud import get_gray_config, get_message_content
-from app.services.memory_context import build_diary_context
+from app.services.memory_context import build_diary_context, build_impression_context
 from app.utils.content_parser import parse_content
 
 logger = logging.getLogger(__name__)
@@ -271,7 +271,7 @@ async def _build_and_stream(
                 f"需要回复 {trigger_username} 的消息（消息中用 ⭐ 标记）。"
             )
 
-    # 群聊注入日记记忆
+    # 群聊注入日记记忆 + 人物印象
     if chat_type != "p2p":
         try:
             diary_text = await build_diary_context(chat_id)
@@ -280,6 +280,15 @@ async def _build_and_stream(
                 context_lines.append(diary_text)
         except Exception as e:
             logger.error(f"Failed to build diary context: {e}")
+
+        try:
+            impression_text = await build_impression_context(
+                chat_id, [trigger_user_id] if trigger_user_id else []
+            )
+            if impression_text:
+                context_lines.append(impression_text)
+        except Exception as e:
+            logger.error(f"Failed to build impression context: {e}")
 
     prompt_vars["user_context"] = "\n".join(context_lines)
 

--- a/apps/agent-service/app/agents/domains/main/agent.py
+++ b/apps/agent-service/app/agents/domains/main/agent.py
@@ -277,7 +277,7 @@ async def _build_and_stream(
         try:
             diary_text = await build_diary_context(chat_id)
             if diary_text:
-                context_lines.append("你最近的日记：")
+                context_lines.append("\n---\n你最近的日记：")
                 context_lines.append(diary_text)
         except Exception as e:
             logger.error(f"Failed to build diary context: {e}")
@@ -287,7 +287,7 @@ async def _build_and_stream(
                 chat_id, chain_user_ids
             )
             if impression_text:
-                context_lines.append(impression_text)
+                context_lines.append("\n---\n" + impression_text)
         except Exception as e:
             logger.error(f"Failed to build impression context: {e}")
 

--- a/apps/agent-service/app/agents/domains/main/context_builder.py
+++ b/apps/agent-service/app/agents/domains/main/context_builder.py
@@ -18,7 +18,7 @@ logger = logging.getLogger(__name__)
 
 async def build_chat_context(
     message_id: str, limit: int = 10
-) -> tuple[list[HumanMessage | AIMessage], list[str], str, str, str, str, str]:
+) -> tuple[list[HumanMessage | AIMessage], list[str], str, str, str, str, str, list[str]]:
     """构建聊天上下文，支持私聊和群聊使用不同组装策略
 
     群聊: 按回复链分组，组装成一条 HumanMessage
@@ -29,14 +29,14 @@ async def build_chat_context(
         limit: 获取的历史消息数量限制
 
     Returns:
-        tuple: (消息列表, 图片URL列表, chat_id, 触发用户名, 聊天类型, 触发用户ID, 群聊名称)
+        tuple: (消息列表, 图片URL列表, chat_id, 触发用户名, 聊天类型, 触发用户ID, 群聊名称, 回复链用户ID列表)
     """
     # L1: 使用 quick_search 拉取近期历史
     l1_results = await quick_search(message_id=message_id, limit=limit)
 
     if not l1_results:
         logger.warning(f"No results found for message_id: {message_id}")
-        return [], [], "", "", "p2p", "", ""
+        return [], [], "", "", "p2p", "", "", []
 
     chat_type = l1_results[-1].chat_type or "p2p"  # 默认私聊
 
@@ -84,6 +84,12 @@ async def build_chat_context(
     # 提取群聊名称
     chat_name = l1_results[-1].chat_name or ""
 
+    # 提取回复链中所有用户ID（去重，排除 assistant）
+    chain_user_ids = list({
+        r.user_id for r in l1_results
+        if r.role != "assistant" and r.user_id
+    })
+
     return (
         messages,
         image_urls,
@@ -92,6 +98,7 @@ async def build_chat_context(
         chat_type,
         trigger_user_id,
         chat_name,
+        chain_user_ids,
     )
 
 

--- a/apps/agent-service/app/agents/domains/main/tools.py
+++ b/apps/agent-service/app/agents/domains/main/tools.py
@@ -6,6 +6,7 @@
 from app.agents.tools.history.members import list_group_members
 from app.agents.tools.history.search import search_group_history
 from app.agents.tools.image import generate_image
+from app.agents.tools.memory import load_memory
 from app.agents.tools.search.allcpp import search_donjin_event
 from app.agents.tools.search.web import search_web
 
@@ -16,4 +17,5 @@ ALL_TOOLS = [
     search_group_history,
     list_group_members,
     generate_image,
+    load_memory,
 ]

--- a/apps/agent-service/app/agents/tools/memory.py
+++ b/apps/agent-service/app/agents/tools/memory.py
@@ -1,0 +1,67 @@
+"""记忆检索工具 - 让赤尾能主动查日记和人物印象"""
+
+import logging
+
+from langchain.tools import tool
+from langgraph.runtime import get_runtime
+
+from app.agents.core.context import AgentContext
+from app.agents.tools.decorators import tool_error_handler
+from app.orm.crud import (
+    get_diary_by_date,
+    get_impressions_for_users,
+    get_username,
+    search_user_by_name,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@tool
+@tool_error_handler(error_message="记忆检索失败")
+async def load_memory(query_type: str, query: str) -> str:
+    """从赤尾的记忆中检索信息。
+
+    两种模式：
+    - query_type="diary": 按日期查日记，query 为日期如 "2026-03-10"
+    - query_type="impression": 按人名查印象，query 为用户名如 "陈儒"
+
+    Args:
+        query_type: 查询类型，"diary" 或 "impression"
+        query: 查询内容（日期或人名）
+    """
+    context = get_runtime(AgentContext).context
+    chat_id = context.message.chat_id
+
+    if query_type == "diary":
+        return await _load_diary(chat_id, query)
+    elif query_type == "impression":
+        return await _load_impression(chat_id, query)
+    else:
+        return f"不支持的查询类型: {query_type}，请使用 diary 或 impression"
+
+
+async def _load_diary(chat_id: str, date_str: str) -> str:
+    """按日期查日记"""
+    diary = await get_diary_by_date(chat_id, date_str)
+    if not diary:
+        return "那天没有写日记哦"
+    return f"--- {diary.diary_date} 的日记 ---\n{diary.content}"
+
+
+async def _load_impression(chat_id: str, name: str) -> str:
+    """按人名查印象"""
+    users = await search_user_by_name(name)
+    if not users:
+        return "还没有对这个人形成印象呢"
+
+    user_ids = [u.union_id for u in users]
+    impressions = await get_impressions_for_users(chat_id, user_ids)
+    if not impressions:
+        return "还没有对这个人形成印象呢"
+
+    lines = []
+    for imp in impressions:
+        username = await get_username(imp.user_id) or imp.user_id[:8]
+        lines.append(f"【{username}】{imp.impression_text}")
+    return "\n".join(lines)

--- a/apps/agent-service/app/orm/crud.py
+++ b/apps/agent-service/app/orm/crud.py
@@ -407,6 +407,28 @@ async def get_all_impressions_for_chat(chat_id: str) -> list[PersonImpression]:
         return list(result.scalars().all())
 
 
+async def get_diary_by_date(chat_id: str, diary_date: str) -> DiaryEntry | None:
+    """查指定群指定日期的日记"""
+    async with AsyncSessionLocal() as session:
+        result = await session.execute(
+            select(DiaryEntry)
+            .where(DiaryEntry.chat_id == chat_id)
+            .where(DiaryEntry.diary_date == diary_date)
+        )
+        return result.scalar_one_or_none()
+
+
+async def search_user_by_name(name: str) -> list[LarkUser]:
+    """按名字模糊查 lark_user"""
+    async with AsyncSessionLocal() as session:
+        result = await session.execute(
+            select(LarkUser)
+            .where(LarkUser.name.ilike(f"%{name}%"))
+            .limit(5)
+        )
+        return list(result.scalars().all())
+
+
 async def upsert_person_impression(
     chat_id: str, user_id: str, impression_text: str
 ) -> None:

--- a/apps/agent-service/app/orm/crud.py
+++ b/apps/agent-service/app/orm/crud.py
@@ -11,6 +11,7 @@ from .models import (
     LarkUser,
     ModelMapping,
     ModelProvider,
+    PersonImpression,
     UserKnowledge,
 )
 
@@ -377,3 +378,55 @@ async def get_username(user_id: str) -> str | None:
             select(LarkUser.name).where(LarkUser.union_id == user_id)
         )
         return result.scalar_one_or_none()
+
+
+# ==================== PersonImpression CRUD ====================
+
+
+async def get_impressions_for_users(
+    chat_id: str, user_ids: list[str]
+) -> list[PersonImpression]:
+    """查询指定群中指定用户的印象"""
+    if not user_ids:
+        return []
+    async with AsyncSessionLocal() as session:
+        result = await session.execute(
+            select(PersonImpression)
+            .where(PersonImpression.chat_id == chat_id)
+            .where(PersonImpression.user_id.in_(user_ids))
+        )
+        return list(result.scalars().all())
+
+
+async def get_all_impressions_for_chat(chat_id: str) -> list[PersonImpression]:
+    """查询指定群的所有已有印象"""
+    async with AsyncSessionLocal() as session:
+        result = await session.execute(
+            select(PersonImpression).where(PersonImpression.chat_id == chat_id)
+        )
+        return list(result.scalars().all())
+
+
+async def upsert_person_impression(
+    chat_id: str, user_id: str, impression_text: str
+) -> None:
+    """插入或更新人物印象"""
+    async with AsyncSessionLocal() as session:
+        result = await session.execute(
+            select(PersonImpression)
+            .where(PersonImpression.chat_id == chat_id)
+            .where(PersonImpression.user_id == user_id)
+        )
+        existing = result.scalar_one_or_none()
+
+        if existing:
+            existing.impression_text = impression_text
+        else:
+            session.add(
+                PersonImpression(
+                    chat_id=chat_id,
+                    user_id=user_id,
+                    impression_text=impression_text,
+                )
+            )
+        await session.commit()

--- a/apps/agent-service/app/orm/models.py
+++ b/apps/agent-service/app/orm/models.py
@@ -161,3 +161,22 @@ class LarkGroupMember(Base):
     updated_at: Mapped[datetime] = mapped_column(
         DateTime, server_default=func.now(), onupdate=func.now()
     )
+
+
+class PersonImpression(Base):
+    """赤尾对群友的人物印象"""
+
+    __tablename__ = "person_impression"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    chat_id: Mapped[str] = mapped_column(String(100), nullable=False)
+    user_id: Mapped[str] = mapped_column(String(100), nullable=False)
+    impression_text: Mapped[str] = mapped_column(Text, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now()
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now()
+    )
+
+    __table_args__ = (UniqueConstraint("chat_id", "user_id"),)

--- a/apps/agent-service/app/services/memory_context.py
+++ b/apps/agent-service/app/services/memory_context.py
@@ -7,13 +7,32 @@ import logging
 from collections import defaultdict
 from datetime import date
 
-from app.orm.crud import get_recent_diaries, get_user_knowledge
+from app.orm.crud import (
+    get_impressions_for_users,
+    get_recent_diaries,
+    get_user_knowledge,
+    get_username,
+)
 from app.orm.models import UserKnowledge
 
 logger = logging.getLogger(__name__)
 
 # 日记注入硬上限：约 2 篇日记
 MAX_DIARY_CHARS = 1500
+
+
+async def build_impression_context(chat_id: str, user_ids: list[str]) -> str:
+    """构建人物印象文本，注入群聊 system prompt"""
+    if not user_ids:
+        return ""
+    impressions = await get_impressions_for_users(chat_id, user_ids)
+    if not impressions:
+        return ""
+    lines = []
+    for imp in impressions:
+        name = await get_username(imp.user_id) or imp.user_id[:8]
+        lines.append(f"【{name}】{imp.impression_text}")
+    return "你对群友的印象：\n" + "\n".join(lines)
 
 
 async def build_diary_context(chat_id: str) -> str:

--- a/apps/agent-service/app/services/memory_context.py
+++ b/apps/agent-service/app/services/memory_context.py
@@ -21,11 +21,14 @@ logger = logging.getLogger(__name__)
 MAX_DIARY_CHARS = 1500
 
 
+MAX_IMPRESSION_USERS = 10
+
+
 async def build_impression_context(chat_id: str, user_ids: list[str]) -> str:
     """构建人物印象文本，注入群聊 system prompt"""
     if not user_ids:
         return ""
-    impressions = await get_impressions_for_users(chat_id, user_ids)
+    impressions = await get_impressions_for_users(chat_id, user_ids[:MAX_IMPRESSION_USERS])
     if not impressions:
         return ""
     lines = []

--- a/apps/agent-service/app/workers/diary_worker.py
+++ b/apps/agent-service/app/workers/diary_worker.py
@@ -204,7 +204,15 @@ async def post_process_impressions(
         diary_content: 刚生成的日记内容
         user_names: user_id → 用户名 映射
     """
-    # 1. 查已有印象
+    # 1. 过滤出日记中提到的用户（减少噪音，提升 LLM 匹配准确率）
+    relevant_users = {
+        uid: name for uid, name in user_names.items() if name in diary_content
+    }
+    if not relevant_users:
+        logger.info(f"No users mentioned in diary for {chat_id}, skip impression")
+        return
+
+    # 2. 查已有印象
     existing = await get_all_impressions_for_chat(chat_id)
     if existing:
         existing_text = "\n".join(
@@ -215,12 +223,12 @@ async def post_process_impressions(
     else:
         existing_text = "（暂无）"
 
-    # 2. 格式化 user_mapping
+    # 3. 格式化 user_mapping（只包含日记中提到的人）
     user_mapping_text = "\n".join(
-        f"- {uid} → {name}" for uid, name in user_names.items()
+        f"- {uid} → {name}" for uid, name in relevant_users.items()
     )
 
-    # 3. 获取 Langfuse prompt 并编译
+    # 4. 获取 Langfuse prompt 并编译
     prompt_template = get_prompt("diary_extract_impressions")
     compiled_prompt = prompt_template.compile(
         diary=diary_content,
@@ -228,7 +236,7 @@ async def post_process_impressions(
         user_mapping=user_mapping_text,
     )
 
-    # 4. 调用 LLM
+    # 5. 调用 LLM
     model = await ModelBuilder.build_chat_model(settings.diary_model)
     response = await model.ainvoke(
         [{"role": "user", "content": compiled_prompt}],
@@ -241,7 +249,7 @@ async def post_process_impressions(
             for part in raw
         )
 
-    # 5. 解析 JSON
+    # 6. 解析 JSON
     # 去掉可能的 markdown 代码块包裹
     raw = raw.strip()
     if raw.startswith("```"):
@@ -255,7 +263,7 @@ async def post_process_impressions(
         logger.warning(f"Impression extraction returned non-list: {type(impressions)}")
         return
 
-    # 6. Upsert 每条印象
+    # 7. Upsert 每条印象
     count = 0
     for item in impressions:
         uid = item.get("user_id")

--- a/apps/agent-service/app/workers/diary_worker.py
+++ b/apps/agent-service/app/workers/diary_worker.py
@@ -3,8 +3,10 @@
 
 每天凌晨 3:00 CST（UTC 19:00）为指定群生成赤尾第一人称日记。
 核心原子函数 generate_diary_for_chat(chat_id, target_date) 可独立调用回溯。
+日记生成后会自动提取/更新人物印象。
 """
 
+import json
 import logging
 from datetime import date, datetime, timedelta, timezone
 
@@ -12,10 +14,12 @@ from app.agents.infra.langfuse_client import get_prompt
 from app.agents.infra.model_builder import ModelBuilder
 from app.config.config import settings
 from app.orm.crud import (
+    get_all_impressions_for_chat,
     get_chat_messages_in_range,
     get_recent_diaries,
     get_username,
     upsert_diary_entry,
+    upsert_person_impression,
 )
 from app.utils.content_parser import parse_content
 
@@ -74,18 +78,25 @@ async def generate_diary_for_chat(chat_id: str, target_date: date) -> str | None
 
     messages = await get_chat_messages_in_range(chat_id, start_ts, end_ts)
 
-    # 2. 格式化消息时间线
-    timeline = await _format_messages_timeline(messages)
+    # 2. 构建 user_id → 用户名 映射（提前构建，供 timeline 和印象后处理复用）
+    user_ids = {msg.user_id for msg in messages}
+    user_names: dict[str, str] = {}
+    for uid in user_ids:
+        name = await get_username(uid)
+        user_names[uid] = name or uid[:8]
+
+    # 3. 格式化消息时间线
+    timeline = _format_messages_timeline(messages, user_names)
 
     if not timeline:
         logger.info(f"No messages for {chat_id} on {date_str}, skip")
         return None
 
-    # 3. 查最近 3 篇日记
+    # 4. 查最近 3 篇日记
     recent = await get_recent_diaries(chat_id, date_str, limit=3)
     recent_diaries_text = _format_recent_diaries(recent)
 
-    # 4. 获取 Langfuse prompt 并编译
+    # 5. 获取 Langfuse prompt 并编译
     prompt_template = get_prompt("diary_generation")
     compiled_prompt = prompt_template.compile(
         date=date_str,
@@ -94,7 +105,7 @@ async def generate_diary_for_chat(chat_id: str, target_date: date) -> str | None
         recent_diaries=recent_diaries_text,
     )
 
-    # 5. 调用 LLM
+    # 6. 调用 LLM
     model = await ModelBuilder.build_chat_model(settings.diary_model)
     response = await model.ainvoke(
         [{"role": "user", "content": compiled_prompt}],
@@ -111,7 +122,7 @@ async def generate_diary_for_chat(chat_id: str, target_date: date) -> str | None
         logger.warning(f"LLM returned empty content for {chat_id} on {date_str}")
         return None
 
-    # 6. 写入数据库（upsert）
+    # 7. 写入数据库（upsert）
     await upsert_diary_entry(
         chat_id=chat_id,
         diary_date=date_str,
@@ -124,25 +135,25 @@ async def generate_diary_for_chat(chat_id: str, target_date: date) -> str | None
         f"Diary generated for {chat_id} on {date_str}: "
         f"{len(messages)} messages, {len(diary_content)} chars"
     )
+
+    # 8. 后处理：从日记中提取/更新人物印象
+    try:
+        await post_process_impressions(chat_id, diary_content, user_names)
+    except Exception as e:
+        logger.error(f"Impression extraction failed for {chat_id}: {e}")
+
     return diary_content
 
 
 # ==================== 辅助函数 ====================
 
 
-async def _format_messages_timeline(messages: list) -> str:
+def _format_messages_timeline(messages: list, user_names: dict[str, str]) -> str:
     """将消息列表格式化为时间线文本
 
     格式: [14:32] 群友A: 今天吃什么
     跳过纯图片/表情包/空内容
     """
-    # 批量收集 user_id 去重，一次查名字
-    user_ids = {msg.user_id for msg in messages}
-    user_names: dict[str, str] = {}
-    for uid in user_ids:
-        name = await get_username(uid)
-        user_names[uid] = name or uid[:8]
-
     lines: list[str] = []
     for msg in messages:
         # 渲染内容（跳过图片）
@@ -176,3 +187,81 @@ def _format_recent_diaries(diaries: list) -> str:
         parts.append(f"--- {diary.diary_date} ---\n{diary.content}")
 
     return "\n\n".join(parts)
+
+
+# ==================== 印象后处理 ====================
+
+
+async def post_process_impressions(
+    chat_id: str,
+    diary_content: str,
+    user_names: dict[str, str],
+) -> None:
+    """从日记中提取人物印象并 upsert 到数据库
+
+    Args:
+        chat_id: 群 ID
+        diary_content: 刚生成的日记内容
+        user_names: user_id → 用户名 映射
+    """
+    # 1. 查已有印象
+    existing = await get_all_impressions_for_chat(chat_id)
+    if existing:
+        existing_text = "\n".join(
+            f"- {user_names.get(imp.user_id, imp.user_id[:8])}(user_id={imp.user_id}): "
+            f"{imp.impression_text}"
+            for imp in existing
+        )
+    else:
+        existing_text = "（暂无）"
+
+    # 2. 格式化 user_mapping
+    user_mapping_text = "\n".join(
+        f"- {uid} → {name}" for uid, name in user_names.items()
+    )
+
+    # 3. 获取 Langfuse prompt 并编译
+    prompt_template = get_prompt("diary_extract_impressions")
+    compiled_prompt = prompt_template.compile(
+        diary=diary_content,
+        existing_impressions=existing_text,
+        user_mapping=user_mapping_text,
+    )
+
+    # 4. 调用 LLM
+    model = await ModelBuilder.build_chat_model(settings.diary_model)
+    response = await model.ainvoke(
+        [{"role": "user", "content": compiled_prompt}],
+    )
+
+    raw = response.content
+    if isinstance(raw, list):
+        raw = "".join(
+            part.get("text", "") if isinstance(part, dict) else str(part)
+            for part in raw
+        )
+
+    # 5. 解析 JSON
+    # 去掉可能的 markdown 代码块包裹
+    raw = raw.strip()
+    if raw.startswith("```"):
+        raw = raw.split("\n", 1)[1] if "\n" in raw else raw[3:]
+        if raw.endswith("```"):
+            raw = raw[:-3]
+        raw = raw.strip()
+
+    impressions = json.loads(raw)
+    if not isinstance(impressions, list):
+        logger.warning(f"Impression extraction returned non-list: {type(impressions)}")
+        return
+
+    # 6. Upsert 每条印象
+    count = 0
+    for item in impressions:
+        uid = item.get("user_id")
+        text = item.get("impression_text")
+        if uid and text and uid in user_names:
+            await upsert_person_impression(chat_id, uid, text)
+            count += 1
+
+    logger.info(f"Impressions updated for {chat_id}: {count} people")


### PR DESCRIPTION
## Summary
- 扩展印象注入范围：从只注入 trigger_user 改为注入回复链中所有用户的印象（上限 10 人）
- 新增 `load_memory` 工具：支持按日期查日记（diary）、按人名查印象（impression）
- 各上下文块（日记/印象）之间增加 `---` 分隔线，便于模型区分

## Changes
| 文件 | 改动 |
|------|------|
| `context_builder.py` | 提取 `chain_user_ids`，返回 8 元组 |
| `agent.py` | 解构 8 元组，用 `chain_user_ids` 注入印象，加分隔线 |
| `memory_context.py` | `MAX_IMPRESSION_USERS=10` 硬上限 |
| `crud.py` | 新增 `get_diary_by_date`、`search_user_by_name` |
| `tools/memory.py` | 新建 `load_memory` 工具 |
| `tools.py` | 注册 `load_memory` |

## Test plan
- [x] 部署到 memory-system 泳道
- [x] 群里 @赤尾，Langfuse trace 确认 user_context 包含多人印象
- [x] 问"你对陈儒是什么印象"，确认 load_memory(impression) 被调用
- [x] 问"你昨天的日记写了什么"，确认 load_memory(diary) 被调用

🤖 Generated with [Claude Code](https://claude.com/claude-code)