### PR TITLE
refactor(paas-engine): ImageRepo git_repo stores user/repo format

### DIFF
--- a/apps/paas-engine/internal/adapter/kubernetes/kaniko.go
+++ b/apps/paas-engine/internal/adapter/kubernetes/kaniko.go
@@ -62,10 +62,7 @@ func (e *KanikoBuildExecutor) Submit(ctx context.Context, sub *port.BuildSubmiss
 	ttl := int32(3600)
 	backoff := int32(0)
 
-	gitContext := sub.GitRepo
-	if strings.HasPrefix(gitContext, "https://") || strings.HasPrefix(gitContext, "http://") {
-		gitContext = "git://" + strings.TrimPrefix(strings.TrimPrefix(gitContext, "https://"), "http://")
-	}
+	gitContext := "git://github.com/" + sub.GitRepo
 	gitRef := sub.GitRef
 	if gitRef != "" && !strings.HasPrefix(gitRef, "refs/") {
 		if isCommitHash(gitRef) {

--- a/apps/paas-engine/internal/domain/validate.go
+++ b/apps/paas-engine/internal/domain/validate.go
@@ -21,13 +21,16 @@ func ValidateK8sName(name string) error {
 // gitRefRegex 白名单：字母、数字、-、_、.、/
 var gitRefRegex = regexp.MustCompile(`^[a-zA-Z0-9._/-]+$`)
 
-// ValidateGitRepo 校验 Git 仓库地址，只允许 https:// 或 git:// 协议，防止 SSRF。
+// gitRepoRegex 匹配 user/repo 格式（如 bezhai/chiwei-platform.git）。
+var gitRepoRegex = regexp.MustCompile(`^[a-zA-Z0-9._-]+/[a-zA-Z0-9._-]+$`)
+
+// ValidateGitRepo 校验 Git 仓库地址，要求 user/repo 格式，由调用方拼装协议前缀。
 func ValidateGitRepo(repo string) error {
 	if repo == "" {
 		return fmt.Errorf("%w: git_repo is required", ErrInvalidInput)
 	}
-	if !strings.HasPrefix(repo, "https://") && !strings.HasPrefix(repo, "git://") {
-		return fmt.Errorf("%w: git_repo must use https:// or git:// protocol", ErrInvalidInput)
+	if !gitRepoRegex.MatchString(repo) {
+		return fmt.Errorf("%w: git_repo must be in user/repo format (e.g. bezhai/chiwei-platform.git)", ErrInvalidInput)
 	}
 	return nil
 }

--- a/apps/paas-engine/internal/service/image_repo_service_test.go
+++ b/apps/paas-engine/internal/service/image_repo_service_test.go
@@ -41,7 +41,7 @@ func TestCreateImageRepo_Success(t *testing.T) {
 	repo, err := svc.CreateImageRepo(context.Background(), CreateImageRepoRequest{
 		Name:       "agent-service",
 		Registry:   "harbor.local/inner-bot/agent-service",
-		GitRepo:    "https://github.com/bezhai/chiwei-platform.git",
+		GitRepo:    "bezhai/chiwei-platform.git",
 		ContextDir: "apps/agent-service",
 	})
 	if err != nil {
@@ -61,7 +61,7 @@ func TestCreateImageRepo_InvalidName(t *testing.T) {
 	_, err := svc.CreateImageRepo(context.Background(), CreateImageRepoRequest{
 		Name:     "INVALID_NAME",
 		Registry: "harbor.local/inner-bot/test",
-		GitRepo:  "https://github.com/example/repo.git",
+		GitRepo:  "example/repo.git",
 	})
 	if !errors.Is(err, domain.ErrInvalidInput) {
 		t.Errorf("expected ErrInvalidInput, got %v", err)
@@ -73,7 +73,7 @@ func TestCreateImageRepo_MissingRegistry(t *testing.T) {
 
 	_, err := svc.CreateImageRepo(context.Background(), CreateImageRepoRequest{
 		Name:    "myrepo",
-		GitRepo: "https://github.com/example/repo.git",
+		GitRepo: "example/repo.git",
 	})
 	if !errors.Is(err, domain.ErrInvalidInput) {
 		t.Errorf("expected ErrInvalidInput, got %v", err)
@@ -86,7 +86,7 @@ func TestCreateImageRepo_InvalidContextDir(t *testing.T) {
 	_, err := svc.CreateImageRepo(context.Background(), CreateImageRepoRequest{
 		Name:       "myrepo",
 		Registry:   "harbor.local/inner-bot/test",
-		GitRepo:    "https://github.com/example/repo.git",
+		GitRepo:    "example/repo.git",
 		ContextDir: "../etc/passwd",
 	})
 	if !errors.Is(err, domain.ErrInvalidInput) {
@@ -111,7 +111,7 @@ func TestUpdateImageRepo_PartialKeepsExisting(t *testing.T) {
 	imageRepoRepo := &stubImageRepoRepo{repo: &domain.ImageRepo{
 		Name:       "myrepo",
 		Registry:   "harbor.local/inner-bot/test",
-		GitRepo:    "https://github.com/example/repo.git",
+		GitRepo:    "example/repo.git",
 		ContextDir: "apps/test",
 		Dockerfile: "Dockerfile.prod",
 		NoCache:    false,
@@ -129,8 +129,8 @@ func TestUpdateImageRepo_PartialKeepsExisting(t *testing.T) {
 	if repo.Registry != "harbor.local/inner-bot/test" {
 		t.Errorf("Registry = %q, want %q", repo.Registry, "harbor.local/inner-bot/test")
 	}
-	if repo.GitRepo != "https://github.com/example/repo.git" {
-		t.Errorf("GitRepo = %q, want %q", repo.GitRepo, "https://github.com/example/repo.git")
+	if repo.GitRepo != "example/repo.git" {
+		t.Errorf("GitRepo = %q, want %q", repo.GitRepo, "example/repo.git")
 	}
 	if repo.ContextDir != "apps/test" {
 		t.Errorf("ContextDir = %q, want %q", repo.ContextDir, "apps/test")


### PR DESCRIPTION
## Summary
- Change `git_repo` field from full URL (`git://github.com/user/repo.git`) to `user/repo` format (`user/repo.git`)
- Kaniko adapter prepends `git://github.com/`, test executor prepends `https://github.com/`
- Eliminates protocol conversion logic between adapters

## Migration
After merging, manually update all ImageRepo records:
```bash
for repo in paas-engine agent-service lark-server lark-proxy tool-service lite-registry api-gateway alert-webhook monitor-dashboard monitor-dashboard-web; do
  curl -X PUT $PAAS_API/api/paas/image-repos/$repo/ \
    -H 'Content-Type: application/json' \
    -H "X-API-Key: $PAAS_TOKEN" \
    -d '{"git_repo":"bezhai/chiwei-platform.git"}'
done
```

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes (including image_repo_service_test.go)
- [x] End-to-end verified on fix-api-usage-errors lane: build + deploy succeeded

🤖 Generated with [Claude Code](https://claude.com/claude-code)