### PR TITLE
feat(api-gateway): expose agent-service via /api/agent/ route

### DIFF
--- a/apps/api-gateway/config/routes.yaml
+++ b/apps/api-gateway/config/routes.yaml
@@ -16,6 +16,12 @@ routes:
     service: lark-proxy
     port: 3003
 
+  # Agent Service（日记/周记调试等）
+  - prefix: /api/agent/
+    service: agent-service
+    port: 8000
+    strip_prefix: /api/agent
+
   # 监控面板 API（JWT 认证）
   - prefix: /dashboard/api/
     service: monitor-dashboard


### PR DESCRIPTION
## Summary
- api-gateway 路由配置新增 `/api/agent/` → `agent-service:8000`，strip_prefix 去掉前缀后透传
- 支持 x-lane header 路由到不同泳道的 agent-service

## Motivation
agent-service 目前只有 ClusterIP，无法通过集群官方入口访问。需要暴露 admin 端点用于手动触发日记/周记生成等调试操作。

## Test plan
- [ ] 部署 api-gateway 到 prod
- [ ] 验证 `$PAAS_API/api/agent/health` 返回 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)