### PR TITLE
fix(lark-server): reject unresolved N.png image refs in markdownToPostContent

### DIFF
--- a/apps/lark-server/src/core/services/message/post-content-processor.ts
+++ b/apps/lark-server/src/core/services/message/post-content-processor.ts
@@ -157,6 +157,10 @@ export function markdownToPostContent(markdown: string): PostContent {
             // 外部 URL，跳过图片节点（模型编造的链接无法显示）
             continue;
         }
+        if (/^@?\d+\.png$/.test(imageKey)) {
+            // 未解析的 ImageRegistry 引用，不能作为飞书 image_key
+            continue;
+        }
         content.push([{ tag: 'img', image_key: imageKey } as ImgPostNode]);
     }
 

--- a/apps/lark-server/src/workers/chat-response-worker.ts
+++ b/apps/lark-server/src/workers/chat-response-worker.ts
@@ -58,7 +58,7 @@ const imageResolveTotal = new Counter({
 });
 
 const SEND_DELAY_MS = 2500;
-const IMAGE_REF_PATTERN = /!\[([^\]]*)\]\(@(\d+\.png)\)/g;
+const IMAGE_REF_PATTERN = /!\[([^\]]*)\]\(@?(\d+\.png)\)/g;
 
 /**
  * Resolve @N.png references in markdown image syntax.


### PR DESCRIPTION
## Summary
- `resolveImageReferences` 正则改为 `@?` 可选，兼容模型输出 `![alt](1.png)` 无 `@` 前缀的情况
- `markdownToPostContent` 添加 `/^@?\d+\.png$/` 防护，与 `wrapMarkdownAsV2` 对齐，防止未解析引用作为 image_key 发给飞书

## Test plan
- [x] fix-chat 泳道部署验证

🤖 Generated with [Claude Code](https://claude.com/claude-code)