### PR TITLE
ci(cronjob): add Docker Hub build and push workflow

### DIFF
--- a/.github/workflows/cronjob-docker.yml
+++ b/.github/workflows/cronjob-docker.yml
@@ -1,0 +1,34 @@
+name: Build and Push Cronjob Image
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'apps/cloud/cronjob/**'
+      - 'packages/ts-shared/**'
+      - 'packages/lark-utils/**'
+      - 'packages/pixiv-client/**'
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: apps/cloud/cronjob/Dockerfile
+          push: true
+          tags: |
+            chiwiio/cronjob-work:latest
+            chiwiio/cronjob-work:${{ github.sha }}
+          build-args: |
+            GIT_SHA=${{ github.sha }}


### PR DESCRIPTION
## Summary
- cronjob 或其依赖 packages 推送到 main 时，自动构建并推送 `chiwiio/cronjob-work` 镜像到 Docker Hub
- 同时打 `latest` 和 `<sha>` 两个 tag

## Secrets 依赖
- `DOCKER_HUB_USERNAME`
- `DOCKER_HUB_ACCESS_TOKEN`

🤖 Generated with [Claude Code](https://claude.com/claude-code)