### PR TITLE
feat(paas-engine): semantic versioning for image tags

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,7 +52,7 @@ SDK 在 `packages/ts-shared/`（TS）和 `packages/py-shared/`（Python）。
 
 ## 通用规范
 
-- 镜像 tag: git short hash（如 `fd8ebe9`）
+- 镜像 tag: 语义化版本号（如 `1.0.0.2`），由 PaaS Engine 服务端分配
 - 敏感配置通过环境变量和 K8s Secret 管理，不写入代码
 
 ## 开发流程
@@ -70,12 +70,12 @@ SDK 在 `packages/ts-shared/`（TS）和 `packages/py-shared/`（Python）。
 ## 部署命令
 
 ```bash
-make deploy APP=<app> [LANE=dev]          # 构建 → 等待 → 发布
-make self-deploy                           # paas-engine 蓝绿自部署
-make release APP=<app> LANE=prod [TAG=x]   # 仅发布（不构建）
-make undeploy APP=<app> LANE=dev           # 删除 Release
-make status [APP=xxx]                      # 查看状态
-make latest-build APP=<app>                # 最近成功构建
+make deploy APP=<app> [LANE=dev] [BUMP=minor] [VERSION=2.0.0.1]  # 构建 → 等待 → 发布
+make self-deploy [BUMP=minor]                                      # paas-engine 蓝绿自部署
+make release APP=<app> LANE=prod VERSION=1.0.0.5                   # 仅发布（不构建，用于回滚）
+make undeploy APP=<app> LANE=dev                                   # 删除 Release
+make status [APP=xxx]                                              # 查看状态
+make latest-build APP=<app>                                        # 最近成功构建
 ```
 
 ## AI 行为约束

--- a/Makefile
+++ b/Makefile
@@ -2,12 +2,14 @@
 
 # ---------- 参数 ----------
 # APP        — 应用名（必填），对应 apps/<APP> 和 PaaS 注册的应用名
-# TAG        — 镜像 tag，默认 git short hash
+# VERSION    — 显式指定版本号（可选）
+# BUMP       — 版本递进："major"/"minor"/"patch"/""（可选）
 # GIT_REF    — 构建分支/tag/commit，默认当前分支
 # LANE       — 部署泳道，默认 prod
 
 GIT_REF  ?= $(shell git rev-parse --abbrev-ref HEAD)
-TAG      ?= $(shell git rev-parse --short $(GIT_REF))
+VERSION  ?=
+BUMP     ?=
 LANE     ?= prod
 
 define require_app
@@ -48,18 +50,19 @@ endef
 # ---------- 命令 ----------
 
 ## 一键部署：构建 → 等待 → 发布到指定泳道
-## 用法: make deploy APP=my-service [LANE=dev]
+## 用法: make deploy APP=my-service [LANE=dev] [BUMP=minor] [VERSION=2.0.0.1]
 deploy:
 	@$(call require_app)
 	$(call require_main_for_prod)
 	$(call require_pushed)
-	@echo ">>> 部署 $(APP): $(GIT_REF) -> $(TAG) -> $(LANE)"
-	@BUILD_ID=$$(curl -sf -X POST $(PAAS_API)/api/paas/apps/$(APP)/builds/ \
+	@echo ">>> 部署 $(APP): $(GIT_REF) -> $(LANE)"
+	@BUILD_RESP=$$(curl -sf -X POST $(PAAS_API)/api/paas/apps/$(APP)/builds/ \
 		-H 'Content-Type: application/json' \
 		-H 'X-API-Key: $(PAAS_TOKEN)' \
-		-d '{"git_ref":"$(GIT_REF)","image_tag":"$(TAG)"}' \
-		| python3 -c "import sys,json; print(json.load(sys.stdin)['data']['id'])") && \
-	echo ">>> 构建已触发: $$BUILD_ID" && \
+		-d '{"git_ref":"$(GIT_REF)","version":"$(VERSION)","bump":"$(BUMP)"}') && \
+	BUILD_ID=$$(echo "$$BUILD_RESP" | python3 -c "import sys,json; print(json.load(sys.stdin)['data']['id'])") && \
+	BUILD_VER=$$(echo "$$BUILD_RESP" | python3 -c "import sys,json; print(json.load(sys.stdin)['data']['version'])") && \
+	echo ">>> 构建已触发: $$BUILD_ID (版本: $$BUILD_VER)" && \
 	while true; do \
 		STATUS=$$(curl -sf $(PAAS_API)/api/paas/apps/$(APP)/builds/$$BUILD_ID/ \
 			-H 'X-API-Key: $(PAAS_TOKEN)' | python3 -c "import sys,json; print(json.load(sys.stdin)['data']['status'])"); \
@@ -71,26 +74,27 @@ deploy:
 		esac; \
 		sleep 5; \
 	done && \
