### PR TITLE
fix(lark-server): handle individual image OSS timeout in daily photo

### DIFF
--- a/apps/lark-server/src/core/services/media/photo/upload.ts
+++ b/apps/lark-server/src/core/services/media/photo/upload.ts
@@ -9,32 +9,36 @@ export async function fetchUploadedImages(params: ListPixivImageDto): Promise<Im
 
     for (const image of images) {
         if (!image.image_key) {
-            if (!image.tos_file_name) {
-                console.error(`Missing tos_file_name for image: ${image.pixiv_addr}`);
-                continue;
+            try {
+                if (!image.tos_file_name) {
+                    console.error(`Missing tos_file_name for image: ${image.pixiv_addr}`);
+                    continue;
+                }
+                const imageFile = await getOss().getFile(image.tos_file_name);
+                if (!imageFile) {
+                    console.error(`Failed to retrieve file for OSS file name: ${image.tos_file_name}`);
+                    continue;
+                }
+
+                const { outFile, imgWidth, imgHeight } = await resizeImage(imageFile.content);
+
+                const uploadRes = await uploadImage(outFile);
+
+                // Update image object with new key and dimensions
+                image.image_key = uploadRes?.image_key;
+                image.width = imgWidth;
+                image.height = imgHeight;
+
+                reportLarkUpload({
+                    pixiv_addr: image.pixiv_addr,
+                    image_key: image.image_key!,
+                    width: imgWidth,
+                    height: imgHeight,
+                });
+            } catch (e) {
+                console.error(`Failed to process image ${image.pixiv_addr}:`, e);
             }
-            const imageFile = await getOss().getFile(image.tos_file_name);
-            if (!imageFile) {
-                console.error(`Failed to retrieve file for OSS file name: ${image.tos_file_name}`);
-                continue;
-            }
-
-            const { outFile, imgWidth, imgHeight } = await resizeImage(imageFile.content);
-
-            const uploadRes = await uploadImage(outFile);
-
-            // Update image object with new key and dimensions
-            image.image_key = uploadRes?.image_key;
-            image.width = imgWidth;
-            image.height = imgHeight;
-
-            reportLarkUpload({
-                pixiv_addr: image.pixiv_addr,
-                image_key: image.image_key!,
-                width: imgWidth,
-                height: imgHeight,
-            });
         }
     }
-    return images;
+    return images.filter((image) => image.image_key);
 }


### PR DESCRIPTION
## Summary
- 单张图片 OSS 下载超时不再导致整个每日新图批次失败
- 给 `fetchUploadedImages` 中每张图的处理加了 try-catch，失败跳过继续
- 最后 filter 掉没有 image_key 的图片

## Root cause
昨天 daily-new-photo 执行时 OSS `getFile()` 超时 60s，异常冒泡导致整个任务失败，卡片未发出

🤖 Generated with [Claude Code](https://claude.com/claude-code)