### PR TITLE
feat(agent-service): sub-agent delegation for complex tasks

### DIFF
--- a/apps/agent-service/app/agents/__init__.py
+++ b/apps/agent-service/app/agents/__init__.py
@@ -36,8 +36,6 @@ from app.agents.domains import stream_chat
 # Pre Graph
 from app.agents.graphs import (
     BlockReason,
-    Complexity,
-    ComplexityResult,
     PreState,
     SafetyResult,
     run_pre,
@@ -74,7 +72,5 @@ __all__ = [
     "run_pre",
     "PreState",
     "SafetyResult",
-    "ComplexityResult",
-    "Complexity",
     "BlockReason",
 ]

--- a/apps/agent-service/app/agents/core/__init__.py
+++ b/apps/agent-service/app/agents/core/__init__.py
@@ -11,10 +11,12 @@ from app.agents.core.context import (
     MediaContext,
     MessageContext,
 )
+from app.agents.core.sub_agent import SubAgent
 
 __all__ = [
     # Agent
     "ChatAgent",
+    "SubAgent",
     # Context
     "AgentContext",
     "MessageContext",

--- a/apps/agent-service/app/agents/core/config.py
+++ b/apps/agent-service/app/agents/core/config.py
@@ -55,15 +55,6 @@ AgentRegistry.register(
 )
 
 AgentRegistry.register(
-    "pre-complexity",
-    AgentConfig(
-        prompt_id="pre_complexity_classification",
-        model_id="pre-complexity-model",
-        trace_name="pre",
-    ),
-)
-
-AgentRegistry.register(
     "research",
     AgentConfig(
         prompt_id="research_agent",

--- a/apps/agent-service/app/agents/core/config.py
+++ b/apps/agent-service/app/agents/core/config.py
@@ -62,3 +62,12 @@ AgentRegistry.register(
         trace_name="pre",
     ),
 )
+
+AgentRegistry.register(
+    "research",
+    AgentConfig(
+        prompt_id="research_agent",
+        model_id="main-chat-model",
+        trace_name="research",
+    ),
+)

--- a/apps/agent-service/app/agents/core/config.py
+++ b/apps/agent-service/app/agents/core/config.py
@@ -58,7 +58,7 @@ AgentRegistry.register(
     "research",
     AgentConfig(
         prompt_id="research_agent",
-        model_id="main-chat-model",
+        model_id="research-model",
         trace_name="research",
     ),
 )

--- a/apps/agent-service/app/agents/core/sub_agent.py
+++ b/apps/agent-service/app/agents/core/sub_agent.py
@@ -1,0 +1,73 @@
+"""子 Agent 基类
+
+将子 Agent 包装为可调用的形式，统一处理：
+- 工具集默认继承主 Agent（排除委派工具）
+- AgentContext 透传
+- Langfuse trace 继承
+"""
+
+import logging
+
+from langchain.messages import AIMessage, HumanMessage
+
+from app.agents.core.agent import ChatAgent
+from app.agents.core.config import AgentRegistry
+from app.agents.core.context import AgentContext
+
+logger = logging.getLogger(__name__)
+
+
+class SubAgent:
+    """子 Agent 基类
+
+    子 Agent 使用 ChatAgent.run()（非流式）执行任务，
+    结果作为 ToolMessage 返回给主 Agent。
+
+    工具集默认与主 Agent 一致（排除委派工具），也可显式指定。
+    """
+
+    def __init__(self, config_name: str, tools: list | None = None):
+        self.config_name = config_name
+        self._tools = tools
+
+    def _resolve_tools(self) -> list:
+        """解析工具集：显式指定则用之，否则取 BASE_TOOLS"""
+        if self._tools is not None:
+            return self._tools
+        from app.agents.domains.main.tools import BASE_TOOLS
+
+        return list(BASE_TOOLS)
+
+    async def run(
+        self,
+        task: str,
+        context: AgentContext,
+        prompt_vars: dict | None = None,
+    ) -> str:
+        """执行子 Agent 任务
+
+        Args:
+            task: 任务描述（作为 HumanMessage 传入）
+            context: 主 Agent 透传的执行上下文
+            prompt_vars: 额外的 prompt 模板变量
+
+        Returns:
+            子 Agent 的文本输出
+        """
+        config = AgentRegistry.get(self.config_name)
+        tools = self._resolve_tools()
+
+        agent = ChatAgent(
+            prompt_id=config.prompt_id,
+            tools=tools,
+            model_id=config.model_id,
+            trace_name=config.trace_name,
+        )
+
+        messages = [HumanMessage(content=task)]
+        result: AIMessage = await agent.run(
+            messages,
+            context=context,
+            prompt_vars=prompt_vars or {},
+        )
+        return result.content or ""

--- a/apps/agent-service/app/agents/domains/main/agent.py
+++ b/apps/agent-service/app/agents/domains/main/agent.py
@@ -46,7 +46,11 @@ CORRECTION_MESSAGE = (
 COMPLEXITY_HINTS = {
     Complexity.SIMPLE: "【简洁模式】倾向于直接回答或单次工具调用，快速响应用户。",
     Complexity.COMPLEX: "【深度模式】可以多步推理，充分利用工具收集信息后再综合回答。",
-    Complexity.SUPER_COMPLEX: "【研究模式】这是一个复杂的研究任务，可以进行深入分析和多轮工具调用。",
+    Complexity.SUPER_COMPLEX: (
+        "【研究模式】这是一个需要深入研究的复杂任务。"
+        "请优先使用 deep_research 工具委派给调研 Agent 进行多轮搜索和信息综合，"
+        "拿到调研报告后再用你自己的风格组织回答。"
+    ),
 }
 
 

--- a/apps/agent-service/app/agents/domains/main/agent.py
+++ b/apps/agent-service/app/agents/domains/main/agent.py
@@ -19,7 +19,7 @@ from app.agents.core import (
 )
 from app.agents.domains.main.context_builder import build_chat_context
 from app.agents.domains.main.tools import ALL_TOOLS
-from app.agents.graphs.pre import Complexity, run_pre
+from app.agents.graphs.pre import run_pre
 from app.orm.crud import get_gray_config, get_message_content
 from app.services.memory_context import build_diary_context, build_impression_context
 from app.utils.content_parser import parse_content
@@ -42,16 +42,6 @@ CORRECTION_MESSAGE = (
     "但这不会显示任何图片。请使用 generate_image 工具重新生成图片。"
 )
 
-# 复杂度行为引导
-COMPLEXITY_HINTS = {
-    Complexity.SIMPLE: "【简洁模式】倾向于直接回答或单次工具调用，快速响应用户。",
-    Complexity.COMPLEX: "【深度模式】可以多步推理，充分利用工具收集信息后再综合回答。",
-    Complexity.SUPER_COMPLEX: (
-        "【研究模式】这是一个需要深入研究的复杂任务。"
-        "请优先使用 deep_research 工具委派给调研 Agent 进行多轮搜索和信息综合，"
-        "拿到调研报告后再用你自己的风格组织回答。"
-    ),
-}
 
 
 async def stream_chat(
@@ -101,23 +91,15 @@ async def stream_chat(
                     yield GUARD_REJECT_MESSAGE
                     return
 
-                complexity_result = pre_result["complexity_result"]
-                complexity = (
-                    complexity_result.complexity
-                    if complexity_result
-                    else Complexity.SIMPLE
-                )
-                logger.info(f"复杂度路由: complexity={complexity.value}")
-
                 async for text in _build_and_stream(
-                    message_id, complexity, gray_config, request_id
+                    message_id, gray_config, request_id
                 ):
                     yield text
             else:
                 # === 并行模式：pre 在后台运行，主模型同时流式生成 ===
                 logger.info(f"并行模式启动: message_id={message_id}")
                 raw_stream = _build_and_stream(
-                    message_id, Complexity.SIMPLE, gray_config, request_id
+                    message_id, gray_config, request_id
                 )
 
                 async for text in _buffer_until_pre(raw_stream, pre_task, message_id):
@@ -238,14 +220,12 @@ async def _buffer_until_pre(
 
 async def _build_and_stream(
     message_id: str,
-    complexity: Complexity,
     gray_config: dict,
     session_id: str | None = None,
 ) -> AsyncGenerator[str, None]:
     """构建 agent + 上下文，执行流式生成（两种模式共用）"""
-    # 构建 prompt 变量（注入复杂度引导）
     prompt_vars = {
-        "complexity_hint": COMPLEXITY_HINTS.get(complexity, ""),
+        "complexity_hint": "",
         "user_context": "",
     }
 

--- a/apps/agent-service/app/agents/domains/main/tools.py
+++ b/apps/agent-service/app/agents/domains/main/tools.py
@@ -1,8 +1,10 @@
 """Main Agent 工具集
 
 所有工具始终可用，通过 prompt 引导 Agent 根据复杂度调整行为。
+BASE_TOOLS 是子 Agent 可复用的基础工具集（不含委派工具）。
 """
 
+from app.agents.tools.delegation.research import deep_research
 from app.agents.tools.history.members import list_group_members
 from app.agents.tools.history.search import search_group_history
 from app.agents.tools.image import generate_image
@@ -10,12 +12,18 @@ from app.agents.tools.memory import load_memory
 from app.agents.tools.search.allcpp import search_donjin_event
 from app.agents.tools.search.web import search_web
 
-# 所有可用工具
-ALL_TOOLS = [
+# 基础工具（子 Agent 默认继承此集合）
+BASE_TOOLS = [
     search_web,
     search_donjin_event,
     search_group_history,
     list_group_members,
     generate_image,
     load_memory,
+]
+
+# 主 Agent 完整工具集（基础 + 委派）
+ALL_TOOLS = [
+    *BASE_TOOLS,
+    deep_research,
 ]

--- a/apps/agent-service/app/agents/domains/research/__init__.py
+++ b/apps/agent-service/app/agents/domains/research/__init__.py
@@ -1,0 +1,5 @@
+"""Research Agent 域"""
+
+from app.agents.domains.research.agent import research_agent
+
+__all__ = ["research_agent"]

--- a/apps/agent-service/app/agents/domains/research/agent.py
+++ b/apps/agent-service/app/agents/domains/research/agent.py
@@ -1,0 +1,9 @@
+"""Research Agent - 深度调研子 Agent
+
+工具集默认继承主 Agent（排除委派工具），通过独立的 prompt 聚焦调研任务。
+"""
+
+from app.agents.core.sub_agent import SubAgent
+
+# 不指定 tools → 运行时自动取 BASE_TOOLS
+research_agent = SubAgent("research")

--- a/apps/agent-service/app/agents/graphs/__init__.py
+++ b/apps/agent-service/app/agents/graphs/__init__.py
@@ -5,8 +5,6 @@
 
 from app.agents.graphs.pre import (
     BlockReason,
-    Complexity,
-    ComplexityResult,
     PreState,
     SafetyResult,
     run_pre,
@@ -16,7 +14,5 @@ __all__ = [
     "run_pre",
     "PreState",
     "SafetyResult",
-    "ComplexityResult",
-    "Complexity",
     "BlockReason",
 ]

--- a/apps/agent-service/app/agents/graphs/pre/__init__.py
+++ b/apps/agent-service/app/agents/graphs/pre/__init__.py
@@ -3,8 +3,6 @@
 from app.agents.graphs.pre.graph import get_pre_graph, run_pre
 from app.agents.graphs.pre.state import (
     BlockReason,
-    Complexity,
-    ComplexityResult,
     PreState,
     SafetyResult,
 )
@@ -14,7 +12,5 @@ __all__ = [
     "get_pre_graph",
     "PreState",
     "SafetyResult",
-    "ComplexityResult",
-    "Complexity",
     "BlockReason",
 ]

--- a/apps/agent-service/app/agents/graphs/pre/graph.py
+++ b/apps/agent-service/app/agents/graphs/pre/graph.py
@@ -1,8 +1,6 @@
 """Pre Graph 定义
 
-前置处理链路，包含：
-1. 安全检测（并行）
-2. 复杂度分类（与安全检测并行）
+前置处理链路：安全检测（并行）→ 聚合 → 路由
 """
 
 from functools import lru_cache
@@ -16,7 +14,6 @@ from app.agents.graphs.pre.nodes import (
     check_banned_word_node,
     check_prompt_injection,
     check_sensitive_politics,
-    classify_complexity,
 )
 from app.agents.graphs.pre.state import PreState
 
@@ -32,34 +29,24 @@ def _create_pre_graph() -> StateGraph:
     """创建 Pre 处理图
 
     图结构：
-                        ┌─────────────────┐
-                        │     START       │
-                        └────────┬────────┘
-                                 │
-            ┌────────────────────┼────────────────────┐
-            │                    │                    │
-            ▼                    ▼                    ▼
-    ┌───────────────┐   ┌───────────────┐   ┌───────────────┐
-    │ safety_checks │   │  classify     │   │  (可扩展...)  │
-    │ ├─banned_word │   │  complexity   │   │               │
-    │ ├─injection   │   │  (轻量LLM)    │   │               │
-    │ └─politics    │   │               │   │               │
-    └───────┬───────┘   └───────┬───────┘   └───────┬───────┘
-            │                    │                    │
-            └────────────────────┼────────────────────┘
-                                 │
-                                 ▼
-                        ┌─────────────────┐
-                        │   aggregate     │
-                        └────────┬────────┘
-                                 │
-                  ┌──────────────┴──────────────┐
-                  │                             │
-                  ▼                             ▼
-             [reject]                       [pass]
-                  │                             │
-                  ▼                             ▼
-                 END                           END
+                    ┌─────────────────┐
+                    │     START       │
+                    └────────┬────────┘
+                             │
+            ┌────────────────┼────────────────┐
+            ▼                ▼                ▼
+      banned_word       injection         politics
+            │                │                │
+            └────────────────┼────────────────┘
+                             ▼
+                        aggregate
+                             │
+                  ┌──────────┴──────────┐
+                  ▼                     ▼
+              [reject]              [pass]
+                  │                     │
+                  ▼                     ▼
+                 END                   END
     """
     builder = StateGraph(PreState)
 
@@ -68,9 +55,6 @@ def _create_pre_graph() -> StateGraph:
     builder.add_node("check_prompt_injection", check_prompt_injection)
     builder.add_node("check_sensitive_politics", check_sensitive_politics)
 
-    # 复杂度分类节点（与安全检测并行）
-    builder.add_node("classify_complexity", classify_complexity)
-
     # 聚合节点
     builder.add_node("aggregate", aggregate_results)
 
@@ -78,13 +62,11 @@ def _create_pre_graph() -> StateGraph:
     builder.add_edge(START, "check_banned_word")
     builder.add_edge(START, "check_prompt_injection")
     builder.add_edge(START, "check_sensitive_politics")
-    builder.add_edge(START, "classify_complexity")
 
     # 汇聚到 aggregate
     builder.add_edge("check_banned_word", "aggregate")
     builder.add_edge("check_prompt_injection", "aggregate")
     builder.add_edge("check_sensitive_politics", "aggregate")
-    builder.add_edge("classify_complexity", "aggregate")
 
     # 条件路由
     builder.add_conditional_edges(
@@ -109,7 +91,7 @@ async def run_pre(message_content: str) -> PreState:
         message_content: 待处理的消息内容
 
     Returns:
-        PreState: 包含安全检测结果和复杂度分类结果
+        PreState: 包含安全检测结果
     """
     graph = get_pre_graph()
 
@@ -121,7 +103,6 @@ async def run_pre(message_content: str) -> PreState:
     initial_state: PreState = {
         "message_content": message_content,
         "safety_results": [],
-        "complexity_result": None,
         "is_blocked": False,
         "block_reason": None,
     }

--- a/apps/agent-service/app/agents/graphs/pre/nodes/__init__.py
+++ b/apps/agent-service/app/agents/graphs/pre/nodes/__init__.py
@@ -1,6 +1,5 @@
 """Pre Graph 节点"""
 
-from app.agents.graphs.pre.nodes.complexity import classify_complexity
 from app.agents.graphs.pre.nodes.safety import (
     aggregate_results,
     check_banned_word_node,
@@ -9,7 +8,6 @@ from app.agents.graphs.pre.nodes.safety import (
 )
 
 __all__ = [
-    "classify_complexity",
     "check_banned_word_node",
     "check_prompt_injection",
     "check_sensitive_politics",

--- a/apps/agent-service/app/agents/graphs/pre/state.py
+++ b/apps/agent-service/app/agents/graphs/pre/state.py
@@ -15,14 +15,6 @@ class BlockReason(str, Enum):
     SENSITIVE_POLITICS = "sensitive_politics"
 
 
-class Complexity(str, Enum):
-    """任务复杂度"""
-
-    SIMPLE = "simple"  # 简单：直接回答或单次工具调用
-    COMPLEX = "complex"  # 复杂：需要多步推理或多次工具调用
-    SUPER_COMPLEX = "super_complex"  # 超复杂：预留，未来可启用子 Agent
-
-
 @dataclass
 class SafetyResult:
     """安全检测结果"""
@@ -30,14 +22,6 @@ class SafetyResult:
     blocked: bool = False
     reason: BlockReason | None = None
     detail: str | None = None
-
-
-@dataclass
-class ComplexityResult:
-    """复杂度分类结果"""
-
-    complexity: Complexity = Complexity.SIMPLE
-    confidence: float = 1.0
 
 
 def merge_safety_results(
@@ -55,9 +39,6 @@ class PreState(TypedDict):
 
     # 安全检测结果（并行合并）
     safety_results: Annotated[list[SafetyResult], merge_safety_results]
-
-    # 复杂度分类结果
-    complexity_result: ComplexityResult | None
 
     # 最终输出
     is_blocked: bool

--- a/apps/agent-service/app/agents/tools/delegation/__init__.py
+++ b/apps/agent-service/app/agents/tools/delegation/__init__.py
@@ -1,0 +1,5 @@
+"""委派工具 - 将复杂任务委派给子 Agent"""
+
+from app.agents.tools.delegation.research import deep_research
+
+__all__ = ["deep_research"]

--- a/apps/agent-service/app/agents/tools/delegation/research.py
+++ b/apps/agent-service/app/agents/tools/delegation/research.py
@@ -1,0 +1,39 @@
+"""深度调研委派工具"""
+
+import logging
+
+from langchain.tools import tool
+from langgraph.runtime import get_runtime
+
+from app.agents.core.context import AgentContext
+from app.agents.tools.decorators import tool_error_handler
+
+logger = logging.getLogger(__name__)
+
+
+@tool
+@tool_error_handler(error_message="深度调研失败")
+async def deep_research(task: str) -> str:
+    """深度调研工具。将复杂的研究任务委派给专门的调研 Agent。
+
+    适用场景：
+    - 需要多轮搜索、从多个来源收集信息并综合分析
+    - 需要对比不同来源的信息，形成全面的认识
+    - 需要深入了解某个作品、人物、事件的来龙去脉
+    - 问题本身涉及多个维度，单次搜索无法覆盖
+
+    不适用场景：
+    - 简单的事实性问题（直接用 search_web）
+    - 不需要搜索就能回答的问题
+
+    Args:
+        task: 调研任务的详细描述，应包含用户的具体问题和需要关注的方面
+    """
+    # 懒导入避免循环依赖
+    from app.agents.domains.research import research_agent
+
+    context = get_runtime(AgentContext).context
+    result = await research_agent.run(task=task, context=context)
+
+    logger.info("Research agent completed, result length: %d", len(result))
+    return result

--- a/apps/agent-service/tests/unit/test_sub_agent.py
+++ b/apps/agent-service/tests/unit/test_sub_agent.py
@@ -1,0 +1,108 @@
+"""test_sub_agent.py — SubAgent 基类测试"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.agents.core.config import AgentConfig, AgentRegistry
+from app.agents.core.context import AgentContext, MessageContext
+from app.agents.core.sub_agent import SubAgent
+
+pytestmark = pytest.mark.unit
+
+
+class TestSubAgentResolveTools:
+    """工具集解析逻辑"""
+
+    def test_explicit_tools_returned_as_is(self):
+        explicit = [MagicMock(), MagicMock()]
+        agent = SubAgent("research", tools=explicit)
+        assert agent._resolve_tools() is explicit
+
+    def test_none_tools_resolves_to_base_tools(self):
+        fake_base = [MagicMock(name="search_web"), MagicMock(name="load_memory")]
+        agent = SubAgent("research", tools=None)
+        with patch(
+            "app.agents.core.sub_agent.BASE_TOOLS",
+            fake_base,
+            create=True,
+        ):
+            pass
+        with patch(
+            "app.agents.domains.main.tools.BASE_TOOLS",
+            fake_base,
+        ):
+            result = agent._resolve_tools()
+        assert len(result) == len(fake_base)
+        assert result is not fake_base  # 返回新列表
+
+    def test_default_tools_is_none(self):
+        agent = SubAgent("research")
+        assert agent._tools is None
+
+
+class TestSubAgentRun:
+    """run() 调用逻辑"""
+
+    @pytest.fixture()
+    def context(self):
+        return AgentContext(
+            message=MessageContext(message_id="msg_1", chat_id="chat_1"),
+        )
+
+    @pytest.fixture(autouse=True)
+    def _register_research(self):
+        if not AgentRegistry.has("research"):
+            AgentRegistry.register(
+                "research",
+                AgentConfig(
+                    prompt_id="research_agent",
+                    model_id="main-chat-model",
+                    trace_name="research",
+                ),
+            )
+
+    @pytest.mark.asyncio
+    async def test_run_delegates_to_chat_agent(self, context):
+        mock_ai_message = MagicMock()
+        mock_ai_message.content = "调研报告内容"
+
+        mock_chat_agent = MagicMock()
+        mock_chat_agent.run = AsyncMock(return_value=mock_ai_message)
+
+        agent = SubAgent("research", tools=[MagicMock()])
+
+        with patch(
+            "app.agents.core.sub_agent.ChatAgent",
+            return_value=mock_chat_agent,
+        ) as MockChatAgent:
+            result = await agent.run(task="研究葬送的芙莉莲", context=context)
+
+        assert result == "调研报告内容"
+        MockChatAgent.assert_called_once_with(
+            prompt_id="research_agent",
+            tools=agent._resolve_tools(),
+            model_id="main-chat-model",
+            trace_name="research",
+        )
+        mock_chat_agent.run.assert_called_once()
+        call_kwargs = mock_chat_agent.run.call_args
+        assert call_kwargs.kwargs["context"] is context
+
+    @pytest.mark.asyncio
+    async def test_run_returns_empty_string_on_none_content(self, context):
+        mock_ai_message = MagicMock()
+        mock_ai_message.content = None
+
+        mock_chat_agent = MagicMock()
+        mock_chat_agent.run = AsyncMock(return_value=mock_ai_message)
+
+        agent = SubAgent("research", tools=[MagicMock()])
+
+        with patch(
+            "app.agents.core.sub_agent.ChatAgent",
+            return_value=mock_chat_agent,
+        ):
+            result = await agent.run(task="test", context=context)
+
+        assert result == ""


### PR DESCRIPTION
## Summary
- Introduce Tool-as-Agent pattern: main agent delegates complex research tasks to sub-agents via `deep_research` tool
- SubAgent base class auto-inherits main agent's toolset (excluding delegation tools), differentiated by independent prompt and model config
- Remove complexity classifier from Pre Graph (saves 1 LLM call per request), let main model decide when to delegate
- Langfuse prompt `research_agent` created, main prompt v52 updated with deep_research tool description

## Test plan
- [x] SubAgent unit tests 5/5 passed
- [x] All unit tests 73 passed (2 pre-existing content_parser failures unrelated)
- [x] AST syntax check passed for all files
- [x] End-to-end verification after configuring `research-model` in database

🤖 Generated with [Claude Code](https://claude.com/claude-code)