### PR TITLE
fix(ops): improve error propagation for ops-db queries

### DIFF
--- a/.claude/skills/ops-db/query.py
+++ b/.claude/skills/ops-db/query.py
@@ -64,7 +64,7 @@ def main():
 
     result = subprocess.run(
         [
-            "curl", "-sf", "-X", "POST",
+            "curl", "-sfS", "-X", "POST",
             f"{paas_api}/dashboard/api/ops/db-query",
             "-H", "Content-Type: application/json",
             "-H", f"X-API-Key: {cc_token}",

--- a/apps/monitor-dashboard/src/index.ts
+++ b/apps/monitor-dashboard/src/index.ts
@@ -47,14 +47,17 @@ const bootstrap = async () => {
     try {
       await next();
     } catch (err: unknown) {
-      const status = (err as { response?: { status?: number } })?.response?.status
+      const axiosResp = (err as { response?: { status?: number; data?: unknown } })?.response;
+      const status = axiosResp?.status
         || (err as { status?: number })?.status
         || 500;
+      // Prefer upstream error body (e.g. PaaS Engine's {"error":"..."})
+      const upstream = axiosResp?.data;
+      const message = (upstream && typeof upstream === 'object' && 'error' in upstream)
+        ? (upstream as Record<string, unknown>).error
+        : err instanceof Error ? err.message : String(err);
       ctx.status = status;
-      ctx.body = {
-        message: err instanceof Error ? err.message : String(err),
-        status,
-      };
+      ctx.body = { message, status };
     }
   });
 

--- a/apps/monitor-dashboard/src/index.ts
+++ b/apps/monitor-dashboard/src/index.ts
@@ -51,10 +51,11 @@ const bootstrap = async () => {
       const status = axiosResp?.status
         || (err as { status?: number })?.status
         || 500;
-      // Prefer upstream error body (e.g. PaaS Engine's {"error":"..."})
-      const upstream = axiosResp?.data;
+      // Prefer upstream error body (e.g. PaaS Engine's {data:{error:"..."}})
+      const raw = axiosResp?.data as Record<string, unknown> | undefined;
+      const upstream = (raw && typeof raw === 'object' && 'data' in raw) ? raw.data as Record<string, unknown> : raw;
       const message = (upstream && typeof upstream === 'object' && 'error' in upstream)
-        ? (upstream as Record<string, unknown>).error
+        ? upstream.error
         : err instanceof Error ? err.message : String(err);
       ctx.status = status;
       ctx.body = { message, status };


### PR DESCRIPTION
## Summary
- `query.py`: `curl -sf` → `-sfS`，HTTP 错误时显示具体信息而非空白
- `monitor-dashboard`: 全局错误处理器 unwrap PaaS Engine `{data:{error:...}}` 信封，透传上游错误详情
- 已通过 PaaS API 给 paas-engine 添加 `CHIWEI_DATABASE_URL`，chiwei 数据库查询现已可用

## Test plan
- [x] 部署到 `fix-ops-db` 泳道验证
- [x] 对比 prod vs 测试泳道：错误信息从 `Request failed with status code 400` → `unknown database "nonexistent", available: paas_engine, chiwei`
- [x] `ops-db @chiwei schema` 查询正常返回 25 张表
- [x] 测试泳道已清理

🤖 Generated with [Claude Code](https://claude.com/claude-code)