### PR TITLE
perf(agent): 回复分段优化 - 工具调用自动切分 + prompt 精简

### DIFF
--- a/apps/agent-service/app/agents/domains/main/agent.py
+++ b/apps/agent-service/app/agents/domains/main/agent.py
@@ -4,7 +4,7 @@ import asyncio
 import logging
 import uuid
 from collections.abc import AsyncGenerator
-from langchain.messages import AIMessageChunk
+from langchain.messages import AIMessageChunk, ToolMessage
 from langfuse import get_client as get_langfuse
 from langfuse import propagate_attributes
 
@@ -26,6 +26,9 @@ logger = logging.getLogger(__name__)
 
 # 统一的拒绝响应
 GUARD_REJECT_MESSAGE = "你发了一些赤尾不想讨论的话题呢~"
+
+# 分段标记（consumer 侧检测并拆分为多条消息）
+SPLIT_MARKER = "---split---"
 
 # 复杂度行为引导
 COMPLEXITY_HINTS = {
@@ -294,6 +297,7 @@ async def _build_and_stream(
     prompt_vars["user_context"] = "\n".join(context_lines)
 
     full_content = ""
+    has_text_in_current_turn = False
 
     try:
         async for token in agent.stream(
@@ -314,9 +318,19 @@ async def _build_and_stream(
                 if finish_reason == "length":
                     yield "(后续内容被截断)"
                     return
+
                 if token.text:
+                    has_text_in_current_turn = True
                     full_content += token.text
                     yield token.text
+
+                # text → tool call 边界，注入分隔符
+                if token.tool_call_chunks and has_text_in_current_turn:
+                    yield SPLIT_MARKER
+                    has_text_in_current_turn = False
+
+            elif isinstance(token, ToolMessage):
+                has_text_in_current_turn = False
 
         # Fire-and-forget: publish to post safety check queue
         if full_content and session_id:


### PR DESCRIPTION
## Summary
- agent.py: 检测 text→tool call 边界，自动注入 `---split---` 分隔符，让 consumer 在工具调用前立即发出已有文本
- Langfuse prompt v48: 精简 25%（删除冗余段落），修复自相矛盾的约束，新增「自然过渡」「禁止外部图片URL」等规则

## Test plan
- [x] 部署 perf-split 泳道验证
- [x] 工具调用前模型先说话再调工具（自然过渡生效）
- [x] 长文本闲聊场景使用 `---split---` 分段
- [x] 图片生成使用 generate_image 工具而非外部 URL
- [x] production prompt (v44) 不受影响

🤖 Generated with [Claude Code](https://claude.com/claude-code)