### PR TITLE
feat(agent): weekly review + reduce diary hallucination

### DIFF
--- a/apps/agent-service/app/api/router.py
+++ b/apps/agent-service/app/api/router.py
@@ -3,6 +3,7 @@ API路由汇总
 """
 
 import os
+from datetime import date, timedelta
 
 from fastapi import APIRouter
 
@@ -36,3 +37,40 @@ def import_time():
     from datetime import datetime
 
     return datetime.now().isoformat()
+
+
+# ==================== 调试端点 ====================
+
+
+@api_router.post("/admin/trigger-weekly-review", tags=["Admin"])
+async def trigger_weekly_review(chat_id: str, week_start: str | None = None):
+    """手动触发周记生成
+
+    Args:
+        chat_id: 群 ID
+        week_start: 目标周的周一日期（如 "2026-03-03"），默认上周一
+    """
+    from app.workers.diary_worker import generate_weekly_review_for_chat
+
+    target_monday = date.fromisoformat(week_start) if week_start else None
+    content = await generate_weekly_review_for_chat(chat_id, target_monday)
+    if content is None:
+        return {"ok": False, "message": "该周无日记，跳过"}
+    return {"ok": True, "content": content}
+
+
+@api_router.post("/admin/trigger-diary", tags=["Admin"])
+async def trigger_diary(chat_id: str, target_date: str | None = None):
+    """手动触发日记生成
+
+    Args:
+        chat_id: 群 ID
+        target_date: 目标日期（如 "2026-03-12"），默认昨天
+    """
+    from app.workers.diary_worker import generate_diary_for_chat
+
+    d = date.fromisoformat(target_date) if target_date else date.today() - timedelta(days=1)
+    content = await generate_diary_for_chat(chat_id, d)
+    if content is None:
+        return {"ok": False, "message": "该日无消息，跳过"}
+    return {"ok": True, "date": d.isoformat(), "content": content}

--- a/apps/agent-service/app/orm/crud.py
+++ b/apps/agent-service/app/orm/crud.py
@@ -13,6 +13,7 @@ from .models import (
     ModelProvider,
     PersonImpression,
     UserKnowledge,
+    WeeklyReview,
 )
 
 
@@ -385,6 +386,72 @@ async def get_recent_diaries(
             .where(DiaryEntry.chat_id == chat_id)
             .where(DiaryEntry.diary_date < before_date)
             .order_by(DiaryEntry.diary_date.desc())
+            .limit(limit)
+        )
+        return list(result.scalars().all())
+
+
+async def get_diaries_in_range(
+    chat_id: str, start_date: str, end_date: str
+) -> list[DiaryEntry]:
+    """查日期范围内的日记（含首尾）"""
+    async with AsyncSessionLocal() as session:
+        result = await session.execute(
+            select(DiaryEntry)
+            .where(DiaryEntry.chat_id == chat_id)
+            .where(DiaryEntry.diary_date >= start_date)
+            .where(DiaryEntry.diary_date <= end_date)
+            .order_by(DiaryEntry.diary_date.asc())
+        )
+        return list(result.scalars().all())
+
+
+# ==================== WeeklyReview CRUD ====================
+
+
+async def upsert_weekly_review(
+    chat_id: str,
+    week_start: str,
+    week_end: str,
+    content: str,
+    model: str | None = None,
+) -> None:
+    """插入或更新周记（upsert by chat_id + week_start）"""
+    async with AsyncSessionLocal() as session:
+        result = await session.execute(
+            select(WeeklyReview)
+            .where(WeeklyReview.chat_id == chat_id)
+            .where(WeeklyReview.week_start == week_start)
+        )
+        existing = result.scalar_one_or_none()
+
+        if existing:
+            existing.content = content
+            existing.week_end = week_end
+            existing.model = model
+        else:
+            session.add(
+                WeeklyReview(
+                    chat_id=chat_id,
+                    week_start=week_start,
+                    week_end=week_end,
+                    content=content,
+                    model=model,
+                )
+            )
+        await session.commit()
+
+
+async def get_latest_weekly_review(
+    chat_id: str, before_date: str, limit: int = 1
+) -> list[WeeklyReview]:
+    """查最近 N 篇周记（week_start 在 before_date 之前）"""
+    async with AsyncSessionLocal() as session:
+        result = await session.execute(
+            select(WeeklyReview)
+            .where(WeeklyReview.chat_id == chat_id)
+            .where(WeeklyReview.week_start < before_date)
+            .order_by(WeeklyReview.week_start.desc())
             .limit(limit)
         )
         return list(result.scalars().all())

--- a/apps/agent-service/app/orm/models.py
+++ b/apps/agent-service/app/orm/models.py
@@ -163,6 +163,24 @@ class LarkGroupMember(Base):
     )
 
 
+class WeeklyReview(Base):
+    """赤尾周记"""
+
+    __tablename__ = "weekly_review"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    chat_id: Mapped[str] = mapped_column(String(100), nullable=False)
+    week_start: Mapped[str] = mapped_column(String(10), nullable=False)  # "2026-03-10" (周一)
+    week_end: Mapped[str] = mapped_column(String(10), nullable=False)  # "2026-03-16" (周日)
+    content: Mapped[str] = mapped_column(Text, nullable=False)
+    model: Mapped[str | None] = mapped_column(String(100), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now()
+    )
+
+    __table_args__ = (UniqueConstraint("chat_id", "week_start"),)
+
+
 class PersonImpression(Base):
     """赤尾对群友的人物印象"""
 

--- a/apps/agent-service/app/services/memory_context.py
+++ b/apps/agent-service/app/services/memory_context.py
@@ -9,6 +9,7 @@ from datetime import date
 
 from app.orm.crud import (
     get_impressions_for_users,
+    get_latest_weekly_review,
     get_recent_diaries,
     get_user_knowledge,
     get_username,
@@ -17,8 +18,8 @@ from app.orm.models import UserKnowledge
 
 logger = logging.getLogger(__name__)
 
-# 日记注入硬上限：约 2 篇日记
-MAX_DIARY_CHARS = 1500
+# 日记+周记注入硬上限
+MAX_DIARY_CHARS = 2000
 
 
 MAX_IMPRESSION_USERS = 10
@@ -39,17 +40,27 @@ async def build_impression_context(chat_id: str, user_ids: list[str]) -> str:
 
 
 async def build_diary_context(chat_id: str) -> str:
-    """构建日记记忆文本，注入群聊 system prompt
+    """构建日记+周记记忆文本，注入群聊 system prompt
 
-    查 today 之前最近 2 篇日记，时间正序拼接。
+    - 最近 2 篇日记（鲜明记忆）
+    - 最近 1 篇周记（褪色记忆）
     """
     today = date.today().isoformat()
