### PR TITLE
fix: MQ publish 懒声明泳道队列，解决跨泳道消息丢失

### DIFF
--- a/apps/agent-service/app/agents/domains/main/agent.py
+++ b/apps/agent-service/app/agents/domains/main/agent.py
@@ -353,12 +353,12 @@ async def _publish_post_check(
 ) -> None:
     """发布 post safety check 消息到 RabbitMQ"""
     try:
-        from app.clients.rabbitmq import RK_SAFETY_CHECK, RabbitMQClient
+        from app.clients.rabbitmq import SAFETY_CHECK, RabbitMQClient
         from app.utils.middlewares.trace import get_lane
 
         client = RabbitMQClient.get_instance()
         await client.publish(
-            RK_SAFETY_CHECK,
+            SAFETY_CHECK,
             {
                 "session_id": session_id,
                 "response_text": response_text,

--- a/apps/agent-service/app/clients/rabbitmq.py
+++ b/apps/agent-service/app/clients/rabbitmq.py
@@ -4,7 +4,7 @@ import json
 import logging
 import os
 from collections.abc import Callable, Coroutine
-from typing import Any
+from typing import Any, NamedTuple
 
 import aio_pika
 from aio_pika import DeliveryMode, ExchangeType, Message
@@ -19,17 +19,20 @@ EXCHANGE_NAME = "post_processing"
 DLX_NAME = "post_processing_dlx"
 DLQ_NAME = "dead_letters"
 
-QUEUE_SAFETY_CHECK = "safety_check"
-QUEUE_RECALL = "recall"
-QUEUE_VECTORIZE = "vectorize"
-QUEUE_CHAT_REQUEST = "chat_request"
-QUEUE_CHAT_RESPONSE = "chat_response"
 
-RK_SAFETY_CHECK = "post.safety.check"
-RK_RECALL = "action.recall"
-RK_VECTORIZE = "task.vectorize"
-RK_CHAT_REQUEST = "chat.request"
-RK_CHAT_RESPONSE = "chat.response"
+# Route 当前假设 queue:rk = 1:1，未来如果需要演进为更灵活的结构需另行讨论。
+class Route(NamedTuple):
+    queue: str
+    rk: str
+
+
+CHAT_REQUEST = Route("chat_request", "chat.request")
+CHAT_RESPONSE = Route("chat_response", "chat.response")
+SAFETY_CHECK = Route("safety_check", "post.safety.check")
+RECALL = Route("recall", "action.recall")
+VECTORIZE = Route("vectorize", "task.vectorize")
+
+ALL_ROUTES = [CHAT_REQUEST, CHAT_RESPONSE, SAFETY_CHECK, RECALL, VECTORIZE]
 
 # 非 prod 队列空闲自动删除（24h）
 _NON_PROD_EXPIRES_MS = 86_400_000
@@ -60,6 +63,21 @@ def _lane_rk(base: str, lane: str | None) -> str:
     """返回泳道 routing key：base 或 base.{lane}"""
     return f"{base}.{lane}" if lane else base
 
+def _build_queue_args(prod_rk: str, lane: str | None) -> dict[str, Any]:
+    """构建队列参数：prod 队列用 DLX → DLQ；lane 队列用 TTL → 主 exchange fallback 到 prod"""
+    extra: dict[str, Any] = {}
+    if lane:
+        extra["x-expires"] = _NON_PROD_EXPIRES_MS
+    if not lane:
+        return {"x-dead-letter-exchange": DLX_NAME, **extra}
+    return {
+        "x-message-ttl": _LANE_FALLBACK_TTL_MS,
+        "x-dead-letter-exchange": EXCHANGE_NAME,
+        "x-dead-letter-routing-key": prod_rk,
+        **extra,
+    }
+
+
 MessageHandler = Callable[[AbstractIncomingMessage], Coroutine[Any, Any, None]]
 
 
@@ -72,6 +90,7 @@ class RabbitMQClient:
         self._connection: aio_pika.abc.AbstractRobustConnection | None = None
         self._channel: aio_pika.abc.AbstractRobustChannel | None = None
         self._exchange: aio_pika.abc.AbstractExchange | None = None
+        self._declared_lane_queues: set[str] = set()
 
     @classmethod
     def get_instance(cls) -> "RabbitMQClient":
@@ -88,6 +107,7 @@ class RabbitMQClient:
         self._connection = await aio_pika.connect_robust(url)
         self._channel = await self._connection.channel()
         await self._channel.set_qos(prefetch_count=10)
+        self._declared_lane_queues = set()
         logger.info("RabbitMQ connected: %s", url.split("@")[-1])
 
     async def declare_topology(self) -> None:
@@ -111,71 +131,36 @@ class RabbitMQClient:
             arguments={"x-delayed-type": "topic"},
         )
 
-        # 队列参数：prod 队列用 DLX → DLQ；lane 队列用 TTL → 主 exchange fallback 到 prod
-        def queue_args(prod_rk: str) -> dict[str, Any]:
-            extra: dict[str, Any] = {}
-            if lane:
-                extra["x-expires"] = _NON_PROD_EXPIRES_MS
-            if not lane:
-                return {"x-dead-letter-exchange": DLX_NAME, **extra}
-            return {
-                "x-message-ttl": _LANE_FALLBACK_TTL_MS,
-                "x-dead-letter-exchange": EXCHANGE_NAME,
-                "x-dead-letter-routing-key": prod_rk,
-                **extra,
-            }
-
-        # safety_check queue
-        q_safety = await self._channel.declare_queue(
-            _lane_queue(QUEUE_SAFETY_CHECK, lane),
-            durable=True,
-            arguments=queue_args(RK_SAFETY_CHECK),
-        )
-        await q_safety.bind(self._exchange, routing_key=_lane_rk(RK_SAFETY_CHECK, lane))
-
-        # recall queue
-        q_recall = await self._channel.declare_queue(
-            _lane_queue(QUEUE_RECALL, lane),
-            durable=True,
-            arguments=queue_args(RK_RECALL),
-        )
-        await q_recall.bind(self._exchange, routing_key=_lane_rk(RK_RECALL, lane))
-
-        # vectorize queue
-        q_vectorize = await self._channel.declare_queue(
-            _lane_queue(QUEUE_VECTORIZE, lane),
-            durable=True,
-            arguments=queue_args(RK_VECTORIZE),
-        )
-        await q_vectorize.bind(
-            self._exchange, routing_key=_lane_rk(RK_VECTORIZE, lane)
-        )
-
-        # chat_request queue
-        q_chat_req = await self._channel.declare_queue(
-            _lane_queue(QUEUE_CHAT_REQUEST, lane),
-            durable=True,
-            arguments=queue_args(RK_CHAT_REQUEST),
-        )
-        await q_chat_req.bind(
-            self._exchange, routing_key=_lane_rk(RK_CHAT_REQUEST, lane)
-        )
-
-        # chat_response queue
-        q_chat_resp = await self._channel.declare_queue(
-            _lane_queue(QUEUE_CHAT_RESPONSE, lane),
-            durable=True,
-            arguments=queue_args(RK_CHAT_RESPONSE),
-        )
-        await q_chat_resp.bind(
-            self._exchange, routing_key=_lane_rk(RK_CHAT_RESPONSE, lane)
-        )
+        for route in ALL_ROUTES:
+            q = await self._channel.declare_queue(
+                _lane_queue(route.queue, lane),
+                durable=True,
+                arguments=_build_queue_args(route.rk, lane),
+            )
+            await q.bind(
+                self._exchange, routing_key=_lane_rk(route.rk, lane)
+            )
 
         logger.info("RabbitMQ topology declared (lane=%s)", lane or "prod")
 
+    async def _ensure_lane_queue(self, route: Route, lane: str) -> None:
+        """懒声明泳道队列：publish 时若目标泳道队列尚未声明，则自动创建并绑定"""
+        cache_key = f"{route.queue}_{lane}"
+        if cache_key in self._declared_lane_queues:
+            return
+        assert self._channel is not None, "must call connect() first"
+        q = await self._channel.declare_queue(
+            _lane_queue(route.queue, lane),
+            durable=True,
+            arguments=_build_queue_args(route.rk, lane),
+        )
+        await q.bind(self._exchange, routing_key=_lane_rk(route.rk, lane))
+        self._declared_lane_queues.add(cache_key)
+        logger.info("Lazy-declared lane queue: %s_%s", route.queue, lane)
+
     async def publish(
         self,
-        routing_key: str,
+        route: Route,
         body: dict,
         delay_ms: int | None = None,
         headers: dict | None = None,
@@ -190,7 +175,10 @@ class RabbitMQClient:
         if lane == "prod":
             lane = None
 
-        actual_rk = _lane_rk(routing_key, lane)
+        if lane:
+            await self._ensure_lane_queue(route, lane)
+
+        actual_rk = _lane_rk(route.rk, lane)
 
         msg_headers: dict[str, Any] = headers or {}
         if delay_ms is not None:

--- a/apps/agent-service/app/workers/chat_consumer.py
+++ b/apps/agent-service/app/workers/chat_consumer.py
@@ -12,8 +12,8 @@ from aio_pika.abc import AbstractIncomingMessage
 
 from app.agents import stream_chat
 from app.clients.rabbitmq import (
-    QUEUE_CHAT_REQUEST,
-    RK_CHAT_RESPONSE,
+    CHAT_REQUEST,
+    CHAT_RESPONSE,
     RabbitMQClient,
     _current_lane,
     _lane_queue,
@@ -83,7 +83,7 @@ async def handle_chat_request(message: AbstractIncomingMessage) -> None:
                     part = pending[:idx].strip()
                     if part:
                         await client.publish(
-                            RK_CHAT_RESPONSE,
+                            CHAT_RESPONSE,
                             {
                                 **base_response,
                                 "content": part,
@@ -108,7 +108,7 @@ async def handle_chat_request(message: AbstractIncomingMessage) -> None:
 
             if remaining or messages_sent == 0:
                 await client.publish(
-                    RK_CHAT_RESPONSE,
+                    CHAT_RESPONSE,
                     {
                         **base_response,
                         "content": remaining or full_content,
@@ -122,7 +122,7 @@ async def handle_chat_request(message: AbstractIncomingMessage) -> None:
             else:
                 # split marker 后没有内容，仍需通知 worker 结束
                 await client.publish(
-                    RK_CHAT_RESPONSE,
+                    CHAT_RESPONSE,
                     {
                         **base_response,
                         "content": "",
@@ -148,7 +148,7 @@ async def handle_chat_request(message: AbstractIncomingMessage) -> None:
                 traceback.format_exc(),
             )
             await client.publish(
-                RK_CHAT_RESPONSE,
+                CHAT_RESPONSE,
                 {
                     **base_response,
                     "content": "",
@@ -165,6 +165,6 @@ async def start_chat_consumer() -> None:
     await client.connect()
     await client.declare_topology()
     lane = _current_lane()
-    queue = _lane_queue(QUEUE_CHAT_REQUEST, lane)
+    queue = _lane_queue(CHAT_REQUEST.queue, lane)
     await client.consume(queue, handle_chat_request)
     logger.info("Chat request consumer started (queue=%s)", queue)

--- a/apps/agent-service/app/workers/post_consumer.py
+++ b/apps/agent-service/app/workers/post_consumer.py
@@ -14,8 +14,8 @@ from sqlalchemy import text
 
 from app.agents.graphs.post import run_post_safety
 from app.clients.rabbitmq import (
-    QUEUE_SAFETY_CHECK,
-    RK_RECALL,
+    RECALL,
+    SAFETY_CHECK,
     RabbitMQClient,
     _current_lane,
     _lane_queue,
@@ -77,7 +77,7 @@ async def handle_safety_check(message: AbstractIncomingMessage) -> None:
             )
             client = RabbitMQClient.get_instance()
             await client.publish(
-                RK_RECALL,
+                RECALL,
                 {
                     "session_id": session_id,
                     "chat_id": chat_id,
@@ -103,6 +103,6 @@ async def start_post_consumer() -> None:
     await client.connect()
     await client.declare_topology()
     lane = _current_lane()
-    queue = _lane_queue(QUEUE_SAFETY_CHECK, lane)
+    queue = _lane_queue(SAFETY_CHECK.queue, lane)
     await client.consume(queue, handle_safety_check)
     logger.info("Post safety consumer started (queue=%s)", queue)

--- a/apps/agent-service/app/workers/vectorize_worker.py
+++ b/apps/agent-service/app/workers/vectorize_worker.py
@@ -20,8 +20,7 @@ from sqlalchemy.future import select
 from app.agents import InstructionBuilder, create_client
 from app.clients.image_client import image_client
 from app.clients.rabbitmq import (
-    QUEUE_VECTORIZE,
-    RK_VECTORIZE,
+    VECTORIZE,
     RabbitMQClient,
     _current_lane,
     _lane_queue,
@@ -282,7 +281,7 @@ async def start_vectorize_consumer() -> None:
     await client.connect()
     await client.declare_topology()
     lane = _current_lane()
-    queue = _lane_queue(QUEUE_VECTORIZE, lane)
+    queue = _lane_queue(VECTORIZE.queue, lane)
     await client.consume(queue, handle_vectorize)
     logger.info("Vectorize consumer started (queue=%s)", queue)
 
@@ -332,7 +331,7 @@ async def scan_pending_messages() -> int:
 
         # 推送到 RabbitMQ
         for message_id in message_ids:
-            await client.publish(RK_VECTORIZE, {"message_id": message_id})
+            await client.publish(VECTORIZE, {"message_id": message_id})
             total_pushed += 1
 
         logger.info(f"已推送 {len(message_ids)} 条 pending 消息到队列")

--- a/apps/lark-server/src/core/services/ai/reply.ts
+++ b/apps/lark-server/src/core/services/ai/reply.ts
@@ -3,7 +3,7 @@ import { context } from '@middleware/context';
 import { v4 as uuidv4 } from 'uuid';
 import { AgentResponseRepository } from '@repositories/repositories';
 import { AgentResponse } from '@entities/agent-response';
-import { rabbitmqClient, RK_CHAT_REQUEST, getLane } from '@integrations/rabbitmq';
+import { rabbitmqClient, CHAT_REQUEST, getLane } from '@integrations/rabbitmq';
 
 /**
  * 队列模式回复：发布 chat.request 到 RabbitMQ，立即返回。
@@ -29,7 +29,7 @@ export async function makeTextReply(message: Message): Promise<void> {
     // 发布到 chat.request 队列
     const lane = context.getLane() || getLane() || undefined;
     await rabbitmqClient.publish(
-        RK_CHAT_REQUEST,
+        CHAT_REQUEST,
         {
             session_id: sessionId,
             message_id: message.messageId,

--- a/apps/lark-server/src/infrastructure/integrations/memory.ts
+++ b/apps/lark-server/src/infrastructure/integrations/memory.ts
@@ -1,7 +1,7 @@
 import { ChatMessage } from 'types/chat';
 import { ConversationMessageRepository } from 'infrastructure/dal/repositories/repositories';
 import { context } from '@middleware/context';
-import { rabbitmqClient, RK_VECTORIZE } from '@integrations/rabbitmq';
+import { rabbitmqClient, VECTORIZE } from '@integrations/rabbitmq';
 
 /**
  * 判断消息内容是否为空
@@ -48,7 +48,7 @@ export async function storeMessage(message: ChatMessage): Promise<void> {
         if (!isEmpty) {
             const lane = context.getLane() || undefined;
             await rabbitmqClient.publish(
-                RK_VECTORIZE,
+                VECTORIZE,
                 { message_id: message.message_id, lane: lane },
                 undefined,
                 undefined,

--- a/apps/lark-server/src/infrastructure/integrations/rabbitmq.ts
+++ b/apps/lark-server/src/infrastructure/integrations/rabbitmq.ts
@@ -4,14 +4,19 @@ const EXCHANGE_NAME = 'post_processing';
 const DLX_NAME = 'post_processing_dlx';
 const DLQ_NAME = 'dead_letters';
 
-export const QUEUE_RECALL = 'recall';
-export const QUEUE_VECTORIZE = 'vectorize';
-export const QUEUE_CHAT_REQUEST = 'chat_request';
-export const QUEUE_CHAT_RESPONSE = 'chat_response';
-export const RK_RECALL = 'action.recall';
-export const RK_VECTORIZE = 'task.vectorize';
-export const RK_CHAT_REQUEST = 'chat.request';
-export const RK_CHAT_RESPONSE = 'chat.response';
+// Route 当前假设 queue:rk = 1:1，未来如果需要演进为更灵活的结构需另行讨论。
+export interface Route {
+    readonly queue: string;
+    readonly rk: string;
+}
+
+export const CHAT_REQUEST: Route = { queue: 'chat_request', rk: 'chat.request' };
+export const CHAT_RESPONSE: Route = { queue: 'chat_response', rk: 'chat.response' };
+export const SAFETY_CHECK: Route = { queue: 'safety_check', rk: 'post.safety.check' };
+export const RECALL: Route = { queue: 'recall', rk: 'action.recall' };
+export const VECTORIZE: Route = { queue: 'vectorize', rk: 'task.vectorize' };
+
+const ALL_ROUTES: Route[] = [CHAT_REQUEST, CHAT_RESPONSE, SAFETY_CHECK, RECALL, VECTORIZE];
 
 const NON_PROD_EXPIRES_MS = 86_400_000;
 const LANE_FALLBACK_TTL_MS = 10_000;
@@ -35,12 +40,28 @@ export function laneRK(base: string, lane?: string): string {
     return lane ? `${base}.${lane}` : base;
 }
 
+function buildQueueArgs(prodRK: string, lane?: string): Record<string, unknown> {
+    const extra: Record<string, unknown> = lane
+        ? { 'x-expires': NON_PROD_EXPIRES_MS }
+        : {};
+    if (!lane) {
+        return { 'x-dead-letter-exchange': DLX_NAME, ...extra };
+    }
+    return {
+        'x-message-ttl': LANE_FALLBACK_TTL_MS,
+        'x-dead-letter-exchange': EXCHANGE_NAME,
+        'x-dead-letter-routing-key': prodRK,
+        ...extra,
+    };
+}
+
 class RabbitMQClient {
     private static instance: RabbitMQClient;
     private conn: ChannelModel | null = null;
     private channel: Channel | null = null;
     private reconnecting = false;
     private consumers: Array<{ queue: string; handler: MessageHandler }> = [];
+    private declaredLaneQueues = new Set<string>();
 
     private constructor() {}
 
@@ -91,47 +112,28 @@ class RabbitMQClient {
             arguments: { 'x-delayed-type': 'topic' },
         });
 
-        // 队列参数：prod 队列用 DLX → DLQ；lane 队列用 TTL → 主 exchange fallback 到 prod
-        function queueArgs(prodRK: string): Record<string, unknown> {
-            const extra: Record<string, unknown> = lane
-                ? { 'x-expires': NON_PROD_EXPIRES_MS }
-                : {};
-            if (!lane) {
-                return { 'x-dead-letter-exchange': DLX_NAME, ...extra };
-            }
-            return {
-                'x-message-ttl': LANE_FALLBACK_TTL_MS,
-                'x-dead-letter-exchange': EXCHANGE_NAME,
-                'x-dead-letter-routing-key': prodRK,
-                ...extra,
-            };
+        for (const route of ALL_ROUTES) {
+            const qName = laneQueue(route.queue, lane);
+            await ch.assertQueue(qName, { durable: true, arguments: buildQueueArgs(route.rk, lane) });
+            await ch.bindQueue(qName, EXCHANGE_NAME, laneRK(route.rk, lane));
         }
-
-        // recall queue
-        const recallQ = laneQueue(QUEUE_RECALL, lane);
-        await ch.assertQueue(recallQ, { durable: true, arguments: queueArgs(RK_RECALL) });
-        await ch.bindQueue(recallQ, EXCHANGE_NAME, laneRK(RK_RECALL, lane));
-
-        // vectorize queue
-        const vectorizeQ = laneQueue(QUEUE_VECTORIZE, lane);
-        await ch.assertQueue(vectorizeQ, { durable: true, arguments: queueArgs(RK_VECTORIZE) });
-        await ch.bindQueue(vectorizeQ, EXCHANGE_NAME, laneRK(RK_VECTORIZE, lane));
-
-        // chat_request queue
-        const chatReqQ = laneQueue(QUEUE_CHAT_REQUEST, lane);
-        await ch.assertQueue(chatReqQ, { durable: true, arguments: queueArgs(RK_CHAT_REQUEST) });
-        await ch.bindQueue(chatReqQ, EXCHANGE_NAME, laneRK(RK_CHAT_REQUEST, lane));
-
-        // chat_response queue
-        const chatRespQ = laneQueue(QUEUE_CHAT_RESPONSE, lane);
-        await ch.assertQueue(chatRespQ, { durable: true, arguments: queueArgs(RK_CHAT_RESPONSE) });
-        await ch.bindQueue(chatRespQ, EXCHANGE_NAME, laneRK(RK_CHAT_RESPONSE, lane));
 
         console.info(`[RabbitMQ] topology declared (lane=${lane || 'prod'})`);
     }
 
+    private async ensureLaneQueue(route: Route, lane: string): Promise<void> {
+        const cacheKey = `${route.queue}_${lane}`;
+        if (this.declaredLaneQueues.has(cacheKey)) return;
+        const ch = this.getChannel();
+        const qName = laneQueue(route.queue, lane);
+        await ch.assertQueue(qName, { durable: true, arguments: buildQueueArgs(route.rk, lane) });
+        await ch.bindQueue(qName, EXCHANGE_NAME, laneRK(route.rk, lane));
+        this.declaredLaneQueues.add(cacheKey);
+        console.info(`[RabbitMQ] Lazy-declared lane queue: ${route.queue}_${lane}`);
+    }
+
     async publish(
-        routingKey: string,
+        route: Route,
         body: Record<string, unknown>,
         delayMs?: number,
         headers?: Record<string, unknown>,
@@ -142,7 +144,12 @@ class RabbitMQClient {
         // 默认取当前泳道；传入 lane 则使用传入值
         const effectiveLane =
             lane !== undefined ? (lane === 'prod' ? undefined : lane) : getLane();
-        const actualRK = laneRK(routingKey, effectiveLane);
+
+        if (effectiveLane) {
+            await this.ensureLaneQueue(route, effectiveLane);
+        }
+
+        const actualRK = laneRK(route.rk, effectiveLane);
 
         const msgHeaders: Record<string, unknown> = { ...headers };
         if (delayMs !== undefined) {
@@ -215,6 +222,7 @@ class RabbitMQClient {
     private scheduleReconnect(): void {
         if (this.reconnecting) return;
         this.reconnecting = true;
+        this.declaredLaneQueues.clear();
         setTimeout(async () => {
             this.reconnecting = false;
             try {

--- a/apps/lark-server/src/workers/chat-response-worker.ts
+++ b/apps/lark-server/src/workers/chat-response-worker.ts
@@ -20,7 +20,7 @@ import AppDataSource from 'ormconfig';
 import { AgentResponse } from '@entities/agent-response';
 import {
     rabbitmqClient,
-    QUEUE_CHAT_RESPONSE,
+    CHAT_RESPONSE,
     getLane,
     laneQueue,
 } from '@integrations/rabbitmq';
@@ -215,7 +215,7 @@ async function main(): Promise<void> {
 
     // 4. 开始消费
     const lane = getLane();
-    const queue = laneQueue(QUEUE_CHAT_RESPONSE, lane);
+    const queue = laneQueue(CHAT_RESPONSE.queue, lane);
     await rabbitmqClient.consume(queue, handleChatResponse);
     console.info(
         `[ChatResponseWorker] Consuming queue: ${queue}, waiting for messages...`,

--- a/apps/lark-server/src/workers/recall-worker.ts
+++ b/apps/lark-server/src/workers/recall-worker.ts
@@ -20,8 +20,7 @@ import AppDataSource from 'ormconfig';
 import { AgentResponse } from '@entities/agent-response';
 import {
     rabbitmqClient,
-    RK_RECALL,
-    QUEUE_RECALL,
+    RECALL,
     getLane,
     laneQueue,
 } from '@integrations/rabbitmq';
@@ -62,7 +61,7 @@ async function handleRecall(msg: ConsumeMessage): Promise<void> {
                     `retrying (${retryCount + 1}/${MAX_RETRY}) with delay ${delayMs}ms`,
             );
             await rabbitmqClient.publish(
-                RK_RECALL,
+                RECALL,
                 payload as unknown as Record<string, unknown>,
                 delayMs,
                 { 'x-retry-count': retryCount + 1 },
@@ -145,7 +144,7 @@ async function main(): Promise<void> {
 
     // 4. 开始消费（按泳道）
     const lane = getLane();
-    const queue = laneQueue(QUEUE_RECALL, lane);
+    const queue = laneQueue(RECALL.queue, lane);
     await rabbitmqClient.consume(queue, handleRecall);
     console.info(`[RecallWorker] Consuming queue: ${queue}, waiting for messages...`);
 }


### PR DESCRIPTION
## Summary
- 引入 `Route` 抽象（Python NamedTuple / TS interface），替代散落的 `QUEUE_*` / `RK_*` 常量
- `publish()` 时自动懒声明目标泳道队列（`_ensure_lane_queue`），解决泳道没有部署消费服务时队列不存在、消息被 exchange 丢弃的问题
- `declare_topology()` 用 `ALL_ROUTES` 循环替代重复代码

## Test plan
- [x] 部署 agent-service + lark-server 到 `fix-tool-async-block` 泳道
- [x] 确认日志出现 `Lazy-declared lane queue` 
- [x] 飞书 dev bot 发消息，消息完整流转不丢失

🤖 Generated with [Claude Code](https://claude.com/claude-code)