### PR TITLE
fix(tool-service,agent-service,lark-server): reduce image pipeline latency and errors

### DIFF
--- a/apps/agent-service/app/agents/domains/main/context_builder.py
+++ b/apps/agent-service/app/agents/domains/main/context_builder.py
@@ -12,8 +12,12 @@ from langchain.messages import AIMessage, HumanMessage
 from app.agents.infra.langfuse_client import get_prompt
 from app.clients.image_client import image_client
 from app.clients.image_registry import ImageRegistry
+from sqlalchemy import select
+
+from app.orm.base import AsyncSessionLocal
+from app.orm.models import ConversationMessage
 from app.services.quick_search import QuickSearchResult, quick_search
-from app.utils.content_parser import parse_content
+from app.utils.content_parser import parse_content, update_tos_files
 
 logger = logging.getLogger(__name__)
 
@@ -40,28 +44,54 @@ async def build_chat_context(
 
     chat_type = l1_results[-1].chat_type or "p2p"  # 默认私聊
 
-    # 1. 从 content 里批量提取图片 keys
-    all_image_keys: list[tuple[str, str, str]] = []  # (key, message_id, role)
+    # 1. 从 content 里批量提取图片 keys，区分已缓存 vs 未缓存
+    cached_keys: list[tuple[str, str]]  = []  # (image_key, tos_file)
+    uncached_keys: list[tuple[str, str, str]] = []  # (image_key, message_id, role)
     for msg in l1_results:
         parsed = parse_content(msg.content)
         for key in parsed.image_keys:
-            all_image_keys.append((key, msg.message_id, msg.role))
+            tos_file = parsed.tos_files.get(key)
+            if tos_file:
+                cached_keys.append((key, tos_file))
+            else:
+                uncached_keys.append((key, msg.message_id, msg.role))
 
-    # 2. 批量处理所有图片 → TOS URL
+    # 2a. 已缓存的图片：只签 URL，不走飞书下载
     image_key_to_url: dict[str, str] = {}
-    if all_image_keys:
-        image_tasks = [
-            image_client.process_image(key, msg_id if role == "user" else None)
-            for key, msg_id, role in all_image_keys
-        ]
-        image_results = await asyncio.gather(*image_tasks, return_exceptions=True)
-
-        for i, result in enumerate(image_results):
-            key, msg_id, _ = all_image_keys[i]
+    image_key_to_file: dict[str, str] = {}  # 用于回写 DB
+    if cached_keys:
+        url_tasks = [image_client.get_url(tos_file) for _, tos_file in cached_keys]
+        url_results = await asyncio.gather(*url_tasks, return_exceptions=True)
+        for i, result in enumerate(url_results):
+            key, tos_file = cached_keys[i]
             if isinstance(result, str) and result:
                 image_key_to_url[key] = result
+                image_key_to_file[key] = tos_file
+            else:
+                # URL 签名失败（文件可能被清理），回退到完整 pipeline
+                uncached_keys.append((key, "", ""))
+                logger.warning(f"TOS URL 签名失败，回退完整 pipeline: {key}")
+
+    # 2b. 未缓存的图片：走完整 pipeline（飞书下载 → 压缩 → TOS）
+    if uncached_keys:
+        process_tasks = [
+            image_client.process_image(key, msg_id if role == "user" else None)
+            for key, msg_id, role in uncached_keys
+        ]
+        process_results = await asyncio.gather(*process_tasks, return_exceptions=True)
+
+        for i, result in enumerate(process_results):
+            key, msg_id, _ = uncached_keys[i]
+            if isinstance(result, dict) and result:
+                image_key_to_url[key] = result["url"]
+                if result.get("file_name"):
+                    image_key_to_file[key] = result["file_name"]
             else:
                 logger.warning(f"图片处理失败: key={key}, message_id={msg_id}")
+
+    # 2c. 将新获取的 tos_file 回写到消息 content（后台执行，不阻塞）
+    if image_key_to_file:
+        asyncio.create_task(_persist_tos_files(l1_results, image_key_to_file))
 
     # 3. 注册所有图片到 ImageRegistry
     registry = ImageRegistry(message_id)
@@ -104,6 +134,42 @@ async def build_chat_context(
         chat_name,
         chain_user_ids,
     )
+
+
+async def _persist_tos_files(
+    messages: list[QuickSearchResult], image_key_to_file: dict[str, str]
+) -> None:
+    """后台将 tos_file 回写到消息 content 的 image items 中。"""
+    try:
+        # 按 message_id 聚合需要更新的 image_key → file_name
+        msg_updates: dict[str, dict[str, str]] = {}  # message_id → {key: file_name}
+        for msg in messages:
+            parsed = parse_content(msg.content)
+            new_mappings = {}
+            for key in parsed.image_keys:
+                if key in image_key_to_file and key not in parsed.tos_files:
+                    new_mappings[key] = image_key_to_file[key]
+            if new_mappings:
+                msg_updates[msg.message_id] = new_mappings
+
+        if not msg_updates:
+            return
+
+        async with AsyncSessionLocal() as session:
+            for mid, mapping in msg_updates.items():
+                row = await session.scalar(
+                    select(ConversationMessage).where(
+                        ConversationMessage.message_id == mid
+                    )
+                )
+                if row:
+                    updated = update_tos_files(row.content, mapping)
+                    if updated:
+                        row.content = updated
+            await session.commit()
+            logger.info(f"tos_file 回写完成: {len(msg_updates)} 条消息")
+    except Exception:
+        logger.warning("tos_file 回写失败", exc_info=True)
 
 
 def _extract_reply_chain(

--- a/apps/agent-service/app/agents/domains/main/context_builder.py
+++ b/apps/agent-service/app/agents/domains/main/context_builder.py
@@ -50,6 +50,8 @@ async def build_chat_context(
     for msg in l1_results:
         parsed = parse_content(msg.content)
         for key in parsed.image_keys:
+            if key.startswith("@"):
+                continue  # skip @N.png references (not real image keys)
             tos_file = parsed.tos_files.get(key)
             if tos_file:
                 cached_keys.append((key, tos_file))

--- a/apps/agent-service/app/clients/image_client.py
+++ b/apps/agent-service/app/clients/image_client.py
@@ -39,9 +39,9 @@ class ImageProcessClient:
 
     async def process_image(
         self, file_key: str, message_id: str | None, bot_name: str | None = None
-    ) -> str | None:
+    ) -> dict | None:
         """
-        处理图片，返回图片URL
+        处理图片，返回 {"url": ..., "file_name": ...}
 
         Args:
             file_key: 图片文件key
@@ -49,7 +49,7 @@ class ImageProcessClient:
             bot_name: 机器人名称（用于多 bot 场景）
 
         Returns:
-            str: 图片URL，如果失败返回None
+            dict: {"url": str, "file_name": str}，如果失败返回None
         """
         # 优先使用传入的 bot_name，否则从上下文获取
         app_name = bot_name or get_app_name() or ""
@@ -78,8 +78,9 @@ class ImageProcessClient:
                 data = response.json()
 
                 if data.get("success") and data.get("data"):
-                    logger.info(f"图片处理成功: {file_key} -> {data['data']['url']}")
-                    return data["data"]["url"]
+                    result = data["data"]
+                    logger.info(f"图片处理成功: {file_key} -> {result['url']}")
+                    return {"url": result["url"], "file_name": result.get("file_name", "")}
                 else:
                     logger.error(f"图片处理失败: {data.get('message', '未知错误')}")
                     return None
@@ -94,6 +95,35 @@ class ImageProcessClient:
             return None
         except Exception as e:
             logger.error(f"调用图片处理接口失败: {str(e)}")
+            return None
+        finally:
+            _record_outbound("POST", status, time.monotonic() - start)
+
+    async def get_url(self, file_name: str) -> str | None:
+        """根据 TOS file_name 获取预签名 URL（不触发飞书下载）"""
+        start = time.monotonic()
+        status = "network_error"
+        try:
+            base_url = lane_router.base_url("tool-service")
+            async with httpx.AsyncClient(timeout=self.timeout) as client:
+                response = await client.post(
+                    f"{base_url}/api/image-pipeline/get-url",
+                    json={"file_name": file_name},
+                    headers={
+                        "Content-Type": "application/json",
+                        "Authorization": f"Bearer {settings.inner_http_secret}",
+                        "X-Trace-Id": get_trace_id() or "",
+                        **lane_router.get_headers(),
+                    },
+                )
+                status = str(response.status_code)
+                response.raise_for_status()
+                data = response.json()
+                if data.get("success") and data.get("data"):
+                    return data["data"]["url"]
+                return None
+        except Exception as e:
+            logger.warning(f"获取图片URL失败: {file_name} - {e}")
             return None
         finally:
             _record_outbound("POST", status, time.monotonic() - start)
@@ -239,10 +269,11 @@ class ImageProcessClient:
         """
         try:
             # 1. 获取图片URL
-            image_url = await self.process_image(file_key, message_id, bot_name)
-            if not image_url:
+            result = await self.process_image(file_key, message_id, bot_name)
+            if not result:
                 logger.warning(f"无法获取图片URL: {file_key}")
                 return None
+            image_url = result["url"]
 
             # 2. 下载图片内容
             async with httpx.AsyncClient(timeout=30.0) as client:

--- a/apps/agent-service/app/utils/content_parser.py
+++ b/apps/agent-service/app/utils/content_parser.py
@@ -31,6 +31,9 @@ class ParsedContent:
     mentions: list[dict] = field(
         default_factory=list
     )  # @提及的用户列表 [{user_id, name}]
+    tos_files: dict[str, str] = field(
+        default_factory=dict
+    )  # image_key → TOS file_name (已处理过的图片)
 
     def render(self, image_fn: ImageRenderFn | None = None) -> str:
         """从 items 结构化渲染文本
@@ -94,12 +97,18 @@ def parse_content(raw: str) -> ParsedContent:
             image_keys = [
                 item["value"] for item in items if item.get("type") == "image"
             ]
+            tos_files = {
+                item["value"]: item["tos_file"]
+                for item in items
+                if item.get("type") == "image" and item.get("tos_file")
+            }
             mentions = data.get("mentions", [])
             return ParsedContent(
                 text=text,
                 image_keys=image_keys,
                 items=items,
                 mentions=mentions,
+                tos_files=tos_files,
             )
     except (json.JSONDecodeError, TypeError):
         pass
@@ -107,3 +116,26 @@ def parse_content(raw: str) -> ParsedContent:
     # 非 v2 格式，视为纯文本
     logger.debug("Non-v2 content format, treating as plain text")
     return ParsedContent(text=raw, image_keys=[])
+
+
+def update_tos_files(raw: str, mapping: dict[str, str]) -> str | None:
+    """将 tos_file 写入 v2 content 的 image items，返回更新后的 JSON 字符串。
+
+    如果没有需要更新的 item 或非 v2 格式，返回 None（无需更新）。
+    """
+    try:
+        data = json.loads(raw)
+    except (json.JSONDecodeError, TypeError):
+        return None
+    if not isinstance(data, dict) or data.get("v") != 2:
+        return None
+
+    updated = False
+    for item in data.get("items", []):
+        if item.get("type") == "image":
+            key = item.get("value")
+            if key in mapping and item.get("tos_file") != mapping[key]:
+                item["tos_file"] = mapping[key]
+                updated = True
+
+    return json.dumps(data, ensure_ascii=False) if updated else None

--- a/apps/lark-server/src/core/models/message-content.ts
+++ b/apps/lark-server/src/core/models/message-content.ts
@@ -144,6 +144,10 @@ export class MessageContentUtils {
         let match: RegExpExecArray | null;
 
         while ((match = IMAGE_PATTERN.exec(markdown)) !== null) {
+            const imageRef = match[1];
+            // @N.png 是 ImageRegistry 引用，不是真实 image_key，保留为文本
+            const isUnresolved = /^@?\d+\.png$/.test(imageRef);
+
             // match 之前的文本部分
             if (match.index > lastIndex) {
                 items.push({
@@ -151,11 +155,18 @@ export class MessageContentUtils {
                     value: markdown.slice(lastIndex, match.index),
                 });
             }
-            // image item
-            items.push({
-                type: ContentType.Image,
-                value: match[1],
-            });
+            if (isUnresolved) {
+                // 未解析的引用保留为文本，不创建 image item
+                items.push({
+                    type: ContentType.Text,
+                    value: match[0],
+                });
+            } else {
+                items.push({
+                    type: ContentType.Image,
+                    value: imageRef,
+                });
+            }
             lastIndex = match.index + match[0].length;
         }
 

--- a/apps/tool-service/app/api/image_pipeline.py
+++ b/apps/tool-service/app/api/image_pipeline.py
@@ -4,7 +4,13 @@ from fastapi import APIRouter, Depends, Header, HTTPException, Request
 from pydantic import BaseModel
 
 from app.middleware.auth import verify_bearer_token
-from app.services.image_pipeline import process_image_pipeline, upload_base64_image, upload_to_tos
+from app.services.image_pipeline import (
+    UpstreamError,
+    get_file_url,
+    process_image_pipeline,
+    upload_base64_image,
+    upload_to_tos,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -14,6 +20,10 @@ router = APIRouter(dependencies=[Depends(verify_bearer_token)])
 class ProcessRequest(BaseModel):
     message_id: str | None = None
     file_key: str
+
+
+class GetUrlRequest(BaseModel):
+    file_name: str
 
 
 class UploadToTosRequest(BaseModel):
@@ -41,6 +51,17 @@ async def process(request: ProcessRequest, x_app_name: str = Header(alias="X-App
         raise HTTPException(status_code=500, detail=str(e))
 
 
+@router.post("/get-url")
+async def get_url(request: GetUrlRequest):
+    """Get pre-signed URL for an already-uploaded TOS file. No Lark download."""
+    try:
+        result = await get_file_url(file_name=request.file_name)
+        return {"success": True, "data": result, "message": "ok"}
+    except Exception as e:
+        logger.error(f"Get URL failed: {e}", exc_info=True)
+        raise HTTPException(status_code=500, detail=str(e))
+
+
 @router.post("/to-tos")
 async def to_tos(request: UploadToTosRequest):
     try:
@@ -51,6 +72,9 @@ async def to_tos(request: UploadToTosRequest):
         return {"success": True, "data": result, "message": "ok"}
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
+    except UpstreamError as e:
+        logger.warning(f"Upload to TOS upstream error: {e}")
+        raise HTTPException(status_code=e.status_code, detail=str(e))
     except Exception as e:
         logger.error(f"Upload to TOS failed: {e}", exc_info=True)
         raise HTTPException(status_code=500, detail=str(e))

--- a/apps/tool-service/app/infrastructure/lark_client.py
+++ b/apps/tool-service/app/infrastructure/lark_client.py
@@ -1,3 +1,4 @@
+import asyncio
 import io
 import logging
 
@@ -14,6 +15,22 @@ from app.infrastructure.database import get_session_factory
 from app.orm.bot_config import BotConfig
 
 logger = logging.getLogger(__name__)
+
+_MAX_RETRIES = 3
+_RETRY_BACKOFF = (0.5, 1.0, 2.0)
+
+
+def _extract_error(response) -> str:
+    """Extract error details from Lark SDK response, including raw HTTP info."""
+    parts = [f"code={response.code}", f"msg={response.msg}"]
+    if response.raw:
+        parts.append(f"http_status={response.raw.status_code}")
+        try:
+            body = response.raw.content[:500].decode("utf-8", errors="replace")
+            parts.append(f"body={body}")
+        except Exception:
+            pass
+    return ", ".join(parts)
 
 # bot_name -> lark.Client
 _clients: dict[str, lark.Client] = {}
@@ -50,29 +67,49 @@ def get_client(bot_name: str) -> lark.Client:
 
 
 async def download_message_resource(bot_name: str, message_id: str, file_key: str) -> bytes:
-    """Download a resource (image/file) attached to a message."""
+    """Download a resource (image/file) attached to a message, with retry."""
     client = get_client(bot_name)
-    request = GetMessageResourceRequest.builder() \
-        .message_id(message_id) \
-        .file_key(file_key) \
-        .type("image") \
-        .build()
-    response = await client.im.v1.message_resource.aget(request)
-    if not response.success():
-        raise RuntimeError(f"Download resource failed: {response.code} {response.msg}")
-    return response.file.read()
+    last_error = None
+    for attempt in range(_MAX_RETRIES):
+        request = GetMessageResourceRequest.builder() \
+            .message_id(message_id) \
+            .file_key(file_key) \
+            .type("image") \
+            .build()
+        response = await client.im.v1.message_resource.aget(request)
+        if response.success():
+            return response.file.read()
+        error_detail = _extract_error(response)
+        last_error = error_detail
+        logger.warning(
+            "Download resource attempt %d/%d failed: %s (file_key=%s)",
+            attempt + 1, _MAX_RETRIES, error_detail, file_key,
+        )
+        if attempt < _MAX_RETRIES - 1:
+            await asyncio.sleep(_RETRY_BACKOFF[attempt])
+    raise RuntimeError(f"Download resource failed after {_MAX_RETRIES} retries: {last_error}")
 
 
 async def download_image(bot_name: str, image_key: str) -> bytes:
-    """Download an image by image_key."""
+    """Download an image by image_key, with retry."""
     client = get_client(bot_name)
-    request = GetImageRequest.builder() \
-        .image_key(image_key) \
-        .build()
-    response = await client.im.v1.image.aget(request)
-    if not response.success():
-        raise RuntimeError(f"Download image failed: {response.code} {response.msg}")
-    return response.file.read()
+    last_error = None
+    for attempt in range(_MAX_RETRIES):
+        request = GetImageRequest.builder() \
+            .image_key(image_key) \
+            .build()
+        response = await client.im.v1.image.aget(request)
+        if response.success():
+            return response.file.read()
+        error_detail = _extract_error(response)
+        last_error = error_detail
+        logger.warning(
+            "Download image attempt %d/%d failed: %s (image_key=%s)",
+            attempt + 1, _MAX_RETRIES, error_detail, image_key,
+        )
+        if attempt < _MAX_RETRIES - 1:
+            await asyncio.sleep(_RETRY_BACKOFF[attempt])
+    raise RuntimeError(f"Download image failed after {_MAX_RETRIES} retries: {last_error}")
 
 
 async def upload_image(bot_name: str, image_data: bytes) -> str:

--- a/apps/tool-service/app/services/image_pipeline.py
+++ b/apps/tool-service/app/services/image_pipeline.py
@@ -10,6 +10,21 @@ from app.services.image_service import process_image
 
 logger = logging.getLogger(__name__)
 
+
+class UpstreamError(Exception):
+    """Error from an upstream service (Lark API, external URL)."""
+
+    def __init__(self, message: str, status_code: int = 502):
+        super().__init__(message)
+        self.status_code = status_code
+
+
+class UpstreamTimeoutError(UpstreamError):
+    """Timeout from an upstream service."""
+
+    def __init__(self, message: str):
+        super().__init__(message, status_code=504)
+
 IMAGE_PIPELINE_DURATION = Histogram(
     "image_pipeline_step_duration_seconds",
     "Duration of each image pipeline step",
@@ -73,7 +88,17 @@ async def process_image_pipeline(
         url = await tos_client.get_file_url(file_name)
         await redis_client.redis_set_with_expire(url_cache_key, url, _URL_CACHE_TTL)
 
-    return {"url": url, "file_key": file_key}
+    return {"url": url, "file_key": file_key, "file_name": file_name}
+
+
+async def get_file_url(file_name: str) -> dict:
+    """Get pre-signed URL for an already-uploaded TOS file. No Lark download."""
+    url_cache_key = f"image_url:{file_name}"
+    url = await redis_client.redis_get(url_cache_key)
+    if not url:
+        url = await tos_client.get_file_url(file_name)
+        await redis_client.redis_set_with_expire(url_cache_key, url, _URL_CACHE_TTL)
+    return {"url": url, "file_name": file_name}
 
 
 async def upload_to_tos(source_type: str, data: str) -> dict:
@@ -104,10 +129,18 @@ async def upload_to_tos(source_type: str, data: str) -> dict:
         from app.config.config import settings as _settings
 
         proxy = _settings.forward_proxy_url
-        async with httpx.AsyncClient(timeout=30, proxy=proxy) as client:
-            resp = await client.get(data)
-            resp.raise_for_status()
-            image_bytes = resp.content
+        try:
+            async with httpx.AsyncClient(timeout=10, proxy=proxy) as client:
+                resp = await client.get(data)
+                resp.raise_for_status()
+                image_bytes = resp.content
+        except httpx.TimeoutException:
+            raise UpstreamTimeoutError(f"URL download timed out: {data[:200]}")
+        except httpx.HTTPStatusError as e:
+            raise UpstreamError(
+                f"URL download failed: {e.response.status_code}",
+                status_code=e.response.status_code,
+            )
         t_download = time.monotonic() - t_start
         IMAGE_PIPELINE_DURATION.labels(step="download_url").observe(t_download)
         file_id = hashlib.md5(image_bytes).hexdigest()[:16]


### PR DESCRIPTION
## Summary
- **tool-service**: 飞书下载加 3 次重试 + 提取真实 HTTP 错误信息；URL 下载超时 30s→10s，错误码区分 502/504；新增 `/get-url` 轻量端点（只签 URL 不下载）
- **agent-service**: context_builder 区分已缓存/未缓存图片，有 `tos_file` 的走 `get_url`（跳过飞书下载），处理后回写 DB；跳过 `@N.png` 假 image_key
- **lark-server**: `wrapMarkdownAsV2` 过滤未解析的 `@N.png` 引用，防止存为 image item

## 背景
agent-service → tool-service P99 延迟 6.8s、错误率 48%、5xx 率 30%。根因：
1. context_builder 每次构建上下文都对所有历史图片调 tool-service，Redis 缓存 miss 后重新从飞书下载，触发限流
2. 外部 URL 下载 30s 超时拉高 P99
3. 历史 assistant 消息存了 `@N.png` 假 image_key，导致飞书 API 234001 错误

## Test plan
- [x] fix-latency 泳道验证：`/get-url` 200、`/process` 200、无 500
- [x] 飞书错误日志现在带完整 HTTP 状态码和 body
- [ ] 生产部署后观察告警是否消退

🤖 Generated with [Claude Code](https://claude.com/claude-code)