### PR TITLE
feat(paas-engine): CI pipeline with auto-trigger via Git Poller

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: deploy self-deploy release undeploy status latest-build pods ops-query logs lane-bind lane-unbind lane-bindings
+.PHONY: deploy self-deploy release undeploy status latest-build pods ops-query logs lane-bind lane-unbind lane-bindings ci-init ci-status ci-logs ci-cleanup ci-trigger ci-list
 
 # ---------- 参数 ----------
 # APP        — 应用名（必填），对应 apps/<APP> 和 PaaS 注册的应用名
@@ -290,3 +290,87 @@ lane-bindings:
 	@curl -sf $(PAAS_API)/api/lark/lane-bindings \
 	  -H 'X-API-Key: $(PAAS_TOKEN)' $(CURL_LANE) \
 	  | python3 -c "import sys,json; [print(f\"  {r['route_type']:6s} | {r['route_key']:30s} | {r['lane_name']}\") for r in json.load(sys.stdin).get('data', [])]"
+
+# ---------- CI Pipeline ----------
+
+BRANCH   ?= $(shell git rev-parse --abbrev-ref HEAD)
+SERVICES ?=
+
+## 注册 CI 泳道
+## 用法: make ci-init LANE=feat-auth BRANCH=feat/auth-rework SERVICES=agent-service,lark-server
+ci-init:
+	$(if $(LANE),,$(error LANE 未指定))
+	$(if $(BRANCH),,$(error BRANCH 未指定))
+	$(if $(SERVICES),,$(error SERVICES 未指定。用法: make ci-init LANE=<lane> BRANCH=<branch> SERVICES=svc1,svc2))
+	@echo ">>> 注册 CI 泳道: $(LANE) <- $(BRANCH) [$(SERVICES)]"
+	@SVC_JSON=$$(echo '$(SERVICES)' | python3 -c "import sys,json; print(json.dumps(sys.stdin.read().strip().split(',')))") && \
+	curl -sf -X POST $(PAAS_API)/api/paas/ci/register \
+	  -H 'Content-Type: application/json' \
+	  -H 'X-API-Key: $(PAAS_TOKEN)' $(CURL_LANE) \
+	  -d "{\"lane\":\"$(LANE)\",\"branch\":\"$(BRANCH)\",\"services\":$$SVC_JSON}" \
+	  | python3 -c "\
+import sys,json; \
+d=json.load(sys.stdin); \
+err=d.get('error'); \
+exit(print(f'ERROR: {err}') or 1) if err else print(json.dumps(d.get('data',{}), indent=2))"
+
+## 查看最近 pipeline run 状态
+## 用法: make ci-status LANE=feat-auth
+ci-status:
+	$(if $(LANE),,$(error LANE 未指定))
+	@echo ">>> CI 状态: $(LANE)"
+	@curl -sf "$(PAAS_API)/api/paas/ci/$(LANE)/runs?limit=5" \
+	  -H 'X-API-Key: $(PAAS_TOKEN)' $(CURL_LANE) \
+	  | python3 -c "\
+import sys,json; \
+runs=json.load(sys.stdin).get('data',[]); \
+[print(f\"  {r['id'][:8]}  {r['status']:10s}  {r['commit_sha'][:8]}  {r.get('message','')}\") for r in runs] if runs else print('  (无 pipeline 记录)')"
+
+## 查看 pipeline run 详情（含 stages + jobs）
+## 用法: make ci-logs LANE=feat-auth [RUN_ID=xxx]
+ci-logs:
+	$(if $(LANE),,$(error LANE 未指定))
+	@if [ -n "$(RUN_ID)" ]; then \
+		curl -sf "$(PAAS_API)/api/paas/ci/runs/$(RUN_ID)/" \
+			-H 'X-API-Key: $(PAAS_TOKEN)' $(CURL_LANE) \
+			| python3 -m json.tool; \
+	else \
+		RUN_ID=$$(curl -sf "$(PAAS_API)/api/paas/ci/$(LANE)/runs?limit=1" \
+			-H 'X-API-Key: $(PAAS_TOKEN)' $(CURL_LANE) \
+			| python3 -c "import sys,json; runs=json.load(sys.stdin).get('data',[]); print(runs[0]['id'] if runs else '')" 2>/dev/null) && \
+		if [ -z "$$RUN_ID" ]; then echo "  无 pipeline 记录"; exit 0; fi && \
+		curl -sf "$(PAAS_API)/api/paas/ci/runs/$$RUN_ID/" \
+			-H 'X-API-Key: $(PAAS_TOKEN)' $(CURL_LANE) \
+			| python3 -m json.tool; \
+	fi
+
+## 注销 CI 泳道 + 删除泳道 Release
+## 用法: make ci-cleanup LANE=feat-auth
+ci-cleanup:
+	$(if $(LANE),,$(error LANE 未指定))
+	@echo ">>> 清理 CI 泳道: $(LANE)"
+	@curl -sf -X DELETE "$(PAAS_API)/api/paas/ci/$(LANE)/" \
+	  -H 'X-API-Key: $(PAAS_TOKEN)' $(CURL_LANE) \
+	  | python3 -m json.tool
+
+## 手动触发 pipeline（调试用）
+## 用法: make ci-trigger LANE=feat-auth
+ci-trigger:
+	$(if $(LANE),,$(error LANE 未指定))
+	@echo ">>> 手动触发 CI: $(LANE)"
+	@curl -sf -X POST "$(PAAS_API)/api/paas/ci/$(LANE)/trigger" \
+	  -H 'Content-Type: application/json' \
+	  -H 'X-API-Key: $(PAAS_TOKEN)' $(CURL_LANE) \
+	  -d '{}' \
+	  | python3 -m json.tool
+
+## 列出所有 CI 配置
+## 用法: make ci-list
+ci-list:
+	@echo ">>> 活跃 CI 配置"
+	@curl -sf "$(PAAS_API)/api/paas/ci/" \
+	  -H 'X-API-Key: $(PAAS_TOKEN)' $(CURL_LANE) \
+	  | python3 -c "\
+import sys,json; \
+configs=json.load(sys.stdin).get('data',[]); \
+[print(f\"  {c['lane']:20s} | {c['branch']:30s} | {','.join(c.get('services',[]))}\") for c in configs] if configs else print('  (无活跃 CI 配置)')"

--- a/apps/paas-engine/cmd/paas-engine/main.go
+++ b/apps/paas-engine/cmd/paas-engine/main.go
@@ -34,6 +34,8 @@ func main() {
 	imageRepoRepo := repository.NewImageRepoRepo(db)
 	buildRepo := repository.NewBuildRepo(db)
 	releaseRepo := repository.NewReleaseRepo(db)
+	ciConfigRepo := repository.NewCIConfigRepo(db)
+	pipelineRunRepo := repository.NewPipelineRunRepo(db)
 
 	// K8s 客户端（可选，无集群时降级运行）
 	cs, _, k8sErr := kubernetes.NewClientset(cfg.KubeconfigPath)
@@ -43,6 +45,7 @@ func main() {
 
 	var deployer port.Deployer
 	var buildExecutor port.BuildExecutor
+	var testExecutor port.TestExecutor
 
 	if cs != nil {
 		deployer = kubernetes.NewK8sDeployer(cs, cfg.DeployNamespace)
@@ -56,6 +59,12 @@ func main() {
 			HttpProxy:          cfg.BuildHttpProxy,
 			NoProxy:            cfg.BuildNoProxy,
 		})
+		testExecutor = kubernetes.NewK8sTestExecutor(cs, kubernetes.TestExecutorConfig{
+			Namespace: cfg.CINamespace,
+			GitRepo:   cfg.CIGitRepo,
+			HttpProxy: cfg.BuildHttpProxy,
+			NoProxy:   cfg.BuildNoProxy,
+		})
 	}
 
 	// Loki 日志查询
@@ -67,6 +76,7 @@ func main() {
 	buildSvc := service.NewBuildService(imageRepoRepo, buildRepo, buildExecutor, lokiClient)
 	releaseSvc := service.NewReleaseService(appRepo, imageRepoRepo, buildRepo, releaseRepo, deployer)
 	logSvc := service.NewLogService(appRepo, lokiClient, cfg.DeployNamespace)
+	pipelineSvc := service.NewPipelineService(ciConfigRepo, pipelineRunRepo, testExecutor, buildSvc, releaseSvc, appRepo, imageRepoRepo)
 
 	// 启动 Build Informer
 	ctx := context.Background()
@@ -74,6 +84,15 @@ func main() {
 		go func() {
 			if err := buildExecutor.Watch(ctx, buildSvc.OnBuildStatusChange); err != nil {
 				slog.Error("build informer error", "error", err)
+			}
+		}()
+	}
+
+	// 启动 Test Informer
+	if testExecutor != nil {
+		go func() {
+			if err := testExecutor.Watch(ctx, pipelineSvc.OnTestJobStatusChange); err != nil {
+				slog.Error("test informer error", "error", err)
 			}
 		}()
 	}
@@ -96,6 +115,7 @@ func main() {
 		httpadapter.NewLogHandler(logSvc),
 		httpadapter.NewImageRepoHandler(imageRepoSvc),
 		httpadapter.NewOpsHandler(opsDbs),
+		httpadapter.NewPipelineHandler(pipelineSvc),
 		cfg.APIToken,
 	)
 

--- a/apps/paas-engine/cmd/paas-engine/main.go
+++ b/apps/paas-engine/cmd/paas-engine/main.go
@@ -76,7 +76,7 @@ func main() {
 	buildSvc := service.NewBuildService(imageRepoRepo, buildRepo, buildExecutor, lokiClient)
 	releaseSvc := service.NewReleaseService(appRepo, imageRepoRepo, buildRepo, releaseRepo, deployer)
 	logSvc := service.NewLogService(appRepo, lokiClient, cfg.DeployNamespace)
-	pipelineSvc := service.NewPipelineService(ciConfigRepo, pipelineRunRepo, testExecutor, buildSvc, releaseSvc, appRepo, imageRepoRepo)
+	pipelineSvc := service.NewPipelineService(ciConfigRepo, pipelineRunRepo, testExecutor, buildSvc, releaseSvc, appRepo, imageRepoRepo, lokiClient, cfg.CINamespace)
 
 	// 启动 Build Informer
 	ctx := context.Background()

--- a/apps/paas-engine/cmd/paas-engine/main.go
+++ b/apps/paas-engine/cmd/paas-engine/main.go
@@ -79,7 +79,8 @@ func main() {
 	pipelineSvc := service.NewPipelineService(ciConfigRepo, pipelineRunRepo, testExecutor, buildSvc, releaseSvc, appRepo, imageRepoRepo, lokiClient, cfg.CINamespace)
 
 	// 启动 Build Informer
-	ctx := context.Background()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	if buildExecutor != nil {
 		go func() {
 			if err := buildExecutor.Watch(ctx, buildSvc.OnBuildStatusChange); err != nil {
@@ -95,6 +96,15 @@ func main() {
 				slog.Error("test informer error", "error", err)
 			}
 		}()
+	}
+
+	// 启动 Git Poller（需要 GITHUB_TOKEN 和 CI_GIT_REPO）
+	if cfg.GitHubToken != "" && cfg.CIGitRepo != "" {
+		poller := service.NewGitPoller(ciConfigRepo, pipelineSvc, cfg.CIGitRepo,
+			cfg.GitHubToken, cfg.GitPollInterval, cfg.BuildHttpProxy)
+		if poller != nil {
+			go poller.Start(ctx)
+		}
 	}
 
 	// Ops 数据库连接池（只读查询）
@@ -138,8 +148,9 @@ func main() {
 	<-quit
 
 	slog.Info("shutting down server")
-	shutdownCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
+	cancel() // 停止 git poller + informer
+	shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer shutdownCancel()
 	if err := srv.Shutdown(shutdownCtx); err != nil {
 		slog.Error("server shutdown error", "error", err)
 	}

--- a/apps/paas-engine/internal/adapter/http/log_handler.go
+++ b/apps/paas-engine/internal/adapter/http/log_handler.go
@@ -62,6 +62,7 @@ func parseLogQueryOptions(r *http.Request) service.LogQueryOptions {
 		App:       q.Get("app"),
 		Lane:      q.Get("lane"),
 		Pod:       q.Get("pod"),
+		Namespace: q.Get("namespace"),
 		Since:     since,
 		Start:     q.Get("start"),
 		End:       q.Get("end"),

--- a/apps/paas-engine/internal/adapter/http/pipeline_handler.go
+++ b/apps/paas-engine/internal/adapter/http/pipeline_handler.go
@@ -1,0 +1,129 @@
+package http
+
+import (
+	"encoding/json"
+	"net/http"
+	"strconv"
+
+	"github.com/chiwei-platform/paas-engine/internal/service"
+	"github.com/go-chi/chi/v5"
+)
+
+type PipelineHandler struct {
+	svc *service.PipelineService
+}
+
+func NewPipelineHandler(svc *service.PipelineService) *PipelineHandler {
+	return &PipelineHandler{svc: svc}
+}
+
+// Register 注册 CI 泳道。
+// POST /api/paas/ci/register
+func (h *PipelineHandler) Register(w http.ResponseWriter, r *http.Request) {
+	var req service.RegisterCIRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, err)
+		return
+	}
+	cfg, err := h.svc.RegisterCI(r.Context(), req)
+	if err != nil {
+		writeError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusCreated, cfg)
+}
+
+// Unregister 注销 CI 泳道。
+// DELETE /api/paas/ci/{lane}
+func (h *PipelineHandler) Unregister(w http.ResponseWriter, r *http.Request) {
+	lane := chi.URLParam(r, "lane")
+	if err := h.svc.UnregisterCI(r.Context(), lane); err != nil {
+		writeError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]string{"archived": lane})
+}
+
+// List 列出所有 CI 配置。
+// GET /api/paas/ci
+func (h *PipelineHandler) List(w http.ResponseWriter, r *http.Request) {
+	configs, err := h.svc.ListCIConfigs(r.Context())
+	if err != nil {
+		writeError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, configs)
+}
+
+// ListRuns 列出泳道的 pipeline 执行记录。
+// GET /api/paas/ci/{lane}/runs
+func (h *PipelineHandler) ListRuns(w http.ResponseWriter, r *http.Request) {
+	lane := chi.URLParam(r, "lane")
+	limit := 10
+	if l := r.URL.Query().Get("limit"); l != "" {
+		if n, err := strconv.Atoi(l); err == nil && n > 0 {
+			limit = n
+		}
+	}
+	runs, err := h.svc.ListPipelineRuns(r.Context(), lane, limit)
+	if err != nil {
+		writeError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, runs)
+}
+
+// GetRun 获取 pipeline run 详情。
+// GET /api/paas/ci/runs/{id}
+func (h *PipelineHandler) GetRun(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	run, err := h.svc.GetPipelineRun(r.Context(), id)
+	if err != nil {
+		writeError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, run)
+}
+
+// CancelRun 取消 pipeline run。
+// POST /api/paas/ci/runs/{id}/cancel
+func (h *PipelineHandler) CancelRun(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	if err := h.svc.CancelPipelineRun(r.Context(), id); err != nil {
+		writeError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]string{"cancelled": id})
+}
+
+// GetLogs 获取 job 日志。
+// GET /api/paas/ci/runs/{id}/logs
+func (h *PipelineHandler) GetLogs(w http.ResponseWriter, r *http.Request) {
+	jobID := r.URL.Query().Get("job")
+	if jobID == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "job query param required"})
+		return
+	}
+	logs, err := h.svc.GetJobLogs(r.Context(), jobID)
+	if err != nil {
+		writeError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]string{"logs": logs})
+}
+
+// Trigger 手动触发 pipeline。
+// POST /api/paas/ci/{lane}/trigger
+func (h *PipelineHandler) Trigger(w http.ResponseWriter, r *http.Request) {
+	lane := chi.URLParam(r, "lane")
+	var req service.TriggerPipelineRequest
+	if r.Body != nil {
+		_ = json.NewDecoder(r.Body).Decode(&req)
+	}
+	run, err := h.svc.TriggerPipeline(r.Context(), lane, req)
+	if err != nil {
+		writeError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusCreated, run)
+}

