### PR TITLE
feat: akao persona enrichment + dynamic schedule system

### DIFF
--- a/apps/agent-service/app/agents/domains/main/agent.py
+++ b/apps/agent-service/app/agents/domains/main/agent.py
@@ -21,6 +21,7 @@ from app.agents.domains.main.tools import ALL_TOOLS
 from app.agents.graphs.pre import run_pre
 from app.orm.crud import get_gray_config, get_message_content
 from app.services.memory_context import build_diary_context, build_impression_context
+from app.services.schedule_context import build_schedule_context
 from app.utils.content_parser import parse_content
 
 logger = logging.getLogger(__name__)
@@ -216,6 +217,7 @@ async def _build_and_stream(
     prompt_vars = {
         "complexity_hint": "",
         "user_context": "",
+        "schedule_context": "",
     }
 
     # 创建 agent
@@ -278,6 +280,14 @@ async def _build_and_stream(
                 context_lines.append("\n---\n" + impression_text)
         except Exception as e:
             logger.error(f"Failed to build impression context: {e}")
+
+    # 注入日程上下文（赤尾现在在干什么）
+    try:
+        schedule_text = await build_schedule_context()
+        if schedule_text:
+            prompt_vars["schedule_context"] = schedule_text
+    except Exception as e:
+        logger.error(f"Failed to build schedule context: {e}")
 
     prompt_vars["user_context"] = "\n".join(context_lines)
 

--- a/apps/agent-service/app/api/router.py
+++ b/apps/agent-service/app/api/router.py
@@ -42,6 +42,37 @@ def import_time():
 # ==================== 调试端点 ====================
 
 
+@api_router.post("/admin/trigger-schedule", tags=["Admin"])
+async def trigger_schedule(
+    plan_type: str = "daily",
+    target_date: str | None = None,
+):
+    """手动触发日程生成
+
+    Args:
+        plan_type: "monthly" | "weekly" | "daily"
+        target_date: 目标日期（如 "2026-03-18"），默认今天
+    """
+    from app.workers.schedule_worker import (
+        generate_daily_plan,
+        generate_monthly_plan,
+        generate_weekly_plan,
+    )
+
+    d = date.fromisoformat(target_date) if target_date else None
+    if plan_type == "monthly":
+        content = await generate_monthly_plan(d)
+        return {"ok": bool(content), "plan_type": "monthly", "content": content}
+    elif plan_type == "weekly":
+        content = await generate_weekly_plan(d)
+        return {"ok": bool(content), "plan_type": "weekly", "content": content}
+    elif plan_type == "daily":
+        entries = await generate_daily_plan(d)
+        return {"ok": bool(entries), "plan_type": "daily", "entries": entries}
+    else:
+        return {"ok": False, "message": f"Unknown plan_type: {plan_type}"}
+
+
 @api_router.post("/admin/trigger-weekly-review", tags=["Admin"])
 async def trigger_weekly_review(chat_id: str, week_start: str | None = None):
     """手动触发周记生成

--- a/apps/agent-service/app/api/router.py
+++ b/apps/agent-service/app/api/router.py
@@ -67,8 +67,8 @@ async def trigger_schedule(
         content = await generate_weekly_plan(d)
         return {"ok": bool(content), "plan_type": "weekly", "content": content}
     elif plan_type == "daily":
-        entries = await generate_daily_plan(d)
-        return {"ok": bool(entries), "plan_type": "daily", "entries": entries}
+        content = await generate_daily_plan(d)
+        return {"ok": bool(content), "plan_type": "daily", "content": content}
     else:
         return {"ok": False, "message": f"Unknown plan_type: {plan_type}"}
 

--- a/apps/agent-service/app/api/schedule.py
+++ b/apps/agent-service/app/api/schedule.py
@@ -1,0 +1,112 @@
+"""赤尾日程 CRUD API"""
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
+
+from app.orm.crud import (
+    delete_schedule,
+    get_daily_entries_for_date,
+    list_schedules,
+    upsert_schedule,
+)
+from app.orm.models import AkaoSchedule
+from app.services.schedule_context import build_schedule_context
+
+router = APIRouter(prefix="/api/schedule", tags=["Schedule"])
+
+
+class ScheduleCreate(BaseModel):
+    plan_type: str  # "monthly" | "weekly" | "daily"
+    period_start: str
+    period_end: str
+    time_start: str | None = None
+    time_end: str | None = None
+    content: str
+    mood: str | None = None
+    energy_level: int | None = None
+    response_style_hint: str | None = None
+    proactive_action: dict | None = None
+    target_chats: list | None = None
+    model: str | None = None
+    is_active: bool = True
+
+
+class ScheduleOut(BaseModel):
+    id: int
+    plan_type: str
+    period_start: str
+    period_end: str
+    time_start: str | None
+    time_end: str | None
+    content: str
+    mood: str | None
+    energy_level: int | None
+    response_style_hint: str | None
+    proactive_action: dict | None
+    target_chats: list | None
+    model: str | None
+    is_active: bool
+
+    model_config = {"from_attributes": True}
+
+
+def _to_out(entry: AkaoSchedule) -> dict:
+    return ScheduleOut.model_validate(entry).model_dump()
+
+
+@router.get("")
+async def api_list_schedules(
+    plan_type: str | None = None,
+    active_only: bool = True,
+    limit: int = 50,
+):
+    entries = await list_schedules(plan_type=plan_type, active_only=active_only, limit=limit)
+    return [_to_out(e) for e in entries]
+
+
+@router.get("/current")
+async def api_current_schedule():
+    """返回当前时刻的日程上下文（和注入 prompt 的内容一致）"""
+    context = await build_schedule_context()
+    return {"context": context}
+
+
+@router.get("/daily/{target_date}")
+async def api_daily_entries(target_date: str):
+    """查指定日期的所有日计划时段"""
+    entries = await get_daily_entries_for_date(target_date)
+    return [_to_out(e) for e in entries]
+
+
+@router.post("")
+async def api_create_schedule(body: ScheduleCreate):
+    if body.plan_type not in ("monthly", "weekly", "daily"):
+        raise HTTPException(400, "plan_type must be monthly, weekly, or daily")
+    if body.plan_type == "daily" and (not body.time_start or not body.time_end):
+        raise HTTPException(400, "daily entries require time_start and time_end")
+
+    entry = AkaoSchedule(
+        plan_type=body.plan_type,
+        period_start=body.period_start,
+        period_end=body.period_end,
+        time_start=body.time_start,
+        time_end=body.time_end,
+        content=body.content,
+        mood=body.mood,
+        energy_level=body.energy_level,
+        response_style_hint=body.response_style_hint,
+        proactive_action=body.proactive_action,
+        target_chats=body.target_chats,
+        model=body.model,
+        is_active=body.is_active,
+    )
+    saved = await upsert_schedule(entry)
+    return _to_out(saved)
+
+
+@router.delete("/{schedule_id}")
+async def api_delete_schedule(schedule_id: int):
+    ok = await delete_schedule(schedule_id)
+    if not ok:
+        raise HTTPException(404, "Schedule entry not found")
+    return {"ok": True}

--- a/apps/agent-service/app/main.py
+++ b/apps/agent-service/app/main.py
@@ -7,6 +7,7 @@ from fastapi import FastAPI
 from inner_shared import hello as shared_hello
 
 from app.api.router import api_router
+from app.api.schedule import router as schedule_router
 from app.config import settings
 from app.services.qdrant import init_qdrant_collections
 from app.utils.middlewares import HeaderContextMiddleware
@@ -66,3 +67,4 @@ app.add_middleware(HeaderContextMiddleware)
 
 # 注册API路由
 app.include_router(api_router)
+app.include_router(schedule_router)

--- a/apps/agent-service/app/orm/crud.py
+++ b/apps/agent-service/app/orm/crud.py
@@ -5,6 +5,7 @@ from sqlalchemy.future import select
 
 from .base import AsyncSessionLocal
 from .models import (
+    AkaoSchedule,
     ConversationMessage,
     DiaryEntry,
     LarkBaseChatInfo,
@@ -352,3 +353,156 @@ async def upsert_person_impression(
                 )
             )
         await session.commit()
+
+
+# ==================== AkaoSchedule CRUD ====================
+
+
+_WEEKDAY_MAP = {
+    "monday": 0, "tuesday": 1, "wednesday": 2, "thursday": 3,
+    "friday": 4, "saturday": 5, "sunday": 6,
+}
+
+
+async def get_current_schedule(
+    now_date: str, now_time: str, weekday: int
+) -> list[AkaoSchedule]:
+    """查询当前时刻生效的日程条目
+
+    优先级：daily（精确日期的时段）> weekly > monthly
+    返回所有匹配的活跃条目，由调用方组装上下文。
+
+    Args:
+        now_date: 当前日期 "2026-03-18"
+        now_time: 当前时间 "14:30"
+        weekday: 星期几 (0=Monday, 6=Sunday)
+    """
+    async with AsyncSessionLocal() as session:
+        result = await session.execute(
+            select(AkaoSchedule)
+            .where(AkaoSchedule.is_active.is_(True))
+            .where(AkaoSchedule.period_start <= now_date)
+            .where(AkaoSchedule.period_end >= now_date)
+            .order_by(AkaoSchedule.plan_type.asc())  # daily < monthly < weekly 字母序
+        )
+        all_entries = list(result.scalars().all())
+
+    matched: list[AkaoSchedule] = []
+    for entry in all_entries:
+        if entry.plan_type in ("monthly", "weekly"):
+            matched.append(entry)
+        elif entry.plan_type == "daily":
+            # daily 条目需要匹配 time_start <= now_time < time_end
+            if entry.time_start and entry.time_end:
+                if entry.time_start <= now_time < entry.time_end:
+                    matched.append(entry)
+    return matched
+
+
+async def get_latest_plan(plan_type: str, before_date: str) -> AkaoSchedule | None:
+    """查指定类型的最近一条计划（用于生成下一期计划时的上下文）"""
+    async with AsyncSessionLocal() as session:
+        result = await session.execute(
+            select(AkaoSchedule)
+            .where(AkaoSchedule.plan_type == plan_type)
+            .where(AkaoSchedule.is_active.is_(True))
+            .where(AkaoSchedule.period_end < before_date)
+            .order_by(AkaoSchedule.period_end.desc())
+            .limit(1)
+        )
+        return result.scalar_one_or_none()
+
+
+async def get_plan_for_period(
+    plan_type: str, period_start: str, period_end: str
+) -> AkaoSchedule | None:
+    """查指定周期的计划"""
+    async with AsyncSessionLocal() as session:
+        result = await session.execute(
+            select(AkaoSchedule)
+            .where(AkaoSchedule.plan_type == plan_type)
+            .where(AkaoSchedule.period_start == period_start)
+            .where(AkaoSchedule.period_end == period_end)
+        )
+        return result.scalar_one_or_none()
+
+
+async def get_daily_entries_for_date(target_date: str) -> list[AkaoSchedule]:
+    """查指定日期的所有日计划时段"""
+    async with AsyncSessionLocal() as session:
+        result = await session.execute(
+            select(AkaoSchedule)
+            .where(AkaoSchedule.plan_type == "daily")
+            .where(AkaoSchedule.period_start == target_date)
+            .where(AkaoSchedule.is_active.is_(True))
+            .order_by(AkaoSchedule.time_start.asc())
+        )
+        return list(result.scalars().all())
+
+
+async def list_schedules(
+    plan_type: str | None = None,
+    active_only: bool = True,
+    limit: int = 50,
+) -> list[AkaoSchedule]:
+    """列出日程条目"""
+    async with AsyncSessionLocal() as session:
+        stmt = select(AkaoSchedule)
+        if plan_type:
+            stmt = stmt.where(AkaoSchedule.plan_type == plan_type)
+        if active_only:
+            stmt = stmt.where(AkaoSchedule.is_active.is_(True))
+        stmt = stmt.order_by(
+            AkaoSchedule.period_start.desc(), AkaoSchedule.time_start.asc()
+        ).limit(limit)
+        result = await session.execute(stmt)
+        return list(result.scalars().all())
+
+
+async def upsert_schedule(entry: AkaoSchedule) -> AkaoSchedule:
+    """插入或更新日程条目（按 unique key 匹配）"""
+    async with AsyncSessionLocal() as session:
+        result = await session.execute(
+            select(AkaoSchedule)
+            .where(AkaoSchedule.plan_type == entry.plan_type)
+            .where(AkaoSchedule.period_start == entry.period_start)
+            .where(AkaoSchedule.period_end == entry.period_end)
+            .where(
+                AkaoSchedule.time_start == entry.time_start
+                if entry.time_start
+                else AkaoSchedule.time_start.is_(None)
+            )
+        )
+        existing = result.scalar_one_or_none()
+
+        if existing:
+            existing.content = entry.content
+            existing.mood = entry.mood
+            existing.energy_level = entry.energy_level
+            existing.response_style_hint = entry.response_style_hint
+            existing.proactive_action = entry.proactive_action
+            existing.target_chats = entry.target_chats
+            existing.model = entry.model
+            existing.is_active = entry.is_active
+            await session.commit()
+            await session.refresh(existing)
+            return existing
+        else:
+            session.add(entry)
+            await session.commit()
+            await session.refresh(entry)
+            return entry
+
+
+async def delete_schedule(schedule_id: int) -> bool:
+    """删除日程条目"""
+    async with AsyncSessionLocal() as session:
+        result = await session.execute(
+            select(AkaoSchedule).where(AkaoSchedule.id == schedule_id)
+        )
+        entry = result.scalar_one_or_none()
+        if not entry:
+            return False
+        await session.delete(entry)
+        await session.commit()
+        return True

--- a/apps/agent-service/app/orm/models.py
+++ b/apps/agent-service/app/orm/models.py
@@ -125,6 +125,63 @@ class DiaryEntry(Base):
     )
 
 
+class AkaoSchedule(Base):
+    """赤尾日程条目
+
+    支持三层时间维度的计划：
+    - monthly: 月度方向（兴趣倾向、生活基调）
+    - weekly: 周计划（本周大致安排）
+    - daily: 日计划（逐时段活动、心情、精力）
+
+    月/周计划由 LLM 离线生成，给出方向而非限制。
+    日计划继承月/周计划，填充具体时段。
+    event 类型覆盖同时段的 routine。
+    """
+
+    __tablename__ = "akao_schedule"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+
+    # 计划层级: "monthly" | "weekly" | "daily"
+    plan_type: Mapped[str] = mapped_column(String(20), nullable=False)
+
+    # 时间周期
+    period_start: Mapped[str] = mapped_column(String(10), nullable=False)  # "2026-03-01"
+    period_end: Mapped[str] = mapped_column(String(10), nullable=False)  # "2026-03-31"
+
+    # 日计划专用：当天内的时间段
+    time_start: Mapped[str | None] = mapped_column(String(5), nullable=True)  # "07:00"
+    time_end: Mapped[str | None] = mapped_column(String(5), nullable=True)  # "08:30"
+
+    # 内容：叙事性描述（所有层级都有）
+    content: Mapped[str] = mapped_column(Text, nullable=False)
+
+    # 结构化元数据（主要用于日计划时段）
+    mood: Mapped[str | None] = mapped_column(String(50), nullable=True)
+    energy_level: Mapped[int | None] = mapped_column(Integer, nullable=True)  # 1-5
+    response_style_hint: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+    # Phase 2: 主动行为配置
+    proactive_action: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
+    target_chats: Mapped[list | None] = mapped_column(JSONB, nullable=True)
+
+    # 生成元信息
+    model: Mapped[str | None] = mapped_column(String(100), nullable=True)
+    is_active: Mapped[bool] = mapped_column(Boolean, default=True)
+
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now()
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now()
+    )
+
+    __table_args__ = (
+        # 月/周计划：同类型同周期只有一条
+        UniqueConstraint("plan_type", "period_start", "period_end", "time_start"),
+    )
+
+
 class LarkGroupMember(Base):
     """群成员信息"""
 

--- a/apps/agent-service/app/services/schedule_context.py
+++ b/apps/agent-service/app/services/schedule_context.py
@@ -1,99 +1,33 @@
 """日程上下文构建
 
-查询当前时刻的月/周/日计划，组装为自然语言注入 system prompt。
-让赤尾知道自己「现在在干什么」「这周/这个月的生活状态」。
+查询今日的手帐/备忘录，注入 system prompt。
+让赤尾知道自己「今天在过什么样的日子」。
 """
 
 import logging
 from datetime import datetime, timedelta, timezone
 
-from app.orm.crud import get_current_schedule
+from app.orm.crud import get_plan_for_period
 
 logger = logging.getLogger(__name__)
 
 CST = timezone(timedelta(hours=8))
 
-_WEEKDAY_CN = ["周一", "周二", "周三", "周四", "周五", "周六", "周日"]
-
-# 精力值对应的描述
-_ENERGY_DESC = {
-    1: "很困，精力很低",
-    2: "有点疲惫",
-    3: "状态一般",
-    4: "精力不错",
-    5: "精力充沛，状态很好",
-}
-
 
 async def build_schedule_context() -> str:
-    """构建当前时刻的日程上下文，注入 system prompt
+    """构建当前的日程上下文，注入 system prompt
+
+    只注入今日手帐内容。月/周计划不直接注入聊天，
+    它们的作用是在生成日计划时提供方向。
 
     Returns:
-        格式化后的日程文本，空字符串表示无日程数据
+        今日手帐文本，空字符串表示无数据
     """
     now = datetime.now(CST)
-    now_date = now.strftime("%Y-%m-%d")
-    now_time = now.strftime("%H:%M")
-    weekday = now.weekday()
-    weekday_cn = _WEEKDAY_CN[weekday]
-    hour = now.hour
+    today = now.strftime("%Y-%m-%d")
 
-    entries = await get_current_schedule(now_date, now_time, weekday)
-    if not entries:
+    daily = await get_plan_for_period("daily", today, today)
+    if not daily:
         return ""
 
-    parts: list[str] = []
-
-    # 时间感知
-    time_desc = _time_of_day_desc(hour)
-    parts.append(f"现在是{now_date}（{weekday_cn}）{now_time}，{time_desc}。")
-
-    # 按 plan_type 分组
-    monthly = None
-    weekly = None
-    daily = None
-    for entry in entries:
-        if entry.plan_type == "monthly" and not monthly:
-            monthly = entry
-        elif entry.plan_type == "weekly" and not weekly:
-            weekly = entry
-        elif entry.plan_type == "daily" and not daily:
-            daily = entry
-
-    # 月度方向（简短）
-    if monthly:
-        parts.append(f"这个月的状态：{monthly.content}")
-
-    # 周计划
-    if weekly:
-        parts.append(f"这周：{weekly.content}")
-
-    # 日计划时段（最重要，直接影响回复风格）
-    if daily:
-        parts.append(f"你现在正在：{daily.content}")
-        if daily.mood:
-            parts.append(f"心情：{daily.mood}")
-        if daily.energy_level:
-            parts.append(f"精力：{_ENERGY_DESC.get(daily.energy_level, '')}")
-        if daily.response_style_hint:
-            parts.append(f"（{daily.response_style_hint}）")
-
-    return "\n".join(parts)
-
-
-def _time_of_day_desc(hour: int) -> str:
-    """根据小时返回时段描述"""
-    if hour < 6:
-        return "深夜/凌晨"
-    elif hour < 9:
-        return "早上"
-    elif hour < 12:
-        return "上午"
-    elif hour < 14:
-        return "中午"
-    elif hour < 18:
-        return "下午"
-    elif hour < 21:
-        return "晚上"
-    else:
-        return "深夜"
+    return daily.content

--- a/apps/agent-service/app/services/schedule_context.py
+++ b/apps/agent-service/app/services/schedule_context.py
@@ -1,0 +1,99 @@
+"""日程上下文构建
+
+查询当前时刻的月/周/日计划，组装为自然语言注入 system prompt。
+让赤尾知道自己「现在在干什么」「这周/这个月的生活状态」。
+"""
+
+import logging
+from datetime import datetime, timedelta, timezone
+
+from app.orm.crud import get_current_schedule
+
+logger = logging.getLogger(__name__)
+
+CST = timezone(timedelta(hours=8))
+
+_WEEKDAY_CN = ["周一", "周二", "周三", "周四", "周五", "周六", "周日"]
+
+# 精力值对应的描述
+_ENERGY_DESC = {
+    1: "很困，精力很低",
+    2: "有点疲惫",
+    3: "状态一般",
+    4: "精力不错",
+    5: "精力充沛，状态很好",
+}
+
+
+async def build_schedule_context() -> str:
+    """构建当前时刻的日程上下文，注入 system prompt
+
+    Returns:
+        格式化后的日程文本，空字符串表示无日程数据
+    """
+    now = datetime.now(CST)
+    now_date = now.strftime("%Y-%m-%d")
+    now_time = now.strftime("%H:%M")
+    weekday = now.weekday()
+    weekday_cn = _WEEKDAY_CN[weekday]
+    hour = now.hour
+
+    entries = await get_current_schedule(now_date, now_time, weekday)
+    if not entries:
+        return ""
+
+    parts: list[str] = []
+
+    # 时间感知
+    time_desc = _time_of_day_desc(hour)
+    parts.append(f"现在是{now_date}（{weekday_cn}）{now_time}，{time_desc}。")
+
+    # 按 plan_type 分组
+    monthly = None
+    weekly = None
+    daily = None
+    for entry in entries:
+        if entry.plan_type == "monthly" and not monthly:
+            monthly = entry
+        elif entry.plan_type == "weekly" and not weekly:
+            weekly = entry
+        elif entry.plan_type == "daily" and not daily:
+            daily = entry
+
+    # 月度方向（简短）
+    if monthly:
+        parts.append(f"这个月的状态：{monthly.content}")
+
+    # 周计划
+    if weekly:
+        parts.append(f"这周：{weekly.content}")
+
+    # 日计划时段（最重要，直接影响回复风格）
+    if daily:
+        parts.append(f"你现在正在：{daily.content}")
+        if daily.mood:
+            parts.append(f"心情：{daily.mood}")
+        if daily.energy_level:
+            parts.append(f"精力：{_ENERGY_DESC.get(daily.energy_level, '')}")
+        if daily.response_style_hint:
+            parts.append(f"（{daily.response_style_hint}）")
+
+    return "\n".join(parts)
+
+
+def _time_of_day_desc(hour: int) -> str:
+    """根据小时返回时段描述"""
+    if hour < 6:
+        return "深夜/凌晨"
+    elif hour < 9:
+        return "早上"
+    elif hour < 12:
+        return "上午"
+    elif hour < 14:
+        return "中午"
+    elif hour < 18:
+        return "下午"
+    elif hour < 21:
+        return "晚上"
+    else:
+        return "深夜"

--- a/apps/agent-service/app/workers/diary_worker.py
+++ b/apps/agent-service/app/workers/diary_worker.py
@@ -406,9 +406,10 @@ async def generate_weekly_review_for_chat(
     else:
         impressions_context = "（暂无）"
 
-    # 4. 获取 Langfuse prompt 并编译
+    # 4. 获取 Langfuse prompt 并编译（注入 persona_core）
     prompt_template = get_prompt("weekly_review_generation")
     compiled_prompt = prompt_template.compile(
+        persona_core=_get_persona_core(),
         week_start=week_start,
         week_end=week_end,
         diaries=diaries_text,

--- a/apps/agent-service/app/workers/diary_worker.py
+++ b/apps/agent-service/app/workers/diary_worker.py
@@ -34,6 +34,15 @@ CST = timezone(timedelta(hours=8))
 _WEEKDAY_CN = ["周一", "周二", "周三", "周四", "周五", "周六", "周日"]
 
 
+def _get_persona_core() -> str:
+    """加载 persona_core prompt 作为人设上下文"""
+    try:
+        return get_prompt("persona_core").compile()
+    except Exception as e:
+        logger.warning(f"Failed to load persona_core prompt: {e}")
+        return ""
+
+
 # ==================== ArQ cron 入口 ====================
 
 
@@ -99,9 +108,11 @@ async def generate_diary_for_chat(chat_id: str, target_date: date) -> str | None
     recent = await get_recent_diaries(chat_id, date_str, limit=3)
     recent_diaries_text = _format_recent_diaries(recent)
 
-    # 5. 获取 Langfuse prompt 并编译
+    # 5. 获取 Langfuse prompt 并编译（注入 persona_core）
+    persona_core = _get_persona_core()
     prompt_template = get_prompt("diary_generation")
     compiled_prompt = prompt_template.compile(
+        persona_core=persona_core,
         date=date_str,
         weekday=weekday,
         messages=timeline,

--- a/apps/agent-service/app/workers/diary_worker.py
+++ b/apps/agent-service/app/workers/diary_worker.py
@@ -34,12 +34,12 @@ CST = timezone(timedelta(hours=8))
 _WEEKDAY_CN = ["周一", "周二", "周三", "周四", "周五", "周六", "周日"]
 
 
-def _get_persona_core() -> str:
-    """加载 persona_core prompt 作为人设上下文"""
+def _get_persona_lite() -> str:
+    """加载 persona_lite prompt 作为轻量人设（语气指导）"""
     try:
-        return get_prompt("persona_core").compile()
+        return get_prompt("persona_lite").compile()
     except Exception as e:
-        logger.warning(f"Failed to load persona_core prompt: {e}")
+        logger.warning(f"Failed to load persona_lite prompt: {e}")
         return ""
 
 
@@ -109,10 +109,10 @@ async def generate_diary_for_chat(chat_id: str, target_date: date) -> str | None
     recent_diaries_text = _format_recent_diaries(recent)
 
     # 5. 获取 Langfuse prompt 并编译（注入 persona_core）
-    persona_core = _get_persona_core()
+    persona_lite = _get_persona_lite()
     prompt_template = get_prompt("diary_generation")
     compiled_prompt = prompt_template.compile(
-        persona_core=persona_core,
+        persona_lite=persona_lite,
         date=date_str,
         weekday=weekday,
         messages=timeline,
@@ -409,7 +409,7 @@ async def generate_weekly_review_for_chat(
     # 4. 获取 Langfuse prompt 并编译（注入 persona_core）
     prompt_template = get_prompt("weekly_review_generation")
     compiled_prompt = prompt_template.compile(
-        persona_core=_get_persona_core(),
+        persona_lite=_get_persona_lite(),
         week_start=week_start,
         week_end=week_end,
         diaries=diaries_text,

--- a/apps/agent-service/app/workers/schedule_worker.py
+++ b/apps/agent-service/app/workers/schedule_worker.py
@@ -53,6 +53,15 @@ def _schedule_model() -> str:
     return settings.diary_model
 
 
+def _get_persona_core() -> str:
+    """加载 persona_core prompt 作为人设上下文注入生成器"""
+    try:
+        return get_prompt("persona_core").compile()
+    except Exception as e:
+        logger.warning(f"Failed to load persona_core prompt: {e}")
+        return ""
+
+
 # ==================== ArQ cron 入口 ====================
 
 
@@ -121,9 +130,10 @@ async def generate_monthly_plan(target_date: date | None = None) -> str | None:
     season = _get_season(month_start.month)
     month_cn = f"{month_start.year}年{month_start.month}月"
 
-    # 获取 Langfuse prompt
+    # 获取 Langfuse prompt（注入 persona_core）
     prompt_template = get_prompt("schedule_monthly")
     compiled = prompt_template.compile(
+        persona_core=_get_persona_core(),
         month=month_cn,
         season=season,
         previous_monthly_plan=prev_plan_text,
@@ -197,9 +207,10 @@ async def generate_weekly_plan(target_date: date | None = None) -> str | None:
 
     week_desc = f"{period_start}（{_WEEKDAY_CN[week_start.weekday()]}）~ {period_end}（{_WEEKDAY_CN[week_end.weekday()]}）"
 
-    # 获取 Langfuse prompt
+    # 获取 Langfuse prompt（注入 persona_core）
     prompt_template = get_prompt("schedule_weekly")
     compiled = prompt_template.compile(
+        persona_core=_get_persona_core(),
         week=week_desc,
         monthly_plan=monthly_text,
         previous_weekly_plan=prev_plan_text,
@@ -308,9 +319,10 @@ async def generate_daily_plan(target_date: date | None = None) -> list[dict] | N
     else:
         yesterday_plan = "（暂无昨天的日计划）"
 
-    # 获取 Langfuse prompt
+    # 获取 Langfuse prompt（注入 persona_core）
     prompt_template = get_prompt("schedule_daily")
     compiled = prompt_template.compile(
+        persona_core=_get_persona_core(),
         date=date_str,
         weekday=weekday,
         is_weekend="是" if is_weekend else "否",

--- a/apps/agent-service/app/workers/schedule_worker.py
+++ b/apps/agent-service/app/workers/schedule_worker.py
@@ -241,17 +241,17 @@ async def generate_weekly_plan(target_date: date | None = None) -> str | None:
 # ==================== 日计划生成 ====================
 
 
-async def generate_daily_plan(target_date: date | None = None) -> list[dict] | None:
-    """生成日计划
+async def generate_daily_plan(target_date: date | None = None) -> str | None:
+    """生成日计划（手帐式 markdown）
 
-    基于月计划 + 周计划 + 昨天日记，为今天生成逐时段的安排。
-    输出 JSON 数组，每个元素是一个时段。
+    基于月计划 + 周计划 + 昨天日记，为今天写一篇私人手帐。
+    每天一条记录，内容是自然的 markdown 文本。
 
     Args:
         target_date: 目标日期，默认今天
 
     Returns:
-        生成的时段列表
+        生成的手帐内容
     """
     if target_date is None:
         target_date = date.today()
@@ -261,10 +261,10 @@ async def generate_daily_plan(target_date: date | None = None) -> list[dict] | N
     is_weekend = target_date.weekday() >= 5
 
     # 检查是否已有
-    existing = await get_daily_entries_for_date(date_str)
+    existing = await get_plan_for_period("daily", date_str, date_str)
     if existing:
-        logger.info(f"Daily plan already exists for {date_str}, skip ({len(existing)} entries)")
-        return None
+        logger.info(f"Daily plan already exists for {date_str}, skip")
+        return existing.content
 
     # 上下文
     # 1. 月计划
@@ -282,25 +282,15 @@ async def generate_daily_plan(target_date: date | None = None) -> list[dict] | N
     weekly = await get_plan_for_period("weekly", week_start.isoformat(), week_end.isoformat())
     weekly_text = weekly.content if weekly else "（暂无周计划）"
 
-    # 3. 昨天的日记（最近 2 篇，作为生活连续性参考）
-    recent_diaries = await get_recent_diaries(
-        # 日记是按 chat_id 存的，这里取所有群的不太合适
-        # 但日程是全局的，取任一活跃群的日记作为参考即可
-        # TODO: 后续可改为取多群日记的摘要
-        chat_id="__global__",  # 占位，实际逻辑见下方 fallback
-        before_date=date_str,
-        limit=2,
-    )
-    # fallback: 如果 __global__ 无日记，尝试从任意活跃群取
-    if not recent_diaries:
-        from app.orm.crud import get_active_diary_chat_ids
-        active_chats = await get_active_diary_chat_ids(min_replies=3, days=7)
-        for cid in active_chats[:1]:
-            recent_diaries = await get_recent_diaries(cid, date_str, limit=2)
-            if recent_diaries:
-                break
+    # 3. 最近日记（从活跃群取）
+    recent_diaries = []
+    from app.orm.crud import get_active_diary_chat_ids
+    active_chats = await get_active_diary_chat_ids(min_replies=3, days=7)
+    for cid in active_chats[:1]:
+        recent_diaries = await get_recent_diaries(cid, date_str, limit=2)
+        if recent_diaries:
+            break
 
-    diary_text = ""
     if recent_diaries:
         diary_parts = []
         for d in reversed(recent_diaries):
@@ -309,15 +299,10 @@ async def generate_daily_plan(target_date: date | None = None) -> list[dict] | N
     else:
         diary_text = "（暂无近期日记）"
 
-    # 4. 昨天的日计划（参考连续性）
+    # 4. 昨天的手帐
     yesterday = (target_date - timedelta(days=1)).isoformat()
-    yesterday_entries = await get_daily_entries_for_date(yesterday)
-    if yesterday_entries:
-        yesterday_plan = "\n".join(
-            f"{e.time_start}-{e.time_end}: {e.content}" for e in yesterday_entries
-        )
-    else:
-        yesterday_plan = "（暂无昨天的日计划）"
+    yesterday_plan = await get_plan_for_period("daily", yesterday, yesterday)
+    yesterday_text = yesterday_plan.content if yesterday_plan else "（暂无昨天的手帐）"
 
     # 获取 Langfuse prompt（注入 persona_core）
     prompt_template = get_prompt("schedule_daily")
@@ -325,45 +310,33 @@ async def generate_daily_plan(target_date: date | None = None) -> list[dict] | N
         persona_core=_get_persona_core(),
         date=date_str,
         weekday=weekday,
-        is_weekend="是" if is_weekend else "否",
+        is_weekend="周末！" if is_weekend else "",
         monthly_plan=monthly_text,
         weekly_plan=weekly_text,
         recent_diary=diary_text,
-        yesterday_plan=yesterday_plan,
+        yesterday_plan=yesterday_text,
     )
 
     # 调用 LLM
     model = await ModelBuilder.build_chat_model(_schedule_model())
     response = await model.ainvoke([{"role": "user", "content": compiled}])
-    raw = _extract_text(response.content)
+    content = _extract_text(response.content)
 
-    if not raw:
+    if not content:
         logger.warning(f"LLM returned empty daily plan for {date_str}")
         return None
 
-    # 解析 JSON 数组
-    entries = _parse_daily_entries(raw)
-    if not entries:
-        logger.warning(f"Failed to parse daily plan for {date_str}: {raw[:200]}")
-        return None
+    # 写入数据库（每天一条记录）
+    await upsert_schedule(AkaoSchedule(
+        plan_type="daily",
+        period_start=date_str,
+        period_end=date_str,
+        content=content,
+        model=_schedule_model(),
+    ))
 
-    # 写入数据库
-    for entry_data in entries:
-        await upsert_schedule(AkaoSchedule(
-            plan_type="daily",
-            period_start=date_str,
-            period_end=date_str,
-            time_start=entry_data["time_start"],
-            time_end=entry_data["time_end"],
-            content=entry_data["content"],
-            mood=entry_data.get("mood"),
-            energy_level=entry_data.get("energy_level"),
-            response_style_hint=entry_data.get("response_style_hint"),
-            model=_schedule_model(),
-        ))
-
-    logger.info(f"Daily plan generated for {date_str} ({weekday}): {len(entries)} time blocks")
-    return entries
+    logger.info(f"Daily plan generated for {date_str} ({weekday}): {len(content)} chars")
+    return content
 
 
 # ==================== 辅助函数 ====================
@@ -379,63 +352,3 @@ def _extract_text(content) -> str:
     return content or ""
 
 
-def _parse_daily_entries(raw: str) -> list[dict] | None:
-    """从 LLM 输出中解析日计划 JSON 数组
-
-    期望格式:
-    [
-        {
-            "time_start": "07:00",
-            "time_end": "08:30",
-            "content": "赖床中，闹钟响了但不想起来",
-            "mood": "困",
-            "energy_level": 2,
-            "response_style_hint": "迷迷糊糊，说话断断续续"
-        },
-        ...
-    ]
-    """
-    raw = raw.strip()
-
-    # 去掉 markdown 代码块包裹
-    if raw.startswith("```"):
-        raw = raw.split("\n", 1)[1] if "\n" in raw else raw[3:]
-        if raw.endswith("```"):
-            raw = raw[:-3]
-        raw = raw.strip()
-
-    try:
-        entries = json.loads(raw)
-    except json.JSONDecodeError:
-        logger.warning("Daily plan JSON parse failed, attempting to extract JSON array")
-        # 尝试从文本中提取 JSON 数组
-        start = raw.find("[")
-        end = raw.rfind("]")
-        if start >= 0 and end > start:
-            try:
-                entries = json.loads(raw[start : end + 1])
-            except json.JSONDecodeError:
-                return None
-        else:
-            return None
-
-    if not isinstance(entries, list):
-        return None
-
-    # 验证必需字段
-    valid = []
-    for entry in entries:
-        if not isinstance(entry, dict):
-            continue
-        if not entry.get("time_start") or not entry.get("time_end") or not entry.get("content"):
-            continue
-        valid.append({
-            "time_start": entry["time_start"],
-            "time_end": entry["time_end"],
-            "content": entry["content"],
-            "mood": entry.get("mood"),
-            "energy_level": entry.get("energy_level"),
-            "response_style_hint": entry.get("response_style_hint"),
-        })
-
-    return valid if valid else None

--- a/apps/agent-service/app/workers/schedule_worker.py
+++ b/apps/agent-service/app/workers/schedule_worker.py
@@ -62,6 +62,39 @@ def _get_persona_core() -> str:
         return ""
 
 
+async def _gather_world_context(target_date: date) -> str:
+    """搜索真实世界素材，为日计划提供延伸锚点
+
+    搜索当季番剧、天气、热门话题等，让日计划能基于真实世界生长，
+    而不是只在 persona 锚点里打转。
+    """
+    from app.agents.tools.search.web import search_web
+
+    month = target_date.month
+    season = _get_season(month)
+    queries = [
+        f"{target_date.year}年{month}月 新番动画 推荐",
+        f"{season} 生活 日常 有趣的事",
+    ]
+
+    snippets: list[str] = []
+    for q in queries:
+        try:
+            results = await search_web(query=q, num=3)
+            for r in results[:3]:
+                if r.get("snippet"):
+                    snippets.append(r["snippet"])
+        except Exception as e:
+            logger.warning(f"World context search failed for '{q}': {e}")
+
+    if not snippets:
+        return ""
+
+    return "以下是一些真实世界的近期信息（作为生活素材参考，自然融入而非罗列）：\n" + "\n".join(
+        f"- {s}" for s in snippets[:6]
+    )
+
+
 # ==================== ArQ cron 入口 ====================
 
 
@@ -304,7 +337,10 @@ async def generate_daily_plan(target_date: date | None = None) -> str | None:
     yesterday_plan = await get_plan_for_period("daily", yesterday, yesterday)
     yesterday_text = yesterday_plan.content if yesterday_plan else "（暂无昨天的手帐）"
 
-    # 获取 Langfuse prompt（注入 persona_core）
+    # 5. 搜索真实世界素材（当季番剧、热门话题等）
+    world_context = await _gather_world_context(target_date)
+
+    # 获取 Langfuse prompt（注入 persona_core + world_context）
     prompt_template = get_prompt("schedule_daily")
     compiled = prompt_template.compile(
         persona_core=_get_persona_core(),
@@ -315,6 +351,7 @@ async def generate_daily_plan(target_date: date | None = None) -> str | None:
         weekly_plan=weekly_text,
         recent_diary=diary_text,
         yesterday_plan=yesterday_text,
+        world_context=world_context,
     )
 
     # 调用 LLM

--- a/apps/agent-service/app/workers/schedule_worker.py
+++ b/apps/agent-service/app/workers/schedule_worker.py
@@ -1,0 +1,429 @@
+"""
+赤尾日程生成 Worker — 多时间维度离线计划
+
+三层生成器，各自独立节奏：
+- 月计划（每月1号凌晨）：本月生活方向、兴趣倾向、季节氛围
+- 周计划（每周日凌晨）：本周大致安排、松紧节奏
+- 日计划（每天凌晨，紧跟日记之后）：逐时段的活动、心情、精力
+
+每层继承上层输出，自上而下细化。方向性指导而非刻板时间表。
+日记系统回馈日计划（昨天的日记影响今天的安排）。
+"""
+
+import json
+import logging
+from datetime import date, datetime, timedelta, timezone
+
+from app.agents.infra.langfuse_client import get_prompt
+from app.agents.infra.model_builder import ModelBuilder
+from app.config.config import settings
+from app.orm.crud import (
+    get_daily_entries_for_date,
+    get_latest_plan,
+    get_plan_for_period,
+    get_recent_diaries,
+    upsert_schedule,
+)
+from app.orm.models import AkaoSchedule
+
+logger = logging.getLogger(__name__)
+
+CST = timezone(timedelta(hours=8))
+
+_WEEKDAY_CN = ["周一", "周二", "周三", "周四", "周五", "周六", "周日"]
+
+# 季节判定
+_SEASON_MAP = {
+    (3, 4, 5): "春天",
+    (6, 7, 8): "夏天",
+    (9, 10, 11): "秋天",
+    (12, 1, 2): "冬天",
+}
+
+
+def _get_season(month: int) -> str:
+    for months, name in _SEASON_MAP.items():
+        if month in months:
+            return name
+    return "未知"
+
+
+def _schedule_model() -> str:
+    """日程生成使用的模型，复用 diary_model 配置"""
+    return settings.diary_model
+
+
+# ==================== ArQ cron 入口 ====================
+
+
+async def cron_generate_monthly_plan(ctx) -> None:
+    """cron 入口：生成本月计划"""
+    try:
+        await generate_monthly_plan()
+    except Exception as e:
+        logger.error(f"Monthly plan generation failed: {e}", exc_info=True)
+
+
+async def cron_generate_weekly_plan(ctx) -> None:
+    """cron 入口：生成本周计划"""
+    try:
+        await generate_weekly_plan()
+    except Exception as e:
+        logger.error(f"Weekly plan generation failed: {e}", exc_info=True)
+
+
+async def cron_generate_daily_plan(ctx) -> None:
+    """cron 入口：生成今天的日计划"""
+    try:
+        await generate_daily_plan()
+    except Exception as e:
+        logger.error(f"Daily plan generation failed: {e}", exc_info=True)
+
+
+# ==================== 月计划生成 ====================
+
+
+async def generate_monthly_plan(target_date: date | None = None) -> str | None:
+    """生成月度计划
+
+    给出本月的生活方向和兴趣倾向，不要太具体。
+    像一个真人月初时对这个月的模糊预期。
+
+    Args:
+        target_date: 目标月份的某一天，默认今天
+
+    Returns:
+        生成的月计划内容
+    """
+    if target_date is None:
+        target_date = date.today()
+
+    month_start = target_date.replace(day=1)
+    # 月末
+    if month_start.month == 12:
+        month_end = date(month_start.year + 1, 1, 1) - timedelta(days=1)
+    else:
+        month_end = date(month_start.year, month_start.month + 1, 1) - timedelta(days=1)
+
+    period_start = month_start.isoformat()
+    period_end = month_end.isoformat()
+
+    # 检查是否已有
+    existing = await get_plan_for_period("monthly", period_start, period_end)
+    if existing:
+        logger.info(f"Monthly plan already exists for {period_start}~{period_end}, skip")
+        return existing.content
+
+    # 上下文：上月计划
+    prev_plan = await get_latest_plan("monthly", period_start)
+    prev_plan_text = prev_plan.content if prev_plan else "（这是第一个月计划）"
+
+    season = _get_season(month_start.month)
+    month_cn = f"{month_start.year}年{month_start.month}月"
+
+    # 获取 Langfuse prompt
+    prompt_template = get_prompt("schedule_monthly")
+    compiled = prompt_template.compile(
+        month=month_cn,
+        season=season,
+        previous_monthly_plan=prev_plan_text,
+    )
+
+    # 调用 LLM
+    model = await ModelBuilder.build_chat_model(_schedule_model())
+    response = await model.ainvoke([{"role": "user", "content": compiled}])
+    content = _extract_text(response.content)
+
+    if not content:
+        logger.warning(f"LLM returned empty monthly plan for {month_cn}")
+        return None
+
+    # 写入数据库
+    await upsert_schedule(AkaoSchedule(
+        plan_type="monthly",
+        period_start=period_start,
+        period_end=period_end,
+        content=content,
+        model=_schedule_model(),
+    ))
+
+    logger.info(f"Monthly plan generated: {month_cn}, {len(content)} chars")
+    return content
+
+
+# ==================== 周计划生成 ====================
+
+
+async def generate_weekly_plan(target_date: date | None = None) -> str | None:
+    """生成周计划
+
+    基于月计划给出本周的大致安排。
+    像一个真人周末时对下周的模糊规划。
+
+    Args:
+        target_date: 目标周的某一天，默认今天
+
+    Returns:
+        生成的周计划内容
+    """
+    if target_date is None:
+        target_date = date.today()
+
+    # 本周一和周日
+    week_start = target_date - timedelta(days=target_date.weekday())
+    week_end = week_start + timedelta(days=6)
+    period_start = week_start.isoformat()
+    period_end = week_end.isoformat()
+
+    # 检查是否已有
+    existing = await get_plan_for_period("weekly", period_start, period_end)
+    if existing:
+        logger.info(f"Weekly plan already exists for {period_start}~{period_end}, skip")
+        return existing.content
+
+    # 上下文
+    # 1. 当前月计划
+    month_start = target_date.replace(day=1).isoformat()
+    if target_date.month == 12:
+        month_end_d = date(target_date.year + 1, 1, 1) - timedelta(days=1)
+    else:
+        month_end_d = date(target_date.year, target_date.month + 1, 1) - timedelta(days=1)
+    monthly = await get_plan_for_period("monthly", month_start, month_end_d.isoformat())
+    monthly_text = monthly.content if monthly else "（暂无月计划）"
+
+    # 2. 上周计划
+    prev_plan = await get_latest_plan("weekly", period_start)
+    prev_plan_text = prev_plan.content if prev_plan else "（这是第一个周计划）"
+
+    week_desc = f"{period_start}（{_WEEKDAY_CN[week_start.weekday()]}）~ {period_end}（{_WEEKDAY_CN[week_end.weekday()]}）"
+
+    # 获取 Langfuse prompt
+    prompt_template = get_prompt("schedule_weekly")
+    compiled = prompt_template.compile(
+        week=week_desc,
+        monthly_plan=monthly_text,
+        previous_weekly_plan=prev_plan_text,
+    )
+
+    # 调用 LLM
+    model = await ModelBuilder.build_chat_model(_schedule_model())
+    response = await model.ainvoke([{"role": "user", "content": compiled}])
+    content = _extract_text(response.content)
+
+    if not content:
+        logger.warning(f"LLM returned empty weekly plan for {week_desc}")
+        return None
+
+    # 写入数据库
+    await upsert_schedule(AkaoSchedule(
+        plan_type="weekly",
+        period_start=period_start,
+        period_end=period_end,
+        content=content,
+        model=_schedule_model(),
+    ))
+
+    logger.info(f"Weekly plan generated: {week_desc}, {len(content)} chars")
+    return content
+
+
+# ==================== 日计划生成 ====================
+
+
+async def generate_daily_plan(target_date: date | None = None) -> list[dict] | None:
+    """生成日计划
+
+    基于月计划 + 周计划 + 昨天日记，为今天生成逐时段的安排。
+    输出 JSON 数组，每个元素是一个时段。
+
+    Args:
+        target_date: 目标日期，默认今天
+
+    Returns:
+        生成的时段列表
+    """
+    if target_date is None:
+        target_date = date.today()
+
+    date_str = target_date.isoformat()
+    weekday = _WEEKDAY_CN[target_date.weekday()]
+    is_weekend = target_date.weekday() >= 5
+
+    # 检查是否已有
+    existing = await get_daily_entries_for_date(date_str)
+    if existing:
+        logger.info(f"Daily plan already exists for {date_str}, skip ({len(existing)} entries)")
+        return None
+
+    # 上下文
+    # 1. 月计划
+    month_start = target_date.replace(day=1).isoformat()
+    if target_date.month == 12:
+        month_end_d = date(target_date.year + 1, 1, 1) - timedelta(days=1)
+    else:
+        month_end_d = date(target_date.year, target_date.month + 1, 1) - timedelta(days=1)
+    monthly = await get_plan_for_period("monthly", month_start, month_end_d.isoformat())
+    monthly_text = monthly.content if monthly else "（暂无月计划）"
+
+    # 2. 周计划
+    week_start = target_date - timedelta(days=target_date.weekday())
+    week_end = week_start + timedelta(days=6)
+    weekly = await get_plan_for_period("weekly", week_start.isoformat(), week_end.isoformat())
+    weekly_text = weekly.content if weekly else "（暂无周计划）"
+
+    # 3. 昨天的日记（最近 2 篇，作为生活连续性参考）
+    recent_diaries = await get_recent_diaries(
+        # 日记是按 chat_id 存的，这里取所有群的不太合适
+        # 但日程是全局的，取任一活跃群的日记作为参考即可
+        # TODO: 后续可改为取多群日记的摘要
+        chat_id="__global__",  # 占位，实际逻辑见下方 fallback
+        before_date=date_str,
+        limit=2,
+    )
+    # fallback: 如果 __global__ 无日记，尝试从任意活跃群取
+    if not recent_diaries:
+        from app.orm.crud import get_active_diary_chat_ids
+        active_chats = await get_active_diary_chat_ids(min_replies=3, days=7)
+        for cid in active_chats[:1]:
+            recent_diaries = await get_recent_diaries(cid, date_str, limit=2)
+            if recent_diaries:
+                break
+
+    diary_text = ""
+    if recent_diaries:
+        diary_parts = []
+        for d in reversed(recent_diaries):
+            diary_parts.append(f"--- {d.diary_date} ---\n{d.content}")
+        diary_text = "\n\n".join(diary_parts)
+    else:
+        diary_text = "（暂无近期日记）"
+
+    # 4. 昨天的日计划（参考连续性）
+    yesterday = (target_date - timedelta(days=1)).isoformat()
+    yesterday_entries = await get_daily_entries_for_date(yesterday)
+    if yesterday_entries:
+        yesterday_plan = "\n".join(
+            f"{e.time_start}-{e.time_end}: {e.content}" for e in yesterday_entries
+        )
+    else:
+        yesterday_plan = "（暂无昨天的日计划）"
+
+    # 获取 Langfuse prompt
+    prompt_template = get_prompt("schedule_daily")
+    compiled = prompt_template.compile(
+        date=date_str,
+        weekday=weekday,
+        is_weekend="是" if is_weekend else "否",
+        monthly_plan=monthly_text,
+        weekly_plan=weekly_text,
+        recent_diary=diary_text,
+        yesterday_plan=yesterday_plan,
+    )
+
+    # 调用 LLM
+    model = await ModelBuilder.build_chat_model(_schedule_model())
+    response = await model.ainvoke([{"role": "user", "content": compiled}])
+    raw = _extract_text(response.content)
+
+    if not raw:
+        logger.warning(f"LLM returned empty daily plan for {date_str}")
+        return None
+
+    # 解析 JSON 数组
+    entries = _parse_daily_entries(raw)
+    if not entries:
+        logger.warning(f"Failed to parse daily plan for {date_str}: {raw[:200]}")
+        return None
+
+    # 写入数据库
+    for entry_data in entries:
+        await upsert_schedule(AkaoSchedule(
+            plan_type="daily",
+            period_start=date_str,
+            period_end=date_str,
+            time_start=entry_data["time_start"],
+            time_end=entry_data["time_end"],
+            content=entry_data["content"],
+            mood=entry_data.get("mood"),
+            energy_level=entry_data.get("energy_level"),
+            response_style_hint=entry_data.get("response_style_hint"),
+            model=_schedule_model(),
+        ))
+
+    logger.info(f"Daily plan generated for {date_str} ({weekday}): {len(entries)} time blocks")
+    return entries
+
+
+# ==================== 辅助函数 ====================
+
+
+def _extract_text(content) -> str:
+    """从 LLM 响应中提取文本"""
+    if isinstance(content, list):
+        return "".join(
+            part.get("text", "") if isinstance(part, dict) else str(part)
+            for part in content
+        )
+    return content or ""
+
+
+def _parse_daily_entries(raw: str) -> list[dict] | None:
+    """从 LLM 输出中解析日计划 JSON 数组
+
+    期望格式:
+    [
+        {
+            "time_start": "07:00",
+            "time_end": "08:30",
+            "content": "赖床中，闹钟响了但不想起来",
+            "mood": "困",
+            "energy_level": 2,
+            "response_style_hint": "迷迷糊糊，说话断断续续"
+        },
+        ...
+    ]
+    """
+    raw = raw.strip()
+
+    # 去掉 markdown 代码块包裹
+    if raw.startswith("```"):
+        raw = raw.split("\n", 1)[1] if "\n" in raw else raw[3:]
+        if raw.endswith("```"):
+            raw = raw[:-3]
+        raw = raw.strip()
+
+    try:
+        entries = json.loads(raw)
+    except json.JSONDecodeError:
+        logger.warning("Daily plan JSON parse failed, attempting to extract JSON array")
+        # 尝试从文本中提取 JSON 数组
+        start = raw.find("[")
+        end = raw.rfind("]")
+        if start >= 0 and end > start:
+            try:
+                entries = json.loads(raw[start : end + 1])
+            except json.JSONDecodeError:
+                return None
+        else:
+            return None
+
+    if not isinstance(entries, list):
+        return None
+
+    # 验证必需字段
+    valid = []
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        if not entry.get("time_start") or not entry.get("time_end") or not entry.get("content"):
+            continue
+        valid.append({
+            "time_start": entry["time_start"],
+            "time_end": entry["time_end"],
+            "content": entry["content"],
+            "mood": entry.get("mood"),
+            "energy_level": entry.get("energy_level"),
+            "response_style_hint": entry.get("response_style_hint"),
+        })
+
+    return valid if valid else None

--- a/apps/agent-service/app/workers/unified_worker.py
+++ b/apps/agent-service/app/workers/unified_worker.py
@@ -15,6 +15,11 @@ from inner_shared.logger import setup_logging
 from app.config.config import settings
 from app.long_tasks.executor import poll_and_execute_tasks
 from app.workers.diary_worker import cron_generate_diaries, cron_generate_weekly_reviews
+from app.workers.schedule_worker import (
+    cron_generate_daily_plan,
+    cron_generate_monthly_plan,
+    cron_generate_weekly_plan,
+)
 from app.workers.vectorize_worker import cron_scan_pending_messages
 
 logger = logging.getLogger(__name__)
@@ -62,4 +67,8 @@ class UnifiedWorkerSettings:
         cron(cron_generate_diaries, hour={3}, minute={0}),
         # 4. 周记生成：每周一 CST 04:00（日记 cron 之后 1 小时）
         cron(cron_generate_weekly_reviews, weekday={0}, hour={4}, minute={0}),
+        # 5. 日程生成：日计划每天 CST 03:30（日记之后），周计划每周日，月计划每月1号
+        cron(cron_generate_daily_plan, hour={3}, minute={30}),
+        cron(cron_generate_weekly_plan, weekday={6}, hour={23}, minute={0}),
+        cron(cron_generate_monthly_plan, day={1}, hour={2}, minute={0}),
     ]


### PR DESCRIPTION
## Summary

- **Dynamic schedule system**: Three-layer LLM-generated schedule (monthly → weekly → daily) giving akao a sense of daily life. Daily plan is a notebook-style markdown (手帐), not a rigid timetable
- **Enriched persona**: `persona_core` (full character anchors for schedule/plan generators) + `persona_lite` (lightweight tone guide for diary/chat) — anchor-point philosophy, not exhaustive lists
- **Real-world grounding**: Daily plan generator calls `search_web` to bring in actual anime seasons, trending topics etc., preventing closed-loop persona anchor recombination
- **Schedule context injection**: Today's notebook injected into chat system prompt via `{{schedule_context}}`, monthly/weekly plans only used as generation context

## Key design decisions

- persona_core is the "backstage soul" — it drives generators but is NOT injected into chat prompt
- Diary/weekly review use persona_lite to avoid LLM hallucinating persona interests over actual group chat content
- Daily plan format: free-form markdown notebook, not structured JSON time blocks

## Files changed

- 3 new files: schedule API, schedule context builder, schedule worker
- 7 modified files: models, CRUD, main agent, diary worker, unified worker, router, main app
- DB: `akao_schedule` table (already migrated)
- Langfuse: 7 prompts created/updated (persona_core, persona_lite, schedule_monthly/weekly/daily, diary_generation v4, weekly_review v3, main v60)

## Test plan

- [x] Manual trigger of monthly/weekly/daily plan generation
- [x] Diary generation with persona_lite (verified no persona anchor hallucination)
- [x] Schedule context injection into chat prompt
- [x] search_web integration in daily plan generator
- [ ] ArQ cron execution in production (needs prod deploy of arq-worker)
- [ ] Post-deploy: trigger initial monthly → weekly → daily plans

🤖 Generated with [Claude Code](https://claude.com/claude-code)