### PR TITLE
fix: ship skill adds stale commit check and conflict confirmation

### DIFF
--- a/.claude/skills/ship/SKILL.md
+++ b/.claude/skills/ship/SKILL.md
@@ -22,7 +22,15 @@ user_invocable: true
 - **APP**: 从参数获取，或从 `git diff --name-only main...HEAD` 检测。涉及多个 app 且未指定时才问。如果只改了根目录文件（Makefile、CLAUDE.md 等），标记为"仅合码，无需部署"。
 - **分支**: `git branch --show-current`，禁止在 main 上执行。
 
-### 2. 自动处理脏状态
+### 2. 检查是否有不属于当前工作的改动
+
+对比分支上的全部改动文件（`git diff --name-only main...HEAD`）和当前对话中实际修改过的文件。如果发现有**不是当前对话改动的文件**（如之前遗留的 commit），必须提醒用户：
+
+> 分支上还有以下不属于本次改动的文件：xxx，是否一起合入？
+
+等用户确认后再继续。如果所有改动都是当前对话的工作范围内，直接继续。
+
+### 3. 自动处理脏状态
 
 不要问，直接做：
 
@@ -34,7 +42,7 @@ git add -A && git commit -m "wip: auto commit before ship"
 git push -u origin <branch>
 ```
 
-### 3. 创建 PR 并合码
+### 4. 创建 PR 并合码
 
 ```bash
 # 创建 PR（已存在则跳过）
@@ -44,11 +52,11 @@ ghc pr create --fill 2>/dev/null || true
 ghc pr merge --squash --delete-branch
 ```
 
-合并冲突时：自动 rebase，解决冲突后重新 push 并重试。
+**合并冲突处理**：遇到冲突时，展示冲突文件和冲突内容，等用户指示如何解决。解决后重新 push 并重试。不要自行选择保留哪个版本。
 
-### 4. 部署
+### 5. 部署
 
-如果标记为"无需部署"，跳到步骤 5。
+如果标记为"无需部署"，跳到步骤 6。
 
 **必须在主仓库的 main 分支执行部署**。通过 `git worktree list` 找到主仓库路径（bare 或 main worktree）。
 
@@ -63,9 +71,9 @@ git checkout main && git pull
 
 超时 10 分钟。
 
-### 5. 清理当前分支的测试泳道
+### 6. 清理当前分支的测试泳道
 
-只清理**当前分支对应的泳道**（即步骤 1 中按分支名生成的 LANE：`/` → `-`，截前 20 字符），不要动其他泳道。
+只清理**当前分支对应的泳道**（即按分支名生成的 LANE：`/` → `-`，截前 20 字符），不要动其他泳道。
 
 ```bash
 make undeploy APP=<APP> LANE=<当前分支对应的泳道名>
@@ -74,7 +82,7 @@ make lane-unbind TYPE=bot KEY=dev
 
 如果该泳道不存在则跳过，不报错。
 
-### 6. 验证并输出
+### 7. 验证并输出
 
 ```bash
 kubectl -n prod get pods -l app=<APP>


### PR DESCRIPTION
## Summary
- ship skill 新增步骤：检查分支上是否有不属于当前工作的遗留改动，有则提醒用户确认
- 合并冲突处理改为展示冲突内容等用户指示，不再自动解决

## Test plan
- [ ] 在有遗留 commit 的分支上执行 /ship，确认会提醒
- [ ] 在干净分支上执行 /ship，确认不会多余确认

🤖 Generated with [Claude Code](https://claude.com/claude-code)