### PR TITLE
fix(agent-service): DeepSeek reasoning model support + client_type cleanup

### DIFF
--- a/apps/agent-service/app/agents/clients/base.py
+++ b/apps/agent-service/app/agents/clients/base.py
@@ -29,13 +29,17 @@ class ClientType:
     """底层客户端类型枚举。
 
     主要通过 model_provider.client_type 进行配置：
-    - "openai": OpenAI 兼容客户端
+    - "openai-responses": OpenAI Responses API（仅 OpenAI 原生端点）
+    - "openai-completion": OpenAI Chat Completions API（兼容第三方如 DeepSeek）
+    - "openai": 等同于 openai-completion（向后兼容）
     - "ark": 火山引擎 Ark Runtime 客户端
     - "azure-http": 仅支持生图的 HTTP 客户端
     - "google": Google Generative AI 客户端
     """
 
     OPENAI = "openai"
+    OPENAI_RESPONSES = "openai-responses"
+    OPENAI_COMPLETION = "openai-completion"
     ARK = "ark"
     AZURE_HTTP = "azure-http"
     GOOGLE = "google"

--- a/apps/agent-service/app/agents/clients/base.py
+++ b/apps/agent-service/app/agents/clients/base.py
@@ -29,9 +29,9 @@ class ClientType:
     """底层客户端类型枚举。
 
     主要通过 model_provider.client_type 进行配置：
+    - "openai": 标准 OpenAI 兼容（Chat Completions API）
     - "openai-responses": OpenAI Responses API（仅 OpenAI 原生端点）
-    - "openai-completion": OpenAI Chat Completions API（兼容第三方如 DeepSeek）
-    - "openai": 等同于 openai-completion（向后兼容）
+    - "deepseek": DeepSeek 专用（Completions API + reasoning_content 保留）
     - "ark": 火山引擎 Ark Runtime 客户端
     - "azure-http": 仅支持生图的 HTTP 客户端
     - "google": Google Generative AI 客户端
@@ -39,7 +39,7 @@ class ClientType:
 
     OPENAI = "openai"
     OPENAI_RESPONSES = "openai-responses"
-    OPENAI_COMPLETION = "openai-completion"
+    DEEPSEEK = "deepseek"
     ARK = "ark"
     AZURE_HTTP = "azure-http"
     GOOGLE = "google"

--- a/apps/agent-service/app/agents/infra/model_builder.py
+++ b/apps/agent-service/app/agents/infra/model_builder.py
@@ -45,16 +45,18 @@ class _ReasoningChatOpenAI(ChatOpenAI):
 
     @staticmethod
     def _normalize_content(content):
-        """将 list content 归一化为字符串（DeepSeek API 只接受字符串）。"""
-        if not isinstance(content, list):
-            return content
-        text_parts = []
-        for block in content:
-            if isinstance(block, str):
-                text_parts.append(block)
-            elif isinstance(block, dict) and block.get("type") == "text":
-                text_parts.append(block.get("text", ""))
-        return "".join(text_parts) or None
+        """将 content 归一化为字符串（DeepSeek API 只接受字符串，不接受 null 或数组）。"""
+        if isinstance(content, list):
+            text_parts = []
+            for block in content:
+                if isinstance(block, str):
+                    text_parts.append(block)
+                elif isinstance(block, dict) and block.get("type") == "text":
+                    text_parts.append(block.get("text", ""))
+            return "".join(text_parts)
+        if content is None:
+            return ""
+        return content
 
     def _get_request_payload(self, input_, *, stop=None, **kwargs):
         """DeepSeek API 适配：注入 reasoning_content + content 归一化。"""

--- a/apps/agent-service/app/agents/infra/model_builder.py
+++ b/apps/agent-service/app/agents/infra/model_builder.py
@@ -197,13 +197,16 @@ class ModelBuilder:
 
                 return ChatGoogleGenerativeAI(**chat_params)
             else:
-                # 默认使用 ChatOpenAI（Response API）
+                # openai-responses: OpenAI Responses API
+                # openai-completion 或其他: 标准 Chat Completions API
+                use_responses_api = client_type == "openai-responses"
+
                 chat_params = {
                     "api_key": model_info["api_key"],
                     "base_url": model_info["base_url"],
                     "model": model_info["model_name"],
                     "max_retries": max_retries,
-                    "use_responses_api": True,
+                    "use_responses_api": use_responses_api,
                     **kwargs,
                 }
 

--- a/apps/agent-service/app/agents/infra/model_builder.py
+++ b/apps/agent-service/app/agents/infra/model_builder.py
@@ -8,11 +8,39 @@ import time
 from typing import Any
 
 from langchain_core.language_models.chat_models import BaseChatModel
+from langchain_core.messages import AIMessage
 from langchain_openai import AzureChatOpenAI, ChatOpenAI
 
 from .exceptions import ModelBuilderError, ModelConfigError, UnsupportedModelError
 
 logger = logging.getLogger(__name__)
+
+
+class _ReasoningChatOpenAI(ChatOpenAI):
+    """ChatOpenAI 子类，保留 reasoning_content 供 DeepSeek 等推理模型使用。
+
+    langchain-openai 的 _format_message_content 会丢弃 reasoning_content block，
+    导致 DeepSeek reasoner 在多轮 tool calling 时报 400。
+    此子类在 payload 构建后将 reasoning_content 从 additional_kwargs 注入回去。
+    """
+
+    def _get_request_payload(self, input_, *, stop=None, **kwargs):
+        messages = self._convert_input(input_).to_messages()
+        payload = super()._get_request_payload(input_, stop=stop, **kwargs)
+
+        if "messages" not in payload:
+            return payload
+
+        for lc_msg, api_msg in zip(messages, payload["messages"]):
+            if (
+                isinstance(lc_msg, AIMessage)
+                and api_msg.get("role") == "assistant"
+            ):
+                rc = lc_msg.additional_kwargs.get("reasoning_content")
+                if rc is not None:
+                    api_msg["reasoning_content"] = rc
+
+        return payload
 
 # ---------------------------------------------------------------------------
 # 模块级 TTL 缓存（asyncio 单线程安全，无需锁）
@@ -196,26 +224,39 @@ class ModelBuilder:
                 )
 
                 return ChatGoogleGenerativeAI(**chat_params)
-            else:
-                # openai-responses: OpenAI Responses API
-                # openai-completion 或其他: 标准 Chat Completions API
-                use_responses_api = client_type == "openai-responses"
-
+            elif client_type == "openai-responses":
                 chat_params = {
                     "api_key": model_info["api_key"],
                     "base_url": model_info["base_url"],
                     "model": model_info["model_name"],
                     "max_retries": max_retries,
-                    "use_responses_api": use_responses_api,
+                    "use_responses_api": True,
                     **kwargs,
                 }
 
                 logger.info(
-                    f"为模型 {model_id} 构建ChatOpenAI实例，"
+                    f"为模型 {model_id} 构建ChatOpenAI实例（Responses API），"
                     f"参数: {list(chat_params.keys())}"
                 )
 
                 return ChatOpenAI(**chat_params)
+            else:
+                # openai / openai-completion / 其他: Chat Completions API
+                # 使用 _ReasoningChatOpenAI 保留 reasoning_content
+                chat_params = {
+                    "api_key": model_info["api_key"],
+                    "base_url": model_info["base_url"],
+                    "model": model_info["model_name"],
+                    "max_retries": max_retries,
+                    **kwargs,
+                }
+
+                logger.info(
+                    f"为模型 {model_id} 构建ChatOpenAI实例（Completions API），"
+                    f"参数: {list(chat_params.keys())}"
+                )
+
+                return _ReasoningChatOpenAI(**chat_params)
 
         except Exception as e:
             if isinstance(e, ModelBuilderError):

--- a/apps/agent-service/app/agents/infra/model_builder.py
+++ b/apps/agent-service/app/agents/infra/model_builder.py
@@ -43,39 +43,40 @@ class _ReasoningChatOpenAI(ChatOpenAI):
 
         return result
 
-    def _get_request_payload(self, input_, *, stop=None, **kwargs):
-        """将 additional_kwargs 中的 reasoning_content 注入回 message dict。
+    @staticmethod
+    def _normalize_content(content):
+        """将 list content 归一化为字符串（DeepSeek API 只接受字符串）。"""
+        if not isinstance(content, list):
+            return content
+        text_parts = []
+        for block in content:
+            if isinstance(block, str):
+                text_parts.append(block)
+            elif isinstance(block, dict) and block.get("type") == "text":
+                text_parts.append(block.get("text", ""))
+        return "".join(text_parts) or None
 
