### PR TITLE
feat(langfuse): prompt 泳道路由 + 缓存 TTL 调整

### DIFF
--- a/apps/agent-service/app/agents/infra/langfuse_client.py
+++ b/apps/agent-service/app/agents/infra/langfuse_client.py
@@ -1,15 +1,21 @@
 """Langfuse 集成
 
 惰性初始化单例客户端 + prompt 缓存（SDK 原生 cache_ttl_seconds）
+泳道支持：非 prod 泳道自动尝试 label=lane，失败 fallback production
 """
+
+import logging
 
 from langfuse import Langfuse
 
 from app.config import settings
+from app.utils.middlewares.trace import get_lane
 
 _client: Langfuse | None = None
 
-_PROMPT_CACHE_TTL_SECONDS: int = 300  # 5 分钟
+_PROMPT_CACHE_TTL_SECONDS: int = 60
+
+logger = logging.getLogger(__name__)
 
 
 def get_client() -> Langfuse:
@@ -29,13 +35,20 @@ def get_prompt(
     label: str | None = None,
     cache_ttl_seconds: int = _PROMPT_CACHE_TTL_SECONDS,
 ):
-    """获取 Langfuse prompt（带 SDK 原生缓存）
+    """获取 Langfuse prompt（带 SDK 原生缓存 + 泳道路由）
 
-    Args:
-        prompt_id: Prompt 标识
-        label: 可选标签（如 production/staging）
-        cache_ttl_seconds: 缓存 TTL 秒数，默认 300s（Langfuse SDK >=3.3.4 支持）
+    非 prod 泳道时先尝试 label=lane，找不到则 fallback production。
     """
+    lane = get_lane()
+    effective_label = label
+    if not effective_label and lane and lane != "prod":
+        try:
+            return get_client().get_prompt(
+                prompt_id, label=lane, cache_ttl_seconds=cache_ttl_seconds
+            )
+        except Exception:
+            logger.debug("prompt %s 无泳道 label=%s，fallback production", prompt_id, lane)
+
     return get_client().get_prompt(
-        prompt_id, label=label, cache_ttl_seconds=cache_ttl_seconds
+        prompt_id, label=effective_label, cache_ttl_seconds=cache_ttl_seconds
     )

--- a/apps/agent-service/tests/unit/test_langfuse.py
+++ b/apps/agent-service/tests/unit/test_langfuse.py
@@ -1,9 +1,10 @@
-"""test_langfuse.py — Langfuse 惰性初始化 + prompt 缓存测试
+"""test_langfuse.py — Langfuse 惰性初始化 + prompt 缓存 + 泳道路由测试
 
 场景覆盖：
 - 惰性初始化：import 时不创建客户端
 - 单例保证：多次调用 get_client() 返回同一实例
 - get_prompt 传递 cache_ttl_seconds 给 SDK
+- 泳道路由：非 prod 泳道尝试 label=lane，失败 fallback production
 """
 
 from unittest.mock import MagicMock, patch
@@ -62,9 +63,10 @@ class TestSingleton:
 class TestGetPrompt:
     """get_prompt 缓存参数传递"""
 
+    @patch("app.agents.infra.langfuse_client.get_lane", return_value=None)
     @patch("app.agents.infra.langfuse_client.Langfuse")
-    def test_default_cache_ttl(self, mock_langfuse_cls):
-        """默认 cache_ttl_seconds=300"""
+    def test_default_cache_ttl(self, mock_langfuse_cls, _mock_lane):
+        """默认 cache_ttl_seconds=60"""
         mock_instance = MagicMock()
         mock_langfuse_cls.return_value = mock_instance
 
@@ -73,26 +75,28 @@ class TestGetPrompt:
         mock_instance.get_prompt.assert_called_once_with(
             "test-prompt",
             label=None,
-            cache_ttl_seconds=300,
+            cache_ttl_seconds=60,
         )
 
+    @patch("app.agents.infra.langfuse_client.get_lane", return_value=None)
     @patch("app.agents.infra.langfuse_client.Langfuse")
-    def test_custom_cache_ttl(self, mock_langfuse_cls):
+    def test_custom_cache_ttl(self, mock_langfuse_cls, _mock_lane):
         """自定义 cache_ttl_seconds"""
         mock_instance = MagicMock()
         mock_langfuse_cls.return_value = mock_instance
 
