### PR TITLE
feat(monitor-dashboard): optimize frontend UI/UX and add fuzzy search filters

### DIFF
--- a/apps/monitor-dashboard-web/src/App.tsx
+++ b/apps/monitor-dashboard-web/src/App.tsx
@@ -145,7 +145,7 @@ export default function App() {
     />
   );
 
-  const brand = (
+    const brand = (
     <div
       className="app-logo"
       style={{
@@ -160,7 +160,7 @@ export default function App() {
       <div style={{
         width: 32,
         height: 32,
-        background: `linear-gradient(135deg, ${primaryColor}, #3b82f6)`,
+        background: '#000',
         borderRadius: 8,
         display: 'flex',
         alignItems: 'center',
@@ -170,7 +170,7 @@ export default function App() {
         fontWeight: 'bold',
         fontSize: 20,
         flexShrink: 0,
-        boxShadow: '0 4px 6px -1px rgba(37, 99, 235, 0.3)'
+        boxShadow: '0 4px 6px -1px rgba(0, 0, 0, 0.2)'
       }}>🔭</div>
       {(!collapsed || isMobile) && (
         <Text strong style={{ fontSize: 18, color: '#0f172a' }}>赤尾观测中心</Text>

--- a/apps/monitor-dashboard-web/src/App.tsx
+++ b/apps/monitor-dashboard-web/src/App.tsx
@@ -145,7 +145,7 @@ export default function App() {
     />
   );
 
-    const brand = (
+  const brand = (
     <div
       className="app-logo"
       style={{
@@ -160,7 +160,7 @@ export default function App() {
       <div style={{
         width: 32,
         height: 32,
-        background: '#000',
+        background: `linear-gradient(135deg, #38bdf8, ${primaryColor})`,
         borderRadius: 8,
         display: 'flex',
         alignItems: 'center',
@@ -170,7 +170,7 @@ export default function App() {
         fontWeight: 'bold',
         fontSize: 20,
         flexShrink: 0,
-        boxShadow: '0 4px 6px -1px rgba(0, 0, 0, 0.2)'
+        boxShadow: '0 4px 6px -1px rgba(37, 99, 235, 0.3)'
       }}>🔭</div>
       {(!collapsed || isMobile) && (
         <Text strong style={{ fontSize: 18, color: '#0f172a' }}>赤尾观测中心</Text>

--- a/apps/monitor-dashboard-web/src/pages/Activity.tsx
+++ b/apps/monitor-dashboard-web/src/pages/Activity.tsx
@@ -306,7 +306,7 @@ export default function Activity() {
       title: '赤尾回复',
       dataIndex: 'bot_replies',
       key: 'bot_replies',
-      width: 100,
+      width: 120,
       sorter: (a: GroupStat, b: GroupStat) => a.bot_replies - b.bot_replies,
       defaultSortOrder: 'descend' as const,
       render: (val: number) => <Tag bordered={false} color={val > 0 ? 'blue' : 'default'}>{val.toLocaleString()}</Tag>

--- a/apps/monitor-dashboard-web/src/pages/Activity.tsx
+++ b/apps/monitor-dashboard-web/src/pages/Activity.tsx
@@ -60,7 +60,7 @@ function renderInlineMarkdown(text: string): ReactNode[] {
       return <del key={index}>{part.slice(2, -2)}</del>;
     }
     if (part.startsWith('`') && part.endsWith('`')) {
-      return <Text key={index} code>{part.slice(1, -1)}</Text>;
+      return <Text key={index} code style={{ background: '#f1f5f9', border: 'none', color: '#0f172a' }}>{part.slice(1, -1)}</Text>;
     }
     return <span key={index}>{part}</span>;
   });
@@ -81,17 +81,17 @@ function renderMarkdownLikeContent(content: string) {
     }
 
     if (trimmed.startsWith('### ')) {
-      blocks.push(<Title key={blocks.length} level={5}>{renderInlineMarkdown(trimmed.slice(4))}</Title>);
+      blocks.push(<Title key={blocks.length} level={5} style={{ marginTop: 16, marginBottom: 8, color: '#0f172a' }}>{renderInlineMarkdown(trimmed.slice(4))}</Title>);
       index++;
       continue;
     }
     if (trimmed.startsWith('## ')) {
-      blocks.push(<Title key={blocks.length} level={4}>{renderInlineMarkdown(trimmed.slice(3))}</Title>);
+      blocks.push(<Title key={blocks.length} level={4} style={{ marginTop: 24, marginBottom: 12, color: '#0f172a' }}>{renderInlineMarkdown(trimmed.slice(3))}</Title>);
       index++;
       continue;
     }
     if (trimmed.startsWith('# ')) {
-      blocks.push(<Title key={blocks.length} level={3}>{renderInlineMarkdown(trimmed.slice(2))}</Title>);
+      blocks.push(<Title key={blocks.length} level={3} style={{ marginTop: 32, marginBottom: 16, color: '#0f172a' }}>{renderInlineMarkdown(trimmed.slice(2))}</Title>);
       index++;
       continue;
     }
@@ -103,7 +103,7 @@ function renderMarkdownLikeContent(content: string) {
         index++;
       }
       blocks.push(
-        <ul key={blocks.length} style={{ paddingInlineStart: 20, marginTop: 0, marginBottom: 16 }}>
+        <ul key={blocks.length} style={{ paddingInlineStart: 20, marginTop: 8, marginBottom: 16, color: '#334155' }}>
           {items.map((item, itemIndex) => (
             <li key={itemIndex} style={{ marginBottom: 6 }}>
               {renderInlineMarkdown(item)}
@@ -121,7 +121,7 @@ function renderMarkdownLikeContent(content: string) {
         index++;
       }
       blocks.push(
-        <ol key={blocks.length} style={{ paddingInlineStart: 20, marginTop: 0, marginBottom: 16 }}>
+        <ol key={blocks.length} style={{ paddingInlineStart: 20, marginTop: 8, marginBottom: 16, color: '#334155' }}>
           {items.map((item, itemIndex) => (
             <li key={itemIndex} style={{ marginBottom: 6 }}>
               {renderInlineMarkdown(item)}
@@ -142,10 +142,12 @@ function renderMarkdownLikeContent(content: string) {
         <div
           key={blocks.length}
           style={{
-            borderInlineStart: '3px solid #d9d9d9',
-            paddingInlineStart: 12,
-            color: '#595959',
+            borderInlineStart: '3px solid #cbd5e1',
+            background: '#f8fafc',
+            padding: '12px 16px',
+            color: '#475569',
             marginBottom: 16,
+            borderRadius: '0 8px 8px 0',
             whiteSpace: 'pre-wrap',
           }}
         >
@@ -176,7 +178,7 @@ function renderMarkdownLikeContent(content: string) {
       index++;
     }
     blocks.push(
-      <Paragraph key={blocks.length} style={{ whiteSpace: 'pre-wrap' }}>
+      <Paragraph key={blocks.length} style={{ whiteSpace: 'pre-wrap', color: '#334155', marginBottom: 16, lineHeight: 1.6 }}>
         {paragraphLines.map((paragraphLine, paragraphIndex) => (
           <span key={paragraphIndex}>
             {paragraphIndex > 0 ? <br /> : null}
@@ -200,12 +202,12 @@ function Sparkline({ data }: { data: Array<{ date: string; count: number }> }) {
   const values = [...byDate.values()];
   const max = Math.max(...values, 1);
   const width = values.length * 6;
-  const height = 20;
+  const height = 24;
 
   return (
-    <svg width={width} height={height} style={{ verticalAlign: 'middle' }}>
+    <svg width={width} height={height} style={{ verticalAlign: 'middle', overflow: 'visible' }}>
       {values.map((v, i) => {
-        const h = Math.max((v / max) * height, 1);
+        const h = Math.max((v / max) * height, 2);
         return (
           <rect
             key={i}
@@ -213,9 +215,9 @@ function Sparkline({ data }: { data: Array<{ date: string; count: number }> }) {
             y={height - h}
             width={4}
             height={h}
-            fill="#2563eb"
-            opacity={0.7}
-            rx={1}
+            fill="#000000"
+            opacity={0.8}
+            rx={2}
           />
         );
       })}
@@ -276,7 +278,7 @@ export default function Activity() {
       render: (name: string, record: GroupStat) => (
         <Button
           type="link"
-          style={{ padding: 0 }}
+          style={{ padding: 0, fontWeight: 500, color: '#000000' }}
           onClick={() => {
             const lane = getLane();
             navigate(lane ? `/messages?chatId=${record.chat_id}&x-lane=${lane}` : `/messages?chatId=${record.chat_id}`);
@@ -289,15 +291,16 @@ export default function Activity() {
     {
       title: '7天趋势',
       key: 'sparkline',
-      width: 80,
+      width: 100,
       render: (_: unknown, record: GroupStat) => <Sparkline data={record.daily_counts} />,
     },
     {
       title: '消息数',
       dataIndex: 'message_count',
       key: 'message_count',
-      width: 90,
+      width: 100,
       sorter: (a: GroupStat, b: GroupStat) => a.message_count - b.message_count,
+      render: (val: number) => <Text strong>{val.toLocaleString()}</Text>
     },
     {
       title: '赤尾回复',
@@ -306,6 +309,7 @@ export default function Activity() {
       width: 100,
       sorter: (a: GroupStat, b: GroupStat) => a.bot_replies - b.bot_replies,
       defaultSortOrder: 'descend' as const,
+      render: (val: number) => <Tag bordered={false} color={val > 0 ? 'blue' : 'default'}>{val.toLocaleString()}</Tag>
     },
     {
       title: '最近日记',
@@ -317,18 +321,20 @@ export default function Activity() {
         const isRecent = dayjs().diff(dayjs(d.latest_diary_date), 'day') <= 1;
         const preview = normalizePreviewContent(d.latest_diary_content);
         return (
-          <Space size={8} style={{ width: '100%' }}>
-            <BookOutlined style={{ color: isRecent ? '#52c41a' : '#d9d9d9', flex: 'none' }} />
-            <div style={{ minWidth: 0, flex: 1 }}>
-              <Space size={6} wrap>
-                <Text type={isRecent ? undefined : 'secondary'}>
+          <Space size={12} style={{ width: '100%', alignItems: 'flex-start' }}>
+            <div style={{ background: isRecent ? '#ecfdf5' : '#f8fafc', padding: 8, borderRadius: 8, display: 'flex' }}>
+              <BookOutlined style={{ color: isRecent ? '#10b981' : '#94a3b8', fontSize: 16 }} />
+            </div>
+            <div style={{ minWidth: 0, flex: 1, marginTop: 2 }}>
+              <Space size={8} wrap style={{ marginBottom: 4 }}>
+                <Text strong={isRecent} type={isRecent ? undefined : 'secondary'} style={{ fontSize: 13, color: isRecent ? '#0f172a' : undefined }}>
                   {dayjs(d.latest_diary_date).format('MM-DD')}
                 </Text>
-                <Tag style={{ fontSize: 11, marginInlineEnd: 0 }}>{d.diary_count_7d}/7d</Tag>
+                <Tag bordered={false} color={isRecent ? 'success' : 'default'} style={{ fontSize: 11, marginInlineEnd: 0 }}>{d.diary_count_7d}/7d</Tag>
               </Space>
               <Paragraph
                 type={preview ? undefined : 'secondary'}
-                style={{ marginBottom: 0 }}
+                style={{ marginBottom: 4, color: '#475569', fontSize: 13, lineHeight: 1.5 }}
                 ellipsis={{ rows: 2, tooltip: false }}
               >
                 {preview || '无内容'}
@@ -336,13 +342,13 @@ export default function Activity() {
               <Button
                 type="link"
                 size="small"
-                style={{ padding: 0, height: 'auto' }}
+                style={{ padding: 0, height: 'auto', fontSize: 12, color: '#3b82f6' }}
                 onClick={() => setPreviewModal({
                   title: `${record.group_name} · ${dayjs(d.latest_diary_date).format('YYYY-MM-DD')} 日记`,
                   content: d.latest_diary_content || '无内容',
                 })}
               >
-                查看全文
+                阅读全文
               </Button>
             </div>
           </Space>
@@ -359,18 +365,20 @@ export default function Activity() {
         const isRecent = dayjs().diff(dayjs(w.latest_week_start), 'day') <= 7;
         const preview = normalizePreviewContent(w.latest_weekly_content);
         return (
-          <Space size={8} style={{ width: '100%' }}>
-            <FileTextOutlined style={{ color: isRecent ? '#52c41a' : '#d9d9d9', flex: 'none' }} />
-            <div style={{ minWidth: 0, flex: 1 }}>
-              <Space size={6} wrap>
-                <Text type={isRecent ? undefined : 'secondary'}>
+          <Space size={12} style={{ width: '100%', alignItems: 'flex-start' }}>
+            <div style={{ background: isRecent ? '#eff6ff' : '#f8fafc', padding: 8, borderRadius: 8, display: 'flex' }}>
+              <FileTextOutlined style={{ color: isRecent ? '#3b82f6' : '#94a3b8', fontSize: 16 }} />
+            </div>
+            <div style={{ minWidth: 0, flex: 1, marginTop: 2 }}>
+              <Space size={8} wrap style={{ marginBottom: 4 }}>
+                <Text strong={isRecent} type={isRecent ? undefined : 'secondary'} style={{ fontSize: 13, color: isRecent ? '#0f172a' : undefined }}>
                   {dayjs(w.latest_week_start).format('MM-DD')}
                 </Text>
-                <Tag style={{ fontSize: 11, marginInlineEnd: 0 }}>{w.review_count_4w}/4w</Tag>
+                <Tag bordered={false} color={isRecent ? 'processing' : 'default'} style={{ fontSize: 11, marginInlineEnd: 0 }}>{w.review_count_4w}/4w</Tag>
               </Space>
               <Paragraph
                 type={preview ? undefined : 'secondary'}
-                style={{ marginBottom: 0 }}
+                style={{ marginBottom: 4, color: '#475569', fontSize: 13, lineHeight: 1.5 }}
                 ellipsis={{ rows: 2, tooltip: false }}
               >
                 {preview || '无内容'}
@@ -378,13 +386,13 @@ export default function Activity() {
               <Button
                 type="link"
                 size="small"
-                style={{ padding: 0, height: 'auto' }}
+                style={{ padding: 0, height: 'auto', fontSize: 12, color: '#3b82f6' }}
                 onClick={() => setPreviewModal({
                   title: `${record.group_name} · ${dayjs(w.latest_week_start).format('YYYY-MM-DD')} 周记`,
                   content: w.latest_weekly_content || '无内容',
                 })}
               >
-                查看全文
+                阅读全文
               </Button>
             </div>
           </Space>
@@ -395,54 +403,68 @@ export default function Activity() {
 
   return (
     <div className="page-container">
-      <div style={{ marginBottom: 24, display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+      <div className="page-header">
         <div>
-          <Title level={4} style={{ marginBottom: 4 }}>赤尾动态</Title>
-          <Text type="secondary">群活跃度与日记/周记生成概览</Text>
+          <h1 className="page-title">赤尾动态</h1>
+          <Text type="secondary" style={{ marginTop: 8, display: 'block' }}>群活跃度与日记/周记生成概览</Text>
         </div>
         <Tooltip title="每 60 秒自动刷新">
-          <ReloadOutlined
-            spin={loading}
-            style={{ fontSize: 16, cursor: 'pointer', color: '#8c8c8c' }}
+          <div 
             onClick={() => { setLoading(true); fetchData(); }}
-          />
+            style={{ 
+              display: 'flex', 
+              alignItems: 'center', 
+              gap: 8, 
+              padding: '8px 16px', 
+              background: '#fff', 
+              borderRadius: 8, 
+              cursor: 'pointer',
+              border: '1px solid #e2e8f0',
+              boxShadow: '0 1px 2px rgba(0,0,0,0.05)',
+              transition: 'all 0.2s'
+            }}
+            className="hover-card"
+          >
+            <ReloadOutlined spin={loading} style={{ color: '#64748b' }} />
+            <Text type="secondary" style={{ fontSize: 13, fontWeight: 500 }}>刷新</Text>
+          </div>
         </Tooltip>
       </div>
 
       <Row gutter={[24, 24]} style={{ marginBottom: 24 }}>
         <Col xs={24} sm={8}>
-          <Card bordered={false}>
+          <Card bordered={false} className="content-card" bodyStyle={{ padding: '20px 24px' }}>
             <Statistic
-              title="今日消息总数"
+              title={<Text type="secondary" style={{ fontSize: 13, fontWeight: 500 }}>今日消息总数</Text>}
               value={Number(summary.today_total) || 0}
-              prefix={<MessageOutlined />}
-              valueStyle={{ fontWeight: 600 }}
+              prefix={<MessageOutlined style={{ color: '#64748b' }} />}
+              valueStyle={{ fontWeight: 700, fontSize: 32, color: '#0f172a', marginTop: 8 }}
             />
           </Card>
         </Col>
         <Col xs={24} sm={8}>
-          <Card bordered={false}>
+          <Card bordered={false} className="content-card" bodyStyle={{ padding: '20px 24px' }}>
             <Statistic
-              title="赤尾回复数"
+              title={<Text type="secondary" style={{ fontSize: 13, fontWeight: 500 }}>赤尾回复数</Text>}
               value={Number(summary.today_bot_replies) || 0}
-              prefix={<RobotOutlined style={{ color: '#2563eb' }} />}
-              valueStyle={{ fontWeight: 600, color: '#2563eb' }}
+              prefix={<RobotOutlined style={{ color: '#000000' }} />}
+              valueStyle={{ fontWeight: 700, fontSize: 32, color: '#000000', marginTop: 8 }}
             />
           </Card>
         </Col>
         <Col xs={24} sm={8}>
-          <Card bordered={false}>
+          <Card bordered={false} className="content-card" bodyStyle={{ padding: '20px 24px' }}>
             <Statistic
-              title="今日活跃群数"
+              title={<Text type="secondary" style={{ fontSize: 13, fontWeight: 500 }}>今日活跃群数</Text>}
               value={Number(summary.today_active_groups) || 0}
-              prefix={<TeamOutlined />}
-              valueStyle={{ fontWeight: 600 }}
+              prefix={<TeamOutlined style={{ color: '#64748b' }} />}
+              valueStyle={{ fontWeight: 700, fontSize: 32, color: '#0f172a', marginTop: 8 }}
             />
           </Card>
         </Col>
       </Row>
 
-      <Card bordered={false}>
+      <Card bordered={false} className="content-card" bodyStyle={{ padding: 0, overflow: 'hidden' }}>
         <Table
           dataSource={groups}
           columns={columns}
@@ -456,13 +478,16 @@ export default function Activity() {
 
       <Modal
         open={!!previewModal}
-        title={previewModal?.title}
+        title={<div style={{ fontSize: 18, fontWeight: 600, color: '#0f172a' }}>{previewModal?.title}</div>}
         footer={null}
         onCancel={() => setPreviewModal(null)}
         width={860}
-        styles={{ body: { maxHeight: '70vh', overflowY: 'auto' } }}
+        styles={{ 
+          body: { maxHeight: '70vh', overflowY: 'auto', padding: '24px 0' },
+          content: { borderRadius: 16, overflow: 'hidden', padding: 24 }
+        }}
       >
-        <div style={{ fontSize: 14, lineHeight: 1.8 }}>
+        <div style={{ fontSize: 14, lineHeight: 1.8, color: '#334155' }}>
           {renderMarkdownLikeContent(previewModal?.content || '无内容')}
         </div>
       </Modal>

--- a/apps/monitor-dashboard-web/src/pages/Activity.tsx
+++ b/apps/monitor-dashboard-web/src/pages/Activity.tsx
@@ -215,8 +215,8 @@ function Sparkline({ data }: { data: Array<{ date: string; count: number }> }) {
             y={height - h}
             width={4}
             height={h}
-            fill="#000000"
-            opacity={0.8}
+            fill="#2563eb"
+            opacity={0.7}
             rx={2}
           />
         );
@@ -278,7 +278,7 @@ export default function Activity() {
       render: (name: string, record: GroupStat) => (
         <Button
           type="link"
-          style={{ padding: 0, fontWeight: 500, color: '#000000' }}
+          style={{ padding: 0, fontWeight: 500, color: '#2563eb' }}
           onClick={() => {
             const lane = getLane();
             navigate(lane ? `/messages?chatId=${record.chat_id}&x-lane=${lane}` : `/messages?chatId=${record.chat_id}`);
@@ -447,8 +447,8 @@ export default function Activity() {
             <Statistic
               title={<Text type="secondary" style={{ fontSize: 13, fontWeight: 500 }}>赤尾回复数</Text>}
               value={Number(summary.today_bot_replies) || 0}
-              prefix={<RobotOutlined style={{ color: '#000000' }} />}
-              valueStyle={{ fontWeight: 700, fontSize: 32, color: '#000000', marginTop: 8 }}
+              prefix={<RobotOutlined style={{ color: '#2563eb' }} />}
+              valueStyle={{ fontWeight: 700, fontSize: 32, color: '#0f172a', marginTop: 8 }}
             />
           </Card>
         </Col>

--- a/apps/monitor-dashboard-web/src/pages/AuditLogs.tsx
+++ b/apps/monitor-dashboard-web/src/pages/AuditLogs.tsx
@@ -24,9 +24,9 @@ const callerColors: Record<string, string> = {
 };
 
 const resultColors: Record<string, string> = {
-  success: 'green',
-  error: 'red',
-  denied: 'orange',
+  success: 'success',
+  error: 'error',
+  denied: 'warning',
 };
 
 export default function AuditLogs() {
@@ -72,10 +72,10 @@ export default function AuditLogs() {
       title: '时间',
       dataIndex: 'created_at',
       key: 'created_at',
-      width: 180,
+      width: 160,
       render: (v: string) => (
         <Tooltip title={dayjs(v).format('YYYY-MM-DD HH:mm:ss.SSS')}>
-          <Text type="secondary" style={{ fontSize: 13 }}>
+          <Text type="secondary" style={{ fontSize: 13, fontWeight: 500 }}>
             {dayjs(v).format('MM-DD HH:mm:ss')}
           </Text>
         </Tooltip>
@@ -86,14 +86,14 @@ export default function AuditLogs() {
       dataIndex: 'caller',
       key: 'caller',
       width: 120,
-      render: (v: string) => <Tag color={callerColors[v] || 'default'}>{v}</Tag>,
+      render: (v: string) => <Tag bordered={false} color={callerColors[v] || 'default'} style={{ fontWeight: 500 }}>{v}</Tag>,
     },
     {
       title: '操作',
       dataIndex: 'action',
       key: 'action',
       width: 220,
-      render: (v: string) => <Text code style={{ fontSize: 12 }}>{v}</Text>,
+      render: (v: string) => <Text code style={{ fontSize: 12, background: '#f8fafc', border: 'none' }}>{v}</Text>,
     },
     {
       title: '参数',
@@ -101,11 +101,11 @@ export default function AuditLogs() {
       key: 'params',
       ellipsis: true,
       render: (v: Record<string, unknown> | null) => {
-        if (!v) return '-';
+        if (!v) return <Text type="secondary">-</Text>;
         const str = JSON.stringify(v);
         return (
-          <Tooltip title={<pre style={{ maxHeight: 300, overflow: 'auto', margin: 0, fontSize: 11 }}>{JSON.stringify(v, null, 2)}</pre>}>
-            <Text type="secondary" style={{ fontSize: 12 }}>{str.length > 80 ? str.slice(0, 80) + '...' : str}</Text>
+          <Tooltip title={<pre style={{ maxHeight: 300, overflow: 'auto', margin: 0, fontSize: 11, fontFamily: 'var(--font-mono)' }}>{JSON.stringify(v, null, 2)}</pre>}>
+            <Text type="secondary" style={{ fontSize: 12, fontFamily: 'var(--font-mono)' }}>{str.length > 80 ? str.slice(0, 80) + '...' : str}</Text>
           </Tooltip>
         );
       },
@@ -115,14 +115,14 @@ export default function AuditLogs() {
       dataIndex: 'result',
       key: 'result',
       width: 90,
-      render: (v: string) => <Tag color={resultColors[v] || 'default'}>{v}</Tag>,
+      render: (v: string) => <Tag bordered={false} color={resultColors[v] || 'default'} style={{ fontWeight: 500 }}>{v}</Tag>,
     },
     {
       title: '耗时',
       dataIndex: 'duration_ms',
       key: 'duration_ms',
       width: 80,
-      render: (v: number | null) => v != null ? `${v}ms` : '-',
+      render: (v: number | null) => v != null ? <Text type="secondary" style={{ fontSize: 13 }}>{v}ms</Text> : '-',
     },
     {
       title: '错误信息',
@@ -130,28 +130,42 @@ export default function AuditLogs() {
       key: 'error_message',
       width: 200,
       ellipsis: true,
-      render: (v: string | null) => v ? <Text type="danger" style={{ fontSize: 12 }}>{v}</Text> : '-',
+      render: (v: string | null) => v ? <Text type="danger" style={{ fontSize: 12 }}>{v}</Text> : <Text type="secondary">-</Text>,
     },
   ];
 
   return (
     <div className="page-container">
-      <div style={{ marginBottom: 24, display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+      <div className="page-header">
         <div>
-          <Title level={4} style={{ marginBottom: 4 }}>审计日志</Title>
-          <Text type="secondary">所有 API 操作的完整记录</Text>
+          <h1 className="page-title">审计日志</h1>
+          <Text type="secondary" style={{ marginTop: 8, display: 'block' }}>所有 API 操作的完整安全审计记录</Text>
         </div>
         <Tooltip title="刷新">
-          <ReloadOutlined
-            spin={loading}
-            style={{ fontSize: 16, cursor: 'pointer', color: '#8c8c8c' }}
+          <div 
             onClick={fetchData}
-          />
+            style={{ 
+              display: 'flex', 
+              alignItems: 'center', 
+              gap: 8, 
+              padding: '8px 16px', 
+              background: '#fff', 
+              borderRadius: 8, 
+              cursor: 'pointer',
+              border: '1px solid #e2e8f0',
+              boxShadow: '0 1px 2px rgba(0,0,0,0.05)',
+              transition: 'all 0.2s'
+            }}
+            className="hover-card"
+          >
+            <ReloadOutlined spin={loading} style={{ color: '#64748b' }} />
+            <Text type="secondary" style={{ fontSize: 13, fontWeight: 500 }}>刷新</Text>
+          </div>
         </Tooltip>
       </div>
 
-      <Card bordered={false} style={{ marginBottom: 16 }}>
-        <Space wrap size={[12, 12]}>
+      <div className="filter-card">
+        <Space wrap size={[16, 16]}>
           <Select
             allowClear
             placeholder="调用者"
@@ -166,8 +180,8 @@ export default function AuditLogs() {
           <Input
             allowClear
             placeholder="操作名称"
-            prefix={<SearchOutlined />}
-            style={{ width: 200 }}
+            prefix={<SearchOutlined style={{ color: '#94a3b8' }} />}
+            style={{ width: 220 }}
             value={action}
             onChange={(e) => { setAction(e.target.value || undefined); setPage(1); }}
           />
@@ -188,26 +202,27 @@ export default function AuditLogs() {
             onChange={(v) => { setDateRange(v as [Dayjs | null, Dayjs | null]); setPage(1); }}
           />
           <Button onClick={() => { setCaller(undefined); setAction(undefined); setResult(undefined); setDateRange(undefined); setPage(1); }}>
-            重置
+            重置筛选
           </Button>
         </Space>
-      </Card>
+      </div>
 
-      <Card bordered={false}>
+      <Card bordered={false} className="content-card" bodyStyle={{ padding: 0, overflow: 'hidden' }}>
         <Table
           dataSource={data}
           columns={columns}
           rowKey="id"
           loading={loading}
-          size="small"
+          size="middle"
           pagination={{
             current: page,
             pageSize,
             total,
             showSizeChanger: true,
             pageSizeOptions: ['20', '50', '100'],
-            showTotal: (t) => `共 ${t} 条`,
+            showTotal: (t) => `共 ${t} 条记录`,
             onChange: (p, ps) => { setPage(p); setPageSize(ps); },
+            style: { padding: '16px 24px', margin: 0, borderTop: '1px solid #f1f5f9' }
           }}
           rowClassName={(record) => record.result === 'error' || record.result === 'denied' ? 'audit-row-error' : ''}
         />

--- a/apps/monitor-dashboard-web/src/pages/Messages.tsx
+++ b/apps/monitor-dashboard-web/src/pages/Messages.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useMemo } from 'react';
+import { useEffect, useState, useMemo, useCallback, useRef } from 'react';
 import {
   Button,
   Checkbox,
@@ -230,6 +230,44 @@ export default function Messages() {
   const [total, setTotal] = useState(0);
   const [visibleKeys, setVisibleKeys] = useState<string[]>(loadVisibleColumns);
 
+  // Remote search state for chat/user selects
+  const [chatOptions, setChatOptions] = useState<Array<{ value: string; label: string }>>([]);
+  const [userOptions, setUserOptions] = useState<Array<{ value: string; label: string }>>([]);
+  const chatSearchTimer = useRef<ReturnType<typeof setTimeout>>();
+  const userSearchTimer = useRef<ReturnType<typeof setTimeout>>();
+
+  const searchChats = useCallback((keyword: string) => {
+    clearTimeout(chatSearchTimer.current);
+    chatSearchTimer.current = setTimeout(async () => {
+      try {
+        const { data } = await api.get('/chats', { params: { keyword } });
+        setChatOptions(data.map((c: { chat_id: string; name: string }) => ({
+          value: c.chat_id,
+          label: c.name,
+        })));
+      } catch { /* ignore */ }
+    }, 300);
+  }, []);
+
+  const searchUsers = useCallback((keyword: string) => {
+    clearTimeout(userSearchTimer.current);
+    userSearchTimer.current = setTimeout(async () => {
+      try {
+        const { data } = await api.get('/users', { params: { keyword } });
+        setUserOptions(data.map((u: { user_id: string; name: string }) => ({
+          value: u.user_id,
+          label: u.name,
+        })));
+      } catch { /* ignore */ }
+    }, 300);
+  }, []);
+
+  // Pre-load options on mount
+  useEffect(() => {
+    searchChats('');
+    searchUsers('');
+  }, [searchChats, searchUsers]);
+
   // Define buildColumns inside component or use memo with handlers
   const columns = useMemo(() => {
     const visibleSet = new Set(visibleKeys);
@@ -241,6 +279,14 @@ export default function Messages() {
       // Reset page to 1 when filtering
       setPage(1);
       // Directly trigger fetch with new filters
+      fetchData(1, pageSize, newFilters);
+    };
+
+    // Handler for clicking on User Name
+    const handleUserClick = (userId: string) => {
+      const newFilters = { ...filters, userId };
+      setFilters(newFilters);
+      setPage(1);
       fetchData(1, pageSize, newFilters);
     };
 
@@ -289,7 +335,14 @@ export default function Messages() {
         ellipsis: true,
         render: (text, record) => (
           <Tooltip title={`User ID: ${record.user_id}`}>
-            <span>{text}</span>
+            <Button
+              type="link"
+              size="small"
+              style={{ padding: 0, fontSize: 'inherit', height: 'auto', lineHeight: 'inherit', color: '#0f172a', fontWeight: 500 }}
+              onClick={() => handleUserClick(record.user_id)}
+            >
+              {text}
+            </Button>
           </Tooltip>
         ),
       },
@@ -654,19 +707,33 @@ export default function Messages() {
       <div className="filter-card">
         <Row gutter={[12, 12]}>
           <Col xs={12} sm={8} md={6} lg={4}>
-            <Input
-              placeholder="会话 ID"
-              value={filters.chatId}
-              onChange={(e) => setFilters((prev) => ({ ...prev, chatId: e.target.value }))}
+            <Select
+              placeholder="搜索会话名称"
+              showSearch
+              filterOption={false}
+              value={filters.chatId || undefined}
+              onSearch={searchChats}
+              onChange={(value) => setFilters((prev) => ({ ...prev, chatId: value || '' }))}
+              onFocus={() => searchChats('')}
               allowClear
+              style={{ width: '100%' }}
+              options={chatOptions}
+              notFoundContent={null}
             />
           </Col>
           <Col xs={12} sm={8} md={6} lg={4}>
-            <Input
-              placeholder="用户 ID"
-              value={filters.userId}
-              onChange={(e) => setFilters((prev) => ({ ...prev, userId: e.target.value }))}
+            <Select
+              placeholder="搜索用户名称"
+              showSearch
+              filterOption={false}
+              value={filters.userId || undefined}
+              onSearch={searchUsers}
+              onChange={(value) => setFilters((prev) => ({ ...prev, userId: value || '' }))}
+              onFocus={() => searchUsers('')}
               allowClear
+              style={{ width: '100%' }}
+              options={userOptions}
+              notFoundContent={null}
             />
           </Col>
           <Col xs={12} sm={8} md={6} lg={4}>

--- a/apps/monitor-dashboard-web/src/pages/Messages.tsx
+++ b/apps/monitor-dashboard-web/src/pages/Messages.tsx
@@ -311,20 +311,20 @@ export default function Messages() {
             system: { color: 'orange', text: '系统' },
           };
           const info = map[role] || { color: 'default', text: role };
-          return <Tag color={info.color}>{info.text}</Tag>;
+          return <Tag bordered={false} color={info.color} style={{ fontWeight: 500 }}>{info.text}</Tag>;
         },
       },
       chat_name: {
         title: '会话',
         dataIndex: 'chat_name',
-        width: 180,
+        width: 160,
         ellipsis: true,
         render: (text, record) => {
           const content = (
             <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
               <div><strong>会话名称:</strong> {text}</div>
               <div>
-                <strong>会话 ID:</strong> {record.chat_id}
+                <strong>会话 ID:</strong> <Text code style={{ background: '#f8fafc', border: 'none' }}>{record.chat_id}</Text>
                 <Button 
                   type="text" 
                   size="small" 
@@ -338,9 +338,9 @@ export default function Messages() {
           return (
             <Popover content={content} title="会话信息" trigger="hover">
               <Button 
-                type="text" 
+                type="link" 
                 size="small"
-                style={{ padding: '0 4px', fontSize: 'inherit', height: 'auto', lineHeight: 'inherit' }}
+                style={{ padding: 0, fontSize: 'inherit', height: 'auto', lineHeight: 'inherit', color: '#0f172a', fontWeight: 500 }}
                 onClick={() => handleChatClick(record.chat_id)}
               >
                 {text}
@@ -354,7 +354,7 @@ export default function Messages() {
         dataIndex: 'chat_id',
         width: 180,
         ellipsis: true,
-        render: (text) => <Text copyable>{text}</Text>,
+        render: (text) => <Text copyable style={{ color: '#475569' }}>{text}</Text>,
       },
       chat_type: {
         title: '会话类型',
@@ -362,7 +362,7 @@ export default function Messages() {
         width: 100,
         render: (type: string) => {
           const label = chatTypeMap[type] || type;
-          return <Tag color={type === 'group' ? 'cyan' : 'purple'}>{label}</Tag>;
+          return <Tag bordered={false} color={type === 'group' ? 'cyan' : 'purple'} style={{ fontWeight: 500 }}>{label}</Tag>;
         },
       },
       bot_name: {
@@ -642,7 +642,10 @@ export default function Messages() {
     <div className="page-container">
       {/* Reduced margin-bottom from default 24px to 16px to decrease gap */}
       <div className="page-header" style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 16 }}>
-        <h1 className="page-title" style={{ margin: 0 }}>消息记录</h1>
+        <div>
+          <h1 className="page-title" style={{ margin: 0 }}>消息记录</h1>
+          <Text type="secondary" style={{ marginTop: 8, display: 'block' }}>实时查看系统中的消息流动</Text>
+        </div>
         <Popover content={columnSettingsContent} title="列设置" trigger="click" placement="bottomRight">
           <Button icon={<SettingOutlined />}>列设置</Button>
         </Popover>
@@ -754,7 +757,7 @@ export default function Messages() {
         </Row>
       </div>
 
-      <div className="content-card">
+      <div className="content-card" style={{ padding: 0, overflow: 'hidden' }}>
         <Table
           rowKey="message_id"
           columns={columns}
@@ -765,10 +768,11 @@ export default function Messages() {
             pageSize,
             total,
             showSizeChanger: true,
-            showTotal: (total) => `共 ${total} 条`,
+            showTotal: (total) => `共 ${total} 条记录`,
             onChange: (nextPage, nextPageSize) => {
               fetchData(nextPage, nextPageSize);
             },
+            style: { padding: '16px 24px', margin: 0, borderTop: '1px solid #f1f5f9' }
           }}
           scroll={{ x: 1200 }}
           size="middle"

--- a/apps/monitor-dashboard-web/src/pages/ModelMappings.tsx
+++ b/apps/monitor-dashboard-web/src/pages/ModelMappings.tsx
@@ -7,11 +7,14 @@ import {
   Popconfirm,
   Space,
   Table,
+  Typography,
   message,
 } from 'antd';
 import type { ColumnsType } from 'antd/es/table';
 import { PlusOutlined, EditOutlined, DeleteOutlined } from '@ant-design/icons';
 import { api } from '../api/client';
+
+const { Text } = Typography;
 
 interface ModelMapping {
   id: string;
@@ -95,28 +98,28 @@ export default function ModelMappings() {
   };
 
   const columns: ColumnsType<ModelMapping> = [
-    { title: '别名', dataIndex: 'alias', width: 220, fixed: 'left' },
-    { title: '服务商', dataIndex: 'provider_name', width: 200 },
-    { title: '真实模型', dataIndex: 'real_model_name', width: 240 },
-    { title: '描述', dataIndex: 'description', width: 200, ellipsis: true },
+    { title: '别名', dataIndex: 'alias', width: 200, fixed: 'left', render: (text) => <Text strong style={{ color: '#0f172a' }}>{text}</Text> },
+    { title: '服务商', dataIndex: 'provider_name', width: 180, render: (text) => <Text type="secondary">{text}</Text> },
+    { title: '真实模型', dataIndex: 'real_model_name', width: 220, render: (text) => <Text code style={{ background: '#f8fafc', border: 'none' }}>{text}</Text> },
+    { title: '描述', dataIndex: 'description', width: 200, ellipsis: true, render: (text) => <Text type="secondary">{text || '-'}</Text> },
     {
       title: '配置',
       dataIndex: 'model_config',
-      width: 150,
+      width: 250,
       render: (value: Record<string, unknown>) =>
-        value ? <div className="json-preview" style={{ maxHeight: 100, overflow: 'auto', fontSize: 12 }}>{JSON.stringify(value, null, 2)}</div> : null,
+        value ? <div style={{ maxHeight: 100, overflow: 'auto', fontSize: 12, fontFamily: 'var(--font-mono)', background: '#f8fafc', padding: 8, borderRadius: 6, border: '1px solid #e2e8f0' }}>{JSON.stringify(value, null, 2)}</div> : <Text type="secondary">-</Text>,
     },
     {
       title: '操作',
-      width: 160,
+      width: 140,
       fixed: 'right',
       render: (_, record) => (
         <Space style={{ marginRight: 16 }}>
-          <Button size="small" icon={<EditOutlined />} onClick={() => openModal(record)}>
+          <Button type="text" size="small" icon={<EditOutlined />} onClick={() => openModal(record)}>
             编辑
           </Button>
           <Popconfirm title="确认删除该配置?" onConfirm={() => handleDelete(record.id)}>
-            <Button size="small" danger icon={<DeleteOutlined />}>
+            <Button type="text" danger size="small" icon={<DeleteOutlined />}>
               删除
             </Button>
           </Popconfirm>
@@ -127,14 +130,17 @@ export default function ModelMappings() {
 
   return (
     <div className="page-container">
-      <div className="page-header" style={{ marginBottom: 16 }}>
-        <h1 className="page-title">模型映射配置</h1>
-        <Button type="primary" icon={<PlusOutlined />} onClick={() => openModal()}>
+      <div className="page-header" style={{ marginBottom: 24 }}>
+        <div>
+          <h1 className="page-title">模型映射配置</h1>
+          <Text type="secondary" style={{ marginTop: 8, display: 'block' }}>将前端抽象模型名称映射到具体服务商与底层大模型</Text>
+        </div>
+        <Button type="primary" icon={<PlusOutlined />} onClick={() => openModal()} size="large">
           新建映射
         </Button>
       </div>
 
-      <div className="content-card">
+      <div className="content-card" style={{ padding: 0, overflow: 'hidden' }}>
         <Table 
           rowKey="id" 
           columns={columns} 
@@ -142,51 +148,52 @@ export default function ModelMappings() {
           loading={loading}
           pagination={false}
           size="middle"
-          scroll={{ x: 1300 }}
+          scroll={{ x: 1200 }}
         />
       </div>
 
       <Modal
-        title={editing ? '编辑映射' : '新建映射'}
+        title={<div style={{ fontSize: 18, fontWeight: 600, color: '#0f172a' }}>{editing ? '编辑映射' : '新建映射'}</div>}
         open={open}
         onCancel={() => setOpen(false)}
         onOk={handleOk}
         okText={editing ? '更新' : '创建'}
         cancelText="取消"
-        width={720}
+        width={680}
+        styles={{ content: { borderRadius: 16, padding: 24 } }}
       >
-        <Form layout="vertical" form={form}>
+        <Form layout="vertical" form={form} style={{ marginTop: 24 }}>
           <Form.Item
             name="alias"
-            label="别名 (Alias)"
+            label={<Text strong>别名 (Alias)</Text>}
             rules={[{ required: true, message: '请输入别名' }]}
-            tooltip="应用中调用的模型名称"
+            tooltip="应用中调用的模型名称，如 'gpt-4o-mini'"
           >
-            <Input placeholder="例如: gpt-4o-mini" />
+            <Input placeholder="例如: gpt-4o-mini" size="large" />
           </Form.Item>
           <Form.Item
             name="provider_name"
-            label="服务商名称"
+            label={<Text strong>服务商名称</Text>}
             rules={[{ required: true, message: '请输入服务商名称' }]}
             tooltip="对应 Providers 中的 Name"
           >
-            <Input placeholder="例如: OpenAI Main" />
+            <Input placeholder="例如: OpenAI Main" size="large" />
           </Form.Item>
           <Form.Item
             name="real_model_name"
-            label="真实模型名称"
+            label={<Text strong>真实模型名称</Text>}
             rules={[{ required: true, message: '请输入真实模型名称' }]}
             tooltip="发送给服务商的实际模型参数"
           >
-            <Input placeholder="例如: gpt-4o-mini-2024-07-18" />
+            <Input placeholder="例如: gpt-4o-mini-2024-07-18" size="large" />
           </Form.Item>
-          <Form.Item name="description" label="描述">
-            <Input.TextArea rows={2} placeholder="备注说明" />
+          <Form.Item name="description" label={<Text strong>描述</Text>}>
+            <Input.TextArea rows={3} placeholder="备注说明" style={{ background: '#f8fafc', borderColor: '#e2e8f0' }} />
           </Form.Item>
-          <Form.Item name="model_config" label="模型配置 (JSON)">
+          <Form.Item name="model_config" label={<Text strong>模型配置 (JSON)</Text>} tooltip="覆盖模型默认参数">
             <Input.TextArea
               rows={6}
-              className="json-preview"
+              style={{ fontFamily: 'var(--font-mono)', fontSize: 13, background: '#f8fafc', borderColor: '#e2e8f0' }}
               placeholder={`{
   "temperature": 0.7,
   "max_tokens": 1000

--- a/apps/monitor-dashboard-web/src/pages/Providers.tsx
+++ b/apps/monitor-dashboard-web/src/pages/Providers.tsx
@@ -10,11 +10,14 @@ import {
   Switch,
   Table,
   Tag,
+  Typography,
   message,
 } from 'antd';
 import type { ColumnsType } from 'antd/es/table';
 import { PlusOutlined, EditOutlined, DeleteOutlined } from '@ant-design/icons';
 import { api } from '../api/client';
+
+const { Text } = Typography;
 
 interface Provider {
   provider_id: string;
@@ -99,27 +102,27 @@ export default function Providers() {
   };
 
   const columns: ColumnsType<Provider> = [
-    { title: '名称', dataIndex: 'name', width: 180, fixed: 'left' },
+    { title: '名称', dataIndex: 'name', width: 180, fixed: 'left', render: (text) => <Text strong style={{ color: '#0f172a' }}>{text}</Text> },
     { 
       title: '客户端类型', 
       dataIndex: 'client_type', 
-      width: 120,
-      render: (type) => <Tag>{type}</Tag>
+      width: 140,
+      render: (type) => <Tag bordered={false} color="blue" style={{ fontWeight: 500 }}>{type}</Tag>
     },
     { 
       title: 'API 密钥', 
       dataIndex: 'api_key', 
       width: 200,
       ellipsis: true,
-      render: (text) => text ? `${text.substring(0, 6)}...` : '-'
+      render: (text) => text ? <Text type="secondary" style={{ fontFamily: 'var(--font-mono)', fontSize: 13 }}>{text.substring(0, 6)}...</Text> : '-'
     },
-    { title: '基础地址', dataIndex: 'base_url', width: 300, ellipsis: true },
+    { title: '基础地址', dataIndex: 'base_url', width: 300, ellipsis: true, render: (text) => <Text type="secondary" style={{ fontSize: 13 }}>{text}</Text> },
     {
-      title: '启用状态',
+      title: '状态',
       dataIndex: 'is_active',
-      width: 120,
+      width: 100,
       render: (value: boolean) => (
-        <Tag color={value ? 'success' : 'error'}>
+        <Tag bordered={false} color={value ? 'success' : 'default'} style={{ fontWeight: 500 }}>
           {value ? '启用' : '禁用'}
         </Tag>
       ),
@@ -130,14 +133,14 @@ export default function Providers() {
       fixed: 'right',
       render: (_, record) => (
         <Space style={{ marginRight: 16 }}>
-          <Button size="small" icon={<EditOutlined />} onClick={() => openModal(record)}>
+          <Button type="text" size="small" icon={<EditOutlined />} onClick={() => openModal(record)}>
             编辑
           </Button>
           <Popconfirm
             title="确认删除该服务商?"
             onConfirm={() => handleDelete(record.provider_id)}
           >
-            <Button size="small" danger icon={<DeleteOutlined />}>
+            <Button type="text" danger size="small" icon={<DeleteOutlined />}>
               删除
             </Button>
           </Popconfirm>
@@ -148,14 +151,17 @@ export default function Providers() {
 
   return (
     <div className="page-container">
-      <div className="page-header" style={{ marginBottom: 16 }}>
-        <h1 className="page-title">模型服务商</h1>
-        <Button type="primary" icon={<PlusOutlined />} onClick={() => openModal()}>
+      <div className="page-header" style={{ marginBottom: 24 }}>
+        <div>
+          <h1 className="page-title">模型服务商</h1>
+          <Text type="secondary" style={{ marginTop: 8, display: 'block' }}>管理接入的大模型 API 供应商与凭证</Text>
+        </div>
+        <Button type="primary" icon={<PlusOutlined />} onClick={() => openModal()} size="large">
           新建服务商
         </Button>
       </div>
       
-      <div className="content-card">
+      <div className="content-card" style={{ padding: 0, overflow: 'hidden' }}>
         <Table
           rowKey="provider_id"
           columns={columns}
@@ -163,49 +169,50 @@ export default function Providers() {
           loading={loading}
           pagination={false}
           size="middle"
-          scroll={{ x: 1300 }}
+          scroll={{ x: 1000 }}
         />
       </div>
       
       <Modal
-        title={editing ? '编辑服务商' : '新建服务商'}
+        title={<div style={{ fontSize: 18, fontWeight: 600, color: '#0f172a' }}>{editing ? '编辑服务商' : '新建服务商'}</div>}
         open={open}
         onCancel={() => setOpen(false)}
         onOk={handleOk}
         okText={editing ? '更新' : '创建'}
         cancelText="取消"
+        styles={{ content: { borderRadius: 16, padding: 24 } }}
       >
-        <Form layout="vertical" form={form}>
+        <Form layout="vertical" form={form} style={{ marginTop: 24 }}>
           <Form.Item
             name="name"
-            label="名称"
+            label={<Text strong>名称</Text>}
             rules={[{ required: true, message: '请输入名称' }]}
           >
-            <Input placeholder="例如: OpenAI Main" />
+            <Input placeholder="例如: OpenAI Main" size="large" />
           </Form.Item>
           <Form.Item
             name="api_key"
-            label="API 密钥"
+            label={<Text strong>API 密钥</Text>}
             rules={editing ? [] : [{ required: true, message: '请输入 API Key' }]}
           >
-            <Input.Password placeholder={editing ? '留空表示不更新' : 'sk-...'} />
+            <Input.Password placeholder={editing ? '留空表示不更新' : 'sk-...'} size="large" />
           </Form.Item>
           <Form.Item
             name="base_url"
-            label="基础地址"
+            label={<Text strong>基础地址</Text>}
             rules={[{ required: true, message: '请输入 Base URL' }]}
           >
-            <Input placeholder="https://api.openai.com/v1" />
+            <Input placeholder="https://api.openai.com/v1" size="large" />
           </Form.Item>
           <Form.Item
             name="client_type"
-            label="客户端类型"
+            label={<Text strong>客户端类型</Text>}
             initialValue="openai"
             rules={[{ required: true }]}
           >
-            <Select options={clientTypeOptions} />
+            <Select options={clientTypeOptions} size="large" />
           </Form.Item>
-          <Form.Item name="is_active" label="启用状态" valuePropName="checked" initialValue>
+          <Form.Item name="is_active" label={<Text strong>启用状态</Text>} valuePropName="checked" initialValue>
             <Switch />
           </Form.Item>
         </Form>

--- a/apps/monitor-dashboard-web/src/pages/ServiceStatus.tsx
+++ b/apps/monitor-dashboard-web/src/pages/ServiceStatus.tsx
@@ -93,16 +93,16 @@ function PodDetail({ app, lane }: { app: string; lane: string }) {
   if (!data) return <Text type="secondary">无法获取 Pod 信息</Text>;
 
   return (
-    <div style={{ padding: '4px 0' }}>
-      <Text type="secondary" style={{ fontSize: 12 }}>
-        Desired: {data.desired} / Ready: {data.ready} / Available: {data.available}
+    <div style={{ padding: '8px 12px', background: '#f8fafc', borderRadius: 8, marginTop: 8, border: '1px solid #e2e8f0' }}>
+      <Text type="secondary" style={{ fontSize: 12, display: 'block', marginBottom: 8, fontWeight: 500 }}>
+        预期: {data.desired} / 就绪: {data.ready} / 可用: {data.available}
       </Text>
       {data.pods?.map((pod) => (
-        <div key={pod.name} style={{ fontSize: 12, marginTop: 4 }}>
-          <Tag color={pod.ready ? 'green' : 'red'} style={{ fontSize: 11 }}>{pod.status}</Tag>
-          <Text code style={{ fontSize: 11 }}>{pod.name}</Text>
-          {pod.restarts > 0 && <Text type="warning" style={{ marginLeft: 8, fontSize: 11 }}>restarts: {pod.restarts}</Text>}
-          {pod.reason && <Text type="danger" style={{ marginLeft: 8, fontSize: 11 }}>{pod.reason}</Text>}
+        <div key={pod.name} style={{ fontSize: 12, marginBottom: 4, display: 'flex', alignItems: 'center', gap: 8 }}>
+          <Tag color={pod.ready ? 'green' : 'red'} style={{ margin: 0, fontSize: 11, border: 'none' }}>{pod.status}</Tag>
+          <Text code style={{ fontSize: 11, background: 'transparent', border: 'none', padding: 0 }}>{pod.name}</Text>
+          {pod.restarts > 0 && <Text type="warning" style={{ fontSize: 11 }}>重启: {pod.restarts}</Text>}
+          {pod.reason && <Text type="danger" style={{ fontSize: 11 }}>{pod.reason}</Text>}
         </div>
       ))}
     </div>
@@ -160,21 +160,22 @@ export default function ServiceStatus() {
       title: '服务名',
       dataIndex: 'name',
       key: 'name',
-      render: (name: string) => <Text strong>{name}</Text>,
+      render: (name: string) => <Text strong style={{ color: '#0f172a' }}>{name}</Text>,
     },
     {
       title: '描述',
       dataIndex: 'description',
       key: 'description',
       ellipsis: true,
+      render: (desc: string) => <Text type="secondary">{desc}</Text>,
     },
     {
       title: '端口',
       dataIndex: 'port',
       key: 'port',
-      width: 80,
+      width: 100,
       render: (port: number | string) =>
-        port === 0 ? <Tag>Worker</Tag> : port,
+        port === 0 ? <Tag bordered={false}>Worker</Tag> : <Text type="secondary">{port}</Text>,
     },
     {
       title: '部署泳道',
@@ -190,7 +191,7 @@ export default function ServiceStatus() {
               const cfg = statusConfig[rel.status] || statusConfig.pending;
               return (
                 <Tooltip key={rel.id} title={`${rel.status} · ${tag}`}>
-                  <Tag color={cfg.color} icon={cfg.icon} style={{ marginRight: 0 }}>
+                  <Tag bordered={false} color={cfg.color} icon={cfg.icon} style={{ marginRight: 0, fontWeight: 500 }}>
                     {rel.lane}
                   </Tag>
                 </Tooltip>
@@ -201,19 +202,19 @@ export default function ServiceStatus() {
       },
     },
     {
-      title: '版本',
+      title: '主线版本',
       key: 'version',
-      width: 100,
+      width: 120,
       render: (_: unknown, row: ServiceRow) => {
         const prodRelease = row.releases.find((r) => r.lane === 'prod');
         const tag = prodRelease ? getImageTag(prodRelease.image) : '';
-        return tag ? <Tag>{tag}</Tag> : <Text type="secondary">-</Text>;
+        return tag ? <Tag bordered={false}>{tag}</Tag> : <Text type="secondary">-</Text>;
       },
     },
     {
       title: '最后更新',
       key: 'updatedAt',
-      width: 140,
+      width: 160,
       render: (_: unknown, row: ServiceRow) => {
         const latest = row.releases
           .map((r) => r.updated_at)
@@ -232,61 +233,75 @@ export default function ServiceStatus() {
 
   return (
     <div className="page-container">
-      <div style={{ marginBottom: 24, display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+      <div className="page-header">
         <div>
-          <Title level={4} style={{ marginBottom: 4 }}>服务状态</Title>
-          <Text type="secondary">实时监控所有服务的部署状态</Text>
+          <h1 className="page-title">服务状态</h1>
+          <Text type="secondary" style={{ marginTop: 8, display: 'block' }}>实时监控所有服务的部署状态与资源情况</Text>
         </div>
         <Tooltip title="每 30 秒自动刷新">
-          <ReloadOutlined
-            spin={loading}
-            style={{ fontSize: 16, cursor: 'pointer', color: '#8c8c8c' }}
+          <div 
             onClick={() => { setLoading(true); fetchData(); }}
-          />
+            style={{ 
+              display: 'flex', 
+              alignItems: 'center', 
+              gap: 8, 
+              padding: '8px 16px', 
+              background: '#fff', 
+              borderRadius: 8, 
+              cursor: 'pointer',
+              border: '1px solid #e2e8f0',
+              boxShadow: '0 1px 2px rgba(0,0,0,0.05)',
+              transition: 'all 0.2s'
+            }}
+            className="hover-card"
+          >
+            <ReloadOutlined spin={loading} style={{ color: '#64748b' }} />
+            <Text type="secondary" style={{ fontSize: 13, fontWeight: 500 }}>刷新</Text>
+          </div>
         </Tooltip>
       </div>
 
       <Row gutter={[24, 24]} style={{ marginBottom: 24 }}>
         <Col xs={24} sm={8}>
-          <Card bordered={false}>
+          <Card bordered={false} className="content-card" bodyStyle={{ padding: '20px 24px' }}>
             <Statistic
-              title="总服务数"
+              title={<Text type="secondary" style={{ fontSize: 13, fontWeight: 500 }}>总服务数</Text>}
               value={apps.length}
-              prefix={<CloudServerOutlined />}
-              valueStyle={{ fontWeight: 600 }}
+              prefix={<CloudServerOutlined style={{ color: '#64748b' }} />}
+              valueStyle={{ fontWeight: 700, fontSize: 32, color: '#0f172a', marginTop: 8 }}
             />
           </Card>
         </Col>
         <Col xs={24} sm={8}>
-          <Card bordered={false}>
+          <Card bordered={false} className="content-card" bodyStyle={{ padding: '20px 24px' }}>
             <Statistic
-              title="运行中"
+              title={<Text type="secondary" style={{ fontSize: 13, fontWeight: 500 }}>运行中</Text>}
               value={runningCount}
-              prefix={<CheckCircleOutlined style={{ color: '#52c41a' }} />}
-              valueStyle={{ fontWeight: 600, color: '#52c41a' }}
-              suffix={failedCount > 0 ? <Text type="danger" style={{ fontSize: 14 }}> / {failedCount} 异常</Text> : undefined}
+              prefix={<CheckCircleOutlined style={{ color: '#10b981' }} />}
+              valueStyle={{ fontWeight: 700, fontSize: 32, color: '#0f172a', marginTop: 8 }}
+              suffix={failedCount > 0 ? <Text type="danger" style={{ fontSize: 14, fontWeight: 500, marginLeft: 8 }}>/ {failedCount} 异常</Text> : undefined}
             />
           </Card>
         </Col>
         <Col xs={24} sm={8}>
-          <Card bordered={false}>
+          <Card bordered={false} className="content-card" bodyStyle={{ padding: '20px 24px' }}>
             <Statistic
-              title="活跃泳道"
+              title={<Text type="secondary" style={{ fontSize: 13, fontWeight: 500 }}>活跃泳道</Text>}
               value={lanes.length}
-              prefix={<DeploymentUnitOutlined />}
-              valueStyle={{ fontWeight: 600 }}
+              prefix={<DeploymentUnitOutlined style={{ color: '#8b5cf6' }} />}
+              valueStyle={{ fontWeight: 700, fontSize: 32, color: '#0f172a', marginTop: 8 }}
             />
           </Card>
         </Col>
       </Row>
 
       {laneBindings.length > 0 && (
-        <Card bordered={false} style={{ marginBottom: 24 }} size="small">
-          <Text strong style={{ fontSize: 13 }}>泳道绑定</Text>
-          <div style={{ marginTop: 8 }}>
+        <Card bordered={false} className="content-card" style={{ marginBottom: 24 }} bodyStyle={{ padding: '16px 24px' }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 16 }}>
+            <Text strong style={{ fontSize: 14, color: '#334155' }}>路由绑定</Text>
             <Space wrap size={[8, 6]}>
               {laneBindings.map((b) => (
-                <Tag key={`${b.route_type}-${b.route_key}`} color="blue">
+                <Tag key={`${b.route_type}-${b.route_key}`} bordered={false} color="blue" style={{ margin: 0, fontWeight: 500 }}>
                   {b.route_type}:{b.route_key} → {b.lane_name}
                 </Tag>
               ))}
@@ -295,7 +310,7 @@ export default function ServiceStatus() {
         </Card>
       )}
 
-      <Card bordered={false}>
+      <Card bordered={false} className="content-card" bodyStyle={{ padding: 0, overflow: 'hidden' }}>
         <Table
           dataSource={dataSource}
           columns={columns}
@@ -310,16 +325,16 @@ export default function ServiceStatus() {
             expandIcon: ({ expanded, onExpand, record }) =>
               record.releases.length > 0 ? (
                 expanded
-                  ? <DownOutlined style={{ cursor: 'pointer', fontSize: 12, marginRight: 8 }} onClick={(e) => onExpand(record, e)} />
-                  : <RightOutlined style={{ cursor: 'pointer', fontSize: 12, marginRight: 8 }} onClick={(e) => onExpand(record, e)} />
+                  ? <DownOutlined style={{ cursor: 'pointer', fontSize: 12, marginRight: 8, color: '#64748b' }} onClick={(e) => onExpand(record, e)} />
+                  : <RightOutlined style={{ cursor: 'pointer', fontSize: 12, marginRight: 8, color: '#64748b' }} onClick={(e) => onExpand(record, e)} />
               ) : <span style={{ width: 20, display: 'inline-block' }} />,
             expandedRowRender: (record) => (
-              <div style={{ padding: '8px 0' }}>
+              <div style={{ padding: '16px 32px', background: '#fafafa', borderTop: '1px solid #f1f5f9' }}>
                 {record.releases.map((rel) => (
-                  <div key={rel.id} style={{ marginBottom: 12 }}>
-                    <Space size={8} style={{ marginBottom: 4 }}>
-                      <Tag color={statusConfig[rel.status]?.color || 'default'}>{rel.lane}</Tag>
-                      <Text code style={{ fontSize: 12 }}>{getImageTag(rel.image)}</Text>
+                  <div key={rel.id} style={{ marginBottom: 16, background: '#fff', padding: 16, borderRadius: 12, border: '1px solid #e2e8f0', boxShadow: '0 1px 2px rgba(0,0,0,0.02)' }}>
+                    <Space size={12} style={{ marginBottom: 8 }}>
+                      <Tag bordered={false} color={statusConfig[rel.status]?.color || 'default'} style={{ fontWeight: 500 }}>{rel.lane}</Tag>
+                      <Text code style={{ fontSize: 12, border: 'none', background: '#f1f5f9' }}>{getImageTag(rel.image)}</Text>
                       <Text type="secondary" style={{ fontSize: 12 }}>
                         {dayjs(rel.updated_at).format('YYYY-MM-DD HH:mm:ss')}
                       </Text>

--- a/apps/monitor-dashboard-web/src/styles.css
+++ b/apps/monitor-dashboard-web/src/styles.css
@@ -302,7 +302,7 @@ a {
 }
 
 .page-title {
-  font-size: 28px;
+  font-size: 24px;
   font-weight: 700;
   color: #0f172a;
   margin: 0;
@@ -576,7 +576,7 @@ a {
 
   .page-title,
   .explorer-title {
-    font-size: 24px;
+    font-size: 20px;
   }
 
   .route-loading-card {

--- a/apps/monitor-dashboard-web/src/styles.css
+++ b/apps/monitor-dashboard-web/src/styles.css
@@ -44,11 +44,13 @@ a {
 }
 
 .app-shell {
-  background: #fafafa;
+  background:
+    radial-gradient(circle at top left, rgba(37, 99, 235, 0.06), transparent 28%),
+    linear-gradient(180deg, #f8fbff 0%, #fafafa 280px, #fafafa 100%);
 }
 
 .app-sider {
-  box-shadow: 1px 0 0 0 #e2e8f0;
+  box-shadow: 4px 0 16px rgba(15, 23, 42, 0.03);
 }
 
 .route-loading-shell {
@@ -129,7 +131,7 @@ a {
   right: -10%;
   width: 600px;
   height: 600px;
-  background: radial-gradient(circle, rgba(15, 23, 42, 0.03) 0%, rgba(15, 23, 42, 0) 70%);
+  background: radial-gradient(circle, rgba(56, 189, 248, 0.12) 0%, rgba(56, 189, 248, 0) 70%);
   border-radius: 50%;
   z-index: 0;
 }
@@ -141,7 +143,7 @@ a {
   left: -5%;
   width: 500px;
   height: 500px;
-  background: radial-gradient(circle, rgba(15, 23, 42, 0.04) 0%, rgba(15, 23, 42, 0) 70%);
+  background: radial-gradient(circle, rgba(96, 165, 250, 0.08) 0%, rgba(96, 165, 250, 0) 70%);
   border-radius: 50%;
   z-index: 0;
 }
@@ -161,7 +163,7 @@ a {
 .brand-icon {
   width: 40px;
   height: 40px;
-  background: #000;
+  background: linear-gradient(135deg, #38bdf8, #2563eb);
   border-radius: 10px;
   display: flex;
   align-items: center;
@@ -169,7 +171,7 @@ a {
   color: white;
   font-weight: bold;
   font-size: 20px;
-  box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.2);
+  box-shadow: 0 4px 6px -1px rgba(37, 99, 235, 0.35);
 }
 
 .brand-text {
@@ -261,8 +263,8 @@ a {
 .custom-input .ant-input-affix-wrapper:hover,
 .custom-input .ant-input-affix-wrapper:focus-within {
   background-color: #ffffff;
-  border-color: #0f172a;
-  box-shadow: 0 0 0 2px rgba(15, 23, 42, 0.1);
+  border-color: #2563eb;
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.1);
 }
 
 /* Submit Button */
@@ -271,13 +273,13 @@ a {
   border-radius: 10px;
   font-size: 16px;
   font-weight: 600;
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  box-shadow: 0 4px 6px -1px rgba(37, 99, 235, 0.2);
   transition: all 0.2s;
 }
 
 .submit-btn:hover {
   transform: translateY(-1px);
-  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.15);
+  box-shadow: 0 10px 15px -3px rgba(37, 99, 235, 0.25);
 }
 
 @media (max-width: 1024px) {
@@ -456,8 +458,8 @@ a {
 
 .code-input:focus {
   background: #ffffff !important;
-  border-color: #000000 !important;
-  box-shadow: 0 0 0 2px rgba(0, 0, 0, 0.1) !important;
+  border-color: #2563eb !important;
+  box-shadow: 0 0 0 2px rgba(37, 99, 235, 0.1) !important;
 }
 
 .documents-list {
@@ -523,8 +525,8 @@ a {
 .mongo-explorer-container .ant-select-selector:focus,
 .mongo-explorer-container .ant-select-focused .ant-select-selector {
   background-color: #ffffff !important;
-  border-color: #000000 !important;
-  box-shadow: 0 0 0 2px rgba(0, 0, 0, 0.1) !important;
+  border-color: #2563eb !important;
+  box-shadow: 0 0 0 2px rgba(37, 99, 235, 0.1) !important;
 }
 
 @media (max-width: 1024px) {

--- a/apps/monitor-dashboard-web/src/styles.css
+++ b/apps/monitor-dashboard-web/src/styles.css
@@ -9,7 +9,7 @@
 body {
   margin: 0;
   font-family: var(--font-sans);
-  background-color: #f1f5f9;
+  background-color: #fafafa;
   color: #0f172a;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
@@ -44,13 +44,11 @@ a {
 }
 
 .app-shell {
-  background:
-    radial-gradient(circle at top left, rgba(37, 99, 235, 0.08), transparent 28%),
-    linear-gradient(180deg, #f8fbff 0%, #f1f5f9 280px, #eef2f7 100%);
+  background: #fafafa;
 }
 
 .app-sider {
-  box-shadow: 12px 0 32px rgba(15, 23, 42, 0.04);
+  box-shadow: 1px 0 0 0 #e2e8f0;
 }
 
 .route-loading-shell {
@@ -70,7 +68,7 @@ a {
   border-radius: 16px;
   background: rgba(255, 255, 255, 0.88);
   border: 1px solid rgba(226, 232, 240, 0.9);
-  box-shadow: 0 18px 40px rgba(15, 23, 42, 0.08);
+  box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.05), 0 2px 4px -1px rgba(0, 0, 0, 0.03);
   backdrop-filter: blur(10px);
 }
 
@@ -89,10 +87,11 @@ a {
 
 .iframe-container {
   background: #fff;
-  border-radius: 8px;
+  border-radius: 12px;
   overflow: hidden;
   box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px 0 rgba(0, 0, 0, 0.06);
   height: calc(100vh - 140px);
+  border: 1px solid #e2e8f0;
 }
 
 .iframe-container iframe {
@@ -112,13 +111,14 @@ a {
 
 .login-left {
   flex: 1;
-  background-color: #f8fafc;
+  background-color: #fafafa;
   position: relative;
   display: flex;
   flex-direction: column;
   justify-content: space-between;
   padding: 60px;
   overflow: hidden;
+  border-right: 1px solid #e2e8f0;
 }
 
 /* Decorative background elements for left side */
@@ -129,7 +129,7 @@ a {
   right: -10%;
   width: 600px;
   height: 600px;
-  background: radial-gradient(circle, rgba(56, 189, 248, 0.15) 0%, rgba(56, 189, 248, 0) 70%);
+  background: radial-gradient(circle, rgba(15, 23, 42, 0.03) 0%, rgba(15, 23, 42, 0) 70%);
   border-radius: 50%;
   z-index: 0;
 }
@@ -141,7 +141,7 @@ a {
   left: -5%;
   width: 500px;
   height: 500px;
-  background: radial-gradient(circle, rgba(96, 165, 250, 0.1) 0%, rgba(96, 165, 250, 0) 70%);
+  background: radial-gradient(circle, rgba(15, 23, 42, 0.04) 0%, rgba(15, 23, 42, 0) 70%);
   border-radius: 50%;
   z-index: 0;
 }
@@ -161,7 +161,7 @@ a {
 .brand-icon {
   width: 40px;
   height: 40px;
-  background: linear-gradient(135deg, #38bdf8, #60a5fa);
+  background: #000;
   border-radius: 10px;
   display: flex;
   align-items: center;
@@ -169,7 +169,7 @@ a {
   color: white;
   font-weight: bold;
   font-size: 20px;
-  box-shadow: 0 4px 6px -1px rgba(56, 189, 248, 0.4);
+  box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.2);
 }
 
 .brand-text {
@@ -205,7 +205,7 @@ a {
   backdrop-filter: blur(12px);
   padding: 24px;
   border-radius: 16px;
-  border: 1px solid rgba(255, 255, 255, 0.5);
+  border: 1px solid rgba(226, 232, 240, 0.8);
   max-width: 420px;
   box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.05);
 }
@@ -261,8 +261,8 @@ a {
 .custom-input .ant-input-affix-wrapper:hover,
 .custom-input .ant-input-affix-wrapper:focus-within {
   background-color: #ffffff;
-  border-color: #3b82f6;
-  box-shadow: 0 0 0 4px rgba(59, 130, 246, 0.1);
+  border-color: #0f172a;
+  box-shadow: 0 0 0 2px rgba(15, 23, 42, 0.1);
 }
 
 /* Submit Button */
@@ -271,13 +271,13 @@ a {
   border-radius: 10px;
   font-size: 16px;
   font-weight: 600;
-  box-shadow: 0 4px 6px -1px rgba(37, 99, 235, 0.2);
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
   transition: all 0.2s;
 }
 
 .submit-btn:hover {
   transform: translateY(-1px);
-  box-shadow: 0 10px 15px -3px rgba(37, 99, 235, 0.25);
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.15);
 }
 
 @media (max-width: 1024px) {
@@ -293,14 +293,14 @@ a {
 }
 
 .page-header {
-  margin-bottom: 24px;
+  margin-bottom: 32px;
   display: flex;
   justify-content: space-between;
   align-items: center;
 }
 
 .page-title {
-  font-size: 24px;
+  font-size: 28px;
   font-weight: 700;
   color: #0f172a;
   margin: 0;
@@ -311,18 +311,18 @@ a {
 .filter-card {
   background: #ffffff;
   border: 1px solid #e2e8f0;
-  border-radius: 12px;
+  border-radius: 16px;
   padding: 24px;
   margin-bottom: 24px;
-  box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px 0 rgba(0, 0, 0, 0.06);
+  box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.05);
 }
 
 .content-card {
   background: #ffffff;
   border: 1px solid #e2e8f0;
-  border-radius: 12px;
+  border-radius: 16px;
   padding: 24px;
-  box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px 0 rgba(0, 0, 0, 0.06);
+  box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.05);
 }
 
 @keyframes page-enter {
@@ -338,7 +338,7 @@ a {
 
 /* Mongo Explorer Specific Styles */
 .mongo-explorer-container {
-  padding: 32px 48px;
+  padding: 32px 0;
   max-width: 1400px;
   margin: 0 auto;
   font-family: var(--font-sans);
@@ -359,7 +359,7 @@ a {
 }
 
 .explorer-title {
-  font-size: 24px;
+  font-size: 28px;
   font-weight: 700;
   color: #0f172a;
   letter-spacing: -0.025em;
@@ -403,10 +403,10 @@ a {
 .filter-panel {
   background: #ffffff;
   border: 1px solid #e2e8f0;
-  border-radius: 12px;
+  border-radius: 16px;
   padding: 24px;
   margin-bottom: 32px;
-  box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.05), 0 2px 4px -1px rgba(0, 0, 0, 0.03);
+  box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.05);
   animation: fadeIn 0.2s ease-out;
 }
 
@@ -451,13 +451,13 @@ a {
   border-color: #e2e8f0 !important;
   color: #334155 !important;
   font-size: 13px;
-  border-radius: 6px !important;
+  border-radius: 8px !important;
 }
 
 .code-input:focus {
   background: #ffffff !important;
-  border-color: #3b82f6 !important;
-  box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.1) !important;
+  border-color: #000000 !important;
+  box-shadow: 0 0 0 2px rgba(0, 0, 0, 0.1) !important;
 }
 
 .documents-list {
@@ -468,7 +468,7 @@ a {
 
 .document-card {
   background: #ffffff;
-  border-radius: 8px;
+  border-radius: 12px;
   border: 1px solid #e2e8f0;
   transition: all 0.2s ease-in-out;
   position: relative;
@@ -476,7 +476,7 @@ a {
 
 .document-card:hover {
   border-color: #cbd5e1;
-  box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.05), 0 4px 6px -2px rgba(0, 0, 0, 0.025);
+  box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.05), 0 2px 4px -1px rgba(0, 0, 0, 0.03);
   transform: translateY(-1px);
   z-index: 10;
 }
@@ -514,7 +514,7 @@ a {
 
 .mongo-explorer-container .ant-input,
 .mongo-explorer-container .ant-select-selector {
-  border-radius: 6px !important;
+  border-radius: 8px !important;
   background-color: #f8fafc !important;
   border-color: #e2e8f0 !important;
 }
@@ -523,8 +523,8 @@ a {
 .mongo-explorer-container .ant-select-selector:focus,
 .mongo-explorer-container .ant-select-focused .ant-select-selector {
   background-color: #ffffff !important;
-  border-color: #3b82f6 !important;
-  box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.1) !important;
+  border-color: #000000 !important;
+  box-shadow: 0 0 0 2px rgba(0, 0, 0, 0.1) !important;
 }
 
 @media (max-width: 1024px) {
@@ -574,7 +574,7 @@ a {
 
   .page-title,
   .explorer-title {
-    font-size: 20px;
+    font-size: 24px;
   }
 
   .route-loading-card {

--- a/apps/monitor-dashboard-web/src/theme.ts
+++ b/apps/monitor-dashboard-web/src/theme.ts
@@ -2,36 +2,74 @@ import { ThemeConfig } from 'antd';
 
 export const themeConfig: ThemeConfig = {
   token: {
-    colorPrimary: '#2563eb',
+    colorPrimary: '#000000', // Modern monochrome primary
     colorSuccess: '#10b981',
     colorWarning: '#f59e0b',
     colorError: '#ef4444',
     colorInfo: '#3b82f6',
-    borderRadius: 8,
+    borderRadius: 6, // Slightly sharper for modern feel, but components can be larger
+    borderRadiusLG: 12,
     fontFamily: "'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif",
     fontSize: 14,
-    colorBgLayout: '#f1f5f9',
-    colorTextBase: '#1e293b',
+    colorBgLayout: '#fafafa', // Lighter background for a cleaner canvas
+    colorTextBase: '#0f172a',
+    colorBorder: '#e2e8f0', // Lighter borders
+    colorBorderSecondary: '#f1f5f9',
     wireframe: false,
+    boxShadow: '0 4px 6px -1px rgba(0, 0, 0, 0.05), 0 2px 4px -1px rgba(0, 0, 0, 0.03)',
   },
   components: {
     Layout: {
       siderBg: '#ffffff',
-      headerBg: '#ffffff',
-      bodyBg: '#f1f5f9',
+      headerBg: 'rgba(255, 255, 255, 0.8)',
+      bodyBg: '#fafafa',
     },
     Menu: {
-      itemSelectedBg: '#eff6ff',
-      itemSelectedColor: '#2563eb',
+      itemSelectedBg: '#f1f5f9', // Subtler selection
+      itemSelectedColor: '#0f172a',
       itemColor: '#64748b',
+      itemHoverBg: '#f8fafc',
+      itemBorderRadius: 8,
+      itemMarginInline: 12, // Give menu items some breathing room from the edges
     },
     Card: {
-      boxShadowTertiary: '0 4px 6px -1px rgba(0, 0, 0, 0.05), 0 2px 4px -1px rgba(0, 0, 0, 0.03)',
+      boxShadowTertiary: '0 1px 2px 0 rgba(0, 0, 0, 0.05)',
       paddingLG: 24,
+      borderRadiusLG: 16, // Softer cards
+      colorBorderSecondary: '#e2e8f0', // Define card border specifically
     },
     Typography: {
       titleMarginBottom: 0,
       titleMarginTop: 0,
+    },
+    Table: {
+      headerBg: '#f8fafc',
+      headerColor: '#475569',
+      headerBorderRadius: 8,
+      borderColor: '#f1f5f9',
+      rowHoverBg: '#f8fafc',
+      cellPaddingBlock: 16, // More breathing room in rows
+    },
+    Button: {
+      borderRadius: 6,
+      controlHeight: 36, // Slightly taller default buttons
+      paddingInline: 16,
+      defaultShadow: 'none',
+      primaryShadow: '0 2px 4px rgba(0,0,0,0.1)',
+    },
+    Input: {
+      activeBorderColor: '#000000',
+      hoverBorderColor: '#94a3b8',
+      colorBorder: '#cbd5e1',
+      paddingBlock: 6,
+    },
+    Select: {
+      colorPrimaryHover: '#94a3b8',
+      colorPrimary: '#000000',
+    },
+    Tag: {
+      borderRadiusSM: 4,
+      lineHeight: 2,
     }
   }
 };

--- a/apps/monitor-dashboard-web/src/theme.ts
+++ b/apps/monitor-dashboard-web/src/theme.ts
@@ -2,7 +2,7 @@ import { ThemeConfig } from 'antd';
 
 export const themeConfig: ThemeConfig = {
   token: {
-    colorPrimary: '#000000', // Modern monochrome primary
+    colorPrimary: '#2563eb',
     colorSuccess: '#10b981',
     colorWarning: '#f59e0b',
     colorError: '#ef4444',
@@ -25,8 +25,8 @@ export const themeConfig: ThemeConfig = {
       bodyBg: '#fafafa',
     },
     Menu: {
-      itemSelectedBg: '#f1f5f9', // Subtler selection
-      itemSelectedColor: '#0f172a',
+      itemSelectedBg: '#eff6ff',
+      itemSelectedColor: '#2563eb',
       itemColor: '#64748b',
       itemHoverBg: '#f8fafc',
       itemBorderRadius: 8,
@@ -55,17 +55,17 @@ export const themeConfig: ThemeConfig = {
       controlHeight: 36, // Slightly taller default buttons
       paddingInline: 16,
       defaultShadow: 'none',
-      primaryShadow: '0 2px 4px rgba(0,0,0,0.1)',
+      primaryShadow: '0 2px 4px rgba(37, 99, 235, 0.2)',
     },
     Input: {
-      activeBorderColor: '#000000',
+      activeBorderColor: '#2563eb',
       hoverBorderColor: '#94a3b8',
       colorBorder: '#cbd5e1',
       paddingBlock: 6,
     },
     Select: {
-      colorPrimaryHover: '#94a3b8',
-      colorPrimary: '#000000',
+      colorPrimaryHover: '#3b82f6',
+      colorPrimary: '#2563eb',
     },
     Tag: {
       borderRadiusSM: 4,

--- a/apps/monitor-dashboard/src/routes/messages.ts
+++ b/apps/monitor-dashboard/src/routes/messages.ts
@@ -1,5 +1,5 @@
 import Router from '@koa/router';
-import { AppDataSource, ConversationMessage } from '../db';
+import { AppDataSource, ConversationMessage, LarkUser, LarkGroupChatInfo } from '../db';
 
 const router = new Router();
 
@@ -116,6 +116,28 @@ router.get('/api/messages', async (ctx) => {
     page,
     pageSize,
   };
+});
+
+router.get('/api/chats', async (ctx) => {
+  const keyword = ((ctx.query.keyword as string) || '').trim();
+  const repo = AppDataSource.getRepository(LarkGroupChatInfo);
+  const qb = repo.createQueryBuilder('gc').select(['gc.chat_id AS chat_id', 'gc.name AS name']);
+  if (keyword) {
+    qb.where('gc.name ILIKE :kw', { kw: `%${keyword}%` });
+  }
+  qb.orderBy('gc.name', 'ASC').limit(30);
+  ctx.body = await qb.getRawMany();
+});
+
+router.get('/api/users', async (ctx) => {
+  const keyword = ((ctx.query.keyword as string) || '').trim();
+  const repo = AppDataSource.getRepository(LarkUser);
+  const qb = repo.createQueryBuilder('u').select(['u.union_id AS user_id', 'u.name AS name']);
+  if (keyword) {
+    qb.where('u.name ILIKE :kw', { kw: `%${keyword}%` });
+  }
+  qb.orderBy('u.name', 'ASC').limit(30);
+  ctx.body = await qb.getRawMany();
 });
 
 export default router;


### PR DESCRIPTION
## Summary
- Modernize UI/UX for all dashboard pages (Gemini's work, with color fixes)
- Restore blue color scheme from Gemini's monochrome black theme
- Add fuzzy search filters for chat/user in Messages page (backend + frontend)
- Clickable user names in Messages table to filter by user
- Fix page title font-size, "赤尾回复" column width

## Changed apps
- `monitor-dashboard-web` (frontend)
- `monitor-dashboard` (backend - new search endpoints)

🤖 Generated with [Claude Code](https://claude.com/claude-code)