+
+    # 最近 2 篇日记
     diaries = await get_recent_diaries(chat_id, today, limit=2)
     if not diaries:
         return ""
     parts = []
     for diary in reversed(diaries):  # DB 返回 desc，reversed 变正序（旧→新）
         parts.append(f"--- {diary.diary_date} ---\n{diary.content}")
+
+    # 最近 1 篇周记
+    weekly = await get_latest_weekly_review(chat_id, today, limit=1)
+    if weekly:
+        w = weekly[0]
+        parts.append(f"--- 上周回顾 ({w.week_start} ~ {w.week_end}) ---\n{w.content}")
+
     text = "\n\n".join(parts)
     if len(text) > MAX_DIARY_CHARS:
         text = text[:MAX_DIARY_CHARS] + "……"

--- a/apps/agent-service/app/utils/content_parser.py
+++ b/apps/agent-service/app/utils/content_parser.py
@@ -59,6 +59,8 @@ class ParsedContent:
                 if image_fn:
                     parts.append(image_fn(img_idx, value))
                     img_idx += 1
+                else:
+                    parts.append("[图片]")
             elif item_type == "sticker":
                 parts.append("[表情包]")
             elif item_type == "media":

--- a/apps/agent-service/app/workers/diary_worker.py
+++ b/apps/agent-service/app/workers/diary_worker.py
@@ -8,6 +8,7 @@
 
 import json
 import logging
+from collections import defaultdict
 from datetime import date, datetime, timedelta, timezone
 
 from app.agents.infra.langfuse_client import get_prompt
@@ -17,10 +18,12 @@ from app.orm.crud import (
     get_active_diary_chat_ids,
     get_all_impressions_for_chat,
     get_chat_messages_in_range,
+    get_diaries_in_range,
     get_recent_diaries,
     get_username,
     upsert_diary_entry,
     upsert_person_impression,
+    upsert_weekly_review,
 )
 from app.utils.content_parser import parse_content
 
@@ -149,29 +152,85 @@ async def generate_diary_for_chat(chat_id: str, target_date: date) -> str | None
 
 
 def _format_messages_timeline(messages: list, user_names: dict[str, str]) -> str:
-    """将消息列表格式化为时间线文本
+    """将消息列表格式化为树状时间线
 