-	echo ">>> 发布 $(APP) -> $(LANE), tag: $(TAG)" && \
+	echo ">>> 发布 $(APP) -> $(LANE), 版本: $$BUILD_VER" && \
 	curl -sf -X POST $(PAAS_API)/api/paas/releases/ \
 		-H 'Content-Type: application/json' \
 		-H 'X-API-Key: $(PAAS_TOKEN)' \
-		-d '{"app_name":"$(APP)","lane":"$(LANE)","image_tag":"$(TAG)","replicas":1}' \
+		-d "{\"app_name\":\"$(APP)\",\"lane\":\"$(LANE)\",\"image_tag\":\"$$BUILD_VER\",\"replicas\":1}" \
 		| python3 -m json.tool && \
 	echo ">>> 部署完成"
 
 ## paas-engine 蓝绿自部署：构建 → 等待 → prod → blue
-## 用法: make self-deploy
+## 用法: make self-deploy [BUMP=minor]
 self-deploy:
 	$(call require_main_for_prod)
 	$(call require_pushed)
-	@echo ">>> 蓝绿自部署 paas-engine: $(GIT_REF) -> $(TAG)"
-	@BUILD_ID=$$(curl -sf -X POST $(PAAS_API)/api/paas/apps/paas-engine/builds/ \
+	@echo ">>> 蓝绿自部署 paas-engine: $(GIT_REF) -> prod+blue"
+	@BUILD_RESP=$$(curl -sf -X POST $(PAAS_API)/api/paas/apps/paas-engine/builds/ \
 		-H 'Content-Type: application/json' \
 		-H 'X-API-Key: $(PAAS_TOKEN)' \
-		-d '{"git_ref":"$(GIT_REF)","image_tag":"$(TAG)"}' \
-		| python3 -c "import sys,json; print(json.load(sys.stdin)['data']['id'])") && \
-	echo ">>> 构建已触发: $$BUILD_ID" && \
+		-d '{"git_ref":"$(GIT_REF)","version":"$(VERSION)","bump":"$(BUMP)"}') && \
+	BUILD_ID=$$(echo "$$BUILD_RESP" | python3 -c "import sys,json; print(json.load(sys.stdin)['data']['id'])") && \
+	BUILD_VER=$$(echo "$$BUILD_RESP" | python3 -c "import sys,json; print(json.load(sys.stdin)['data']['version'])") && \
+	echo ">>> 构建已触发: $$BUILD_ID (版本: $$BUILD_VER)" && \
 	while true; do \
 		STATUS=$$(curl -sf $(PAAS_API)/api/paas/apps/paas-engine/builds/$$BUILD_ID/ \
 			-H 'X-API-Key: $(PAAS_TOKEN)' | python3 -c "import sys,json; print(json.load(sys.stdin)['data']['status'])"); \
@@ -102,31 +106,32 @@ self-deploy:
 		esac; \
 		sleep 5; \
 	done && \
-	echo ">>> 发布 paas-engine -> prod, tag: $(TAG)" && \
+	echo ">>> 发布 paas-engine -> prod, 版本: $$BUILD_VER" && \
 	curl -sf -X POST $(PAAS_API)/api/paas/releases/ \
 		-H 'Content-Type: application/json' \
 		-H 'X-API-Key: $(PAAS_TOKEN)' \
-		-d '{"app_name":"paas-engine","lane":"prod","image_tag":"$(TAG)","replicas":1}' \
+		-d "{\"app_name\":\"paas-engine\",\"lane\":\"prod\",\"image_tag\":\"$$BUILD_VER\",\"replicas\":1}" \
 		| python3 -m json.tool && \
 	echo ">>> 等待 prod 泳道就绪..." && sleep 10 && \
-	echo ">>> 发布 paas-engine -> blue, tag: $(TAG)" && \
+	echo ">>> 发布 paas-engine -> blue, 版本: $$BUILD_VER" && \
 	curl -sf -X POST $(PAAS_API)/api/paas/releases/ \
 		-H 'Content-Type: application/json' \
 		-H 'X-API-Key: $(PAAS_TOKEN)' \
-		-d '{"app_name":"paas-engine","lane":"blue","image_tag":"$(TAG)","replicas":1}' \
+		-d "{\"app_name\":\"paas-engine\",\"lane\":\"blue\",\"image_tag\":\"$$BUILD_VER\",\"replicas\":1}" \
 		| python3 -m json.tool && \
 	echo ">>> 蓝绿自部署完成"
 
 ## 仅发布（不构建），用于切换泳道/回滚
-## 用法: make release APP=xxx LANE=yyy [TAG=zzz]
+## 用法: make release APP=xxx LANE=yyy VERSION=1.0.0.5
 release:
 	@$(call require_app)
+	$(if $(VERSION),,$(error VERSION 未指定。用法: make release APP=<app> LANE=<lane> VERSION=<version>))
 	$(if $(LANE),,$(error LANE 未指定))
