### PR TITLE
fix: 三层防御阻止赤尾编造外部图片URL

### DIFF
--- a/apps/agent-service/app/agents/domains/main/agent.py
+++ b/apps/agent-service/app/agents/domains/main/agent.py
@@ -2,9 +2,11 @@
 
 import asyncio
 import logging
+import re
 import uuid
 from collections.abc import AsyncGenerator
-from langchain.messages import AIMessageChunk, ToolMessage
+
+from langchain.messages import AIMessage, AIMessageChunk, HumanMessage, ToolMessage
 from langfuse import get_client as get_langfuse
 from langfuse import propagate_attributes
 
@@ -29,6 +31,16 @@ GUARD_REJECT_MESSAGE = "你发了一些赤尾不想讨论的话题呢~"
 
 # 分段标记（consumer 侧检测并拆分为多条消息）
 SPLIT_MARKER = "---split---"
+
+# 重试标记（consumer 侧检测并丢弃已累积内容）
+RETRY_MARKER = "---retry---"
+
+# 外部图片 URL 检测（模型可能编造 ![image](https://...) 而非调用 generate_image）
+EXTERNAL_IMAGE_URL_PATTERN = re.compile(r"!\[.*?\]\((https?://[^\)]+)\)")
+CORRECTION_MESSAGE = (
+    "你的回复中包含了外部图片URL链接（![image](https://...)），"
+    "但这不会显示任何图片。请使用 generate_image 工具重新生成图片。"
+)
 
 # 复杂度行为引导
 COMPLEXITY_HINTS = {
@@ -331,6 +343,43 @@ async def _build_and_stream(
 
             elif isinstance(token, ToolMessage):
                 has_text_in_current_turn = False
+
+        # 检测外部图片 URL，注入纠错消息重试一次
+        if EXTERNAL_IMAGE_URL_PATTERN.search(full_content):
+            logger.warning(
+                "检测到外部图片URL，注入纠错消息重试: %s", message_id
+            )
+            yield RETRY_MARKER
+
+            retry_messages = messages + [
+                AIMessage(content=full_content),
+                HumanMessage(content=CORRECTION_MESSAGE),
+            ]
+            full_content = ""
+            async for token in agent.stream(
+                retry_messages,
+                context=AgentContext(
+                    message=MessageContext(
+                        message_id=message_id, chat_id=chat_id
+                    ),
+                    media=MediaContext(image_urls=image_urls or []),
+                    features=FeatureFlags(flags=gray_config or {}),
+                ),
+                prompt_vars=prompt_vars,
+            ):
+                if isinstance(token, AIMessageChunk):
+                    finish_reason = token.response_metadata.get(
+                        "finish_reason"
+                    )
+                    if finish_reason == "content_filter":
+                        yield "小尾有点不想讨论这个话题呢~"
+                        return
+                    if finish_reason == "length":
+                        yield "(后续内容被截断)"
+                        return
+                    if token.text:
+                        full_content += token.text
+                        yield token.text
 
         # Fire-and-forget: publish to post safety check queue
         if full_content and session_id:

--- a/apps/agent-service/app/workers/chat_consumer.py
+++ b/apps/agent-service/app/workers/chat_consumer.py
@@ -23,6 +23,7 @@ from app.utils.middlewares.trace import header_vars
 logger = logging.getLogger(__name__)
 
 SPLIT_MARKER = "---split---"
+RETRY_MARKER = "---retry---"
 MAX_MESSAGES = 4
 
 
@@ -73,6 +74,12 @@ async def handle_chat_request(message: AbstractIncomingMessage) -> None:
 
             async for text in stream_chat(message_id, session_id=session_id):
                 if not text:
+                    continue
+                if text == RETRY_MARKER:
+                    # 外部图片URL检测触发重试，丢弃已累积内容
+                    full_content = ""
+                    sent_length = 0
+                    messages_sent = 0
                     continue
                 full_content += text
 

--- a/apps/lark-server/src/core/services/message/post-content-processor.test.ts
+++ b/apps/lark-server/src/core/services/message/post-content-processor.test.ts
@@ -80,4 +80,36 @@ describe('markdownToPostContent', () => {
             ],
         });
     });
+
+    it('should skip external URL images (https)', () => {
+        const md = 'before ![photo](https://example.com/pic.png) after';
+        const result = markdownToPostContent(md);
+        expect(result).toEqual({
+            content: [
+                [{ tag: 'md', text: 'before' }],
+                [{ tag: 'md', text: 'after' }],
+            ],
+        });
+    });
+
+    it('should skip external URL images (http)', () => {
+        const md = '![image](http://r.jina.ai/some-image.jpg)';
+        const result = markdownToPostContent(md);
+        expect(result).toEqual({
+            content: [[{ tag: 'md', text: '' }]],
+        });
+    });
+
+    it('should keep valid image_key but skip external URLs in mixed content', () => {
+        const md = 'Text ![a](img_v3_abc) middle ![b](https://files.oaiusercontent.com/fake.png) end';
+        const result = markdownToPostContent(md);
+        expect(result).toEqual({
+            content: [
+                [{ tag: 'md', text: 'Text' }],
+                [{ tag: 'img', image_key: 'img_v3_abc' }],
+                [{ tag: 'md', text: 'middle' }],
+                [{ tag: 'md', text: 'end' }],
+            ],
+        });
+    });
 });

--- a/apps/lark-server/src/core/services/message/post-content-processor.ts
+++ b/apps/lark-server/src/core/services/message/post-content-processor.ts
@@ -150,8 +150,14 @@ export function markdownToPostContent(markdown: string): PostContent {
                 content.push([{ tag: 'md', text } as MdPostNode]);
             }
         }
-        content.push([{ tag: 'img', image_key: match[1] } as ImgPostNode]);
         lastIndex = match.index + match[0].length;
+
+        const imageKey = match[1];
+        if (imageKey.startsWith('http://') || imageKey.startsWith('https://')) {
+            // 外部 URL，跳过图片节点（模型编造的链接无法显示）
+            continue;
+        }
+        content.push([{ tag: 'img', image_key: imageKey } as ImgPostNode]);
     }
 
     if (lastIndex < markdown.length) {
@@ -162,7 +168,8 @@ export function markdownToPostContent(markdown: string): PostContent {
     }
 
     if (content.length === 0) {
-        content.push([{ tag: 'md', text: markdown } as MdPostNode]);
+        // lastIndex > 0 说明匹配到了图片但全被跳过（外部 URL），不输出原始 markdown
+        content.push([{ tag: 'md', text: lastIndex > 0 ? '' : markdown } as MdPostNode]);
     }
 
     return { content };


### PR DESCRIPTION
## Summary
- **Layer 2 (agent-service)**: 流结束后检测外部图片URL，命中时注入纠错消息重试一次
- **Layer 3 (lark-server)**: `markdownToPostContent` 兜底过滤外部URL图片节点

Layer 1 (Langfuse prompt v51 staging) 已通过 API 更新，待验证后提升为 production。

## Test plan
- [x] lark-server 单测 11/11 通过（含 3 个新增外部URL用例）
- [x] 测试泳道 `fix-chiwei-link-rul` 部署验证

🤖 Generated with [Claude Code](https://claude.com/claude-code)