--- a/apps/paas-engine/internal/adapter/http/router.go
+++ b/apps/paas-engine/internal/adapter/http/router.go
@@ -14,6 +14,7 @@ func NewRouter(
 	logH *LogHandler,
 	imageRepoH *ImageRepoHandler,
 	opsH *OpsHandler,
+	pipelineH *PipelineHandler,
 	apiToken string,
 ) http.Handler {
 	r := chi.NewRouter()
@@ -85,6 +86,22 @@ func NewRouter(
 				r.Get("/", imageRepoH.Get)
 				r.Put("/", imageRepoH.Update)
 				r.Delete("/", imageRepoH.Delete)
+			})
+		})
+
+		// CI Pipeline
+		r.Route("/ci", func(r chi.Router) {
+			r.Post("/register", pipelineH.Register)
+			r.Get("/", pipelineH.List)
+			r.Route("/runs/{id}", func(r chi.Router) {
+				r.Get("/", pipelineH.GetRun)
+				r.Post("/cancel", pipelineH.CancelRun)
+				r.Get("/logs", pipelineH.GetLogs)
+			})
+			r.Route("/{lane}", func(r chi.Router) {
+				r.Delete("/", pipelineH.Unregister)
+				r.Get("/runs", pipelineH.ListRuns)
+				r.Post("/trigger", pipelineH.Trigger)
 			})
 		})
 	})