-	@echo ">>> 发布 $(APP) -> $(LANE), tag: $(TAG)"
+	@echo ">>> 发布 $(APP) -> $(LANE), 版本: $(VERSION)"
 	@curl -sf -X POST $(PAAS_API)/api/paas/releases/ \
 	  -H 'Content-Type: application/json' \
 	  -H 'X-API-Key: $(PAAS_TOKEN)' \
-	  -d '{"app_name":"$(APP)","lane":"$(LANE)","image_tag":"$(TAG)","replicas":1}' \
+	  -d '{"app_name":"$(APP)","lane":"$(LANE)","image_tag":"$(VERSION)","replicas":1}' \
 	  | python3 -m json.tool
 
 ## 按 app+lane 删除 Release

--- a/apps/paas-engine/internal/adapter/repository/build_repo.go
+++ b/apps/paas-engine/internal/adapter/repository/build_repo.go
@@ -78,6 +78,21 @@ func (r *BuildRepo) FindByImageTag(ctx context.Context, imageTag string) (*domai
 	return modelToBuild(&m), nil
 }
 
+func (r *BuildRepo) FindLatestVersioned(ctx context.Context, imageRepoName string) (*domain.Build, error) {
+	var m BuildModel
+	result := r.db.WithContext(ctx).
+		Where("image_repo_name = ? AND version != ''", imageRepoName).
+		Order("created_at desc").
+		First(&m)
+	if result.Error != nil {
+		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
+			return nil, domain.ErrBuildNotFound
+		}
+		return nil, result.Error
+	}
+	return modelToBuild(&m), nil
+}
+
 func (r *BuildRepo) Update(ctx context.Context, build *domain.Build) error {
 	m := buildToModel(build)
 	return r.db.WithContext(ctx).Save(m).Error
@@ -89,6 +104,8 @@ func buildToModel(b *domain.Build) *BuildModel {
 		ImageRepoName: b.ImageRepoName,
 		GitRef:        b.GitRef,
 		ImageTag:      b.ImageTag,
+		Version:       b.Version,
+		Channel:       b.Channel,
 		Status:        string(b.Status),
 		JobName:       b.JobName,
 		Log:           b.Log,
@@ -103,6 +120,8 @@ func modelToBuild(m *BuildModel) *domain.Build {
 		ImageRepoName: m.ImageRepoName,
 		GitRef:        m.GitRef,
 		ImageTag:      m.ImageTag,
+		Version:       m.Version,
+		Channel:       m.Channel,
 		Status:        domain.BuildStatus(m.Status),
 		JobName:       m.JobName,
 		Log:           m.Log,

--- a/apps/paas-engine/internal/adapter/repository/model.go
+++ b/apps/paas-engine/internal/adapter/repository/model.go
@@ -39,6 +39,8 @@ type BuildModel struct {
 	ImageRepoName string `gorm:"index"`
 	GitRef        string
 	ImageTag      string
+	Version       string
+	Channel       string
 	Status        string
 	JobName       string
 	Log           string `gorm:"type:text"`

--- a/apps/paas-engine/internal/domain/build.go
+++ b/apps/paas-engine/internal/domain/build.go
@@ -24,6 +24,8 @@ type Build struct {
 	ImageRepoName string      `json:"image_repo_name"`
 	GitRef        string      `json:"git_ref"` // branch / tag / commit
 	ImageTag      string      `json:"image_tag"`
+	Version       string      `json:"version"`           // 语义化版本号，如 "1.0.0.2"
+	Channel       string      `json:"channel"`           // "stable" 或 "test"
 	Status        BuildStatus `json:"status"`
 	JobName       string      `json:"job_name,omitempty"`
 	Log           string      `json:"log,omitempty"`

--- a/apps/paas-engine/internal/domain/version.go
+++ b/apps/paas-engine/internal/domain/version.go
@@ -1,0 +1,95 @@
+package domain
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+const (
+	ChannelStable = "stable"
+	ChannelTest   = "test"
+)
+
+// Version 是 major.minor.patch.build 语义化版本号。
+type Version struct {
+	Major, Minor, Patch, Build int
+}
+
+// ParseVersion 将 "1.0.0.2" 解析为 Version{1,0,0,2}。
+func ParseVersion(s string) (Version, error) {
+	parts := strings.Split(s, ".")
+	if len(parts) != 4 {
+		return Version{}, fmt.Errorf("invalid version %q: expected major.minor.patch.build", s)
+	}
+	nums := make([]int, 4)
+	for i, p := range parts {
+		n, err := strconv.Atoi(p)
+		if err != nil {
+			return Version{}, fmt.Errorf("invalid version %q: %w", s, err)
+		}
+		if n < 0 {
+			return Version{}, fmt.Errorf("invalid version %q: negative number", s)
+		}
+		nums[i] = n
+	}
+	return Version{Major: nums[0], Minor: nums[1], Patch: nums[2], Build: nums[3]}, nil
+}
+
+// String 返回 "major.minor.patch.build" 格式。
+func (v Version) String() string {
+	return fmt.Sprintf("%d.%d.%d.%d", v.Major, v.Minor, v.Patch, v.Build)
+}
+
+// IsZero 判断是否零值。
+func (v Version) IsZero() bool {
+	return v.Major == 0 && v.Minor == 0 && v.Patch == 0 && v.Build == 0
+}
+
+// Compare 返回 -1、0、1，表示 v 与 other 的大小关系。
+func (v Version) Compare(other Version) int {
+	pairs := [][2]int{
+		{v.Major, other.Major},
+		{v.Minor, other.Minor},
+		{v.Patch, other.Patch},
+		{v.Build, other.Build},
+	}
+	for _, p := range pairs {
+		if p[0] < p[1] {
+			return -1
+		}
+		if p[0] > p[1] {
+			return 1
+		}
+	}
+	return 0
+}
+
+// Next 根据 bump 类型计算下一版本。
+// bump=""    → build+1（零值特殊处理为 1.0.0.1）
+// bump="patch" → patch+1, build=1
+// bump="minor" → minor+1, patch=0, build=1
+// bump="major" → major+1, minor=0, patch=0, build=1
+func (v Version) Next(bump string) Version {
+	if v.IsZero() && bump == "" {
+		return Version{1, 0, 0, 1}
+	}
+	switch bump {
+	case "major":
+		return Version{v.Major + 1, 0, 0, 1}
+	case "minor":
+		return Version{v.Major, v.Minor + 1, 0, 1}
+	case "patch":
+		return Version{v.Major, v.Minor, v.Patch + 1, 1}
+	default:
+		return Version{v.Major, v.Minor, v.Patch, v.Build + 1}
+	}
+}
+
+// ResolveChannel 根据 git ref 决定 channel。main → stable，其余 → test。
+func ResolveChannel(gitRef string) string {
+	if gitRef == "main" {
+		return ChannelStable
+	}
+	return ChannelTest
+}

--- a/apps/paas-engine/internal/domain/version_test.go
+++ b/apps/paas-engine/internal/domain/version_test.go
@@ -1,0 +1,123 @@
+package domain
+
+import "testing"
+
+func TestParseVersion(t *testing.T) {
+	tests := []struct {
+		input   string
+		want    Version
+		wantErr bool
+	}{
+		{"1.0.0.1", Version{1, 0, 0, 1}, false},
+		{"2.3.4.5", Version{2, 3, 4, 5}, false},
+		{"0.0.0.0", Version{0, 0, 0, 0}, false},
+		{"10.20.30.40", Version{10, 20, 30, 40}, false},
+		{"1.0.0", Version{}, true},
+		{"1.0.0.0.0", Version{}, true},
+		{"a.b.c.d", Version{}, true},
+		{"1.0.-1.0", Version{}, true},
+		{"", Version{}, true},
+	}
+	for _, tt := range tests {
+		got, err := ParseVersion(tt.input)
+		if (err != nil) != tt.wantErr {
+			t.Errorf("ParseVersion(%q) error = %v, wantErr %v", tt.input, err, tt.wantErr)
+			continue
+		}
+		if got != tt.want {
+			t.Errorf("ParseVersion(%q) = %v, want %v", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestVersion_String(t *testing.T) {
+	tests := []struct {
+		v    Version
+		want string
+	}{
+		{Version{1, 0, 0, 1}, "1.0.0.1"},
+		{Version{2, 3, 4, 5}, "2.3.4.5"},
+		{Version{0, 0, 0, 0}, "0.0.0.0"},
+	}
+	for _, tt := range tests {
+		if got := tt.v.String(); got != tt.want {
+			t.Errorf("%v.String() = %q, want %q", tt.v, got, tt.want)
+		}
+	}
+}
+
+func TestVersion_IsZero(t *testing.T) {
+	zero := Version{}
+	if !zero.IsZero() {
+		t.Error("zero value should be zero")
+	}
+	nonZero := Version{1, 0, 0, 1}
+	if nonZero.IsZero() {
+		t.Error("1.0.0.1 should not be zero")
+	}
+}
+
+func TestVersion_Compare(t *testing.T) {
+	tests := []struct {
+		a, b Version
+		want int
+	}{
+		{Version{1, 0, 0, 1}, Version{1, 0, 0, 1}, 0},
+		{Version{1, 0, 0, 1}, Version{1, 0, 0, 2}, -1},
+		{Version{1, 0, 0, 2}, Version{1, 0, 0, 1}, 1},
+		{Version{1, 0, 1, 1}, Version{1, 0, 0, 99}, 1},
+		{Version{1, 1, 0, 1}, Version{1, 0, 99, 99}, 1},
+		{Version{2, 0, 0, 1}, Version{1, 99, 99, 99}, 1},
+		{Version{1, 0, 0, 0}, Version{2, 0, 0, 0}, -1},
+	}
+	for _, tt := range tests {
+		if got := tt.a.Compare(tt.b); got != tt.want {
+			t.Errorf("%v.Compare(%v) = %d, want %d", tt.a, tt.b, got, tt.want)
+		}
+	}
+}
+
+func TestVersion_Next(t *testing.T) {
+	tests := []struct {
+		v    Version
+		bump string
+		want Version
+	}{
+		// 零值 → 初始版本
+		{Version{}, "", Version{1, 0, 0, 1}},
+		// build 递增
+		{Version{1, 0, 0, 1}, "", Version{1, 0, 0, 2}},
+		{Version{1, 0, 0, 5}, "", Version{1, 0, 0, 6}},
+		// patch bump
+		{Version{1, 0, 0, 5}, "patch", Version{1, 0, 1, 1}},
+		{Version{1, 0, 2, 5}, "patch", Version{1, 0, 3, 1}},
+		// minor bump
+		{Version{1, 0, 2, 5}, "minor", Version{1, 1, 0, 1}},
+		{Version{1, 2, 3, 5}, "minor", Version{1, 3, 0, 1}},
+		// major bump
+		{Version{1, 2, 3, 5}, "major", Version{2, 0, 0, 1}},
+		{Version{0, 0, 0, 0}, "major", Version{1, 0, 0, 1}},
+	}
+	for _, tt := range tests {
+		if got := tt.v.Next(tt.bump); got != tt.want {
+			t.Errorf("%v.Next(%q) = %v, want %v", tt.v, tt.bump, got, tt.want)
+		}
+	}
+}
+
+func TestResolveChannel(t *testing.T) {
+	tests := []struct {
+		gitRef string
+		want   string
+	}{
+		{"main", ChannelStable},
+		{"develop", ChannelTest},
+		{"feature/foo", ChannelTest},
+		{"v1.0.0", ChannelTest},
+	}
+	for _, tt := range tests {
+		if got := ResolveChannel(tt.gitRef); got != tt.want {
+			t.Errorf("ResolveChannel(%q) = %q, want %q", tt.gitRef, got, tt.want)
+		}
+	}
+}

--- a/apps/paas-engine/internal/port/repository.go
+++ b/apps/paas-engine/internal/port/repository.go
@@ -19,6 +19,7 @@ type BuildRepository interface {
 	FindByID(ctx context.Context, id string) (*domain.Build, error)
 	FindByImageRepo(ctx context.Context, imageRepoName string) ([]*domain.Build, error)
 	FindLatestSuccessful(ctx context.Context, imageRepoName string) (*domain.Build, error)
+	FindLatestVersioned(ctx context.Context, imageRepoName string) (*domain.Build, error)
 	FindByImageTag(ctx context.Context, imageTag string) (*domain.Build, error)
 	Update(ctx context.Context, build *domain.Build) error
 }

--- a/apps/paas-engine/internal/service/build_service.go
+++ b/apps/paas-engine/internal/service/build_service.go
@@ -2,6 +2,8 @@ package service
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"log/slog"
 	"time"
 
@@ -33,8 +35,9 @@ func NewBuildService(
 }
 
 type CreateBuildRequest struct {
-	GitRef   string `json:"git_ref"`
-	ImageTag string `json:"image_tag"` // tag 部分（如 abc123），service 层拼完整 URL
+	GitRef  string `json:"git_ref"`
+	Version string `json:"version,omitempty"` // 显式指定版本（可选）
+	Bump    string `json:"bump,omitempty"`    // "major"/"minor"/"patch"/""（可选）
 }
 
 func (s *BuildService) CreateBuild(ctx context.Context, imageRepoName string, req CreateBuildRequest) (*domain.Build, error) {
@@ -50,12 +53,34 @@ func (s *BuildService) CreateBuild(ctx context.Context, imageRepoName string, re
 		return nil, err
 	}
 
-	// image tag: 请求值 → git ref
-	tag := req.ImageTag
-	if tag == "" {
-		tag = req.GitRef
+	// 解析当前版本
+	var currentVersion domain.Version
+	latestBuild, err := s.buildRepo.FindLatestVersioned(ctx, imageRepoName)
+	if err != nil && !errors.Is(err, domain.ErrNotFound) {
+		return nil, err
 	}
+	if latestBuild != nil {
+		currentVersion, _ = domain.ParseVersion(latestBuild.Version)
+	}
+
+	// 计算下一版本
+	var nextVersion domain.Version
+	if req.Version != "" {
+		nextVersion, err = domain.ParseVersion(req.Version)
+		if err != nil {
+			return nil, fmt.Errorf("%w: %v", domain.ErrInvalidInput, err)
+		}
+		if nextVersion.Compare(currentVersion) <= 0 {
+			return nil, fmt.Errorf("%w: version %s must be greater than current %s",
+				domain.ErrInvalidInput, nextVersion, currentVersion)
+		}
+	} else {
+		nextVersion = currentVersion.Next(req.Bump)
+	}
+
+	tag := nextVersion.String()
 	fullImageRef := imageRepo.FullImageRef(tag)
+	channel := domain.ResolveChannel(req.GitRef)
 
 	now := time.Now()
 	build := &domain.Build{
@@ -63,6 +88,8 @@ func (s *BuildService) CreateBuild(ctx context.Context, imageRepoName string, re
 		ImageRepoName: imageRepoName,
 		GitRef:        req.GitRef,
 		ImageTag:      fullImageRef,
+		Version:       nextVersion.String(),
+		Channel:       channel,
 		Status:        domain.BuildStatusPending,
 		CreatedAt:     now,
 		UpdatedAt:     now,

--- a/apps/paas-engine/internal/service/build_service_test.go
+++ b/apps/paas-engine/internal/service/build_service_test.go
@@ -11,7 +11,8 @@ import (
 // --- stubs for build tests ---
 
 type stubBuildRepo struct {
-	saved *domain.Build
+	saved          *domain.Build
+	latestVersiond *domain.Build // FindLatestVersioned 返回
 }
 
 func (s *stubBuildRepo) Save(_ context.Context, b *domain.Build) error {
@@ -27,43 +28,52 @@ func (s *stubBuildRepo) FindByImageRepo(_ context.Context, _ string) ([]*domain.
 func (s *stubBuildRepo) FindLatestSuccessful(_ context.Context, _ string) (*domain.Build, error) {
 	return nil, domain.ErrBuildNotFound
 }
+func (s *stubBuildRepo) FindLatestVersioned(_ context.Context, _ string) (*domain.Build, error) {
+	if s.latestVersiond != nil {
+		return s.latestVersiond, nil
+	}
+	return nil, domain.ErrBuildNotFound
+}
 func (s *stubBuildRepo) FindByImageTag(_ context.Context, _ string) (*domain.Build, error) {
 	return nil, domain.ErrBuildNotFound
 }
 func (s *stubBuildRepo) Update(_ context.Context, _ *domain.Build) error { return nil }
 
-func TestCreateBuild_UsesImageRepoConfig(t *testing.T) {
-	imageRepoRepo := &stubImageRepoRepo{repo: &domain.ImageRepo{
-		Name:       "agent-service",
-		Registry:   "harbor.local/inner-bot/agent-service",
-		GitRepo:    "https://github.com/bezhai/chiwei-platform.git",
-		ContextDir: "apps/agent-service",
+func newTestImageRepoRepo(name, registry string) *stubImageRepoRepo {
+	return &stubImageRepoRepo{repo: &domain.ImageRepo{
+		Name:     name,
+		Registry: registry,
+		GitRepo:  "https://github.com/example/repo.git",
 	}}
+}
+
+func TestCreateBuild_InitialVersion(t *testing.T) {
+	imageRepoRepo := newTestImageRepoRepo("agent-service", "harbor.local/inner-bot/agent-service")
 	buildRepo := &stubBuildRepo{}
 	svc := NewBuildService(imageRepoRepo, buildRepo, nil, nil)
 
 	build, err := svc.CreateBuild(context.Background(), "agent-service", CreateBuildRequest{
-		GitRef:   "main",
-		ImageTag: "abc123",
+		GitRef: "main",
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if build.ImageRepoName != "agent-service" {
-		t.Errorf("ImageRepoName = %q, want %q", build.ImageRepoName, "agent-service")
+	if build.Version != "1.0.0.1" {
+		t.Errorf("Version = %q, want %q", build.Version, "1.0.0.1")
 	}
-	if build.ImageTag != "harbor.local/inner-bot/agent-service:abc123" {
-		t.Errorf("ImageTag = %q, want %q", build.ImageTag, "harbor.local/inner-bot/agent-service:abc123")
+	if build.ImageTag != "harbor.local/inner-bot/agent-service:1.0.0.1" {
+		t.Errorf("ImageTag = %q, want %q", build.ImageTag, "harbor.local/inner-bot/agent-service:1.0.0.1")
+	}
+	if build.Channel != domain.ChannelStable {
+		t.Errorf("Channel = %q, want %q", build.Channel, domain.ChannelStable)
 	}
 }
 
-func TestCreateBuild_DefaultTagFromGitRef(t *testing.T) {
-	imageRepoRepo := &stubImageRepoRepo{repo: &domain.ImageRepo{
-		Name:     "myapp",
-		Registry: "harbor.local/inner-bot/myapp",
-		GitRepo:  "https://github.com/example/repo.git",
-	}}
-	buildRepo := &stubBuildRepo{}
+func TestCreateBuild_AutoIncrementBuild(t *testing.T) {
+	imageRepoRepo := newTestImageRepoRepo("myapp", "harbor.local/inner-bot/myapp")
+	buildRepo := &stubBuildRepo{
+		latestVersiond: &domain.Build{Version: "1.0.0.3"},
+	}
 	svc := NewBuildService(imageRepoRepo, buildRepo, nil, nil)
 
 	build, err := svc.CreateBuild(context.Background(), "myapp", CreateBuildRequest{
@@ -72,8 +82,145 @@ func TestCreateBuild_DefaultTagFromGitRef(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if build.ImageTag != "harbor.local/inner-bot/myapp:feature-branch" {
-		t.Errorf("ImageTag = %q, want %q", build.ImageTag, "harbor.local/inner-bot/myapp:feature-branch")
+	if build.Version != "1.0.0.4" {
+		t.Errorf("Version = %q, want %q", build.Version, "1.0.0.4")
+	}
+	if build.Channel != domain.ChannelTest {
+		t.Errorf("Channel = %q, want %q", build.Channel, domain.ChannelTest)
+	}
+}
+
+func TestCreateBuild_BumpPatch(t *testing.T) {
+	imageRepoRepo := newTestImageRepoRepo("myapp", "harbor.local/inner-bot/myapp")
+	buildRepo := &stubBuildRepo{
+		latestVersiond: &domain.Build{Version: "1.0.0.5"},
+	}
+	svc := NewBuildService(imageRepoRepo, buildRepo, nil, nil)
+
+	build, err := svc.CreateBuild(context.Background(), "myapp", CreateBuildRequest{
+		GitRef: "main",
+		Bump:   "patch",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if build.Version != "1.0.1.1" {
+		t.Errorf("Version = %q, want %q", build.Version, "1.0.1.1")
+	}
+}
+
+func TestCreateBuild_BumpMinor(t *testing.T) {
+	imageRepoRepo := newTestImageRepoRepo("myapp", "harbor.local/inner-bot/myapp")
+	buildRepo := &stubBuildRepo{
+		latestVersiond: &domain.Build{Version: "1.0.2.5"},
+	}
+	svc := NewBuildService(imageRepoRepo, buildRepo, nil, nil)
+
+	build, err := svc.CreateBuild(context.Background(), "myapp", CreateBuildRequest{
+		GitRef: "main",
+		Bump:   "minor",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if build.Version != "1.1.0.1" {
+		t.Errorf("Version = %q, want %q", build.Version, "1.1.0.1")
+	}
+}
+
+func TestCreateBuild_BumpMajor(t *testing.T) {
+	imageRepoRepo := newTestImageRepoRepo("myapp", "harbor.local/inner-bot/myapp")
+	buildRepo := &stubBuildRepo{
+		latestVersiond: &domain.Build{Version: "1.2.3.5"},
+	}
+	svc := NewBuildService(imageRepoRepo, buildRepo, nil, nil)
+
+	build, err := svc.CreateBuild(context.Background(), "myapp", CreateBuildRequest{
+		GitRef: "main",
+		Bump:   "major",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if build.Version != "2.0.0.1" {
+		t.Errorf("Version = %q, want %q", build.Version, "2.0.0.1")
+	}
+}
+
+func TestCreateBuild_ExplicitVersion(t *testing.T) {
+	imageRepoRepo := newTestImageRepoRepo("myapp", "harbor.local/inner-bot/myapp")
+	buildRepo := &stubBuildRepo{
+		latestVersiond: &domain.Build{Version: "1.0.0.3"},
+	}
+	svc := NewBuildService(imageRepoRepo, buildRepo, nil, nil)
+
+	build, err := svc.CreateBuild(context.Background(), "myapp", CreateBuildRequest{
+		GitRef:  "main",
+		Version: "2.0.0.1",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if build.Version != "2.0.0.1" {
+		t.Errorf("Version = %q, want %q", build.Version, "2.0.0.1")
+	}
+}
+
+func TestCreateBuild_ExplicitVersionTooLow(t *testing.T) {
+	imageRepoRepo := newTestImageRepoRepo("myapp", "harbor.local/inner-bot/myapp")
+	buildRepo := &stubBuildRepo{
+		latestVersiond: &domain.Build{Version: "1.0.0.3"},
+	}
+	svc := NewBuildService(imageRepoRepo, buildRepo, nil, nil)
+
+	_, err := svc.CreateBuild(context.Background(), "myapp", CreateBuildRequest{
+		GitRef:  "main",
+		Version: "1.0.0.2",
+	})
+	if !errors.Is(err, domain.ErrInvalidInput) {
+		t.Errorf("expected ErrInvalidInput, got %v", err)
+	}
+}
+
+func TestCreateBuild_ExplicitVersionEqualCurrent(t *testing.T) {
+	imageRepoRepo := newTestImageRepoRepo("myapp", "harbor.local/inner-bot/myapp")
+	buildRepo := &stubBuildRepo{
+		latestVersiond: &domain.Build{Version: "1.0.0.3"},
+	}
+	svc := NewBuildService(imageRepoRepo, buildRepo, nil, nil)
+
+	_, err := svc.CreateBuild(context.Background(), "myapp", CreateBuildRequest{
+		GitRef:  "main",
+		Version: "1.0.0.3",
+	})
+	if !errors.Is(err, domain.ErrInvalidInput) {
+		t.Errorf("expected ErrInvalidInput, got %v", err)
+	}
+}
+
+func TestCreateBuild_ChannelFromGitRef(t *testing.T) {
+	tests := []struct {
+		gitRef      string
+		wantChannel string
+	}{
+		{"main", domain.ChannelStable},
+		{"develop", domain.ChannelTest},
+		{"feature/foo", domain.ChannelTest},
+	}
+	for _, tt := range tests {
+		imageRepoRepo := newTestImageRepoRepo("myapp", "harbor.local/inner-bot/myapp")
+		buildRepo := &stubBuildRepo{}
+		svc := NewBuildService(imageRepoRepo, buildRepo, nil, nil)
+
+		build, err := svc.CreateBuild(context.Background(), "myapp", CreateBuildRequest{
+			GitRef: tt.gitRef,
+		})
+		if err != nil {
+			t.Fatalf("gitRef=%q: unexpected error: %v", tt.gitRef, err)
+		}
+		if build.Channel != tt.wantChannel {
+			t.Errorf("gitRef=%q: Channel = %q, want %q", tt.gitRef, build.Channel, tt.wantChannel)
+		}
 	}
 }
 

--- a/apps/paas-engine/internal/service/release_service.go
+++ b/apps/paas-engine/internal/service/release_service.go
@@ -67,11 +67,22 @@ func (s *ReleaseService) CreateOrUpdateRelease(ctx context.Context, req CreateRe
 		lane = domain.DefaultLane
 	}
 
-	// prod 泳道只允许 main 分支构建的镜像
+	// prod 泳道禁止 test channel 镜像
 	if lane == domain.DefaultLane && fullImage != "" {
 		build, err := s.buildRepo.FindByImageTag(ctx, fullImage)
-		if err == nil && build.GitRef != "main" {
-			return nil, fmt.Errorf("%w (got %q)", domain.ErrNonMainProdDeploy, build.GitRef)
+		if err == nil {
+			if build.Channel == domain.ChannelTest {
+				return nil, fmt.Errorf("测试版本 %s (channel=%s, git_ref=%s) 不允许部署到 prod 泳道",
+					build.Version, build.Channel, build.GitRef)
+			}
+			// 向后兼容：旧 Build 无 channel，fallback 到检查 GitRef
+			if build.Channel == "" && build.GitRef != "main" {
+				return nil, fmt.Errorf("%w (got %q)", domain.ErrNonMainProdDeploy, build.GitRef)
+			}
+			// 自动继承 Build 版本到 Release
+			if req.Version == "" && build.Version != "" {
+				req.Version = build.Version
+			}
 		}
 		// build not found → 外部镜像，放行
 	}

--- a/apps/paas-engine/internal/service/release_service.go
+++ b/apps/paas-engine/internal/service/release_service.go
@@ -72,8 +72,8 @@ func (s *ReleaseService) CreateOrUpdateRelease(ctx context.Context, req CreateRe
 		build, err := s.buildRepo.FindByImageTag(ctx, fullImage)
 		if err == nil {
 			if build.Channel == domain.ChannelTest {
-				return nil, fmt.Errorf("测试版本 %s (channel=%s, git_ref=%s) 不允许部署到 prod 泳道",
-					build.Version, build.Channel, build.GitRef)
+				return nil, fmt.Errorf("%w: 测试版本 %s (channel=%s, git_ref=%s) 不允许部署到 prod 泳道",
+					domain.ErrInvalidInput, build.Version, build.Channel, build.GitRef)
 			}
 			// 向后兼容：旧 Build 无 channel，fallback 到检查 GitRef
 			if build.Channel == "" && build.GitRef != "main" {


### PR DESCRIPTION
## Summary
- 引入 `major.minor.patch.build` 语义化版本号替代 git hash 作为镜像 tag
- 版本由 PaaS Engine 服务端统一管理，每个 ImageRepo 独立版本序列
- Build 标记 channel（stable/test），禁止 test channel 部署到 prod
- Makefile deploy/self-deploy/release 全部适配新版本方案

## Test plan
- [x] `cd apps/paas-engine && make test` 全量单元测试通过
- [x] `make lint` 通过
- [x] 部署到 refactor-ver 泳道验证：
  - 首次构建 → 1.0.0.1, channel=stable
  - 再次构建 → 1.0.0.2 自动递增
  - bump minor → 1.1.0.1
  - 非 main 分支 → channel=test
  - test channel 部署 prod → 400 拒绝
  - stable channel 部署 prod → 成功 + version 自动填充

🤖 Generated with [Claude Code](https://claude.com/claude-code)