-    格式: [14:32] 群友A: 今天吃什么
-    跳过纯图片/表情包/空内容
+    利用 reply_message_id 构建回复链，用 tree 风格连接符展示层级关系：
+
+    [14:30] 群友A: 今天吃什么
+    ├─ [14:33] 群友B: 火锅吧
+    │  └─ [14:35] 群友C: 好主意
+    └─ [14:36] 群友D: 我也想吃
+    [14:32] 群友E: 那个停车事件看了吗
+    └─ [14:34] 群友F: 看了 太离谱了
     """
-    lines: list[str] = []
+    MAX_DEPTH = 3
+
+    # 1. 过滤并格式化每条消息
+    formatted: dict[str, str] = {}  # msg_id → formatted line
+    msg_order: list[str] = []  # 按时间顺序的 msg_id 列表
     for msg in messages:
-        # 渲染内容（跳过图片）
         rendered = parse_content(msg.content).render()
         if not rendered or not rendered.strip():
             continue
-
-        # 时间戳 → CST 时间
         msg_time = datetime.fromtimestamp(msg.create_time / 1000, tz=CST)
         time_str = msg_time.strftime("%H:%M")
+        speaker = (
+            "赤尾"
+            if msg.role == "assistant"
+            else user_names.get(msg.user_id, msg.user_id[:8])
+        )
+        formatted[msg.message_id] = f"[{time_str}] {speaker}: {rendered}"
+        msg_order.append(msg.message_id)
 
-        # 发言者名称
-        if msg.role == "assistant":
-            speaker = "赤尾"
+    # 2. 构建树：记录每个节点的深度，超过 MAX_DEPTH 的回退为根节点
+    children: dict[str, list[str]] = defaultdict(list)
+    roots: list[str] = []
+    depth_of: dict[str, int] = {}
+
+    for msg in messages:
+        if msg.message_id not in formatted:
+            continue
+        parent = msg.reply_message_id
+        if parent and parent in formatted:
+            parent_depth = depth_of.get(parent, 0)
+            child_depth = parent_depth + 1
+            if child_depth > MAX_DEPTH:
+                roots.append(msg.message_id)
+                depth_of[msg.message_id] = 0
+            else:
+                children[parent].append(msg.message_id)
+                depth_of[msg.message_id] = child_depth
         else:
-            speaker = user_names.get(msg.user_id, msg.user_id[:8])
+            roots.append(msg.message_id)
+            depth_of[msg.message_id] = 0
 
-        lines.append(f"[{time_str}] {speaker}: {rendered}")
+    # 3. 树状渲染
+    lines: list[str] = []
+    rendered_set: set[str] = set()
+
+    def render_node(msg_id: str, prefix: str, is_last: bool, is_root: bool):
+        if msg_id in rendered_set:
+            return
+        rendered_set.add(msg_id)
+        if is_root:
+            lines.append(formatted[msg_id])
+            child_prefix = ""
+        else:
+            connector = "└─ " if is_last else "├─ "
+            lines.append(f"{prefix}{connector}{formatted[msg_id]}")
+            child_prefix = prefix + ("   " if is_last else "│  ")
+
+        child_ids = children.get(msg_id, [])
+        for i, child_id in enumerate(child_ids):
+            render_node(child_id, child_prefix, i == len(child_ids) - 1, False)
+
+    for root_id in roots:
+        render_node(root_id, "", False, True)
+
+    # 4. 兜底：处理未被渲染的消息（循环引用等边界情况）
+    for msg_id in msg_order:
+        if msg_id not in rendered_set and msg_id in formatted:
+            lines.append(formatted[msg_id])
 
     return "\n".join(lines)
 
@@ -273,3 +332,105 @@ async def post_process_impressions(
             count += 1
 
     logger.info(f"Impressions updated for {chat_id}: {count} people")
+
+
+# ==================== 周记生成 ====================
+
+
+async def cron_generate_weekly_reviews(ctx) -> None:
+    """cron 入口：每周一为活跃群生成上周的周记"""
+    chat_ids = await get_active_diary_chat_ids(min_replies=5, days=7)
+    if not chat_ids:
+        logger.info("No active chats for weekly review, skip")
+        return
+    logger.info(f"Weekly review chats: {len(chat_ids)}")
+
+    for chat_id in chat_ids:
+        try:
+            await generate_weekly_review_for_chat(chat_id)
+        except Exception as e:
+            logger.error(f"Weekly review failed for {chat_id}: {e}")
+
+
+async def generate_weekly_review_for_chat(
+    chat_id: str, target_monday: date | None = None
+) -> str | None:
+    """为指定群生成周记
+
+    Args:
+        chat_id: 群 ID
+        target_monday: 目标周的周一日期，默认为上周一
+
+    Returns:
+        生成的周记内容，无日记时返回 None
+    """
+    # 1. 计算上周日期范围
+    if target_monday is None:
+        today = date.today()
+        # 上周一 = 本周一 - 7天
+        target_monday = today - timedelta(days=today.weekday() + 7)
+    week_start = target_monday.isoformat()
+    week_end = (target_monday + timedelta(days=6)).isoformat()  # 周日
+
+    # 2. 查上周的日记
+    diaries = await get_diaries_in_range(chat_id, week_start, week_end)
+    if not diaries:
+        logger.info(f"No diaries for {chat_id} in {week_start}~{week_end}, skip")
+        return None
+
+    diaries_text = "\n\n".join(
+        f"--- {d.diary_date} ({_WEEKDAY_CN[date.fromisoformat(d.diary_date).weekday()]}) ---\n{d.content}"
+        for d in diaries
+    )
+
+    # 3. 查当前人物印象（作为参考上下文）
+    impressions = await get_all_impressions_for_chat(chat_id)
+    if impressions:
+        # 需要 user_id → name 映射
+        impressions_text = []
+        for imp in impressions:
+            name = await get_username(imp.user_id) or imp.user_id[:8]
+            impressions_text.append(f"- {name}: {imp.impression_text}")
+        impressions_context = "\n".join(impressions_text)
+    else:
+        impressions_context = "（暂无）"
+
+    # 4. 获取 Langfuse prompt 并编译
+    prompt_template = get_prompt("weekly_review_generation")
+    compiled_prompt = prompt_template.compile(
+        week_start=week_start,
+        week_end=week_end,
+        diaries=diaries_text,
+        impressions=impressions_context,
+    )
+
+    # 5. 调用 LLM
+    model = await ModelBuilder.build_chat_model(settings.diary_model)
+    response = await model.ainvoke(
+        [{"role": "user", "content": compiled_prompt}],
+    )
+
+    content = response.content
+    if isinstance(content, list):
+        content = "".join(
+            part.get("text", "") if isinstance(part, dict) else str(part)
+            for part in content
+        )
+    if not content:
+        logger.warning(f"LLM returned empty weekly review for {chat_id}")
+        return None
+
+    # 6. 写入数据库
+    await upsert_weekly_review(
+        chat_id=chat_id,
+        week_start=week_start,
+        week_end=week_end,
+        content=content,
+        model=settings.diary_model,
+    )
+
+    logger.info(
+        f"Weekly review generated for {chat_id} ({week_start}~{week_end}): "
+        f"{len(diaries)} diaries, {len(content)} chars"
+    )
+    return content

--- a/apps/agent-service/app/workers/unified_worker.py
+++ b/apps/agent-service/app/workers/unified_worker.py
@@ -14,7 +14,7 @@ from inner_shared.logger import setup_logging
 
 from app.config.config import settings
 from app.long_tasks.executor import poll_and_execute_tasks
-from app.workers.diary_worker import cron_generate_diaries
+from app.workers.diary_worker import cron_generate_diaries, cron_generate_weekly_reviews
 from app.workers.memory_worker import cron_consolidate_profiles
 from app.workers.vectorize_worker import cron_scan_pending_messages
 
@@ -67,4 +67,6 @@ class UnifiedWorkerSettings:
         ),
         # 4. 日记生成：每天 CST 03:00
         cron(cron_generate_diaries, hour={3}, minute={0}),
+        # 5. 周记生成：每周一 CST 04:00（日记 cron 之后 1 小时）
+        cron(cron_generate_weekly_reviews, weekday={0}, hour={4}, minute={0}),
     ]

--- a/apps/api-gateway/config/routes.yaml
+++ b/apps/api-gateway/config/routes.yaml
@@ -16,12 +16,6 @@ routes:
     service: lark-proxy
     port: 3003
 
-  # Agent Service（日记/周记调试等）
-  - prefix: /api/agent/
-    service: agent-service
-    port: 8000
-    strip_prefix: /api/agent
-
   # 监控面板 API（JWT 认证）
   - prefix: /dashboard/api/
     service: monitor-dashboard

--- a/apps/api-gateway/config/routes.yaml
+++ b/apps/api-gateway/config/routes.yaml
@@ -16,6 +16,12 @@ routes:
     service: lark-proxy
     port: 3003
 
+  # Agent Service（日记/周记调试等）
+  - prefix: /api/agent/
+    service: agent-service
+    port: 8000
+    strip_prefix: /api/agent
+
   # 监控面板 API（JWT 认证）
   - prefix: /dashboard/api/
     service: monitor-dashboard


### PR DESCRIPTION
## Summary
- 图片占位符 `[图片]`：content_parser 无 image_fn 时不再丢弃图片消息，避免 LLM 脑补
- 树状 timeline：利用 reply_message_id 构建回复链（├─/└─/│），减少张冠李戴
- 周记系统：WeeklyReview 模型 + CRUD，每周一 CST 04:00 自动生成，注入 system prompt
- Admin 端点：`/admin/trigger-diary` 和 `/admin/trigger-weekly-review` 用于手动调试
- Langfuse prompt：diary_generation v2（防图片幻觉+防编造）、weekly_review_generation v1

## Test plan
- [x] 语法检查通过
- [x] 部署到 `feat-expand-agent-cap` 泳道
- [x] 通过 admin 端点手动触发周记，生成内容质量正常
- [x] DB 写入验证（weekly_review 表）

🤖 Generated with [Claude Code](https://claude.com/claude-code)