--- a/apps/paas-engine/internal/adapter/kubernetes/kaniko.go
+++ b/apps/paas-engine/internal/adapter/kubernetes/kaniko.go
@@ -62,10 +62,7 @@ func (e *KanikoBuildExecutor) Submit(ctx context.Context, sub *port.BuildSubmiss
 	ttl := int32(3600)
 	backoff := int32(0)
 
-	gitContext := sub.GitRepo
-	if strings.HasPrefix(gitContext, "https://") || strings.HasPrefix(gitContext, "http://") {
-		gitContext = "git://" + strings.TrimPrefix(strings.TrimPrefix(gitContext, "https://"), "http://")
-	}
+	gitContext := "git://github.com/" + sub.GitRepo
 	gitRef := sub.GitRef
 	if gitRef != "" && !strings.HasPrefix(gitRef, "refs/") {
 		if isCommitHash(gitRef) {

--- a/apps/paas-engine/internal/adapter/kubernetes/test_executor.go
+++ b/apps/paas-engine/internal/adapter/kubernetes/test_executor.go
@@ -20,11 +20,11 @@ var _ port.TestExecutor = (*K8sTestExecutor)(nil)
 
 const labelJobRunID = "paas.chiwei/jobrun-id"
 
-// runtimeImages 定义每种 runtime 对应的测试镜像。
+// runtimeImages 定义每种 runtime 对应的测试镜像（使用 Harbor 内部镜像）。
 var runtimeImages = map[string]string{
-	"go":     "golang:1.25",
-	"python": "python:3.12-slim",
-	"bun":    "oven/bun:1.2",
+	"go":     "harbor.local:30002/library/golang:1.25-alpine",
+	"python": "harbor.local:30002/library/python:3.11-slim",
+	"bun":    "harbor.local:30002/library/bun:1.3.9-slim",
 }
 
 type K8sTestExecutor struct {
@@ -62,8 +62,8 @@ func (e *K8sTestExecutor) Submit(ctx context.Context, sub *port.TestSubmission) 
 		return "", fmt.Errorf("unsupported runtime %q", sub.Runtime)
 	}
 
-	// 构建 git clone URL
-	gitURL := sub.GitRepo
+	// 拼装 https:// 前缀用于 git clone
+	gitURL := "https://github.com/" + sub.GitRepo
 	gitRef := sub.GitRef
 	if gitRef == "" {
 		gitRef = "main"
@@ -72,10 +72,10 @@ func (e *K8sTestExecutor) Submit(ctx context.Context, sub *port.TestSubmission) 
 	// Init container: clone repo
 	initContainer := corev1.Container{
 		Name:    "git-clone",
-		Image:   "alpine/git:latest",
+		Image:   "harbor.local:30002/library/alpine:latest",
 		Command: []string{"sh", "-c"},
 		Args: []string{
-			fmt.Sprintf("git clone --depth 1 --branch %s %s /workspace", gitRef, gitURL),
+			fmt.Sprintf("apk add --no-cache git && git clone --depth 1 --branch '%s' '%s' /workspace", gitRef, gitURL),
 		},
 		VolumeMounts: []corev1.VolumeMount{
 			{Name: "workspace", MountPath: "/workspace"},

--- a/apps/paas-engine/internal/adapter/kubernetes/test_executor.go
+++ b/apps/paas-engine/internal/adapter/kubernetes/test_executor.go
@@ -1,0 +1,241 @@
+package kubernetes
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/chiwei-platform/paas-engine/internal/domain"
+	"github.com/chiwei-platform/paas-engine/internal/port"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
+)
+
+var _ port.TestExecutor = (*K8sTestExecutor)(nil)
+
+const labelJobRunID = "paas.chiwei/jobrun-id"
+
+// runtimeImages 定义每种 runtime 对应的测试镜像。
+var runtimeImages = map[string]string{
+	"go":     "golang:1.25",
+	"python": "python:3.12-slim",
+	"bun":    "oven/bun:1.2",
+}
+
+type K8sTestExecutor struct {
+	client    kubernetes.Interface
+	namespace string
+	gitRepo   string // monorepo 的 git 地址
+	httpProxy string
+	noProxy   string
+}
+
+type TestExecutorConfig struct {
+	Namespace string
+	GitRepo   string
+	HttpProxy string
+	NoProxy   string
+}
+
+func NewK8sTestExecutor(client kubernetes.Interface, cfg TestExecutorConfig) *K8sTestExecutor {
+	return &K8sTestExecutor{
+		client:    client,
+		namespace: cfg.Namespace,
+		gitRepo:   cfg.GitRepo,
+		httpProxy: cfg.HttpProxy,
+		noProxy:   cfg.NoProxy,
+	}
+}
+
+func (e *K8sTestExecutor) Submit(ctx context.Context, sub *port.TestSubmission) (string, error) {
+	jobName := fmt.Sprintf("ci-test-%s", strings.ReplaceAll(sub.JobRunID, "-", "")[:24])
+	ttl := int32(3600)
+	backoff := int32(0)
+
+	image, ok := runtimeImages[sub.Runtime]
+	if !ok {
+		return "", fmt.Errorf("unsupported runtime %q", sub.Runtime)
+	}
+
+	// 构建 git clone URL
+	gitURL := sub.GitRepo
+	gitRef := sub.GitRef
+	if gitRef == "" {
+		gitRef = "main"
+	}
+
+	// Init container: clone repo
+	initContainer := corev1.Container{
+		Name:    "git-clone",
+		Image:   "alpine/git:latest",
+		Command: []string{"sh", "-c"},
+		Args: []string{
+			fmt.Sprintf("git clone --depth 1 --branch %s %s /workspace", gitRef, gitURL),
+		},
+		VolumeMounts: []corev1.VolumeMount{
+			{Name: "workspace", MountPath: "/workspace"},
+		},
+	}
+
+	// Main container: run test command
+	mainContainer := corev1.Container{
+		Name:       "test",
+		Image:      image,
+		Command:    []string{"sh", "-c"},
+		Args:       []string{sub.Command},
+		WorkingDir: "/workspace",
+		VolumeMounts: []corev1.VolumeMount{
+			{Name: "workspace", MountPath: "/workspace"},
+		},
+	}
+
+	// 注入环境变量
+	for k, v := range sub.Envs {
+		mainContainer.Env = append(mainContainer.Env, corev1.EnvVar{Name: k, Value: v})
+	}
+
+	// 代理设置
+	if e.httpProxy != "" {
+		proxyEnvs := []corev1.EnvVar{
+			{Name: "HTTP_PROXY", Value: e.httpProxy},
+			{Name: "HTTPS_PROXY", Value: e.httpProxy},
+			{Name: "http_proxy", Value: e.httpProxy},
+			{Name: "https_proxy", Value: e.httpProxy},
+		}
+		if e.noProxy != "" {
+			proxyEnvs = append(proxyEnvs,
+				corev1.EnvVar{Name: "NO_PROXY", Value: e.noProxy},
+				corev1.EnvVar{Name: "no_proxy", Value: e.noProxy},
+			)
+		}
+		initContainer.Env = append(initContainer.Env, proxyEnvs...)
+		mainContainer.Env = append(mainContainer.Env, proxyEnvs...)
+	}
+
+	job := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      jobName,
+			Namespace: e.namespace,
+			Labels: map[string]string{
+				labelJobRunID: sub.JobRunID,
+			},
+		},
+		Spec: batchv1.JobSpec{
+			BackoffLimit:            &backoff,
+			TTLSecondsAfterFinished: &ttl,
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{labelJobRunID: sub.JobRunID},
+				},
+				Spec: corev1.PodSpec{
+					RestartPolicy:  corev1.RestartPolicyNever,
+					InitContainers: []corev1.Container{initContainer},
+					Containers:     []corev1.Container{mainContainer},
+					Volumes: []corev1.Volume{
+						{
+							Name: "workspace",
+							VolumeSource: corev1.VolumeSource{
+								EmptyDir: &corev1.EmptyDirVolumeSource{},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	if _, err := e.client.BatchV1().Jobs(e.namespace).Create(ctx, job, metav1.CreateOptions{}); err != nil {
+		return "", err
+	}
+	return jobName, nil
+}
+
+func (e *K8sTestExecutor) Cancel(ctx context.Context, jobName string) error {
+	propagation := metav1.DeletePropagationForeground
+	return e.client.BatchV1().Jobs(e.namespace).Delete(ctx, jobName, metav1.DeleteOptions{
+		PropagationPolicy: &propagation,
+	})
+}
+
+// Watch 启动 Job Informer，监听标签匹配的测试 Job 状态变化。
+func (e *K8sTestExecutor) Watch(ctx context.Context, callback port.TestStatusCallback) error {
+	factory := informers.NewSharedInformerFactoryWithOptions(
+		e.client,
+		0,
+		informers.WithNamespace(e.namespace),
+	)
+	jobInformer := factory.Batch().V1().Jobs().Informer()
+
+	jobInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		UpdateFunc: func(oldObj, newObj any) {
+			job, ok := newObj.(*batchv1.Job)
+			if !ok {
+				return
+			}
+			jobRunID, ok := job.Labels[labelJobRunID]
+			if !ok {
+				return
+			}
+
+			status, log := testJobToStatus(job)
+			if status != "" {
+				callback(jobRunID, status, log)
+			}
+		},
+	})
+
+	factory.Start(ctx.Done())
+	factory.WaitForCacheSync(ctx.Done())
+
+	<-ctx.Done()
+	return ctx.Err()
+}
+
+// GetLogs 通过 jobRunID label 找到 Pod，读取 test 容器日志。
+func (e *K8sTestExecutor) GetLogs(ctx context.Context, jobRunID string) (string, error) {
+	pods, err := e.client.CoreV1().Pods(e.namespace).List(ctx, metav1.ListOptions{
+		LabelSelector: fmt.Sprintf("%s=%s", labelJobRunID, jobRunID),
+	})
+	if err != nil {
+		return "", fmt.Errorf("list pods for job run %s: %w", jobRunID, err)
+	}
+	if len(pods.Items) == 0 {
+		return "", nil
+	}
+
+	pod := pods.Items[0]
+	containerName := "test"
+	stream, err := e.client.CoreV1().Pods(e.namespace).GetLogs(pod.Name, &corev1.PodLogOptions{
+		Container: containerName,
+	}).Stream(ctx)
+	if err != nil {
+		return "", fmt.Errorf("get pod logs %s: %w", pod.Name, err)
+	}
+	defer stream.Close()
+
+	data, err := io.ReadAll(stream)
+	if err != nil {
+		return "", fmt.Errorf("read pod logs %s: %w", pod.Name, err)
+	}
+	return string(data), nil
+}
+
+func testJobToStatus(job *batchv1.Job) (domain.PipelineRunStatus, string) {
+	for _, cond := range job.Status.Conditions {
+		if cond.Type == batchv1.JobComplete && cond.Status == "True" {
+			return domain.PipelineRunSucceeded, ""
+		}
+		if cond.Type == batchv1.JobFailed && cond.Status == "True" {
+			return domain.PipelineRunFailed, cond.Message
+		}
+	}
+	if job.Status.Active > 0 {
+		return domain.PipelineRunRunning, ""
+	}
+	return "", ""
+}

--- a/apps/paas-engine/internal/adapter/kubernetes/test_executor.go
+++ b/apps/paas-engine/internal/adapter/kubernetes/test_executor.go
@@ -72,10 +72,10 @@ func (e *K8sTestExecutor) Submit(ctx context.Context, sub *port.TestSubmission) 
 	// Init container: clone repo
 	initContainer := corev1.Container{
 		Name:    "git-clone",
-		Image:   "harbor.local:30002/library/alpine:latest",
+		Image:   "harbor.local:30002/library/alpine-git:latest",
 		Command: []string{"sh", "-c"},
 		Args: []string{
-			fmt.Sprintf("apk add --no-cache git && git clone --depth 1 --branch '%s' '%s' /workspace", gitRef, gitURL),
+			fmt.Sprintf("git clone --depth 1 --branch '%s' '%s' /workspace", gitRef, gitURL),
 		},
 		VolumeMounts: []corev1.VolumeMount{
 			{Name: "workspace", MountPath: "/workspace"},

--- a/apps/paas-engine/internal/adapter/repository/db.go
+++ b/apps/paas-engine/internal/adapter/repository/db.go
@@ -19,6 +19,10 @@ func OpenDB(dsn string) (*gorm.DB, error) {
 		&ImageRepoModel{},
 		&BuildModel{},
 		&ReleaseModel{},
+		&CIConfigModel{},
+		&PipelineRunModel{},
+		&StageRunModel{},
+		&JobRunModel{},
 	); err != nil {
 		return nil, err
 	}

--- a/apps/paas-engine/internal/adapter/repository/model.go
+++ b/apps/paas-engine/internal/adapter/repository/model.go
@@ -67,3 +67,62 @@ type ReleaseModel struct {
 }
 
 func (ReleaseModel) TableName() string { return "releases" }
+
+// CIConfigModel 是 CIConfig 的数据库持久化模型。
+type CIConfigModel struct {
+	ID        string `gorm:"primaryKey"`
+	Lane      string `gorm:"uniqueIndex"`
+	Branch    string `gorm:"index"`
+	Services  string // JSON 序列化的 []string
+	Status    string
+	CreatedAt time.Time
+	UpdatedAt time.Time
+}
+
+func (CIConfigModel) TableName() string { return "ci_configs" }
+
+// PipelineRunModel 是 PipelineRun 的数据库持久化模型。
+type PipelineRunModel struct {
+	ID         string `gorm:"primaryKey"`
+	CIConfigID string `gorm:"index"`
+	GitRef     string
+	CommitSHA  string `gorm:"index"`
+	Lane       string `gorm:"index"`
+	Services   string // JSON 序列化的 []string
+	Status     string
+	Message    string `gorm:"type:text"`
+	CreatedAt  time.Time
+	UpdatedAt  time.Time
+}
+
+func (PipelineRunModel) TableName() string { return "pipeline_runs" }
+
+// StageRunModel 是 StageRun 的数据库持久化模型。
+type StageRunModel struct {
+	ID            string `gorm:"primaryKey"`
+	PipelineRunID string `gorm:"index"`
+	Stage         string
+	Seq           int
+	Status        string
+	Message       string `gorm:"type:text"`
+	CreatedAt     time.Time
+	UpdatedAt     time.Time
+}
+
+func (StageRunModel) TableName() string { return "stage_runs" }
+
+// JobRunModel 是 JobRun 的数据库持久化模型。
+type JobRunModel struct {
+	ID         string `gorm:"primaryKey"`
+	StageRunID string `gorm:"index"`
+	Name       string
+	JobType    string
+	RefID      string
+	K8sJobName string
+	Status     string
+	Log        string `gorm:"type:text"`
+	CreatedAt  time.Time
+	UpdatedAt  time.Time
+}
+
+func (JobRunModel) TableName() string { return "job_runs" }

--- a/apps/paas-engine/internal/adapter/repository/pipeline_repo.go
+++ b/apps/paas-engine/internal/adapter/repository/pipeline_repo.go
@@ -1,0 +1,330 @@
+package repository
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+
+	"github.com/chiwei-platform/paas-engine/internal/domain"
+	"github.com/chiwei-platform/paas-engine/internal/port"
+	"gorm.io/gorm"
+)
+
+// --- CIConfigRepo ---
+
+var _ port.CIConfigRepository = (*CIConfigRepo)(nil)
+
+type CIConfigRepo struct {
+	db *gorm.DB
+}
+
+func NewCIConfigRepo(db *gorm.DB) *CIConfigRepo {
+	return &CIConfigRepo{db: db}
+}
+
+func (r *CIConfigRepo) Save(ctx context.Context, cfg *domain.CIConfig) error {
+	m := ciConfigToModel(cfg)
+	result := r.db.WithContext(ctx).Create(m)
+	if result.Error != nil {
+		if isUniqueConstraintError(result.Error) {
+			return domain.ErrAlreadyExists
+		}
+		return result.Error
+	}
+	return nil
+}
+
+func (r *CIConfigRepo) FindByID(ctx context.Context, id string) (*domain.CIConfig, error) {
+	var m CIConfigModel
+	result := r.db.WithContext(ctx).First(&m, "id = ?", id)
+	if result.Error != nil {
+		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
+			return nil, domain.ErrCIConfigNotFound
+		}
+		return nil, result.Error
+	}
+	return modelToCIConfig(&m), nil
+}
+
+func (r *CIConfigRepo) FindByLane(ctx context.Context, lane string) (*domain.CIConfig, error) {
+	var m CIConfigModel
+	result := r.db.WithContext(ctx).Where("lane = ? AND status = ?", lane, "active").First(&m)
+	if result.Error != nil {
+		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
+			return nil, domain.ErrCIConfigNotFound
+		}
+		return nil, result.Error
+	}
+	return modelToCIConfig(&m), nil
+}
+
+func (r *CIConfigRepo) FindByBranch(ctx context.Context, branch string) (*domain.CIConfig, error) {
+	var m CIConfigModel
+	result := r.db.WithContext(ctx).Where("branch = ? AND status = ?", branch, "active").First(&m)
+	if result.Error != nil {
+		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
+			return nil, domain.ErrCIConfigNotFound
+		}
+		return nil, result.Error
+	}
+	return modelToCIConfig(&m), nil
+}
+
+func (r *CIConfigRepo) FindActive(ctx context.Context) ([]*domain.CIConfig, error) {
+	var models []CIConfigModel
+	if err := r.db.WithContext(ctx).Where("status = ?", "active").Find(&models).Error; err != nil {
+		return nil, err
+	}
+	configs := make([]*domain.CIConfig, 0, len(models))
+	for i := range models {
+		configs = append(configs, modelToCIConfig(&models[i]))
+	}
+	return configs, nil
+}
+
+func (r *CIConfigRepo) Update(ctx context.Context, cfg *domain.CIConfig) error {
+	m := ciConfigToModel(cfg)
+	return r.db.WithContext(ctx).Save(m).Error
+}
+
+func (r *CIConfigRepo) Delete(ctx context.Context, id string) error {
+	return r.db.WithContext(ctx).Delete(&CIConfigModel{}, "id = ?", id).Error
+}
+
+func ciConfigToModel(c *domain.CIConfig) *CIConfigModel {
+	servicesJSON, _ := json.Marshal(c.Services)
+	return &CIConfigModel{
+		ID:        c.ID,
+		Lane:      c.Lane,
+		Branch:    c.Branch,
+		Services:  string(servicesJSON),
+		Status:    c.Status,
+		CreatedAt: c.CreatedAt,
+		UpdatedAt: c.UpdatedAt,
+	}
+}
+
+func modelToCIConfig(m *CIConfigModel) *domain.CIConfig {
+	var services []string
+	if m.Services != "" {
+		_ = json.Unmarshal([]byte(m.Services), &services)
+	}
+	return &domain.CIConfig{
+		ID:        m.ID,
+		Lane:      m.Lane,
+		Branch:    m.Branch,
+		Services:  services,
+		Status:    m.Status,
+		CreatedAt: m.CreatedAt,
+		UpdatedAt: m.UpdatedAt,
+	}
+}
+
+// --- PipelineRunRepo ---
+
+var _ port.PipelineRunRepository = (*PipelineRunRepo)(nil)
+
+type PipelineRunRepo struct {
+	db *gorm.DB
+}
+
+func NewPipelineRunRepo(db *gorm.DB) *PipelineRunRepo {
+	return &PipelineRunRepo{db: db}
+}
+
+func (r *PipelineRunRepo) Save(ctx context.Context, run *domain.PipelineRun) error {
+	m := pipelineRunToModel(run)
+	return r.db.WithContext(ctx).Create(m).Error
+}
+
+func (r *PipelineRunRepo) FindByID(ctx context.Context, id string) (*domain.PipelineRun, error) {
+	var m PipelineRunModel
+	result := r.db.WithContext(ctx).First(&m, "id = ?", id)
+	if result.Error != nil {
+		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
+			return nil, domain.ErrPipelineRunNotFound
+		}
+		return nil, result.Error
+	}
+	return modelToPipelineRun(&m), nil
+}
+
+func (r *PipelineRunRepo) FindByLane(ctx context.Context, lane string, limit int) ([]*domain.PipelineRun, error) {
+	query := r.db.WithContext(ctx).Where("lane = ?", lane).Order("created_at desc")
+	if limit > 0 {
+		query = query.Limit(limit)
+	}
+	var models []PipelineRunModel
+	if err := query.Find(&models).Error; err != nil {
+		return nil, err
+	}
+	runs := make([]*domain.PipelineRun, 0, len(models))
+	for i := range models {
+		runs = append(runs, modelToPipelineRun(&models[i]))
+	}
+	return runs, nil
+}
+
+func (r *PipelineRunRepo) ExistsByCommitSHA(ctx context.Context, sha string) (bool, error) {
+	var count int64
+	err := r.db.WithContext(ctx).Model(&PipelineRunModel{}).Where("commit_sha = ?", sha).Count(&count).Error
+	return count > 0, err
+}
+
+func (r *PipelineRunRepo) Update(ctx context.Context, run *domain.PipelineRun) error {
+	m := pipelineRunToModel(run)
+	return r.db.WithContext(ctx).Save(m).Error
+}
+
+// --- StageRun CRUD ---
+
+func (r *PipelineRunRepo) SaveStage(ctx context.Context, stage *domain.StageRun) error {
+	m := stageRunToModel(stage)
+	return r.db.WithContext(ctx).Create(m).Error
+}
+
+func (r *PipelineRunRepo) FindStagesByRunID(ctx context.Context, runID string) ([]domain.StageRun, error) {
+	var models []StageRunModel
+	if err := r.db.WithContext(ctx).Where("pipeline_run_id = ?", runID).Order("seq asc").Find(&models).Error; err != nil {
+		return nil, err
+	}
+	stages := make([]domain.StageRun, 0, len(models))
+	for i := range models {
+		stages = append(stages, *modelToStageRun(&models[i]))
+	}
+	return stages, nil
+}
+
+func (r *PipelineRunRepo) UpdateStage(ctx context.Context, stage *domain.StageRun) error {
+	m := stageRunToModel(stage)
+	return r.db.WithContext(ctx).Save(m).Error
+}
+
+// --- JobRun CRUD ---
+
+func (r *PipelineRunRepo) SaveJob(ctx context.Context, job *domain.JobRun) error {
+	m := jobRunToModel(job)
+	return r.db.WithContext(ctx).Create(m).Error
+}
+
+func (r *PipelineRunRepo) FindJobsByStageID(ctx context.Context, stageID string) ([]domain.JobRun, error) {
+	var models []JobRunModel
+	if err := r.db.WithContext(ctx).Where("stage_run_id = ?", stageID).Find(&models).Error; err != nil {
+		return nil, err
+	}
+	jobs := make([]domain.JobRun, 0, len(models))
+	for i := range models {
+		jobs = append(jobs, *modelToJobRun(&models[i]))
+	}
+	return jobs, nil
+}
+
+func (r *PipelineRunRepo) FindJobByID(ctx context.Context, id string) (*domain.JobRun, error) {
+	var m JobRunModel
+	result := r.db.WithContext(ctx).First(&m, "id = ?", id)
+	if result.Error != nil {
+		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
+			return nil, domain.ErrPipelineRunNotFound
+		}
+		return nil, result.Error
+	}
+	return modelToJobRun(&m), nil
+}
+
+func (r *PipelineRunRepo) UpdateJob(ctx context.Context, job *domain.JobRun) error {
+	m := jobRunToModel(job)
+	return r.db.WithContext(ctx).Save(m).Error
+}
+
+// --- Converters ---
+
+func pipelineRunToModel(p *domain.PipelineRun) *PipelineRunModel {
+	servicesJSON, _ := json.Marshal(p.Services)
+	return &PipelineRunModel{
+		ID:         p.ID,
+		CIConfigID: p.CIConfigID,
+		GitRef:     p.GitRef,
+		CommitSHA:  p.CommitSHA,
+		Lane:       p.Lane,
+		Services:   string(servicesJSON),
+		Status:     string(p.Status),
+		Message:    p.Message,
+		CreatedAt:  p.CreatedAt,
+		UpdatedAt:  p.UpdatedAt,
+	}
+}
+
+func modelToPipelineRun(m *PipelineRunModel) *domain.PipelineRun {
+	var services []string
+	if m.Services != "" {
+		_ = json.Unmarshal([]byte(m.Services), &services)
+	}
+	return &domain.PipelineRun{
+		ID:         m.ID,
+		CIConfigID: m.CIConfigID,
+		GitRef:     m.GitRef,
+		CommitSHA:  m.CommitSHA,
+		Lane:       m.Lane,
+		Services:   services,
+		Status:     domain.PipelineRunStatus(m.Status),
+		Message:    m.Message,
+		CreatedAt:  m.CreatedAt,
+		UpdatedAt:  m.UpdatedAt,
+	}
+}
+
+func stageRunToModel(s *domain.StageRun) *StageRunModel {
+	return &StageRunModel{
+		ID:            s.ID,
+		PipelineRunID: s.PipelineRunID,
+		Stage:         string(s.Stage),
+		Seq:           s.Seq,
+		Status:        string(s.Status),
+		Message:       s.Message,
+		CreatedAt:     s.CreatedAt,
+		UpdatedAt:     s.UpdatedAt,
+	}
+}
+
+func modelToStageRun(m *StageRunModel) *domain.StageRun {
+	return &domain.StageRun{
+		ID:            m.ID,
+		PipelineRunID: m.PipelineRunID,
+		Stage:         domain.StageType(m.Stage),
+		Seq:           m.Seq,
+		Status:        domain.PipelineRunStatus(m.Status),
+		Message:       m.Message,
+		CreatedAt:     m.CreatedAt,
+		UpdatedAt:     m.UpdatedAt,
+	}
+}
+
+func jobRunToModel(j *domain.JobRun) *JobRunModel {
+	return &JobRunModel{
+		ID:         j.ID,
+		StageRunID: j.StageRunID,
+		Name:       j.Name,
+		JobType:    j.JobType,
+		RefID:      j.RefID,
+		K8sJobName: j.K8sJobName,
+		Status:     string(j.Status),
+		Log:        j.Log,
+		CreatedAt:  j.CreatedAt,
+		UpdatedAt:  j.UpdatedAt,
+	}
+}
+
+func modelToJobRun(m *JobRunModel) *domain.JobRun {
+	return &domain.JobRun{
+		ID:         m.ID,
+		StageRunID: m.StageRunID,
+		Name:       m.Name,
+		JobType:    m.JobType,
+		RefID:      m.RefID,
+		K8sJobName: m.K8sJobName,
+		Status:     domain.PipelineRunStatus(m.Status),
+		Log:        m.Log,
+		CreatedAt:  m.CreatedAt,
+		UpdatedAt:  m.UpdatedAt,
+	}
+}

--- a/apps/paas-engine/internal/config/config.go
+++ b/apps/paas-engine/internal/config/config.go
@@ -22,6 +22,10 @@ type Config struct {
 	APIToken          string
 	LokiURL           string
 	ChiweiDatabaseURL string
+
+	// CI Pipeline
+	CINamespace string // K8s namespace for CI test jobs
+	CIGitRepo   string // monorepo git URL for CI test jobs
 }
 
 func Load() *Config {
@@ -42,6 +46,9 @@ func Load() *Config {
 		APIToken:          os.Getenv("API_TOKEN"),
 		LokiURL:           getEnv("LOKI_URL", "http://loki-gateway.monitoring.svc.cluster.local"),
 		ChiweiDatabaseURL: os.Getenv("CHIWEI_DATABASE_URL"),
+
+		CINamespace: getEnv("CI_NAMESPACE", "paas-builds"),
+		CIGitRepo:   os.Getenv("CI_GIT_REPO"),
 	}
 }
 

--- a/apps/paas-engine/internal/config/config.go
+++ b/apps/paas-engine/internal/config/config.go
@@ -3,6 +3,7 @@ package config
 import (
 	"os"
 	"strings"
+	"time"
 )
 
 type Config struct {
@@ -24,8 +25,10 @@ type Config struct {
 	ChiweiDatabaseURL string
 
 	// CI Pipeline
-	CINamespace string // K8s namespace for CI test jobs
-	CIGitRepo   string // monorepo git URL for CI test jobs
+	CINamespace     string        // K8s namespace for CI test jobs
+	CIGitRepo       string        // monorepo git URL for CI test jobs
+	GitHubToken     string        // GitHub PAT for polling branch commits
+	GitPollInterval time.Duration // git polling interval (default 60s)
 }
 
 func Load() *Config {
@@ -47,8 +50,10 @@ func Load() *Config {
 		LokiURL:           getEnv("LOKI_URL", "http://loki-gateway.monitoring.svc.cluster.local"),
 		ChiweiDatabaseURL: os.Getenv("CHIWEI_DATABASE_URL"),
 
-		CINamespace: getEnv("CI_NAMESPACE", "paas-builds"),
-		CIGitRepo:   os.Getenv("CI_GIT_REPO"),
+		CINamespace:     getEnv("CI_NAMESPACE", "paas-builds"),
+		CIGitRepo:       os.Getenv("CI_GIT_REPO"),
+		GitHubToken:     os.Getenv("GITHUB_TOKEN"),
+		GitPollInterval: parseDuration(os.Getenv("GIT_POLL_INTERVAL"), 60*time.Second),
 	}
 }
 
@@ -64,6 +69,17 @@ func splitCSV(s string) []string {
 		}
 	}
 	return result
+}
+
+func parseDuration(s string, defaultVal time.Duration) time.Duration {
+	if s == "" {
+		return defaultVal
+	}
+	d, err := time.ParseDuration(s)
+	if err != nil {
+		return defaultVal
+	}
+	return d
 }
 
 func getEnv(key, defaultVal string) string {

--- a/apps/paas-engine/internal/domain/errors.go
+++ b/apps/paas-engine/internal/domain/errors.go
@@ -18,4 +18,7 @@ var (
 	ErrImageRepoNotFound = fmt.Errorf("image repo %w", ErrNotFound)
 
 	ErrNonMainProdDeploy = fmt.Errorf("%w: prod lane only accepts images built from main branch", ErrInvalidInput)
+
+	ErrCIConfigNotFound   = fmt.Errorf("ci config %w", ErrNotFound)
+	ErrPipelineRunNotFound = fmt.Errorf("pipeline run %w", ErrNotFound)
 )

--- a/apps/paas-engine/internal/domain/pipeline.go
+++ b/apps/paas-engine/internal/domain/pipeline.go
@@ -1,0 +1,82 @@
+package domain
+
+import "time"
+
+// PipelineRunStatus 是 PipelineRun / StageRun / JobRun 共用的状态枚举。
+// 状态流转：Pending → Running → (Succeeded | Failed | Cancelled)
+type PipelineRunStatus string
+
+const (
+	PipelineRunPending   PipelineRunStatus = "pending"
+	PipelineRunRunning   PipelineRunStatus = "running"
+	PipelineRunSucceeded PipelineRunStatus = "succeeded"
+	PipelineRunFailed    PipelineRunStatus = "failed"
+	PipelineRunCancelled PipelineRunStatus = "cancelled"
+)
+
+func (s PipelineRunStatus) IsTerminal() bool {
+	return s == PipelineRunSucceeded || s == PipelineRunFailed || s == PipelineRunCancelled
+}
+
+// StageType 表示 pipeline 阶段类型。
+type StageType string
+
+const (
+	StageUnitTest StageType = "unit-test"
+	StageBuild    StageType = "build"
+	StageDeploy   StageType = "deploy"
+	StageE2E      StageType = "e2e"
+)
+
+// CIConfig 注册一个 CI 泳道（make ci-init 创建）。
+type CIConfig struct {
+	ID        string    `json:"id"`
+	Lane      string    `json:"lane"`     // 泳道名，如 "feat-auth"
+	Branch    string    `json:"branch"`   // 监听的分支，如 "feat/auth-rework"
+	Services  []string  `json:"services"` // 要构建/部署/测试的服务列表
+	Status    string    `json:"status"`   // "active" / "archived"
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
+}
+
+// PipelineRun 代表一次 pipeline 执行。
+type PipelineRun struct {
+	ID         string            `json:"id"`
+	CIConfigID string            `json:"ci_config_id,omitempty"` // 关联的 CIConfig（main 分支时为空）
+	GitRef     string            `json:"git_ref"`
+	CommitSHA  string            `json:"commit_sha"`
+	Lane       string            `json:"lane"`
+	Services   []string          `json:"services"`             // 本次参与的服务
+	Status     PipelineRunStatus `json:"status"`
+	Message    string            `json:"message,omitempty"`
+	Stages     []StageRun        `json:"stages,omitempty"`     // 嵌套返回（查详情时）
+	CreatedAt  time.Time         `json:"created_at"`
+	UpdatedAt  time.Time         `json:"updated_at"`
+}
+
+// StageRun 是 pipeline 中的一个阶段。
+type StageRun struct {
+	ID            string            `json:"id"`
+	PipelineRunID string            `json:"pipeline_run_id"`
+	Stage         StageType         `json:"stage"`
+	Seq           int               `json:"seq"`
+	Status        PipelineRunStatus `json:"status"`
+	Message       string            `json:"message,omitempty"`
+	Jobs          []JobRun          `json:"jobs,omitempty"` // 嵌套返回
+	CreatedAt     time.Time         `json:"created_at"`
+	UpdatedAt     time.Time         `json:"updated_at"`
+}
+
+// JobRun 是阶段内单个作业（某个服务的单测/构建/部署）。
+type JobRun struct {
+	ID         string            `json:"id"`
+	StageRunID string            `json:"stage_run_id"`
+	Name       string            `json:"name"`     // 服务名
+	JobType    string            `json:"job_type"` // unit-test / build / deploy / e2e-http / e2e-lark
+	RefID      string            `json:"ref_id,omitempty"`      // 关联 Build.ID 或 Release.ID
+	K8sJobName string            `json:"k8s_job_name,omitempty"`
+	Status     PipelineRunStatus `json:"status"`
+	Log        string            `json:"log,omitempty"`
+	CreatedAt  time.Time         `json:"created_at"`
+	UpdatedAt  time.Time         `json:"updated_at"`
+}

--- a/apps/paas-engine/internal/domain/pipeline_config.go
+++ b/apps/paas-engine/internal/domain/pipeline_config.go
@@ -1,0 +1,23 @@
+package domain
+
+// PipelineConfig 对应 pipeline.yml 的解析结果。
+type PipelineConfig struct {
+	Services map[string]ServiceTestConfig `json:"services"`
+	LarkFlow *LarkFlowConfig              `json:"lark_flow,omitempty"`
+}
+
+// ServiceTestConfig 描述单个服务的测试命令。
+type ServiceTestConfig struct {
+	Runtime  string            `json:"runtime"`
+	UnitTest string            `json:"unit_test,omitempty"`
+	E2ETest  string            `json:"e2e_test,omitempty"`
+	E2EEnv   map[string]string `json:"e2e_env,omitempty"`
+}
+
+// LarkFlowConfig 描述飞书全链路 E2E 测试。
+type LarkFlowConfig struct {
+	Runtime string            `json:"runtime"`
+	Cmd     string            `json:"cmd"`
+	Timeout string            `json:"timeout,omitempty"`
+	Env     map[string]string `json:"env,omitempty"`
+}

--- a/apps/paas-engine/internal/domain/validate.go
+++ b/apps/paas-engine/internal/domain/validate.go
@@ -21,13 +21,16 @@ func ValidateK8sName(name string) error {
 // gitRefRegex 白名单：字母、数字、-、_、.、/
 var gitRefRegex = regexp.MustCompile(`^[a-zA-Z0-9._/-]+$`)
 
-// ValidateGitRepo 校验 Git 仓库地址，只允许 https:// 或 git:// 协议，防止 SSRF。
+// gitRepoRegex 匹配 user/repo 格式（如 bezhai/chiwei-platform.git）。
+var gitRepoRegex = regexp.MustCompile(`^[a-zA-Z0-9._-]+/[a-zA-Z0-9._-]+$`)
+
+// ValidateGitRepo 校验 Git 仓库地址，要求 user/repo 格式，由调用方拼装协议前缀。
 func ValidateGitRepo(repo string) error {
 	if repo == "" {
 		return fmt.Errorf("%w: git_repo is required", ErrInvalidInput)
 	}
-	if !strings.HasPrefix(repo, "https://") && !strings.HasPrefix(repo, "git://") {
-		return fmt.Errorf("%w: git_repo must use https:// or git:// protocol", ErrInvalidInput)
+	if !gitRepoRegex.MatchString(repo) {
+		return fmt.Errorf("%w: git_repo must be in user/repo format (e.g. bezhai/chiwei-platform.git)", ErrInvalidInput)
 	}
 	return nil
 }

--- a/apps/paas-engine/internal/port/pipeline.go
+++ b/apps/paas-engine/internal/port/pipeline.go
@@ -1,0 +1,57 @@
+package port
+
+import (
+	"context"
+
+	"github.com/chiwei-platform/paas-engine/internal/domain"
+)
+
+// TestStatusCallback 在测试 Job 状态变更时被调用。
+type TestStatusCallback func(jobRunID string, status domain.PipelineRunStatus, log string)
+
+// TestSubmission 封装提交给 TestExecutor 的测试参数。
+type TestSubmission struct {
+	JobRunID string
+	GitRepo  string
+	GitRef   string
+	Runtime  string // python / bun / go
+	Command  string // 测试命令
+	Envs     map[string]string
+}
+
+// TestExecutor 负责驱动测试 K8s Job 的生命周期。
+type TestExecutor interface {
+	Submit(ctx context.Context, sub *TestSubmission) (jobName string, err error)
+	Cancel(ctx context.Context, jobName string) error
+	Watch(ctx context.Context, callback TestStatusCallback) error
+	GetLogs(ctx context.Context, jobRunID string) (string, error)
+}
+
+// CIConfigRepository 管理 CI 配置的持久化。
+type CIConfigRepository interface {
+	Save(ctx context.Context, cfg *domain.CIConfig) error
+	FindByID(ctx context.Context, id string) (*domain.CIConfig, error)
+	FindByLane(ctx context.Context, lane string) (*domain.CIConfig, error)
+	FindByBranch(ctx context.Context, branch string) (*domain.CIConfig, error)
+	FindActive(ctx context.Context) ([]*domain.CIConfig, error)
+	Update(ctx context.Context, cfg *domain.CIConfig) error
+	Delete(ctx context.Context, id string) error
+}
+
+// PipelineRunRepository 管理 pipeline 执行记录的持久化。
+type PipelineRunRepository interface {
+	Save(ctx context.Context, run *domain.PipelineRun) error
+	FindByID(ctx context.Context, id string) (*domain.PipelineRun, error)
+	FindByLane(ctx context.Context, lane string, limit int) ([]*domain.PipelineRun, error)
+	ExistsByCommitSHA(ctx context.Context, sha string) (bool, error)
+	Update(ctx context.Context, run *domain.PipelineRun) error
+
+	SaveStage(ctx context.Context, stage *domain.StageRun) error
+	FindStagesByRunID(ctx context.Context, runID string) ([]domain.StageRun, error)
+	UpdateStage(ctx context.Context, stage *domain.StageRun) error
+
+	SaveJob(ctx context.Context, job *domain.JobRun) error
+	FindJobsByStageID(ctx context.Context, stageID string) ([]domain.JobRun, error)
+	FindJobByID(ctx context.Context, id string) (*domain.JobRun, error)
+	UpdateJob(ctx context.Context, job *domain.JobRun) error
+}

--- a/apps/paas-engine/internal/service/git_poller.go
+++ b/apps/paas-engine/internal/service/git_poller.go
@@ -1,0 +1,163 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/chiwei-platform/paas-engine/internal/domain"
+	"github.com/chiwei-platform/paas-engine/internal/port"
+)
+
+// GitPoller 轮询 GitHub API 检测新 commit，自动触发 CI pipeline。
+type GitPoller struct {
+	ciConfigRepo port.CIConfigRepository
+	pipelineSvc  *PipelineService
+	httpClient   *http.Client
+	owner        string
+	repo         string
+	token        string
+	interval     time.Duration
+}
+
+// NewGitPoller 创建 GitPoller。ownerRepo 格式如 "bezhai/chiwei-platform.git"。
+func NewGitPoller(
+	ciConfigRepo port.CIConfigRepository,
+	pipelineSvc *PipelineService,
+	ownerRepo string,
+	token string,
+	interval time.Duration,
+	proxyURL string,
+) *GitPoller {
+	// 解析 owner/repo（去掉 .git 后缀）
+	ownerRepo = strings.TrimSuffix(ownerRepo, ".git")
+	parts := strings.SplitN(ownerRepo, "/", 2)
+	if len(parts) != 2 {
+		slog.Error("invalid owner/repo format", "ownerRepo", ownerRepo)
+		return nil
+	}
+
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	if proxyURL != "" {
+		if u, err := url.Parse(proxyURL); err == nil {
+			transport.Proxy = http.ProxyURL(u)
+		}
+	}
+
+	return &GitPoller{
+		ciConfigRepo: ciConfigRepo,
+		pipelineSvc:  pipelineSvc,
+		httpClient:   &http.Client{Transport: transport, Timeout: 15 * time.Second},
+		owner:        parts[0],
+		repo:         parts[1],
+		token:        token,
+		interval:     interval,
+	}
+}
+
+// Start 启动轮询循环，ctx 取消时退出。
+func (p *GitPoller) Start(ctx context.Context) {
+	slog.Info("git poller started", "owner", p.owner, "repo", p.repo, "interval", p.interval)
+
+	// 启动时立即 poll 一次
+	p.pollAll(ctx)
+
+	ticker := time.NewTicker(p.interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			slog.Info("git poller stopped")
+			return
+		case <-ticker.C:
+			p.pollAll(ctx)
+		}
+	}
+}
+
+// pollAll 遍历所有活跃 CIConfig，轮询各分支的最新 commit。
+func (p *GitPoller) pollAll(ctx context.Context) {
+	configs, err := p.ciConfigRepo.FindActive(ctx)
+	if err != nil {
+		slog.Error("git poller: failed to list active ci configs", "error", err)
+		return
+	}
+
+	for _, cfg := range configs {
+		// 跳过 main/master 分支
+		if cfg.Branch == "main" || cfg.Branch == "master" {
+			continue
+		}
+		p.pollBranch(ctx, cfg.Lane, cfg.Branch)
+	}
+}
+
+// pollBranch 检查单个分支的最新 commit，若有新 commit 则触发 pipeline。
+func (p *GitPoller) pollBranch(ctx context.Context, lane, branch string) {
+	sha, err := p.fetchBranchHead(ctx, branch)
+	if err != nil {
+		slog.Warn("git poller: failed to fetch branch head", "branch", branch, "error", err)
+		return
+	}
+
+	_, err = p.pipelineSvc.TriggerPipeline(ctx, lane, TriggerPipelineRequest{
+		CommitSHA: sha,
+	})
+	if err != nil {
+		// 幂等：同一 SHA 已触发过，静默跳过
+		if errors.Is(err, domain.ErrAlreadyExists) {
+			return
+		}
+		slog.Warn("git poller: failed to trigger pipeline", "lane", lane, "branch", branch, "sha", sha, "error", err)
+		return
+	}
+
+	slog.Info("git poller: triggered pipeline", "lane", lane, "branch", branch, "sha", sha)
+}
+
+// branchResponse 是 GitHub API 返回的分支信息（仅取所需字段）。
+type branchResponse struct {
+	Commit struct {
+		SHA string `json:"sha"`
+	} `json:"commit"`
+}
+
+// fetchBranchHead 调用 GitHub API 获取分支最新 commit SHA。
+func (p *GitPoller) fetchBranchHead(ctx context.Context, branch string) (string, error) {
+	apiURL := fmt.Sprintf("https://api.github.com/repos/%s/%s/branches/%s", p.owner, p.repo, branch)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, apiURL, nil)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Authorization", "Bearer "+p.token)
+	req.Header.Set("Accept", "application/vnd.github.v3+json")
+
+	resp, err := p.httpClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("github api request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("github api returned %d for branch %s", resp.StatusCode, branch)
+	}
+
+	var result branchResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return "", fmt.Errorf("failed to decode github response: %w", err)
+	}
+
+	if result.Commit.SHA == "" {
+		return "", fmt.Errorf("empty commit sha for branch %s", branch)
+	}
+
+	return result.Commit.SHA, nil
+}