-        langfuse_mod.get_prompt("test-prompt", cache_ttl_seconds=60)
+        langfuse_mod.get_prompt("test-prompt", cache_ttl_seconds=30)
 
         mock_instance.get_prompt.assert_called_once_with(
             "test-prompt",
             label=None,
-            cache_ttl_seconds=60,
+            cache_ttl_seconds=30,
         )
 
+    @patch("app.agents.infra.langfuse_client.get_lane", return_value=None)
     @patch("app.agents.infra.langfuse_client.Langfuse")
-    def test_label_passthrough(self, mock_langfuse_cls):
-        """label 参数正确传递"""
+    def test_label_passthrough(self, mock_langfuse_cls, _mock_lane):
+        """显式 label 参数正确传递"""
         mock_instance = MagicMock()
         mock_langfuse_cls.return_value = mock_instance
 
@@ -101,5 +105,72 @@ class TestGetPrompt:
         mock_instance.get_prompt.assert_called_once_with(
             "test-prompt",
             label="production",
-            cache_ttl_seconds=300,
+            cache_ttl_seconds=60,
+        )
+
+
+class TestLaneRouting:
+    """泳道 prompt 路由"""
+
+    @patch("app.agents.infra.langfuse_client.get_lane", return_value="feat-v1")
+    @patch("app.agents.infra.langfuse_client.Langfuse")
+    def test_lane_label_used(self, mock_langfuse_cls, _mock_lane):
+        """非 prod 泳道使用 lane 作为 label"""
+        mock_instance = MagicMock()
+        mock_langfuse_cls.return_value = mock_instance
+
+        langfuse_mod.get_prompt("test-prompt")
+
+        mock_instance.get_prompt.assert_called_once_with(
+            "test-prompt",
+            label="feat-v1",
+            cache_ttl_seconds=60,
+        )
+
+    @patch("app.agents.infra.langfuse_client.get_lane", return_value="feat-v1")
+    @patch("app.agents.infra.langfuse_client.Langfuse")
+    def test_lane_fallback_production(self, mock_langfuse_cls, _mock_lane):
+        """泳道 label 不存在时 fallback production"""
+        mock_instance = MagicMock()
+        mock_langfuse_cls.return_value = mock_instance
+        mock_instance.get_prompt.side_effect = [Exception("not found"), MagicMock()]
+
+        result = langfuse_mod.get_prompt("test-prompt")
+
+        assert result is not None
+        assert mock_instance.get_prompt.call_count == 2
+        calls = mock_instance.get_prompt.call_args_list
+        assert calls[0].args == ("test-prompt",)
+        assert calls[0].kwargs == {"label": "feat-v1", "cache_ttl_seconds": 60}
+        assert calls[1].args == ("test-prompt",)
+        assert calls[1].kwargs == {"label": None, "cache_ttl_seconds": 60}
+
+    @patch("app.agents.infra.langfuse_client.get_lane", return_value="prod")
+    @patch("app.agents.infra.langfuse_client.Langfuse")
+    def test_prod_lane_no_override(self, mock_langfuse_cls, _mock_lane):
+        """prod 泳道不做额外路由"""
+        mock_instance = MagicMock()
+        mock_langfuse_cls.return_value = mock_instance
+
+        langfuse_mod.get_prompt("test-prompt")
+
+        mock_instance.get_prompt.assert_called_once_with(
+            "test-prompt",
+            label=None,
+            cache_ttl_seconds=60,
+        )
+
+    @patch("app.agents.infra.langfuse_client.get_lane", return_value="feat-v1")
+    @patch("app.agents.infra.langfuse_client.Langfuse")
+    def test_explicit_label_skips_lane(self, mock_langfuse_cls, _mock_lane):
+        """显式传 label 时不注入泳道"""
+        mock_instance = MagicMock()
+        mock_langfuse_cls.return_value = mock_instance
+
+        langfuse_mod.get_prompt("test-prompt", label="staging")
+
+        mock_instance.get_prompt.assert_called_once_with(
+            "test-prompt",
+            label="staging",
+            cache_ttl_seconds=60,
         )


### PR DESCRIPTION
## Summary
- `get_prompt` 自动读取当前泳道，非 prod 时尝试 `label=lane`，找不到则 fallback production
- 缓存 TTL 300s → 60s

## Test plan
- [x] 单元测试 10/10 通过
- [x] 泳道 `feat-langfuse-lane-tags` 端到端验证：Langfuse trace 确认命中泳道 prompt v17

🤖 Generated with [Claude Code](https://claude.com/claude-code)