### PR TITLE
fix(daily-report): use pre-built image to prevent DeadlineExceeded

### DIFF
--- a/infra/k8s/daily-report/Dockerfile
+++ b/infra/k8s/daily-report/Dockerfile
@@ -1,0 +1,2 @@
+FROM alpine:3.21
+RUN apk add --no-cache curl jq tzdata

--- a/infra/k8s/daily-report/cronjob.yaml
+++ b/infra/k8s/daily-report/cronjob.yaml
@@ -20,8 +20,8 @@ spec:
             node-role: infra
           containers:
             - name: daily-report
-              image: alpine:3.21
-              command: ["/bin/sh", "-c", "apk add --no-cache curl jq tzdata >/dev/null 2>&1 && /bin/sh /scripts/script.sh"]
+              image: harbor.local:30002/inner-bot/daily-report:1.0.0.1
+              command: ["/bin/sh", "/scripts/script.sh"]
               env:
                 - name: FEISHU_WEBHOOK_URL
                   valueFrom:

--- a/infra/k8s/daily-report/cronjob.yaml
+++ b/infra/k8s/daily-report/cronjob.yaml
@@ -12,7 +12,7 @@ spec:
   jobTemplate:
     spec:
       backoffLimit: 1
-      activeDeadlineSeconds: 120
+      activeDeadlineSeconds: 300
       template:
         spec:
           restartPolicy: Never


### PR DESCRIPTION
## Summary
- daily-report CronJob 每次运行都 `apk add curl jq tzdata`，镜像源慢时超过 120s deadline 导致失败
- 新增 Dockerfile 预装工具，构建为自定义镜像 `daily-report:1.0.0.1`
- `activeDeadlineSeconds` 120 → 300 作为安全余量

## Test plan
- [ ] `kubectl apply -f infra/k8s/daily-report/cronjob.yaml` 更新 CronJob
- [ ] 手动触发一次 `kubectl create job daily-report-test --from=cronjob/daily-report -n prod` 验证执行成功
- [ ] 确认飞书收到巡检卡片

🤖 Generated with [Claude Code](https://claude.com/claude-code)