-        同时将 assistant 消息的 content 归一化为字符串——
-        AIMessage.content 属性会自动注入 reasoning block 导致 content 变成数组，
-        DeepSeek API 只接受字符串。
-        """
+    def _get_request_payload(self, input_, *, stop=None, **kwargs):
+        """DeepSeek API 适配：注入 reasoning_content + content 归一化。"""
         messages = self._convert_input(input_).to_messages()
         payload = super()._get_request_payload(input_, stop=stop, **kwargs)
 
         if "messages" not in payload:
             return payload
 
+        # 1) assistant 消息：注入 reasoning_content
         for lc_msg, api_msg in zip(messages, payload["messages"]):
             if (
                 isinstance(lc_msg, AIMessage)
                 and api_msg.get("role") == "assistant"
             ):
-                # 注入 reasoning_content 为顶层字段
                 rc = lc_msg.additional_kwargs.get("reasoning_content")
                 if rc is not None:
                     api_msg["reasoning_content"] = rc
 
-                # content 归一化：数组 → 字符串（提取纯文本，丢弃 reasoning block）
-                content = api_msg.get("content")
-                if isinstance(content, list):
-                    text_parts = []
-                    for block in content:
-                        if isinstance(block, str):
-                            text_parts.append(block)
-                        elif isinstance(block, dict) and block.get("type") == "text":
-                            text_parts.append(block.get("text", ""))
-                    api_msg["content"] = "".join(text_parts) or None
+        # 2) 所有消息：content 归一化为字符串
+        for api_msg in payload["messages"]:
+            api_msg["content"] = self._normalize_content(api_msg.get("content"))
 
         return payload
 

--- a/apps/agent-service/app/agents/infra/model_builder.py
+++ b/apps/agent-service/app/agents/infra/model_builder.py
@@ -283,6 +283,7 @@ class ModelBuilder:
                     "base_url": model_info["base_url"],
                     "model": model_info["model_name"],
                     "max_retries": max_retries,
+                    "use_responses_api": False,
                     **kwargs,
                 }
                 logger.info(
@@ -296,6 +297,7 @@ class ModelBuilder:
                     "base_url": model_info["base_url"],
                     "model": model_info["model_name"],
                     "max_retries": max_retries,
+                    "use_responses_api": False,
                     **kwargs,
                 }
                 logger.info(

--- a/apps/agent-service/app/agents/infra/model_builder.py
+++ b/apps/agent-service/app/agents/infra/model_builder.py
@@ -44,7 +44,12 @@ class _ReasoningChatOpenAI(ChatOpenAI):
         return result
 
     def _get_request_payload(self, input_, *, stop=None, **kwargs):
-        """将 additional_kwargs 中的 reasoning_content 注入回 message dict。"""
+        """将 additional_kwargs 中的 reasoning_content 注入回 message dict。
+
+        同时将 assistant 消息的 content 归一化为字符串——
+        AIMessage.content 属性会自动注入 reasoning block 导致 content 变成数组，
+        DeepSeek API 只接受字符串。
+        """
         messages = self._convert_input(input_).to_messages()
         payload = super()._get_request_payload(input_, stop=stop, **kwargs)
 
@@ -56,9 +61,21 @@ class _ReasoningChatOpenAI(ChatOpenAI):
                 isinstance(lc_msg, AIMessage)
                 and api_msg.get("role") == "assistant"
             ):
+                # 注入 reasoning_content 为顶层字段
                 rc = lc_msg.additional_kwargs.get("reasoning_content")
                 if rc is not None:
                     api_msg["reasoning_content"] = rc
+
+                # content 归一化：数组 → 字符串（提取纯文本，丢弃 reasoning block）
+                content = api_msg.get("content")
+                if isinstance(content, list):
+                    text_parts = []
+                    for block in content:
+                        if isinstance(block, str):
+                            text_parts.append(block)
+                        elif isinstance(block, dict) and block.get("type") == "text":
+                            text_parts.append(block.get("text", ""))
+                    api_msg["content"] = "".join(text_parts) or None
 
         return payload
 

--- a/apps/agent-service/app/agents/infra/model_builder.py
+++ b/apps/agent-service/app/agents/infra/model_builder.py
@@ -233,16 +233,11 @@ class ModelBuilder:
                     "use_responses_api": True,
                     **kwargs,
                 }
-
                 logger.info(
-                    f"为模型 {model_id} 构建ChatOpenAI实例（Responses API），"
-                    f"参数: {list(chat_params.keys())}"
+                    f"为模型 {model_id} 构建ChatOpenAI（Responses API）"
                 )
-
                 return ChatOpenAI(**chat_params)
-            else:
-                # openai / openai-completion / 其他: Chat Completions API
-                # 使用 _ReasoningChatOpenAI 保留 reasoning_content
+            elif client_type == "deepseek":
                 chat_params = {
                     "api_key": model_info["api_key"],
                     "base_url": model_info["base_url"],
@@ -250,13 +245,23 @@ class ModelBuilder:
                     "max_retries": max_retries,
                     **kwargs,
                 }
-
                 logger.info(
-                    f"为模型 {model_id} 构建ChatOpenAI实例（Completions API），"
-                    f"参数: {list(chat_params.keys())}"
+                    f"为模型 {model_id} 构建DeepSeek ChatOpenAI（Completions API）"
                 )
-
                 return _ReasoningChatOpenAI(**chat_params)
+            else:
+                # openai 及其他: 标准 Chat Completions API
+                chat_params = {
+                    "api_key": model_info["api_key"],
+                    "base_url": model_info["base_url"],
+                    "model": model_info["model_name"],
+                    "max_retries": max_retries,
+                    **kwargs,
+                }
+                logger.info(
+                    f"为模型 {model_id} 构建ChatOpenAI（Completions API）"
+                )
+                return ChatOpenAI(**chat_params)
 
         except Exception as e:
             if isinstance(e, ModelBuilderError):

--- a/apps/agent-service/app/agents/infra/model_builder.py
+++ b/apps/agent-service/app/agents/infra/model_builder.py
@@ -19,12 +19,32 @@ logger = logging.getLogger(__name__)
 class _ReasoningChatOpenAI(ChatOpenAI):
     """ChatOpenAI 子类，保留 reasoning_content 供 DeepSeek 等推理模型使用。
 
