### PR TITLE
feat: allow curl GET in Claude Code permissions

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -115,7 +115,8 @@
       "Bash(mkdir *)",
       "Bash(cp *)",
       "Bash(mv *)",
-      "Bash(rm *)"
+      "Bash(rm *)",
+      "Bash(curl *)"
     ]
   },
   "hooks": {


### PR DESCRIPTION
## Summary
- curl GET 请求加入 allow 列表，免审批
- curl 写操作（POST/PUT/DELETE/PATCH）仍被 ask 规则 + validate-bash.sh hook 双重拦截

🤖 Generated with [Claude Code](https://claude.com/claude-code)