### PR TITLE
fix(tool-service): async Lark SDK + offload PIL to thread

### DIFF
--- a/apps/tool-service/app/infrastructure/lark_client.py
+++ b/apps/tool-service/app/infrastructure/lark_client.py
@@ -57,7 +57,7 @@ async def download_message_resource(bot_name: str, message_id: str, file_key: st
         .file_key(file_key) \
         .type("image") \
         .build()
-    response = client.im.v1.message_resource.get(request)
+    response = await client.im.v1.message_resource.aget(request)
     if not response.success():
         raise RuntimeError(f"Download resource failed: {response.code} {response.msg}")
     return response.file.read()
@@ -69,7 +69,7 @@ async def download_image(bot_name: str, image_key: str) -> bytes:
     request = GetImageRequest.builder() \
         .image_key(image_key) \
         .build()
-    response = client.im.v1.image.get(request)
+    response = await client.im.v1.image.aget(request)
     if not response.success():
         raise RuntimeError(f"Download image failed: {response.code} {response.msg}")
     return response.file.read()
@@ -86,7 +86,7 @@ async def upload_image(bot_name: str, image_data: bytes) -> str:
             .build()
         ) \
         .build()
-    response = client.im.v1.image.create(request)
+    response = await client.im.v1.image.acreate(request)
     if not response.success():
         raise RuntimeError(f"Upload image failed: {response.code} {response.msg}")
     return response.data.image_key

--- a/apps/tool-service/app/services/image_pipeline.py
+++ b/apps/tool-service/app/services/image_pipeline.py
@@ -1,3 +1,4 @@
+import asyncio
 import base64
 import logging
 
@@ -36,9 +37,10 @@ async def process_image_pipeline(
                 else:
                     image_bytes = await lark_client.download_image(bot_name, file_key)
 
-                # Compress: 1440x1440, JPEG q80
-                compressed, _, _ = process_image(
-                    image_bytes, max_width=1440, max_height=1440, quality=80, format="JPEG"
+                # Compress: 1440x1440, JPEG q80 (CPU-bound, offload to thread)
+                compressed, _, _ = await asyncio.to_thread(
+                    process_image,
+                    image_bytes, max_width=1440, max_height=1440, quality=80, format="JPEG",
                 )
 
                 # Upload to TOS


### PR DESCRIPTION
## Summary
- Lark SDK 调用从同步改为原生 async（`.get()` → `.aget()`，`.create()` → `.acreate()`）
- PIL 图片压缩 offload 到线程池（`asyncio.to_thread`）
- 修复事件循环阻塞导致 agent-service → tool-service 出站错误率 56%

## Test plan
- [x] 部署到 fix-agent-err 泳道，tool-service 收到 image-pipeline 请求均 200
- [x] 飞书 dev bot 端到端测试图片处理成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)