--- a/apps/paas-engine/internal/service/image_repo_service_test.go
+++ b/apps/paas-engine/internal/service/image_repo_service_test.go
@@ -41,7 +41,7 @@ func TestCreateImageRepo_Success(t *testing.T) {
 	repo, err := svc.CreateImageRepo(context.Background(), CreateImageRepoRequest{
 		Name:       "agent-service",
 		Registry:   "harbor.local/inner-bot/agent-service",
-		GitRepo:    "https://github.com/bezhai/chiwei-platform.git",
+		GitRepo:    "bezhai/chiwei-platform.git",
 		ContextDir: "apps/agent-service",
 	})
 	if err != nil {
@@ -61,7 +61,7 @@ func TestCreateImageRepo_InvalidName(t *testing.T) {
 	_, err := svc.CreateImageRepo(context.Background(), CreateImageRepoRequest{
 		Name:     "INVALID_NAME",
 		Registry: "harbor.local/inner-bot/test",
-		GitRepo:  "https://github.com/example/repo.git",
+		GitRepo:  "example/repo.git",
 	})
 	if !errors.Is(err, domain.ErrInvalidInput) {
 		t.Errorf("expected ErrInvalidInput, got %v", err)
@@ -73,7 +73,7 @@ func TestCreateImageRepo_MissingRegistry(t *testing.T) {
 
 	_, err := svc.CreateImageRepo(context.Background(), CreateImageRepoRequest{
 		Name:    "myrepo",
-		GitRepo: "https://github.com/example/repo.git",
+		GitRepo: "example/repo.git",
 	})
 	if !errors.Is(err, domain.ErrInvalidInput) {
 		t.Errorf("expected ErrInvalidInput, got %v", err)
@@ -86,7 +86,7 @@ func TestCreateImageRepo_InvalidContextDir(t *testing.T) {
 	_, err := svc.CreateImageRepo(context.Background(), CreateImageRepoRequest{
 		Name:       "myrepo",
 		Registry:   "harbor.local/inner-bot/test",
-		GitRepo:    "https://github.com/example/repo.git",
+		GitRepo:    "example/repo.git",
 		ContextDir: "../etc/passwd",
 	})
 	if !errors.Is(err, domain.ErrInvalidInput) {
@@ -111,7 +111,7 @@ func TestUpdateImageRepo_PartialKeepsExisting(t *testing.T) {
 	imageRepoRepo := &stubImageRepoRepo{repo: &domain.ImageRepo{
 		Name:       "myrepo",
 		Registry:   "harbor.local/inner-bot/test",
-		GitRepo:    "https://github.com/example/repo.git",
+		GitRepo:    "example/repo.git",
 		ContextDir: "apps/test",
 		Dockerfile: "Dockerfile.prod",
 		NoCache:    false,
@@ -129,8 +129,8 @@ func TestUpdateImageRepo_PartialKeepsExisting(t *testing.T) {
 	if repo.Registry != "harbor.local/inner-bot/test" {
 		t.Errorf("Registry = %q, want %q", repo.Registry, "harbor.local/inner-bot/test")
 	}
-	if repo.GitRepo != "https://github.com/example/repo.git" {
-		t.Errorf("GitRepo = %q, want %q", repo.GitRepo, "https://github.com/example/repo.git")
+	if repo.GitRepo != "example/repo.git" {
+		t.Errorf("GitRepo = %q, want %q", repo.GitRepo, "example/repo.git")
 	}
 	if repo.ContextDir != "apps/test" {
 		t.Errorf("ContextDir = %q, want %q", repo.ContextDir, "apps/test")

--- a/apps/paas-engine/internal/service/log_service.go
+++ b/apps/paas-engine/internal/service/log_service.go
@@ -29,6 +29,7 @@ type LogQueryOptions struct {
 	App       string // 逗号分隔多 app，空=查全部
 	Lane      string
 	Pod       string
+	Namespace string // 可选，覆盖默认 deployNamespace
 	Since     string // 与 Start/End 二选一
 	Start     string // RFC3339，优先于 Since
 	End       string // RFC3339，不填=now
@@ -104,8 +105,13 @@ func (s *LogService) QueryLogs(ctx context.Context, opts LogQueryOptions) (strin
 		direction = "backward"
 	}
 
+	namespace := s.deployNamespace
+	if opts.Namespace != "" {
+		namespace = opts.Namespace
+	}
+
 	query := port.AppLogQuery{
-		Namespace: s.deployNamespace,
+		Namespace: namespace,
 		Apps:      apps,
 		Lane:      opts.Lane,
 		Pod:       opts.Pod,

--- a/apps/paas-engine/internal/service/pipeline_service.go
+++ b/apps/paas-engine/internal/service/pipeline_service.go
@@ -375,7 +375,7 @@ func (s *PipelineService) runUnitTestStage(ctx context.Context, run *domain.Pipe
 
 			sub := &port.TestSubmission{
 				JobRunID: job.ID,
-				GitRepo:  s.resolveGitRepo(ctx),
+				GitRepo:  s.resolveGitRepo(ctx, svc),
 				GitRef:   run.GitRef,
 				Runtime:  runtime,
 				Command:  cmd,
@@ -564,13 +564,17 @@ func (s *PipelineService) fillRunDetails(ctx context.Context, run *domain.Pipeli
 	return run, nil
 }
 
-// resolveGitRepo 获取 monorepo 的 git 地址。
-func (s *PipelineService) resolveGitRepo(ctx context.Context) string {
-	repos, err := s.imageRepo.FindAll(ctx)
-	if err != nil || len(repos) == 0 {
+// resolveGitRepo 通过 app → imageRepo 获取 git 仓库地址。
+func (s *PipelineService) resolveGitRepo(ctx context.Context, appName string) string {
+	app, err := s.appRepo.FindByName(ctx, appName)
+	if err != nil || app.ImageRepoName == "" {
 		return ""
 	}
-	return repos[0].GitRepo
+	repo, err := s.imageRepo.FindByName(ctx, app.ImageRepoName)
+	if err != nil {
+		return ""
+	}
+	return repo.GitRepo
 }
 
 // resolveUnitTestCommand 根据服务名推断 runtime 和测试命令。

--- a/apps/paas-engine/internal/service/pipeline_service.go
+++ b/apps/paas-engine/internal/service/pipeline_service.go
@@ -1,0 +1,617 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/chiwei-platform/paas-engine/internal/domain"
+	"github.com/chiwei-platform/paas-engine/internal/port"
+	"github.com/google/uuid"
+)
+
+type PipelineService struct {
+	ciConfigRepo port.CIConfigRepository
+	pipelineRepo port.PipelineRunRepository
+	testExecutor port.TestExecutor
+	buildSvc     *BuildService
+	releaseSvc   *ReleaseService
+	appRepo      port.AppRepository
+	imageRepo    port.ImageRepoRepository
+}
+
+func NewPipelineService(
+	ciConfigRepo port.CIConfigRepository,
+	pipelineRepo port.PipelineRunRepository,
+	testExecutor port.TestExecutor,
+	buildSvc *BuildService,
+	releaseSvc *ReleaseService,
+	appRepo port.AppRepository,
+	imageRepo port.ImageRepoRepository,
+) *PipelineService {
+	return &PipelineService{
+		ciConfigRepo: ciConfigRepo,
+		pipelineRepo: pipelineRepo,
+		testExecutor: testExecutor,
+		buildSvc:     buildSvc,
+		releaseSvc:   releaseSvc,
+		appRepo:      appRepo,
+		imageRepo:    imageRepo,
+	}
+}
+
+// RegisterCIRequest 注册 CI 泳道的请求。
+type RegisterCIRequest struct {
+	Lane     string   `json:"lane"`
+	Branch   string   `json:"branch"`
+	Services []string `json:"services"`
+}
+
+// RegisterCI 注册一个 CI 泳道配置。
+func (s *PipelineService) RegisterCI(ctx context.Context, req RegisterCIRequest) (*domain.CIConfig, error) {
+	if req.Lane == "" || req.Branch == "" || len(req.Services) == 0 {
+		return nil, fmt.Errorf("%w: lane, branch, and services are required", domain.ErrInvalidInput)
+	}
+	if err := domain.ValidateK8sName(req.Lane); err != nil {
+		return nil, err
+	}
+	if req.Lane == domain.DefaultLane {
+		return nil, fmt.Errorf("%w: cannot register CI for prod lane", domain.ErrInvalidInput)
+	}
+
+	now := time.Now()
+	cfg := &domain.CIConfig{
+		ID:        uuid.New().String(),
+		Lane:      req.Lane,
+		Branch:    req.Branch,
+		Services:  req.Services,
+		Status:    "active",
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+	if err := s.ciConfigRepo.Save(ctx, cfg); err != nil {
+		return nil, err
+	}
+	slog.Info("ci config registered", "lane", req.Lane, "branch", req.Branch, "services", req.Services)
+	return cfg, nil
+}
+
+// UnregisterCI 注销 CI 泳道，删除泳道 Release 并归档配置。
+func (s *PipelineService) UnregisterCI(ctx context.Context, lane string) error {
+	cfg, err := s.ciConfigRepo.FindByLane(ctx, lane)
+	if err != nil {
+		return err
+	}
+
+	// 删除泳道上所有 Release
+	for _, svcName := range cfg.Services {
+		if err := s.releaseSvc.DeleteReleaseByAppAndLane(ctx, svcName, lane); err != nil {
+			slog.Warn("failed to delete release during ci cleanup", "app", svcName, "lane", lane, "error", err)
+		}
+	}
+
+	cfg.Status = "archived"
+	cfg.UpdatedAt = time.Now()
+	return s.ciConfigRepo.Update(ctx, cfg)
+}
+
+// ListCIConfigs 列出所有活跃的 CI 配置。
+func (s *PipelineService) ListCIConfigs(ctx context.Context) ([]*domain.CIConfig, error) {
+	return s.ciConfigRepo.FindActive(ctx)
+}
+
+// GetCIConfig 获取指定泳道的 CI 配置。
+func (s *PipelineService) GetCIConfig(ctx context.Context, lane string) (*domain.CIConfig, error) {
+	return s.ciConfigRepo.FindByLane(ctx, lane)
+}
+
+// TriggerPipelineRequest 手动触发 pipeline 的请求。
+type TriggerPipelineRequest struct {
+	CommitSHA string `json:"commit_sha,omitempty"`
+}
+
+// TriggerPipeline 手动触发指定泳道的 pipeline。
+func (s *PipelineService) TriggerPipeline(ctx context.Context, lane string, req TriggerPipelineRequest) (*domain.PipelineRun, error) {
+	cfg, err := s.ciConfigRepo.FindByLane(ctx, lane)
+	if err != nil {
+		return nil, err
+	}
+
+	commitSHA := req.CommitSHA
+	if commitSHA == "" {
+		commitSHA = "manual"
+	}
+
+	// 幂等检查
+	if commitSHA != "manual" {
+		exists, err := s.pipelineRepo.ExistsByCommitSHA(ctx, commitSHA)
+		if err != nil {
+			return nil, err
+		}
+		if exists {
+			return nil, fmt.Errorf("%w: pipeline already exists for commit %s", domain.ErrAlreadyExists, commitSHA)
+		}
+	}
+
+	now := time.Now()
+	run := &domain.PipelineRun{
+		ID:         uuid.New().String(),
+		CIConfigID: cfg.ID,
+		GitRef:     cfg.Branch,
+		CommitSHA:  commitSHA,
+		Lane:       cfg.Lane,
+		Services:   cfg.Services,
+		Status:     domain.PipelineRunPending,
+		CreatedAt:  now,
+		UpdatedAt:  now,
+	}
+	if err := s.pipelineRepo.Save(ctx, run); err != nil {
+		return nil, err
+	}
+
+	// 异步执行 pipeline
+	go s.runPipeline(context.Background(), run, cfg)
+
+	return run, nil
+}
+
+// GetPipelineRun 获取 pipeline run 详情（含嵌套 stages + jobs）。
+func (s *PipelineService) GetPipelineRun(ctx context.Context, id string) (*domain.PipelineRun, error) {
+	run, err := s.pipelineRepo.FindByID(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	return s.fillRunDetails(ctx, run)
+}
+
+// ListPipelineRuns 列出泳道的 pipeline 执行记录。
+func (s *PipelineService) ListPipelineRuns(ctx context.Context, lane string, limit int) ([]*domain.PipelineRun, error) {
+	if limit <= 0 {
+		limit = 10
+	}
+	return s.pipelineRepo.FindByLane(ctx, lane, limit)
+}
+
+// CancelPipelineRun 取消正在执行的 pipeline。
+func (s *PipelineService) CancelPipelineRun(ctx context.Context, id string) error {
+	run, err := s.pipelineRepo.FindByID(ctx, id)
+	if err != nil {
+		return err
+	}
+	if run.Status.IsTerminal() {
+		return fmt.Errorf("%w: pipeline run is already %s", domain.ErrCannotCancel, run.Status)
+	}
+
+	// 取消所有活跃 Job
+	stages, _ := s.pipelineRepo.FindStagesByRunID(ctx, id)
+	for _, stage := range stages {
+		jobs, _ := s.pipelineRepo.FindJobsByStageID(ctx, stage.ID)
+		for _, job := range jobs {
+			if !job.Status.IsTerminal() && job.K8sJobName != "" && s.testExecutor != nil {
+				_ = s.testExecutor.Cancel(ctx, job.K8sJobName)
+			}
+			if !job.Status.IsTerminal() {
+				job.Status = domain.PipelineRunCancelled
+				job.UpdatedAt = time.Now()
+				_ = s.pipelineRepo.UpdateJob(ctx, &job)
+			}
+		}
+		if !stage.Status.IsTerminal() {
+			stage.Status = domain.PipelineRunCancelled
+			stage.UpdatedAt = time.Now()
+			_ = s.pipelineRepo.UpdateStage(ctx, &stage)
+		}
+	}
+
+	run.Status = domain.PipelineRunCancelled
+	run.UpdatedAt = time.Now()
+	return s.pipelineRepo.Update(ctx, run)
+}
+
+// GetJobLogs 获取指定 job 的日志。
+func (s *PipelineService) GetJobLogs(ctx context.Context, jobRunID string) (string, error) {
+	job, err := s.pipelineRepo.FindJobByID(ctx, jobRunID)
+	if err != nil {
+		return "", err
+	}
+
+	// 尝试从 K8s Pod 读实时日志
+	if s.testExecutor != nil && job.JobType == string(domain.StageUnitTest) {
+		logs, err := s.testExecutor.GetLogs(ctx, job.ID)
+		if err == nil && logs != "" {
+			return logs, nil
+		}
+	}
+
+	return job.Log, nil
+}
+
+// OnTestJobStatusChange 是 TestExecutor Informer 的 callback。
+func (s *PipelineService) OnTestJobStatusChange(jobRunID string, status domain.PipelineRunStatus, logMsg string) {
+	ctx := context.Background()
+	job, err := s.pipelineRepo.FindJobByID(ctx, jobRunID)
+	if err != nil {
+		slog.Error("OnTestJobStatusChange: failed to find job", "job_run_id", jobRunID, "error", err)
+		return
+	}
+	if job.Status.IsTerminal() {
+		return
+	}
+	job.Status = status
+	if logMsg != "" {
+		job.Log = logMsg
+	}
+	job.UpdatedAt = time.Now()
+	if err := s.pipelineRepo.UpdateJob(ctx, job); err != nil {
+		slog.Error("OnTestJobStatusChange: failed to update job", "job_run_id", jobRunID, "error", err)
+	}
+}
+
+// runPipeline 执行特性分支 pipeline：unit-test → build → deploy。
+func (s *PipelineService) runPipeline(ctx context.Context, run *domain.PipelineRun, _ *domain.CIConfig) {
+	slog.Info("pipeline started", "id", run.ID, "lane", run.Lane, "services", run.Services)
+
+	run.Status = domain.PipelineRunRunning
+	run.UpdatedAt = time.Now()
+	_ = s.pipelineRepo.Update(ctx, run)
+
+	stages := []struct {
+		stage   domain.StageType
+		handler func(ctx context.Context, run *domain.PipelineRun, stage *domain.StageRun) error
+	}{
+		{domain.StageUnitTest, s.runUnitTestStage},
+		{domain.StageBuild, s.runBuildStage},
+		{domain.StageDeploy, s.runDeployStage},
+	}
+
+	for seq, st := range stages {
+		now := time.Now()
+		stage := &domain.StageRun{
+			ID:            uuid.New().String(),
+			PipelineRunID: run.ID,
+			Stage:         st.stage,
+			Seq:           seq + 1,
+			Status:        domain.PipelineRunRunning,
+			CreatedAt:     now,
+			UpdatedAt:     now,
+		}
+		_ = s.pipelineRepo.SaveStage(ctx, stage)
+
+		if err := st.handler(ctx, run, stage); err != nil {
+			stage.Status = domain.PipelineRunFailed
+			stage.Message = err.Error()
+			stage.UpdatedAt = time.Now()
+			_ = s.pipelineRepo.UpdateStage(ctx, stage)
+
+			run.Status = domain.PipelineRunFailed
+			run.Message = fmt.Sprintf("stage %s failed: %s", st.stage, err.Error())
+			run.UpdatedAt = time.Now()
+			_ = s.pipelineRepo.Update(ctx, run)
+			slog.Error("pipeline failed", "id", run.ID, "stage", st.stage, "error", err)
+			return
+		}
+
+		stage.Status = domain.PipelineRunSucceeded
+		stage.UpdatedAt = time.Now()
+		_ = s.pipelineRepo.UpdateStage(ctx, stage)
+	}
+
+	run.Status = domain.PipelineRunSucceeded
+	run.UpdatedAt = time.Now()
+	_ = s.pipelineRepo.Update(ctx, run)
+	slog.Info("pipeline succeeded", "id", run.ID, "lane", run.Lane)
+}
+
+// runUnitTestStage 并行跑注册服务的单测。
+func (s *PipelineService) runUnitTestStage(ctx context.Context, run *domain.PipelineRun, stage *domain.StageRun) error {
+	if s.testExecutor == nil {
+		slog.Warn("test executor not configured, skipping unit tests")
+		return nil
+	}
+
+	var wg sync.WaitGroup
+	errs := make(chan error, len(run.Services))
+
+	for _, svcName := range run.Services {
+		wg.Add(1)
+		go func(svc string) {
+			defer wg.Done()
+
+			now := time.Now()
+			job := &domain.JobRun{
+				ID:         uuid.New().String(),
+				StageRunID: stage.ID,
+				Name:       svc,
+				JobType:    string(domain.StageUnitTest),
+				Status:     domain.PipelineRunPending,
+				CreatedAt:  now,
+				UpdatedAt:  now,
+			}
+			_ = s.pipelineRepo.SaveJob(ctx, job)
+
+			// 确定 runtime 和命令（使用约定的默认值）
+			runtime, cmd := s.resolveUnitTestCommand(svc)
+			if cmd == "" {
+				job.Status = domain.PipelineRunSucceeded
+				job.Log = "no unit test configured, skipped"
+				job.UpdatedAt = time.Now()
+				_ = s.pipelineRepo.UpdateJob(ctx, job)
+				return
+			}
+
+			sub := &port.TestSubmission{
+				JobRunID: job.ID,
+				GitRepo:  s.resolveGitRepo(ctx),
+				GitRef:   run.GitRef,
+				Runtime:  runtime,
+				Command:  cmd,
+			}
+
+			jobName, err := s.testExecutor.Submit(ctx, sub)
+			if err != nil {
+				job.Status = domain.PipelineRunFailed
+				job.Log = err.Error()
+				job.UpdatedAt = time.Now()
+				_ = s.pipelineRepo.UpdateJob(ctx, job)
+				errs <- fmt.Errorf("service %s unit test submit failed: %w", svc, err)
+				return
+			}
+
+			job.K8sJobName = jobName
+			job.Status = domain.PipelineRunRunning
+			job.UpdatedAt = time.Now()
+			_ = s.pipelineRepo.UpdateJob(ctx, job)
+
+			// 等待 Job 完成（轮询 DB 状态，由 Informer callback 更新）
+			if err := s.waitForJobCompletion(ctx, job.ID, 10*time.Minute); err != nil {
+				errs <- fmt.Errorf("service %s unit test: %w", svc, err)
+				return
+			}
+		}(svcName)
+	}
+
+	wg.Wait()
+	close(errs)
+
+	for err := range errs {
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// runBuildStage 并行构建注册服务的镜像。
+func (s *PipelineService) runBuildStage(ctx context.Context, run *domain.PipelineRun, stage *domain.StageRun) error {
+	var wg sync.WaitGroup
+	errs := make(chan error, len(run.Services))
+
+	for _, svcName := range run.Services {
+		wg.Add(1)
+		go func(svc string) {
+			defer wg.Done()
+
+			now := time.Now()
+			job := &domain.JobRun{
+				ID:         uuid.New().String(),
+				StageRunID: stage.ID,
+				Name:       svc,
+				JobType:    string(domain.StageBuild),
+				Status:     domain.PipelineRunPending,
+				CreatedAt:  now,
+				UpdatedAt:  now,
+			}
+			_ = s.pipelineRepo.SaveJob(ctx, job)
+
+			// 查找 App 关联的 ImageRepo
+			app, err := s.appRepo.FindByName(ctx, svc)
+			if err != nil {
+				job.Status = domain.PipelineRunFailed
+				job.Log = fmt.Sprintf("app %s not found: %v", svc, err)
+				job.UpdatedAt = time.Now()
+				_ = s.pipelineRepo.UpdateJob(ctx, job)
+				errs <- fmt.Errorf("service %s build: app not found", svc)
+				return
+			}
+
+			// 使用 BuildService 创建构建
+			build, err := s.buildSvc.CreateBuild(ctx, app.ImageRepoName, CreateBuildRequest{
+				GitRef: run.GitRef,
+			})
+			if err != nil {
+				job.Status = domain.PipelineRunFailed
+				job.Log = err.Error()
+				job.UpdatedAt = time.Now()
+				_ = s.pipelineRepo.UpdateJob(ctx, job)
+				errs <- fmt.Errorf("service %s build failed: %w", svc, err)
+				return
+			}
+
+			job.RefID = build.ID
+			job.Status = domain.PipelineRunRunning
+			job.UpdatedAt = time.Now()
+			_ = s.pipelineRepo.UpdateJob(ctx, job)
+
+			// 等待 Build 完成
+			if err := s.waitForBuildCompletion(ctx, build.ID, 15*time.Minute); err != nil {
+				job.Status = domain.PipelineRunFailed
+				job.Log = err.Error()
+				job.UpdatedAt = time.Now()
+				_ = s.pipelineRepo.UpdateJob(ctx, job)
+				errs <- fmt.Errorf("service %s build: %w", svc, err)
+				return
+			}
+
+			job.Status = domain.PipelineRunSucceeded
+			job.UpdatedAt = time.Now()
+			_ = s.pipelineRepo.UpdateJob(ctx, job)
+		}(svcName)
+	}
+
+	wg.Wait()
+	close(errs)
+
+	for err := range errs {
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// runDeployStage 部署服务到注册泳道。
+func (s *PipelineService) runDeployStage(ctx context.Context, run *domain.PipelineRun, stage *domain.StageRun) error {
+	for _, svcName := range run.Services {
+		now := time.Now()
+		job := &domain.JobRun{
+			ID:         uuid.New().String(),
+			StageRunID: stage.ID,
+			Name:       svcName,
+			JobType:    string(domain.StageDeploy),
+			Status:     domain.PipelineRunRunning,
+			CreatedAt:  now,
+			UpdatedAt:  now,
+		}
+		_ = s.pipelineRepo.SaveJob(ctx, job)
+
+		app, err := s.appRepo.FindByName(ctx, svcName)
+		if err != nil {
+			job.Status = domain.PipelineRunFailed
+			job.Log = err.Error()
+			job.UpdatedAt = time.Now()
+			_ = s.pipelineRepo.UpdateJob(ctx, job)
+			return fmt.Errorf("deploy %s: %w", svcName, err)
+		}
+
+		// 查找刚构建的最新成功版本
+		latestBuild, err := s.buildSvc.GetLatestSuccessfulBuild(ctx, app.ImageRepoName)
+		if err != nil {
+			job.Status = domain.PipelineRunFailed
+			job.Log = err.Error()
+			job.UpdatedAt = time.Now()
+			_ = s.pipelineRepo.UpdateJob(ctx, job)
+			return fmt.Errorf("deploy %s: no successful build found", svcName)
+		}
+
+		release, err := s.releaseSvc.CreateOrUpdateRelease(ctx, CreateReleaseRequest{
+			AppName:  svcName,
+			Lane:     run.Lane,
+			ImageTag: latestBuild.Version,
+		})
+		if err != nil {
+			job.Status = domain.PipelineRunFailed
+			job.Log = err.Error()
+			job.UpdatedAt = time.Now()
+			_ = s.pipelineRepo.UpdateJob(ctx, job)
+			return fmt.Errorf("deploy %s: %w", svcName, err)
+		}
+
+		job.RefID = release.ID
+		job.Status = domain.PipelineRunSucceeded
+		job.UpdatedAt = time.Now()
+		_ = s.pipelineRepo.UpdateJob(ctx, job)
+	}
+	return nil
+}
+
+// fillRunDetails 填充 PipelineRun 的 stages 和 jobs。
+func (s *PipelineService) fillRunDetails(ctx context.Context, run *domain.PipelineRun) (*domain.PipelineRun, error) {
+	stages, err := s.pipelineRepo.FindStagesByRunID(ctx, run.ID)
+	if err != nil {
+		return run, nil
+	}
+	for i := range stages {
+		jobs, err := s.pipelineRepo.FindJobsByStageID(ctx, stages[i].ID)
+		if err == nil {
+			stages[i].Jobs = jobs
+		}
+	}
+	run.Stages = stages
+	return run, nil
+}
+
+// resolveGitRepo 获取 monorepo 的 git 地址。
+func (s *PipelineService) resolveGitRepo(ctx context.Context) string {
+	repos, err := s.imageRepo.FindAll(ctx)
+	if err != nil || len(repos) == 0 {
+		return ""
+	}
+	return repos[0].GitRepo
+}
+
+// resolveUnitTestCommand 根据服务名推断 runtime 和测试命令。
+func (s *PipelineService) resolveUnitTestCommand(svcName string) (runtime, cmd string) {
+	// 约定：按 app 已知信息推断
+	// 未来由 pipeline.yml 提供，Phase 0 使用硬编码默认值
+	knownServices := map[string][2]string{
+		"paas-engine":   {"go", "cd apps/paas-engine && go test ./... -v -count=1"},
+		"agent-service": {"python", "cd apps/agent-service && uv run pytest tests/ -v"},
+		"lark-server":   {"bun", "cd apps/lark-server && bun test"},
+		"lark-proxy":    {"bun", "cd apps/lark-proxy && bun test"},
+		"tool-service":  {"python", "cd apps/tool-service && uv run pytest tests/ -v"},
+	}
+	if info, ok := knownServices[svcName]; ok {
+		return info[0], info[1]
+	}
+	return "", ""
+}
+
+// waitForJobCompletion 轮询 DB 等待 JobRun 完成。
+func (s *PipelineService) waitForJobCompletion(ctx context.Context, jobID string, timeout time.Duration) error {
+	deadline := time.After(timeout)
+	ticker := time.NewTicker(5 * time.Second)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-deadline:
+			return fmt.Errorf("timeout waiting for job %s", jobID)
+		case <-ticker.C:
+			job, err := s.pipelineRepo.FindJobByID(ctx, jobID)
+			if err != nil {
+				return err
+			}
+			switch job.Status {
+			case domain.PipelineRunSucceeded:
+				return nil
+			case domain.PipelineRunFailed:
+				return fmt.Errorf("job failed: %s", job.Log)
+			case domain.PipelineRunCancelled:
+				return fmt.Errorf("job cancelled")
+			}
+		}
+	}
+}
+
+// waitForBuildCompletion 轮询 DB 等待 Build 完成。
+func (s *PipelineService) waitForBuildCompletion(ctx context.Context, buildID string, timeout time.Duration) error {
+	deadline := time.After(timeout)
+	ticker := time.NewTicker(5 * time.Second)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-deadline:
+			return fmt.Errorf("timeout waiting for build %s", buildID)
+		case <-ticker.C:
+			build, err := s.buildSvc.buildRepo.FindByID(ctx, buildID)
+			if err != nil {
+				return err
+			}
+			switch build.Status {
+			case domain.BuildStatusSucceeded:
+				return nil
+			case domain.BuildStatusFailed:
+				return fmt.Errorf("build failed: %s", build.Log)
+			case domain.BuildStatusCancelled:
+				return fmt.Errorf("build cancelled")
+			}
+		}
+	}
+}

--- a/apps/paas-engine/internal/service/pipeline_service.go
+++ b/apps/paas-engine/internal/service/pipeline_service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"strings"
 	"sync"
 	"time"
 
@@ -20,6 +21,8 @@ type PipelineService struct {
 	releaseSvc   *ReleaseService
 	appRepo      port.AppRepository
 	imageRepo    port.ImageRepoRepository
+	logQuerier   port.LogQuerier
+	ciNamespace  string
 }
 
 func NewPipelineService(
@@ -30,6 +33,8 @@ func NewPipelineService(
 	releaseSvc *ReleaseService,
 	appRepo port.AppRepository,
 	imageRepo port.ImageRepoRepository,
+	logQuerier port.LogQuerier,
+	ciNamespace string,
 ) *PipelineService {
 	return &PipelineService{
 		ciConfigRepo: ciConfigRepo,
@@ -39,6 +44,8 @@ func NewPipelineService(
 		releaseSvc:   releaseSvc,
 		appRepo:      appRepo,
 		imageRepo:    imageRepo,
+		logQuerier:   logQuerier,
+		ciNamespace:  ciNamespace,
 	}
 }
 
@@ -210,21 +217,46 @@ func (s *PipelineService) CancelPipelineRun(ctx context.Context, id string) erro
 	return s.pipelineRepo.Update(ctx, run)
 }
 
-// GetJobLogs 获取指定 job 的日志。
+// GetJobLogs 获取指定 job 的日志。三级降级：Pod → Loki → DB。
 func (s *PipelineService) GetJobLogs(ctx context.Context, jobRunID string) (string, error) {
 	job, err := s.pipelineRepo.FindJobByID(ctx, jobRunID)
 	if err != nil {
 		return "", err
 	}
 
-	// 尝试从 K8s Pod 读实时日志
+	// 1. 尝试从 K8s Pod 读实时日志
 	if s.testExecutor != nil && job.JobType == string(domain.StageUnitTest) {
 		logs, err := s.testExecutor.GetLogs(ctx, job.ID)
 		if err == nil && logs != "" {
 			return logs, nil
 		}
+		if err != nil {
+			slog.Warn("failed to get pod logs for ci job, trying loki", "job_id", jobRunID, "error", err)
+		}
 	}
 
+	// 2. 尝试从 Loki 查询历史日志
+	if s.logQuerier != nil && s.ciNamespace != "" && job.JobType == string(domain.StageUnitTest) {
+		podPrefix := "ci-test-" + strings.ReplaceAll(job.ID, "-", "")[:24]
+		start := job.CreatedAt.Add(-1 * time.Minute)
+		end := job.UpdatedAt.Add(5 * time.Minute)
+		query := port.AppLogQuery{
+			Namespace: s.ciNamespace,
+			Pod:       podPrefix,
+			Start:     start,
+			End:       end,
+			Limit:     5000,
+			Direction: "forward",
+		}
+		logs, err := s.logQuerier.QueryAppLogs(ctx, query)
+		if err != nil {
+			slog.Warn("failed to get loki logs for ci job, falling back to db", "job_id", jobRunID, "error", err)
+		} else if logs != "" {
+			return logs, nil
+		}
+	}
+
+	// 3. 降级：返回 DB 中存储的日志
 	return job.Log, nil
 }
 

--- a/docs/ci-pipeline-roadmap.md
+++ b/docs/ci-pipeline-roadmap.md
@@ -1,0 +1,161 @@
+# CI Pipeline 体系规划
+
+PaaS Engine 内置的自动化 CI 流水线，目标：推送代码到特性分支 → 自动触发 → 单元测试 → 构建 → 部署 → E2E 验证。
+
+## 架构概览
+
+```
+Git Push → GitPoller (60s轮询 GitHub API)
+               ↓
+         PipelineService (异步编排)
+               ↓
+    ┌──────────┼──────────┐──────────┐
+    ↓          ↓          ↓          ↓
+ unit-test   build      deploy      e2e
+ (K8s Job)  (Kaniko)  (Release)  (未实装)
+```
+
+### 关键设计
+
+- **幂等性**: 同一 commit SHA 只触发一次 pipeline（`ExistsByCommitSHA` 检查）
+- **状态机**: `pending → running → succeeded | failed | cancelled`
+- **日志三级降级**: Pod logs → Loki → DB 存储
+- **Callback 异步同步**: K8s Informer 监听 Job 状态变化，更新 DB
+
+## 实现阶段
+
+### Phase 0: 核心三阶段 ✅
+
+三阶段串行、阶段内 Job 并行：
+
+1. **unit-test** — K8s Job（git clone init container + runtime test container）
+2. **build** — 复用 Kaniko 构建
+3. **deploy** — 复用 Release 服务
+
+测试命令硬编码在 `resolveUnitTestCommand()`:
+
+| 服务 | runtime | 命令 |
+|------|---------|------|
+| paas-engine | go | `go test ./... -v -count=1` |
+| agent-service | python | `uv run pytest tests/ -v` |
+| lark-server | bun | `bun test` |
+| lark-proxy | bun | `bun test` |
+| tool-service | python | `uv run pytest tests/ -v` |
+
+API 端点:
+
+| 端点 | 方法 | Makefile |
+|------|------|----------|
+| `/api/paas/ci/register` | POST | `make ci-init` |
+| `/api/paas/ci/` | GET | `make ci-list` |
+| `/api/paas/ci/{lane}/trigger` | POST | `make ci-trigger` |
+| `/api/paas/ci/{lane}/runs` | GET | `make ci-status` |
+| `/api/paas/ci/{lane}/` | DELETE | `make ci-cleanup` |
+| `/api/paas/ci/runs/{id}/` | GET | `make ci-logs` |
+| `/api/paas/ci/runs/{id}/cancel` | POST | — |
+| `/api/paas/ci/runs/{id}/logs` | GET | — |
+
+### Phase 0.5: Git Poller 自动触发 ✅
+
+- 轮询 GitHub API 检测注册分支的新 commit
+- 配置: `GITHUB_TOKEN` + `CI_GIT_REPO`（环境变量）
+- 跳过 main/master 分支
+- 间隔可配: `GIT_POLL_INTERVAL`（默认 60s）
+
+### Phase 1: pipeline.yml 声明式配置
+
+**目标**: 从 monorepo 根目录读取 `pipeline.yml`，替代硬编码。
+
+结构体已定义（`domain/pipeline_config.go`）:
+
+```yaml
+# pipeline.yml（预期格式）
+services:
+  paas-engine:
+    runtime: go
+    unit_test: "go test ./... -v -count=1"
+  agent-service:
+    runtime: python
+    unit_test: "uv run pytest tests/ -v"
+    e2e_test: "uv run pytest tests/e2e/ -v"
+    e2e_env:
+      PAAS_API: "http://paas-engine:8080"
+
+lark_flow:
+  runtime: bun
+  cmd: "bun run test:e2e:lark"
+  timeout: "5m"
+```
+
+实现要点:
+- 从 git clone 后的 workspace 中读取 `pipeline.yml`
+- 校验格式 + 合并默认值
+- 替换 `resolveUnitTestCommand()` 中的 switch-case
+
+### Phase 2: E2E 测试
+
+**目标**: 部署后自动验证服务可用性。
+
+已预留:
+- `StageE2E` stage 类型
+- `JobType`: `"e2e-http"`（HTTP 接口测试）、`"e2e-lark"`（飞书全链路）
+- `ServiceTestConfig.E2ETest` + `E2EEnv`
+- `LarkFlowConfig`（runtime/cmd/timeout/env）
+
+预期流程:
+```
+... → deploy → e2e-http（各服务接口验证） → e2e-lark（飞书消息收发）
+```
+
+实现要点:
+- e2e-http: 部署完成后，在同 namespace 启动 K8s Job 访问服务端点
+- e2e-lark: 需要 dev bot 凭证，发送测试消息并验证回复
+- 超时和重试策略
+
+### Phase 3: GitHub Webhook（可选）
+
+**目标**: 替代轮询，推送即触发，更实时且不占 API 配额。
+
+考虑点:
+- 需要公网可达的 webhook 端点（或通过反向代理暴露）
+- 签名验证（`X-Hub-Signature-256`）
+- 与 GitPoller 可共存，webhook 优先、poller 兜底
+
+## 环境变量
+
+| 变量 | 说明 | 存储 |
+|------|------|------|
+| `CI_NAMESPACE` | CI Job 运行的 namespace | app envs（默认 `paas-builds`）|
+| `CI_GIT_REPO` | monorepo 地址（user/repo 格式）| app envs |
+| `GITHUB_TOKEN` | GitHub PAT | app envs（建议迁至 Secret）|
+| `GIT_POLL_INTERVAL` | 轮询间隔 | app envs（默认 60s）|
+
+## 数据库表
+
+| 表 | 说明 |
+|---|------|
+| `ci_configs` | 泳道 CI 注册（lane UNIQUE）|
+| `pipeline_runs` | pipeline 执行记录（commit_sha 索引）|
+| `stage_runs` | 阶段记录（seq 保证顺序）|
+| `job_runs` | 作业记录（含日志文本）|
+
+## 代码结构
+
+```
+apps/paas-engine/internal/
+  domain/
+    pipeline.go          # PipelineRun/StageRun/JobRun/CIConfig 模型
+    pipeline_config.go   # pipeline.yml 解析结构（Phase 1 预留）
+  port/
+    pipeline.go          # TestExecutor/CIConfigRepository/PipelineRunRepository 接口
+  service/
+    pipeline_service.go  # 核心编排（654 行）
+    git_poller.go        # GitHub API 轮询
+  adapter/
+    kubernetes/
+      test_executor.go   # K8s Job 创建/监听/日志
+    http/
+      pipeline_handler.go
+    repository/
+      pipeline_repo.go   # GORM 持久化
+```


### PR DESCRIPTION
## Summary
- Full CI pipeline: register lane → auto/manual trigger → unit-test → build → deploy (3-stage serial execution)
- Git Poller: polls GitHub API to detect new branch commits, auto-triggers pipeline (idempotent, same SHA won't re-trigger)
- Bug fixes: GitRepo user/repo format, Harbor internal images, Loki log query, resolveGitRepo logic
- CI pipeline roadmap doc

## Test plan
- [x] Git Poller auto-detected new commit and triggered pipeline
- [x] All 3 stages passed: unit-test → build → deploy
- [x] Idempotency verified: same commit not re-triggered
- [x] Compilation passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)