-    langchain-openai 的 _format_message_content 会丢弃 reasoning_content block，
-    导致 DeepSeek reasoner 在多轮 tool calling 时报 400。
-    此子类在 payload 构建后将 reasoning_content 从 additional_kwargs 注入回去。
+    langchain-openai 在两个阶段丢失 reasoning_content：
+    1. _convert_dict_to_message 解析响应时不提取 reasoning_content
+    2. _format_message_content 构建请求时丢弃 reasoning_content block
+
+    此子类通过重写 _create_chat_result 和 _get_request_payload 修复这两个环节。
     """
 
+    def _create_chat_result(self, response, generation_info=None):
+        """从原始响应中提取 reasoning_content 存入 additional_kwargs。"""
+        import openai
+
+        result = super()._create_chat_result(response, generation_info)
+
+        response_dict = (
+            response if isinstance(response, dict) else response.model_dump()
+        )
+        choices = response_dict.get("choices") or []
+        for choice, gen in zip(choices, result.generations):
+            rc = choice.get("message", {}).get("reasoning_content")
+            if rc is not None and isinstance(gen.message, AIMessage):
+                gen.message.additional_kwargs["reasoning_content"] = rc
+
+        return result
+
     def _get_request_payload(self, input_, *, stop=None, **kwargs):
+        """将 additional_kwargs 中的 reasoning_content 注入回 message dict。"""
         messages = self._convert_input(input_).to_messages()
         payload = super()._get_request_payload(input_, stop=stop, **kwargs)
 

--- a/apps/monitor-dashboard-web/src/pages/Providers.tsx
+++ b/apps/monitor-dashboard-web/src/pages/Providers.tsx
@@ -27,9 +27,9 @@ interface Provider {
 }
 
 const clientTypeOptions = [
-  { value: 'openai', label: 'openai (Completions)' },
-  { value: 'openai-responses', label: 'openai-responses (Responses API)' },
-  { value: 'openai-completion', label: 'openai-completion (Completions API)' },
+  { value: 'openai', label: 'openai' },
+  { value: 'openai-responses', label: 'openai-responses' },
+  { value: 'deepseek', label: 'deepseek' },
   { value: 'ark', label: 'ark' },
   { value: 'azure-http', label: 'azure-http' },
   { value: 'google', label: 'google' },

--- a/apps/monitor-dashboard-web/src/pages/Providers.tsx
+++ b/apps/monitor-dashboard-web/src/pages/Providers.tsx
@@ -27,7 +27,9 @@ interface Provider {
 }
 
 const clientTypeOptions = [
-  { value: 'openai', label: 'openai' },
+  { value: 'openai', label: 'openai (Completions)' },
+  { value: 'openai-responses', label: 'openai-responses (Responses API)' },
+  { value: 'openai-completion', label: 'openai-completion (Completions API)' },
   { value: 'ark', label: 'ark' },
   { value: 'azure-http', label: 'azure-http' },
   { value: 'google', label: 'google' },

--- a/apps/monitor-dashboard/src/routes/providers.ts
+++ b/apps/monitor-dashboard/src/routes/providers.ts
@@ -12,7 +12,7 @@ const maskApiKey = (apiKey: string) => {
   return `****${tail}`;
 };
 
-const allowedClientTypes = new Set(['openai', 'ark', 'azure-http', 'google']);
+const allowedClientTypes = new Set(['openai', 'openai-responses', 'openai-completion', 'ark', 'azure-http', 'google']);
 
 router.get('/api/providers', async (ctx) => {
   const repo = AppDataSource.getRepository(ModelProvider);

--- a/apps/monitor-dashboard/src/routes/providers.ts
+++ b/apps/monitor-dashboard/src/routes/providers.ts
@@ -12,7 +12,7 @@ const maskApiKey = (apiKey: string) => {
   return `****${tail}`;
 };
 
-const allowedClientTypes = new Set(['openai', 'openai-responses', 'openai-completion', 'ark', 'azure-http', 'google']);
+const allowedClientTypes = new Set(['openai', 'openai-responses', 'deepseek', 'ark', 'azure-http', 'google']);
 
 router.get('/api/providers', async (ctx) => {
   const repo = AppDataSource.getRepository(ModelProvider);


### PR DESCRIPTION
## Summary
- 新增 `deepseek` client_type，专用 `_ReasoningChatOpenAI` 子类处理 DeepSeek reasoner 的 `reasoning_content` 保留和 content 归一化
- 梳理 client_type 分类：`openai` / `openai-responses` / `deepseek` / `azure-http` / `google` / `ark`
- 非 OpenAI 供应商显式禁用 Responses API，防止 langchain-openai 自动启用导致 404
- Dashboard 前后端同步新 client_type 选项

## Test plan
- [x] 飞书 dev bot 端到端测试 deep_research 工具调用
- [x] 验证 DeepSeek reasoner 多轮 tool calling（reasoning_content 回传）
- [x] 验证 content 归一化（null → ""，数组 → 字符串）

🤖 Generated with [Claude Code](https://claude.com/claude-code)