### PR TITLE
feat(cronjob): make daily download schedule configurable via env

### DIFF
--- a/apps/cloud/cronjob/src/index.ts
+++ b/apps/cloud/cronjob/src/index.ts
@@ -45,7 +45,8 @@ const scheduleTask = (cronTime: string, taskName: string, taskFn: () => Promise<
 };
 
 // 定时任务：下载任务
-scheduleTask('0 10 * * *', 'download task', startDownload);
+const DOWNLOAD_CRON = process.env.DOWNLOAD_CRON || '0 10 * * *';
+scheduleTask(DOWNLOAD_CRON, 'download task', startDownload);
 
 // 定时任务：Bangumi Archive 数据同步 (每周三上午7点)
 scheduleTask('0 7 * * 3', 'bangumi archive sync', syncBangumiArchive);


### PR DESCRIPTION
## Summary
- 将 cronjob 每日下载任务的 cron 时间从硬编码 `0 10 * * *` 改为通过 `DOWNLOAD_CRON` 环境变量注入，不设置时保持默认值

## Test plan
- [ ] 不设置 `DOWNLOAD_CRON`，确认默认每天 10:00 触发
- [ ] 设置 `DOWNLOAD_CRON="30 8 * * *"`，确认按新时间触发

🤖 Generated with [Claude Code](https://claude.com/claude-code)