### PR TITLE
feat(diary): auto-select active chats for diary generation

### DIFF
--- a/apps/agent-service/app/orm/crud.py
+++ b/apps/agent-service/app/orm/crud.py
@@ -1,4 +1,4 @@
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 
 from sqlalchemy import func, text
 from sqlalchemy.future import select
@@ -305,6 +305,25 @@ async def get_active_users_for_consolidation(
 
 
 # ==================== Diary CRUD ====================
+
+
+async def get_active_diary_chat_ids(
+    min_replies: int = 5, days: int = 7
+) -> list[str]:
+    """查询近 N 天内赤尾回复 >= min_replies 次的群 chat_id"""
+    async with AsyncSessionLocal() as session:
+        cutoff_ms = int(
+            (datetime.now(UTC) - timedelta(days=days)).timestamp() * 1000
+        )
+        result = await session.execute(
+            select(ConversationMessage.chat_id)
+            .where(ConversationMessage.chat_type == "group")
+            .where(ConversationMessage.role == "assistant")
+            .where(ConversationMessage.create_time > cutoff_ms)
+            .group_by(ConversationMessage.chat_id)
+            .having(func.count() >= min_replies)
+        )
+        return [row[0] for row in result.all()]
 
 
 async def get_chat_messages_in_range(

--- a/apps/agent-service/app/workers/diary_worker.py
+++ b/apps/agent-service/app/workers/diary_worker.py
@@ -14,6 +14,7 @@ from app.agents.infra.langfuse_client import get_prompt
 from app.agents.infra.model_builder import ModelBuilder
 from app.config.config import settings
 from app.orm.crud import (
+    get_active_diary_chat_ids,
     get_all_impressions_for_chat,
     get_chat_messages_in_range,
     get_recent_diaries,
@@ -34,13 +35,12 @@ _WEEKDAY_CN = ["周一", "周二", "周三", "周四", "周五", "周六", "周�
 
 
 async def cron_generate_diaries(ctx) -> None:
-    """cron 入口：为所有配置的群生成昨天的日记"""
-    chat_ids = [
-        cid.strip() for cid in settings.diary_chat_ids.split(",") if cid.strip()
-    ]
+    """cron 入口：为近7天赤尾活跃的群生成昨天的日记"""
+    chat_ids = await get_active_diary_chat_ids(min_replies=5, days=7)
     if not chat_ids:
-        logger.info("No diary_chat_ids configured, skip")
+        logger.info("No active diary chats found, skip")
         return
+    logger.info(f"Active diary chats: {len(chat_ids)}")
 
     yesterday = date.today() - timedelta(days=1)
 


### PR DESCRIPTION
## Summary
- 日记生成从硬编码 `diary_chat_ids` 改为动态查询：近 7 天赤尾回复 >= 5 次的群自动开启
- 当前命中 8 个群，日均新增 LLM 调用约 x8（可控）

## Test plan
- [x] SQL 逻辑已用 ops-db 验证，结果符合预期
- [ ] 明天检查 cron 日志确认正常生成

🤖 Generated with [Claude Code](https://claude.com/claude-code)