### PR TITLE
feat: add chat pipeline observability (Prometheus metrics + structured Loki logs)

### DIFF
--- a/apps/agent-service/app/agents/domains/main/agent.py
+++ b/apps/agent-service/app/agents/domains/main/agent.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import logging
+import time
 import uuid
 from collections.abc import AsyncGenerator
 
@@ -26,6 +27,7 @@ from app.services.memory_context import (
     build_impression_context,
 )
 from app.services.schedule_context import build_schedule_context
+from app.middleware.chat_metrics import CHAT_PIPELINE_DURATION, CHAT_TOKENS
 from app.utils.content_parser import parse_content
 
 logger = logging.getLogger(__name__)
@@ -56,6 +58,7 @@ async def stream_chat(
 
     with langfuse.start_as_current_observation(as_type="span", name="chat-request"):
         with propagate_attributes(session_id=request_id):
+            t_entry = time.monotonic()
             # 1. 获取消息内容
             raw_content = await get_message_content(message_id)
             if not raw_content:
@@ -68,6 +71,7 @@ async def stream_chat(
 
             # 2. 获取 gray_config（需要提前获取以决定 pre 模式）
             gray_config = (await get_gray_config(message_id)) or {}
+            CHAT_PIPELINE_DURATION.labels(stage="prep").observe(time.monotonic() - t_entry)
             pre_blocking = gray_config.get("pre_blocking", "false")
 
             # 3. 启动 pre task（create_task 复制当前 context，继承父 trace）
@@ -113,6 +117,7 @@ async def _buffer_until_pre(
     使用 Queue + asyncio.wait 实现 race：pre 完成后立即响应，
     不再被动等待下一个 token 到达才检查。
     """
+    t_buf_start = time.monotonic()
     buffer: list[str] = []
     q: asyncio.Queue = asyncio.Queue()
 
@@ -138,6 +143,12 @@ async def _buffer_until_pre(
 
             if pre_task in done:
                 pre_result = pre_task.result()
+                pre_dur = time.monotonic() - t_buf_start
+                CHAT_PIPELINE_DURATION.labels(stage="pre_safety").observe(pre_dur)
+                logger.info(
+                    "pre_safety_done message_id=%s duration=%.0fms blocked=%s buffered=%d",
+                    message_id, pre_dur * 1000, pre_result["is_blocked"], len(buffer),
+                )
                 if pre_result["is_blocked"]:
                     logger.info(
                         f"并行模式拦截: message_id={message_id}, "
@@ -172,6 +183,8 @@ async def _buffer_until_pre(
                     for b in buffer:
                         yield b
                     return
+                pre_dur = time.monotonic() - t_buf_start
+                CHAT_PIPELINE_DURATION.labels(stage="pre_safety").observe(pre_dur)
                 if pre_result["is_blocked"]:
                     logger.info(
                         f"并行模式拦截（流结束后）: message_id={message_id}, "
@@ -218,6 +231,7 @@ async def _build_and_stream(
     session_id: str | None = None,
 ) -> AsyncGenerator[str, None]:
     """构建 agent + 上下文，执行流式生成（两种模式共用）"""
+    t_build_start = time.monotonic()
     from app.skills.registry import SkillRegistry
 
     prompt_vars = {
@@ -250,6 +264,7 @@ async def _build_and_stream(
         chat_name,
         chain_user_ids,
     ) = await build_chat_context(message_id)
+    CHAT_PIPELINE_DURATION.labels(stage="context_build").observe(time.monotonic() - t_build_start)
 
     if not messages:
         logger.warning(f"No results found for message_id: {message_id}")
@@ -322,6 +337,9 @@ async def _build_and_stream(
     has_text_in_current_turn = False
 
     try:
+        t_agent_start = time.monotonic()
+        agent_token_count = 0
+        tool_call_count = 0
         async for token in agent.stream(
             messages,
             context=AgentContext(
@@ -343,6 +361,7 @@ async def _build_and_stream(
 
                 if token.text:
                     has_text_in_current_turn = True
+                    agent_token_count += 1
                     full_content += token.text
                     yield token.text
 
@@ -352,8 +371,22 @@ async def _build_and_stream(
                     has_text_in_current_turn = False
 
             elif isinstance(token, ToolMessage):
+                tool_call_count += 1
                 has_text_in_current_turn = False
 
+        agent_dur = time.monotonic() - t_agent_start
+        CHAT_PIPELINE_DURATION.labels(stage="agent_stream").observe(agent_dur)
+        CHAT_TOKENS.labels(type="text").inc(agent_token_count)
+        CHAT_TOKENS.labels(type="tool_call").inc(tool_call_count)
+        logger.info(
+            "agent_stream_done session_id=%s context=%.0fms agent=%.0fms tokens=%d tools=%d model=%s",
+            session_id,
+            (t_agent_start - t_build_start) * 1000,
+            agent_dur * 1000,
+            agent_token_count,
+            tool_call_count,
+            model_id,
+        )
         # Fire-and-forget: publish to post safety check queue
         if full_content and session_id:
             asyncio.create_task(

--- a/apps/agent-service/app/middleware/chat_metrics.py
+++ b/apps/agent-service/app/middleware/chat_metrics.py
@@ -1,0 +1,31 @@
+"""Prometheus metrics for chat pipeline stages."""
+
+from prometheus_client import Counter, Histogram
+
+# Buckets tuned for chat pipeline: fast path (100ms) to slow LLM (120s)
+PIPELINE_BUCKETS = (0.1, 0.25, 0.5, 1, 2, 5, 10, 20, 30, 60, 120)
+
+CHAT_PIPELINE_DURATION = Histogram(
+    "chat_pipeline_duration_seconds",
+    "Duration of each chat pipeline stage",
+    ["stage"],
+    buckets=PIPELINE_BUCKETS,
+)
+
+CHAT_FIRST_TOKEN = Histogram(
+    "chat_first_token_seconds",
+    "Time to first token from agent stream",
+    buckets=(0.1, 0.25, 0.5, 1, 2, 5, 10, 20, 30),
+)
+
+CHAT_TOKENS = Counter(
+    "chat_tokens_total",
+    "Token count by type",
+    ["type"],
+)
+
+CHAT_QUEUE_WAIT = Histogram(
+    "chat_queue_wait_seconds",
+    "Time spent waiting in MQ queue (chat_request)",
+    buckets=(0.01, 0.05, 0.1, 0.25, 0.5, 1, 2, 5),
+)

--- a/apps/agent-service/app/workers/chat_consumer.py
+++ b/apps/agent-service/app/workers/chat_consumer.py
@@ -6,6 +6,7 @@
 
 import json
 import logging
+import time
 import traceback
 
 from aio_pika.abc import AbstractIncomingMessage
@@ -18,6 +19,12 @@ from app.clients.rabbitmq import (
     _current_lane,
     _lane_queue,
 )
+from app.middleware.chat_metrics import (
+    CHAT_FIRST_TOKEN,
+    CHAT_PIPELINE_DURATION,
+    CHAT_QUEUE_WAIT,
+    CHAT_TOKENS,
+)
 from app.utils.middlewares.trace import header_vars
 
 logger = logging.getLogger(__name__)
@@ -29,6 +36,7 @@ MAX_MESSAGES = 4
 async def handle_chat_request(message: AbstractIncomingMessage) -> None:
     """消费 chat_request queue 中的消息，流式切分发送"""
     async with message.process(requeue=False):
+        t_start = time.monotonic()
         body = json.loads(message.body)
         session_id = body.get("session_id")
         message_id = body.get("message_id")
@@ -38,6 +46,14 @@ async def handle_chat_request(message: AbstractIncomingMessage) -> None:
         user_id = body.get("user_id")
         lane = body.get("lane")
         bot_name = body.get("bot_name")
+
+        # Measure MQ queue wait time
+        queue_wait_ms = 0.0
+        enqueued_at = body.get("enqueued_at")
+        if enqueued_at:
+            queue_wait_s = (time.time() * 1000 - enqueued_at) / 1000
+            queue_wait_ms = queue_wait_s * 1000
+            CHAT_QUEUE_WAIT.observe(queue_wait_s)
 
         # MQ consumer 不走 HTTP 中间件，手动注入 contextvars
         if bot_name:
@@ -70,10 +86,15 @@ async def handle_chat_request(message: AbstractIncomingMessage) -> None:
             sent_length = 0  # 已发送内容的长度
             messages_sent = 0  # 已发送消息条数
             full_content = ""  # 累积的完整内容
+            t_first_token: float | None = None
+            token_count = 0
 
             async for text in stream_chat(message_id, session_id=session_id):
                 if not text:
                     continue
+                if t_first_token is None:
+                    t_first_token = time.monotonic()
+                token_count += 1
                 full_content += text
 
                 # 检测分隔符，逐段发送
@@ -82,6 +103,7 @@ async def handle_chat_request(message: AbstractIncomingMessage) -> None:
                     idx = pending.index(SPLIT_MARKER)
                     part = pending[:idx].strip()
                     if part:
+                        base_response["published_at"] = int(time.time() * 1000)
                         await client.publish(
                             CHAT_RESPONSE,
                             {
@@ -101,12 +123,22 @@ async def handle_chat_request(message: AbstractIncomingMessage) -> None:
                     sent_length += idx + len(SPLIT_MARKER)
                     pending = full_content[sent_length:]
 
+            # 记录流结束时间，观测 TTFT 和 agent_stream 阶段耗时
+            t_stream_end = time.monotonic()
+            stream_ms = (t_stream_end - t_start) * 1000
+            if t_first_token is not None:
+                CHAT_FIRST_TOKEN.observe(t_first_token - t_start)
+            CHAT_PIPELINE_DURATION.labels(stage="agent_stream").observe(t_stream_end - t_start)
+            CHAT_TOKENS.labels(type="text").inc(token_count)
+
             # 流结束，发送剩余内容（去掉残留的 split marker）
             remaining = full_content[sent_length:].replace(SPLIT_MARKER, "").strip()
             # 全量文本（去掉所有 split marker），用于数据库存储
             clean_full = full_content.replace(SPLIT_MARKER, "\n\n").strip()
 
+            t_publish_start = time.monotonic()
             if remaining or messages_sent == 0:
+                base_response["published_at"] = int(time.time() * 1000)
                 await client.publish(
                     CHAT_RESPONSE,
                     {
@@ -121,6 +153,7 @@ async def handle_chat_request(message: AbstractIncomingMessage) -> None:
                 )
             else:
                 # split marker 后没有内容，仍需通知 worker 结束
+                base_response["published_at"] = int(time.time() * 1000)
                 await client.publish(
                     CHAT_RESPONSE,
                     {
@@ -138,6 +171,19 @@ async def handle_chat_request(message: AbstractIncomingMessage) -> None:
                 "Chat response final part %d published: session_id=%s",
                 messages_sent,
                 session_id,
+            )
+
+            # 记录 MQ publish 耗时和全链路总时长
+            t_end = time.monotonic()
+            publish_ms = (t_end - t_publish_start) * 1000
+            total_ms = (t_end - t_start) * 1000
+            ttft_ms = (t_first_token - t_start) * 1000 if t_first_token is not None else 0.0
+            CHAT_PIPELINE_DURATION.labels(stage="mq_publish").observe(t_end - t_publish_start)
+            CHAT_PIPELINE_DURATION.labels(stage="total").observe(t_end - t_start)
+            logger.info(
+                "chat_request_done session_id=%s queue_wait=%.0fms stream=%.0fms ttft=%.0fms "
+                "publish=%.0fms total=%.0fms tokens=%d parts=%d",
+                session_id, queue_wait_ms, stream_ms, ttft_ms, publish_ms, total_ms, token_count, messages_sent + 1,
             )
 
         except Exception as e:

--- a/apps/lark-server/src/core/services/ai/reply.ts
+++ b/apps/lark-server/src/core/services/ai/reply.ts
@@ -40,6 +40,7 @@ export async function makeTextReply(message: Message): Promise<void> {
             bot_name: context.getBotName(),
             is_canary: message.basicChatInfo?.permission_config?.is_canary ?? false,
             lane: lane || undefined,
+            enqueued_at: Date.now(),
         },
         undefined,
         undefined,

--- a/apps/lark-server/src/workers/chat-response-worker.ts
+++ b/apps/lark-server/src/workers/chat-response-worker.ts
@@ -16,6 +16,7 @@ LoggerFactory.createLogger({
     enableConsoleOverride: true,
 });
 
+import { createServer } from 'http';
 import AppDataSource from 'ormconfig';
 import { AgentResponse } from '@entities/agent-response';
 import {
@@ -54,6 +55,21 @@ const imageResolveTotal = new Counter({
     name: 'image_resolve_requests_total',
     help: 'Total image resolve outcomes',
     labelNames: ['status'] as const,  // success, not_found, download_failed, upload_failed
+    registers: [metricsRegistry],
+});
+
+const chatResponseDuration = new Histogram({
+    name: 'chat_response_duration_seconds',
+    help: 'Duration of each chat-response-worker stage',
+    labelNames: ['stage'] as const,  // db_query, resolve, lark_send, db_write, total
+    buckets: [0.01, 0.05, 0.1, 0.25, 0.5, 1, 2, 5],
+    registers: [metricsRegistry],
+});
+
+const chatResponseQueueDelay = new Histogram({
+    name: 'chat_response_queue_delay_seconds',
+    help: 'Time spent waiting in MQ queue (chat_response)',
+    buckets: [0.01, 0.05, 0.1, 0.25, 0.5, 1, 2, 5, 10],
     registers: [metricsRegistry],
 });
 
@@ -175,6 +191,7 @@ function sleep(ms: number): Promise<void> {
 }
 
 async function handleChatResponse(msg: ConsumeMessage): Promise<void> {
+    const tStart = Date.now();
     let payload: ChatResponsePayload;
     try {
         payload = JSON.parse(msg.content.toString());
@@ -182,6 +199,12 @@ async function handleChatResponse(msg: ConsumeMessage): Promise<void> {
         console.error('[ChatResponseWorker] Malformed message, sending to DLQ:', msg.content.toString().slice(0, 200));
         rabbitmqClient.nack(msg, false);
         return;
+    }
+
+    const publishedAt = (payload as any).published_at as number | undefined;
+    const queueDelayMs = publishedAt ? tStart - publishedAt : -1;
+    if (queueDelayMs > 0) {
+        chatResponseQueueDelay.observe(queueDelayMs / 1000);
     }
 
     const {
@@ -199,13 +222,17 @@ async function handleChatResponse(msg: ConsumeMessage): Promise<void> {
     } = payload;
 
     console.info(
-        `[ChatResponseWorker] Processing: session_id=${session_id}, status=${status}, part=${part_index}, is_last=${is_last}`,
+        `[ChatResponseWorker] Processing: session_id=${session_id}, status=${status}, part=${part_index}, is_last=${is_last}, queue_delay=${queueDelayMs}ms`,
     );
 
     const repo = AppDataSource.getRepository(AgentResponse);
 
     // 查询 agent_response 获取 bot_name
+    const tDbQuery0 = Date.now();
     const agentResponse = await repo.findOneBy({ session_id });
+    const dbQueryMs = Date.now() - tDbQuery0;
+    chatResponseDuration.labels({ stage: 'db_query' }).observe(dbQueryMs / 1000);
+
     if (!agentResponse) {
         console.error(`[ChatResponseWorker] No agent_response found: session_id=${session_id}`);
         rabbitmqClient.ack(msg);
@@ -235,16 +262,19 @@ async function handleChatResponse(msg: ConsumeMessage): Promise<void> {
 
         try {
             // 群聊中将 @用户名 替换为 <at union_id="xxx">用户名</at>
+            // 解析 @N.png 引用 → 下载 TOS → 上传飞书 → 替换为 image_key
+            const tResolve0 = Date.now();
             let resolvedContent = is_p2p
                 ? content
                 : await resolveMentionsForGroup(content, chat_id);
-
-            // 解析 @N.png 引用 → 下载 TOS → 上传飞书 → 替换为 image_key
             resolvedContent = await resolveImageReferences(resolvedContent, message_id);
+            const resolveMs = Date.now() - tResolve0;
+            chatResponseDuration.labels({ stage: 'resolve' }).observe(resolveMs / 1000);
 
             const postContent = markdownToPostContent(resolvedContent);
 
             // 发送消息并捕获 AI 消息 ID
+            const tSend0 = Date.now();
             let aiMessageId: string | undefined;
             if (part_index === 0) {
                 // 第一条作为回复
@@ -254,10 +284,13 @@ async function handleChatResponse(msg: ConsumeMessage): Promise<void> {
                 await sleep(SEND_DELAY_MS);
                 aiMessageId = await sendPost(chat_id, postContent);
             }
+            const sendMs = Date.now() - tSend0;
+            chatResponseDuration.labels({ stage: 'lark_send' }).observe(sendMs / 1000);
 
             const effectiveMessageId = aiMessageId || `${message_id}_part${part_index}`;
 
             // 每条消息发完后立即存 conversation_messages
+            const tDbWrite0 = Date.now();
             const now = dayjs().valueOf();
             await storeMessage({
                 user_id: getBotUnionId(),
@@ -301,8 +334,18 @@ async function handleChatResponse(msg: ConsumeMessage): Promise<void> {
                     },
                 );
             }
+            const dbWriteMs = Date.now() - tDbWrite0;
+            chatResponseDuration.labels({ stage: 'db_write' }).observe(dbWriteMs / 1000);
 
             console.info(`[ChatResponseWorker] Reply sent: session_id=${session_id}, part=${part_index}, ai_msg_id=${effectiveMessageId}`);
+
+            const totalMs = Date.now() - tStart;
+            chatResponseDuration.labels({ stage: 'total' }).observe(totalMs / 1000);
+            console.info(
+                `[ChatResponseWorker] done session_id=${session_id} part=${part_index} ` +
+                `queue=${queueDelayMs}ms db_query=${dbQueryMs}ms resolve=${resolveMs}ms ` +
+                `send=${sendMs}ms db_write=${dbWriteMs}ms total=${totalMs}ms`
+            );
         } catch (e) {
             console.error(`[ChatResponseWorker] Failed to send reply: session_id=${session_id}, part=${part_index}`, e);
             try {
@@ -340,6 +383,15 @@ async function main(): Promise<void> {
     console.info(
         `[ChatResponseWorker] Consuming queue: ${queue}, waiting for messages...`,
     );
+
+    // 5. 暴露 Prometheus metrics
+    const metricsPort = parseInt(process.env.METRICS_PORT || '9091', 10);
+    createServer(async (_req, res) => {
+        res.setHeader('Content-Type', metricsRegistry.contentType);
+        res.end(await metricsRegistry.metrics());
+    }).listen(metricsPort, () => {
+        console.info(`[ChatResponseWorker] Metrics server on :${metricsPort}`);
+    });
 }
 
 main().catch((err) => {

--- a/infra/k8s/monitoring/servicemonitors.yaml
+++ b/infra/k8s/monitoring/servicemonitors.yaml
@@ -242,3 +242,23 @@ spec:
         credentials:
           name: qdrant-metrics-token
           key: token
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: chat-response-worker
+  namespace: monitoring
+  labels:
+    release: kube-prometheus-stack
+spec:
+  namespaceSelector:
+    matchNames:
+      - prod
+  selector:
+    matchLabels:
+      app: chat-response-worker
+      lane: prod
+  endpoints:
+    - port: metrics
+      path: /metrics
+      interval: 15s


### PR DESCRIPTION
## Summary
- Add Prometheus Histograms for chat pipeline latency breakdown (prep, context_build, pre_safety, agent_stream, mq_publish, total)
- Add structured logs with session_id for per-request Loki tracing across agent-service and chat-response-worker
- Add /metrics HTTP endpoint to chat-response-worker (port 9091) and ServiceMonitor config
- Add cross-service queue delay measurement via enqueued_at/published_at timestamps

## Test plan
- [x] Python py_compile passes for all modified files
- [x] agent-service deploys and starts cleanly on obs-test lane
- [x] lark-server image builds successfully (includes chat-response-worker compilation)
- [ ] Verify Prometheus metrics appear on /metrics endpoints after prod deploy
- [ ] Send test message and verify structured logs in Loki

🤖 Generated with [Claude Code](https://claude.com/claude-code)