### PR TITLE
fix(cronjob): use minimal workspace for Docker build

### DIFF
--- a/apps/cloud/cronjob/Dockerfile
+++ b/apps/cloud/cronjob/Dockerfile
@@ -2,20 +2,15 @@ FROM oven/bun:1 AS builder
 
 WORKDIR /repo
 
-# 复制 workspace 结构 + lockfile
-COPY package.json bun.lock ./
+# 最小 workspace：只包含 cronjob + 它依赖的 @inner/* 包
+RUN echo '{"private":true,"workspaces":["apps/cloud/cronjob","packages/ts-shared","packages/lark-utils","packages/pixiv-client"]}' > package.json
+
 COPY apps/cloud/cronjob/package.json ./apps/cloud/cronjob/
 COPY packages/ts-shared ./packages/ts-shared
 COPY packages/lark-utils ./packages/lark-utils
 COPY packages/pixiv-client ./packages/pixiv-client
 
-# 占位其他 workspace 成员的 package.json（bun install 需要）
-COPY apps/lark-server/package.json ./apps/lark-server/
-COPY apps/lark-proxy/package.json ./apps/lark-proxy/
-COPY apps/monitor-dashboard/package.json ./apps/monitor-dashboard/
-COPY apps/monitor-dashboard-web/package.json ./apps/monitor-dashboard-web/
-
-RUN bun install --frozen-lockfile
+RUN bun install
 
 # 复制源码
 COPY apps/cloud/cronjob/tsconfig.json ./apps/cloud/cronjob/

--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
     "apps/lark-proxy",
     "apps/monitor-dashboard",
     "apps/monitor-dashboard-web",
-    "apps/cloud/cronjob",
     "packages/ts-shared",
     "packages/pixiv-client",
     "packages/lark-utils"


### PR DESCRIPTION
## Summary
- PR #98 用根 workspace + `--frozen-lockfile` 导致 CI 下载全量依赖触发网络超时
- 改回 Docker 内生成最小 workspace（仅 cronjob + 三个 `@inner/*` 包），`bun install` 不带 `--frozen-lockfile`
- 保留 `bun build --compile` 生成独立二进制
- 从根 `package.json` workspaces 移除 `apps/cloud/cronjob`

## Test plan
- [ ] CI 构建镜像成功
- [ ] `docker run` 不再报 `GetMessageListParams not found`

🤖 Generated with [Claude Code](https://claude.com/claude-code)