### PR TITLE
fix(agent): correct diary cron schedule from UTC to CST

### DIFF
--- a/apps/agent-service/app/workers/unified_worker.py
+++ b/apps/agent-service/app/workers/unified_worker.py
@@ -65,6 +65,6 @@ class UnifiedWorkerSettings:
             hour={2, 6, 10, 14, 18, 22},
             minute={15},
         ),
-        # 4. 日记生成：每天 UTC 19:00（CST 03:00）
-        cron(cron_generate_diaries, hour={19}, minute={0}),
+        # 4. 日记生成：每天 CST 03:00
+        cron(cron_generate_diaries, hour={3}, minute={0}),
     ]


### PR DESCRIPTION
## Summary
- 容器 TZ=Asia/Shanghai，ArQ cron 用本地时区调度，`hour={19}` 实际在 CST 19:00 触发而非预期的 CST 03:00
- 修正为 `hour={3}`，确保日记在凌晨 3 点生成

## Test plan
- [x] 已手动补跑 3/12 日记确认逻辑正确

🤖 Generated with [Claude Code](https://claude.com/claude-code)