### PR TITLE
feat(monitoring): add Loki log-based alerting for message send failures

### DIFF
--- a/infra/k8s/monitoring/loki-alert-rules.yaml
+++ b/infra/k8s/monitoring/loki-alert-rules.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: loki-alert-rules
+  namespace: monitoring
+data:
+  rules.yaml: |
+    groups:
+      - name: lark-message-alerts
+        rules:
+          - alert: ChatResponseSendFailure
+            expr: |
+              sum(count_over_time({namespace="prod", app="chat-response-worker"} |= "Failed to send reply" [5m])) > 0
+            for: 0m
+            labels:
+              severity: critical
+            annotations:
+              summary: "飞书消息发送失败"
+              description: "chat-response-worker 在过去 5 分钟内有消息发送失败，请检查日志。"

--- a/infra/k8s/monitoring/loki-values.yaml
+++ b/infra/k8s/monitoring/loki-values.yaml
@@ -15,6 +15,13 @@ loki:
         index:
           prefix: loki_index_
           period: 24h
+  rulerConfig:
+    alertmanager_url: http://kube-prometheus-stack-alertmanager.monitoring.svc.cluster.local:9093
+    storage:
+      type: local
+      local:
+        directory: /var/loki/rules
+    enable_api: true
 
 singleBinary:
   replicas: 1
@@ -24,6 +31,14 @@ singleBinary:
     enabled: true
     storageClass: ""
     size: 10Gi
+  extraVolumes:
+    - name: loki-alert-rules
+      configMap:
+        name: loki-alert-rules
+  extraVolumeMounts:
+    - name: loki-alert-rules
+      mountPath: /var/loki/rules/fake
+      readOnly: true
 
 # Disable all scalable components
 backend:


### PR DESCRIPTION
## Summary
- 接通 Loki ruler → Alertmanager 管线（配置 `alertmanager_url`）
- 新增日志告警规则：chat-response-worker 出现 `Failed to send reply` 日志时触发 critical 告警
- 告警走现有链路：Loki → Alertmanager → alert-webhook → 飞书告警群

## 背景
线上一条消息因 invalid image_key 导致飞书 API 400，整条消息（含文字）未发出，但无告警通知。

## 变更文件
- `infra/k8s/monitoring/loki-values.yaml` — 添加 rulerConfig + 挂载规则 ConfigMap
- `infra/k8s/monitoring/loki-alert-rules.yaml` — 新建 Loki 告警规则

## 部署步骤
```bash
kubectl apply -f infra/k8s/monitoring/loki-alert-rules.yaml
helm upgrade loki grafana/loki -n monitoring -f infra/k8s/monitoring/loki-values.yaml
```

## Test plan
- [ ] kubectl apply ConfigMap
- [ ] helm upgrade Loki
- [ ] 验证 Loki ruler 加载规则：`curl loki-gateway/loki/api/v1/rules`
- [ ] 可选：模拟一条失败日志验证告警触发

🤖 Generated with [Claude Code](https://claude.com/claude-code)