### PR TITLE
fix(cronjob): minimal workspace + bun compile for Docker build

### DIFF
--- a/apps/cloud/cronjob/Dockerfile
+++ b/apps/cloud/cronjob/Dockerfile
@@ -18,7 +18,7 @@ COPY apps/cloud/cronjob/src ./apps/cloud/cronjob/src
 
 # 编译为独立二进制
 WORKDIR /repo/apps/cloud/cronjob
-RUN bun build src/index.ts --compile --outfile=cronjob
+RUN bun build src/index.ts --compile --outfile=cronjob --external @aws-sdk/client-s3
 
 # --- Runtime ---
 FROM debian:bookworm-slim

--- a/apps/cloud/cronjob/Dockerfile
+++ b/apps/cloud/cronjob/Dockerfile
@@ -2,20 +2,15 @@ FROM oven/bun:1 AS builder
 
 WORKDIR /repo
 
-# 复制 workspace 结构 + lockfile
-COPY package.json bun.lock ./
+# 最小 workspace：只包含 cronjob + 它依赖的 @inner/* 包
+RUN echo '{"private":true,"workspaces":["apps/cloud/cronjob","packages/ts-shared","packages/lark-utils","packages/pixiv-client"]}' > package.json
+
 COPY apps/cloud/cronjob/package.json ./apps/cloud/cronjob/
 COPY packages/ts-shared ./packages/ts-shared
 COPY packages/lark-utils ./packages/lark-utils
 COPY packages/pixiv-client ./packages/pixiv-client
 
-# 占位其他 workspace 成员的 package.json（bun install 需要）
-COPY apps/lark-server/package.json ./apps/lark-server/
-COPY apps/lark-proxy/package.json ./apps/lark-proxy/
-COPY apps/monitor-dashboard/package.json ./apps/monitor-dashboard/
-COPY apps/monitor-dashboard-web/package.json ./apps/monitor-dashboard-web/
-
-RUN bun install --frozen-lockfile
+RUN bun install
 
 # 复制源码
 COPY apps/cloud/cronjob/tsconfig.json ./apps/cloud/cronjob/

--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
     "apps/lark-proxy",
     "apps/monitor-dashboard",
     "apps/monitor-dashboard-web",
-    "apps/cloud/cronjob",
     "packages/ts-shared",
     "packages/pixiv-client",
     "packages/lark-utils"


### PR DESCRIPTION
## Summary
- Dockerfile 改用 Docker 内生成的最小 workspace（仅 cronjob + 三个 @inner/* 包），解决 CI 全量依赖下载超时
- `bun build --compile --external @aws-sdk/client-s3` 生成独立二进制，解决运行时 `@inner/*` 模块解析失败
- 从根 `package.json` workspaces 移除 PR #98 误加的 `apps/cloud/cronjob`
- 已在本地 `docker build` 验证通过

## Test plan
- [x] 本地 `docker build` 成功（bun install + bun build --compile 均通过）
- [ ] CI 构建镜像成功
- [ ] `docker run` 不再报 `GetMessageListParams not found`

🤖 Generated with [Claude Code](https://claude.com/claude-code)