### PR TITLE
feat(agent-service): P2P memory injection with cross-group impressions

### DIFF
--- a/apps/agent-service/app/agents/domains/main/agent.py
+++ b/apps/agent-service/app/agents/domains/main/agent.py
@@ -20,7 +20,11 @@ from app.agents.domains.main.context_builder import build_chat_context
 from app.agents.domains.main.tools import ALL_TOOLS
 from app.agents.graphs.pre import run_pre
 from app.orm.crud import get_gray_config, get_message_content
-from app.services.memory_context import build_diary_context, build_impression_context
+from app.services.memory_context import (
+    build_cross_group_impression_context,
+    build_diary_context,
+    build_impression_context,
+)
 from app.services.schedule_context import build_schedule_context
 from app.utils.content_parser import parse_content
 
@@ -254,6 +258,26 @@ async def _build_and_stream(
     if chat_type == "p2p":
         if trigger_username:
             context_lines.append(f"你正在和 {trigger_username} 私聊。")
+
+        # 私聊注入日记记忆
+        try:
+            diary_text = await build_diary_context(chat_id)
+            if diary_text:
+                context_lines.append("\n---\n你最近的日记：")
+                context_lines.append(diary_text)
+        except Exception as e:
+            logger.error(f"Failed to build p2p diary context: {e}")
+
+        # 私聊注入跨群人物印象（群→私聊，不反向）
+        try:
+            cross_imp = await build_cross_group_impression_context(
+                trigger_user_id, trigger_username
+            )
+            if cross_imp:
+                context_lines.append("\n---\n" + cross_imp)
+        except Exception as e:
+            logger.error(f"Failed to build cross-group impression: {e}")
+
     else:  # group
         if chat_name:
             context_lines.append(f"你在群聊「{chat_name}」中。")
@@ -262,8 +286,7 @@ async def _build_and_stream(
                 f"需要回复 {trigger_username} 的消息（消息中用 ⭐ 标记）。"
             )
 
-    # 群聊注入日记记忆 + 人物印象
-    if chat_type != "p2p":
+        # 群聊注入日记记忆 + 本群人物印象
         try:
             diary_text = await build_diary_context(chat_id)
             if diary_text:

--- a/apps/agent-service/app/orm/crud.py
+++ b/apps/agent-service/app/orm/crud.py
@@ -9,6 +9,7 @@ from .models import (
     ConversationMessage,
     DiaryEntry,
     LarkBaseChatInfo,
+    LarkGroupChatInfo,
     LarkUser,
     ModelMapping,
     ModelProvider,
@@ -140,6 +141,50 @@ async def get_active_diary_chat_ids(
             .having(func.count() >= min_replies)
         )
         return [row[0] for row in result.all()]
+
+
+async def get_active_p2p_chat_ids(
+    min_replies: int = 2, days: int = 1
+) -> list[str]:
+    """查询近 N 天内赤尾回复 >= min_replies 次的私聊 chat_id"""
+    async with AsyncSessionLocal() as session:
+        cutoff_ms = int(
+            (datetime.now(UTC) - timedelta(days=days)).timestamp() * 1000
+        )
+        result = await session.execute(
+            select(ConversationMessage.chat_id)
+            .where(ConversationMessage.chat_type == "p2p")
+            .where(ConversationMessage.role == "assistant")
+            .where(ConversationMessage.create_time > cutoff_ms)
+            .group_by(ConversationMessage.chat_id)
+            .having(func.count() >= min_replies)
+        )
+        return [row[0] for row in result.all()]
+
+
+async def get_cross_group_impressions(
+    user_id: str, limit: int = 5
+) -> list[tuple[PersonImpression, str]]:
+    """查询某用户在所有群聊中的印象（按更新时间倒序）
+
+    JOIN lark_group_chat_info 自然过滤掉 P2P chat_id，
+    确保只返回群聊来源的印象。
+
+    Returns:
+        list of (PersonImpression, group_name)
+    """
+    async with AsyncSessionLocal() as session:
+        result = await session.execute(
+            select(PersonImpression, LarkGroupChatInfo.name)
+            .join(
+                LarkGroupChatInfo,
+                PersonImpression.chat_id == LarkGroupChatInfo.chat_id,
+            )
+            .where(PersonImpression.user_id == user_id)
+            .order_by(PersonImpression.updated_at.desc())
+            .limit(limit)
+        )
+        return [(row[0], row[1]) for row in result.all()]
 
 
 async def get_chat_messages_in_range(

--- a/apps/agent-service/app/services/memory_context.py
+++ b/apps/agent-service/app/services/memory_context.py
@@ -7,6 +7,7 @@ import logging
 from datetime import date
 
 from app.orm.crud import (
+    get_cross_group_impressions,
     get_impressions_for_users,
     get_latest_weekly_review,
     get_recent_diaries,
@@ -20,6 +21,7 @@ MAX_DIARY_CHARS = 2000
 
 
 MAX_IMPRESSION_USERS = 10
+MAX_CROSS_GROUP_IMPRESSIONS = 5
 
 
 async def build_impression_context(chat_id: str, user_ids: list[str]) -> str:
@@ -62,3 +64,20 @@ async def build_diary_context(chat_id: str) -> str:
     if len(text) > MAX_DIARY_CHARS:
         text = text[:MAX_DIARY_CHARS] + "……"
     return text
+
+
+async def build_cross_group_impression_context(
+    user_id: str, trigger_username: str
+) -> str:
+    """构建跨群人物印象文本，注入私聊 system prompt
+
+    从所有群聊中取该用户的印象（JOIN lark_group_chat_info 自然过滤 P2P），
+    按 updated_at 倒序取最多 5 条，标注来源群名。
+    """
+    rows = await get_cross_group_impressions(user_id, limit=MAX_CROSS_GROUP_IMPRESSIONS)
+    if not rows:
+        return ""
+    lines = []
+    for imp, group_name in rows:
+        lines.append(f"【{group_name}】{imp.impression_text}")
+    return f"你在群聊中对 {trigger_username} 的印象：\n" + "\n".join(lines)

--- a/apps/agent-service/app/workers/diary_worker.py
+++ b/apps/agent-service/app/workers/diary_worker.py
@@ -16,6 +16,7 @@ from app.agents.infra.model_builder import ModelBuilder
 from app.config.config import settings
 from app.orm.crud import (
     get_active_diary_chat_ids,
+    get_active_p2p_chat_ids,
     get_all_impressions_for_chat,
     get_chat_messages_in_range,
     get_diaries_in_range,
@@ -47,16 +48,24 @@ def _get_persona_lite() -> str:
 
 
 async def cron_generate_diaries(ctx) -> None:
-    """cron 入口：为近7天赤尾活跃的群生成昨天的日记"""
-    chat_ids = await get_active_diary_chat_ids(min_replies=5, days=7)
-    if not chat_ids:
-        logger.info("No active diary chats found, skip")
-        return
-    logger.info(f"Active diary chats: {len(chat_ids)}")
-
+    """cron 入口：为活跃的群聊和私聊生成昨天的日记"""
     yesterday = date.today() - timedelta(days=1)
 
-    for chat_id in chat_ids:
+    # 群聊：近 7 天赤尾回复 >= 5 次
+    group_ids = await get_active_diary_chat_ids(min_replies=5, days=7)
+    # 私聊：近 1 天赤尾回复 >= 2 次
+    p2p_ids = await get_active_p2p_chat_ids(min_replies=2, days=1)
+
+    all_ids = group_ids + p2p_ids
+    if not all_ids:
+        logger.info("No active diary chats found, skip")
+        return
+    logger.info(
+        f"Active diary chats: {len(all_ids)} "
+        f"(group={len(group_ids)}, p2p={len(p2p_ids)})"
+    )
+
+    for chat_id in all_ids:
         try:
             await generate_diary_for_chat(chat_id, yesterday)
         except Exception as e:
@@ -67,10 +76,10 @@ async def cron_generate_diaries(ctx) -> None:
 
 
 async def generate_diary_for_chat(chat_id: str, target_date: date) -> str | None:
-    """为指定群生成指定日期的日记
+    """为指定群或私聊生成指定日期的日记
 
     Args:
-        chat_id: 群 ID
+        chat_id: 群/私聊 ID
         target_date: 目标日期
 
     Returns:
@@ -104,15 +113,29 @@ async def generate_diary_for_chat(chat_id: str, target_date: date) -> str | None
         logger.info(f"No messages for {chat_id} on {date_str}, skip")
         return None
 
+    # 判断聊天类型，构建 chat_hint 供 prompt 区分
+    is_p2p = messages[0].chat_type == "p2p" if messages else False
+    if is_p2p:
+        # 私聊对象 = 非 assistant 的用户
+        peer_names = [
+            user_names[uid] for uid in user_ids
+            if any(m.user_id == uid and m.role != "assistant" for m in messages)
+        ]
+        peer = peer_names[0] if peer_names else "对方"
+        chat_hint = f"这是你和 {peer} 的私聊记录。记录你们之间的对话、话题和感受。"
+    else:
+        chat_hint = "这是群聊记录。记录群里发生的事、话题和你观察到的群友动态。"
+
     # 4. 查最近 3 篇日记
     recent = await get_recent_diaries(chat_id, date_str, limit=3)
     recent_diaries_text = _format_recent_diaries(recent)
 
-    # 5. 获取 Langfuse prompt 并编译（注入 persona_core）
+    # 5. 获取 Langfuse prompt 并编译
     persona_lite = _get_persona_lite()
     prompt_template = get_prompt("diary_generation")
     compiled_prompt = prompt_template.compile(
         persona_lite=persona_lite,
+        chat_hint=chat_hint,
         date=date_str,
         weekday=weekday,
         messages=timeline,


### PR DESCRIPTION
## Summary
- P2P 私聊注入日记记忆和跨群人物印象（群→私聊方向，不反向）
- 日记 cron 支持 P2P（近 1 天赤尾回复 >= 2 次触发）
- diary_generation prompt 加 `chat_hint` 区分群聊/私聊语境
- Langfuse diary_generation v5 已就绪（staging + feat-schedule label）

## Test plan
- [x] 部署到 feat-persona-consist 泳道
- [x] 私聊 dev bot，Langfuse trace 确认跨群印象注入成功
- [ ] 合码后将 diary_generation v5 提升为 production

🤖 Generated with [Claude Code](https://claude.com/claude-code)