### PR TITLE
fix(agent-service): add download permission check in context_builder

### DIFF
--- a/apps/agent-service/app/agents/domains/main/context_builder.py
+++ b/apps/agent-service/app/agents/domains/main/context_builder.py
@@ -16,6 +16,7 @@ from sqlalchemy import select
 
 from app.orm.base import AsyncSessionLocal
 from app.orm.models import ConversationMessage
+from app.services.download_permission import check_group_allows_download
 from app.services.quick_search import QuickSearchResult, quick_search
 from app.utils.content_parser import parse_content, update_tos_files
 
@@ -74,7 +75,16 @@ async def build_chat_context(
                 uncached_keys.append((key, "", ""))
                 logger.warning(f"TOS URL 签名失败，回退完整 pipeline: {key}")
 
-    # 2b. 未缓存的图片：走完整 pipeline（飞书下载 → 压缩 → TOS）
+    # 2b. 权限检查：禁止下载的群跳过飞书图片下载
+    if uncached_keys:
+        chat_id = l1_results[0].chat_id or ""
+        if not await check_group_allows_download(chat_id, chat_type):
+            logger.info(
+                f"群 {chat_id} 不允许下载资源，跳过 {len(uncached_keys)} 张未缓存图片"
+            )
+            uncached_keys = []
+
+    # 2c. 未缓存的图片：走完整 pipeline（飞书下载 → 压缩 → TOS）
     if uncached_keys:
         process_tasks = [
             image_client.process_image(key, msg_id if role == "user" else None)

--- a/apps/agent-service/app/services/download_permission.py
+++ b/apps/agent-service/app/services/download_permission.py
@@ -1,0 +1,48 @@
+"""群聊下载权限检查（带内存缓存）"""
+
+import logging
+import time
+
+from sqlalchemy.future import select
+
+from app.orm.base import AsyncSessionLocal
+from app.orm.models import LarkGroupChatInfo
+
+logger = logging.getLogger(__name__)
+
+# 下载权限缓存: chat_id -> (allows_download, expire_time)
+_download_permission_cache: dict[str, tuple[bool, float]] = {}
+_PERMISSION_CACHE_TTL = 600  # 10 分钟
+
+
+async def check_group_allows_download(chat_id: str, chat_type: str) -> bool:
+    """检查群聊是否允许下载资源（带缓存）
+
+    - P2P 直接返回 True
+    - group 类型查 DB，download_has_permission_setting != 'not_anyone' 时允许
+    - DB 查询失败时 fail-open（返回 True）
+    """
+    if chat_type == "p2p":
+        return True
+
+    now = time.monotonic()
+    cached = _download_permission_cache.get(chat_id)
+    if cached and cached[1] > now:
+        return cached[0]
+
+    try:
+        async with AsyncSessionLocal() as session:
+            result = await session.execute(
+                select(LarkGroupChatInfo.download_has_permission_setting).where(
+                    LarkGroupChatInfo.chat_id == chat_id
+                )
+            )
+            row = result.scalar_one_or_none()
+            # 无记录或字段为空 → 默认允许；仅 'not_anyone' 时禁止
+            allows = row != "not_anyone"
+    except Exception:
+        logger.warning(f"查询群 {chat_id} 下载权限失败，默认允许")
+        allows = True
+
+    _download_permission_cache[chat_id] = (allows, now + _PERMISSION_CACHE_TTL)
+    return allows

--- a/apps/agent-service/app/workers/vectorize_worker.py
+++ b/apps/agent-service/app/workers/vectorize_worker.py
@@ -9,7 +9,6 @@ import asyncio
 import json
 import logging
 import signal
-import time
 import uuid
 
 from aio_pika.abc import AbstractIncomingMessage
@@ -27,7 +26,8 @@ from app.clients.rabbitmq import (
 )
 from app.clients.redis import AsyncRedisClient
 from app.orm.base import AsyncSessionLocal
-from app.orm.models import ConversationMessage, LarkGroupChatInfo
+from app.orm.models import ConversationMessage
+from app.services.download_permission import check_group_allows_download
 from app.services.qdrant import qdrant_service
 from app.utils.content_parser import parse_content
 
@@ -49,44 +49,6 @@ def _get_semaphore() -> asyncio.Semaphore:
     if _semaphore is None:
         _semaphore = asyncio.Semaphore(CONCURRENCY_LIMIT)
     return _semaphore
-
-
-# 下载权限缓存: chat_id -> (allows_download, expire_time)
-_download_permission_cache: dict[str, tuple[bool, float]] = {}
-_PERMISSION_CACHE_TTL = 600  # 10 分钟
-
-
-async def check_group_allows_download(chat_id: str, chat_type: str) -> bool:
-    """检查群聊是否允许下载资源（带缓存）
-
-    - P2P 直接返回 True
-    - group 类型查 DB，download_has_permission_setting != 'not_anyone' 时允许
-    - DB 查询失败时 fail-open（返回 True）
-    """
-    if chat_type == "p2p":
-        return True
-
-    now = time.monotonic()
-    cached = _download_permission_cache.get(chat_id)
-    if cached and cached[1] > now:
-        return cached[0]
-
-    try:
-        async with AsyncSessionLocal() as session:
-            result = await session.execute(
-                select(LarkGroupChatInfo.download_has_permission_setting).where(
-                    LarkGroupChatInfo.chat_id == chat_id
-                )
-            )
-            row = result.scalar_one_or_none()
-            # 无记录或字段为空 → 默认允许；仅 'not_anyone' 时禁止
-            allows = row != "not_anyone"
-    except Exception:
-        logger.warning(f"查询群 {chat_id} 下载权限失败，默认允许")
-        allows = True
-
-    _download_permission_cache[chat_id] = (allows, now + _PERMISSION_CACHE_TTL)
-    return allows
 
 
 def _handle_signal(signum, frame):


### PR DESCRIPTION
## Summary
- 无权限群发图片时 context_builder 无条件调 tool-service 下载，Lark API 返回错误导致 agent-service → tool-service 100% 错误率告警
- 将 `check_group_allows_download` 提取为共享模块 `download_permission.py`，在图片下载前检查权限
- 禁止下载的群跳过未缓存图片的飞书下载流程，已缓存 TOS 图片不受影响

## Test plan
- [x] 部署 fix-img 泳道，绑定无权限群验证无 tool-service 报错