### PR TITLE
refactor: remove temporary /api/v1 route

### DIFF
--- a/apps/paas-engine/internal/adapter/http/router.go
+++ b/apps/paas-engine/internal/adapter/http/router.go
@@ -27,8 +27,7 @@ func NewRouter(
 	})
 	r.Handle("/metrics", promhttp.Handler())
 
-	// 注册 API 路由到指定前缀
-	mountAPI := func(r chi.Router) {
+	r.Route("/api/paas", func(r chi.Router) {
 		r.Use(authMiddleware(apiToken))
 
 		// Logs (通用查询)
@@ -88,10 +87,7 @@ func NewRouter(
 				r.Delete("/", imageRepoH.Delete)
 			})
 		})
-	}
-
-	r.Route("/api/paas", mountAPI)
-	r.Route("/api/v1", mountAPI) // 临时兼容：网关 rewrite 升级后移除
+	})
 
 	return r
 }


### PR DESCRIPTION
## Summary
- 网关已部署完成（不再 rewrite），移除 paas-engine 的临时 `/api/v1` 兼容路由

## Test plan
- [x] `make build && make test` 通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)