### PR TITLE
feat(config): unified config system (ConfigBundle)

### DIFF
--- a/apps/paas-engine/cmd/paas-engine/main.go
+++ b/apps/paas-engine/cmd/paas-engine/main.go
@@ -75,7 +75,8 @@ func main() {
 	appSvc := service.NewAppService(appRepo, imageRepoRepo, releaseRepo, configBundleRepo)
 	imageRepoSvc := service.NewImageRepoService(imageRepoRepo, appRepo)
 	buildSvc := service.NewBuildService(imageRepoRepo, buildRepo, buildExecutor, lokiClient)
-	releaseSvc := service.NewReleaseService(appRepo, imageRepoRepo, buildRepo, releaseRepo, deployer)
+	configBundleSvc := service.NewConfigBundleService(configBundleRepo, appRepo, releaseRepo)
+	releaseSvc := service.NewReleaseService(appRepo, imageRepoRepo, buildRepo, releaseRepo, deployer, configBundleSvc)
 	logSvc := service.NewLogService(appRepo, lokiClient, cfg.DeployNamespace)
 	pipelineSvc := service.NewPipelineService(ciConfigRepo, pipelineRunRepo, testExecutor, buildSvc, releaseSvc, appRepo, imageRepoRepo, lokiClient, cfg.CINamespace)
 
@@ -127,6 +128,7 @@ func main() {
 		httpadapter.NewImageRepoHandler(imageRepoSvc),
 		httpadapter.NewOpsHandler(opsDbs),
 		httpadapter.NewPipelineHandler(pipelineSvc),
+		httpadapter.NewConfigBundleHandler(configBundleSvc),
 		cfg.APIToken,
 	)
 

--- a/apps/paas-engine/cmd/paas-engine/main.go
+++ b/apps/paas-engine/cmd/paas-engine/main.go
@@ -36,6 +36,7 @@ func main() {
 	releaseRepo := repository.NewReleaseRepo(db)
 	ciConfigRepo := repository.NewCIConfigRepo(db)
 	pipelineRunRepo := repository.NewPipelineRunRepo(db)
+	configBundleRepo := repository.NewConfigBundleRepo(db)
 
 	// K8s 客户端（可选，无集群时降级运行）
 	cs, _, k8sErr := kubernetes.NewClientset(cfg.KubeconfigPath)
@@ -71,7 +72,7 @@ func main() {
 	lokiClient := loki.NewClient(cfg.LokiURL)
 
 	// 服务层
-	appSvc := service.NewAppService(appRepo, imageRepoRepo, releaseRepo)
+	appSvc := service.NewAppService(appRepo, imageRepoRepo, releaseRepo, configBundleRepo)
 	imageRepoSvc := service.NewImageRepoService(imageRepoRepo, appRepo)
 	buildSvc := service.NewBuildService(imageRepoRepo, buildRepo, buildExecutor, lokiClient)
 	releaseSvc := service.NewReleaseService(appRepo, imageRepoRepo, buildRepo, releaseRepo, deployer)

--- a/apps/paas-engine/internal/adapter/http/config_bundle_handler.go
+++ b/apps/paas-engine/internal/adapter/http/config_bundle_handler.go
@@ -1,0 +1,177 @@
+package http
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+
+	"github.com/chiwei-platform/paas-engine/internal/service"
+	"github.com/go-chi/chi/v5"
+)
+
+type ConfigBundleHandler struct {
+	svc *service.ConfigBundleService
+}
+
+func NewConfigBundleHandler(svc *service.ConfigBundleService) *ConfigBundleHandler {
+	return &ConfigBundleHandler{svc: svc}
+}
+
+func (h *ConfigBundleHandler) Create(w http.ResponseWriter, r *http.Request) {
+	var req service.CreateBundleRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, err)
+		return
+	}
+	bundle, err := h.svc.CreateBundle(r.Context(), req)
+	if err != nil {
+		writeError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusCreated, bundle)
+}
+
+func (h *ConfigBundleHandler) List(w http.ResponseWriter, r *http.Request) {
+	bundles, err := h.svc.ListBundles(r.Context())
+	if err != nil {
+		writeError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, bundles)
+}
+
+func (h *ConfigBundleHandler) Get(w http.ResponseWriter, r *http.Request) {
+	name := chi.URLParam(r, "bundle")
+	bundle, err := h.svc.GetBundle(r.Context(), name)
+	if err != nil {
+		writeError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, bundle)
+}
+
+func (h *ConfigBundleHandler) Update(w http.ResponseWriter, r *http.Request) {
+	name := chi.URLParam(r, "bundle")
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		writeError(w, err)
+		return
+	}
+	bundle, err := h.svc.UpdateBundle(r.Context(), name, body)
+	if err != nil {
+		writeError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, bundle)
+}
+
+func (h *ConfigBundleHandler) Delete(w http.ResponseWriter, r *http.Request) {
+	name := chi.URLParam(r, "bundle")
+	if err := h.svc.DeleteBundle(r.Context(), name); err != nil {
+		writeError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]string{"deleted": name})
+}
+
+func (h *ConfigBundleHandler) SetKeys(w http.ResponseWriter, r *http.Request) {
+	name := chi.URLParam(r, "bundle")
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		writeError(w, err)
+		return
+	}
+	bundle, err := h.svc.SetKeys(r.Context(), name, body)
+	if err != nil {
+		writeError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, bundle)
+}
+
+func (h *ConfigBundleHandler) DeleteKey(w http.ResponseWriter, r *http.Request) {
+	name := chi.URLParam(r, "bundle")
+	key := chi.URLParam(r, "key")
+	bundle, err := h.svc.DeleteKey(r.Context(), name, key)
+	if err != nil {
+		writeError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, bundle)
+}
+
+func (h *ConfigBundleHandler) GenerateKey(w http.ResponseWriter, r *http.Request) {
+	name := chi.URLParam(r, "bundle")
+	key := chi.URLParam(r, "key")
+
+	var length int
+	body, err := io.ReadAll(r.Body)
+	if err == nil && len(body) > 0 {
+		var req struct {
+			Length int `json:"length"`
+		}
+		if err := json.Unmarshal(body, &req); err == nil {
+			length = req.Length
+		}
+	}
+	if length <= 0 {
+		length = 32
+	}
+
+	bundle, err := h.svc.GenerateKey(r.Context(), name, key, length)
+	if err != nil {
+		writeError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, bundle)
+}
+
+func (h *ConfigBundleHandler) SetLaneOverrides(w http.ResponseWriter, r *http.Request) {
+	name := chi.URLParam(r, "bundle")
+	lane := chi.URLParam(r, "lane")
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		writeError(w, err)
+		return
+	}
+	bundle, err := h.svc.SetLaneOverrides(r.Context(), name, lane, body)
+	if err != nil {
+		writeError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, bundle)
+}
+
+func (h *ConfigBundleHandler) DeleteLaneOverrides(w http.ResponseWriter, r *http.Request) {
+	name := chi.URLParam(r, "bundle")
+	lane := chi.URLParam(r, "lane")
+	bundle, err := h.svc.DeleteLaneOverrides(r.Context(), name, lane)
+	if err != nil {
+		writeError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, bundle)
+}
+
+func (h *ConfigBundleHandler) DeleteLaneOverrideKey(w http.ResponseWriter, r *http.Request) {
+	name := chi.URLParam(r, "bundle")
+	lane := chi.URLParam(r, "lane")
+	key := chi.URLParam(r, "key")
+	bundle, err := h.svc.DeleteLaneOverrideKey(r.Context(), name, lane, key)
+	if err != nil {
+		writeError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, bundle)
+}
+
+func (h *ConfigBundleHandler) ResolveConfig(w http.ResponseWriter, r *http.Request) {
+	appName := chi.URLParam(r, "app")
+	lane := r.URL.Query().Get("lane")
+	config, err := h.svc.ResolveConfig(r.Context(), appName, lane)
+	if err != nil {
+		writeError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, config)
+}

--- a/apps/paas-engine/internal/adapter/http/router.go
+++ b/apps/paas-engine/internal/adapter/http/router.go
@@ -15,6 +15,7 @@ func NewRouter(
 	imageRepoH *ImageRepoHandler,
 	opsH *OpsHandler,
 	pipelineH *PipelineHandler,
+	configBundleH *ConfigBundleHandler,
 	apiToken string,
 ) http.Handler {
 	r := chi.NewRouter()
@@ -43,6 +44,7 @@ func NewRouter(
 				r.Put("/", appH.Update)
 				r.Delete("/", appH.Delete)
 				r.Get("/logs", logH.GetLogs)
+				r.Get("/resolved-config", configBundleH.ResolveConfig)
 
 				// Builds (under apps)
 				r.Route("/builds", func(r chi.Router) {
@@ -102,6 +104,25 @@ func NewRouter(
 				r.Delete("/", pipelineH.Unregister)
 				r.Get("/runs", pipelineH.ListRuns)
 				r.Post("/trigger", pipelineH.Trigger)
+			})
+		})
+
+		// Config Bundles
+		r.Route("/config-bundles", func(r chi.Router) {
+			r.Post("/", configBundleH.Create)
+			r.Get("/", configBundleH.List)
+			r.Route("/{bundle}", func(r chi.Router) {
+				r.Get("/", configBundleH.Get)
+				r.Put("/", configBundleH.Update)
+				r.Delete("/", configBundleH.Delete)
+				r.Put("/keys", configBundleH.SetKeys)
+				r.Delete("/keys/{key}", configBundleH.DeleteKey)
+				r.Post("/keys/{key}/generate", configBundleH.GenerateKey)
+				r.Route("/lanes/{lane}", func(r chi.Router) {
+					r.Put("/", configBundleH.SetLaneOverrides)
+					r.Delete("/", configBundleH.DeleteLaneOverrides)
+					r.Delete("/{key}", configBundleH.DeleteLaneOverrideKey)
+				})
 			})
 		})
 	})

--- a/apps/paas-engine/internal/adapter/kubernetes/deployer.go
+++ b/apps/paas-engine/internal/adapter/kubernetes/deployer.go
@@ -32,8 +32,8 @@ func NewK8sDeployer(client kubernetes.Interface, namespace string) *K8sDeployer 
 	return &K8sDeployer{client: client, namespace: namespace}
 }
 
-func (d *K8sDeployer) Deploy(ctx context.Context, release *domain.Release, app *domain.App) error {
-	if err := d.applyDeployment(ctx, release, app); err != nil {
+func (d *K8sDeployer) Deploy(ctx context.Context, release *domain.Release, app *domain.App, bundleEnvs map[string]string) error {
+	if err := d.applyDeployment(ctx, release, app, bundleEnvs); err != nil {
 		return fmt.Errorf("apply deployment: %w", err)
 	}
 	if app.Port > 0 { // Worker 无端口，跳过 Service
@@ -180,11 +180,20 @@ func (d *K8sDeployer) GetDeploymentStatus(ctx context.Context, name string) (*do
 	return status, nil
 }
 
-func (d *K8sDeployer) applyDeployment(ctx context.Context, release *domain.Release, app *domain.App) error {
+func (d *K8sDeployer) applyDeployment(ctx context.Context, release *domain.Release, app *domain.App, bundleEnvs map[string]string) error {
 	name := release.ResourceName()
 	labels := map[string]string{
 		"app":  release.AppName,
 		"lane": release.Lane,
+	}
+
+	// Bundle envs → auto-managed K8s Secret
+	var bundleSecretName string
+	if len(bundleEnvs) > 0 {
+		bundleSecretName = name + "-config"
+		if err := d.applySecret(ctx, bundleSecretName, bundleEnvs); err != nil {
+			return fmt.Errorf("apply config secret: %w", err)
+		}
 	}
 
 	mergedEnvs := mergeEnvs(app.Envs, release.Envs)
@@ -193,12 +202,23 @@ func (d *K8sDeployer) applyDeployment(ctx context.Context, release *domain.Relea
 	}
 	mergedEnvs["LANE"] = release.Lane
 	envVars := envsToK8s(mergedEnvs)
+
+	// EnvFrom: legacy sources first, then bundle secret (bundle overrides legacy for duplicate keys)
+	envFrom := buildEnvFrom(app.EnvFromSecrets, app.EnvFromConfigMaps)
+	if bundleSecretName != "" {
+		envFrom = append(envFrom, corev1.EnvFromSource{
+			SecretRef: &corev1.SecretEnvSource{
+				LocalObjectReference: corev1.LocalObjectReference{Name: bundleSecretName},
+			},
+		})
+	}
+
 	replicas := release.Replicas
 
 	container := corev1.Container{
 		Name:    app.Name,
 		Image:   release.Image,
-		EnvFrom: buildEnvFrom(app.EnvFromSecrets, app.EnvFromConfigMaps),
+		EnvFrom: envFrom,
 		Env:     envVars,
 	}
 	if len(app.Command) > 0 {
@@ -320,6 +340,29 @@ func (d *K8sDeployer) applyBaseService(ctx context.Context, release *domain.Rele
 	}
 	existing.Spec.Ports = svc.Spec.Ports
 	_, err = d.client.CoreV1().Services(d.namespace).Update(ctx, existing, metav1.UpdateOptions{})
+	return err
+}
+
+func (d *K8sDeployer) applySecret(ctx context.Context, name string, data map[string]string) error {
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: d.namespace,
+			Labels:    map[string]string{"managed-by": "paas-engine"},
+		},
+		StringData: data,
+	}
+
+	existing, err := d.client.CoreV1().Secrets(d.namespace).Get(ctx, name, metav1.GetOptions{})
+	if errors.IsNotFound(err) {
+		_, err = d.client.CoreV1().Secrets(d.namespace).Create(ctx, secret, metav1.CreateOptions{})
+		return err
+	}
+	if err != nil {
+		return err
+	}
+	existing.StringData = data
+	_, err = d.client.CoreV1().Secrets(d.namespace).Update(ctx, existing, metav1.UpdateOptions{})
 	return err
 }
 

--- a/apps/paas-engine/internal/adapter/kubernetes/deployer_test.go
+++ b/apps/paas-engine/internal/adapter/kubernetes/deployer_test.go
@@ -209,7 +209,7 @@ func TestApplyDeploymentWorker(t *testing.T) {
 		Replicas: 1,
 	}
 
-	if err := deployer.applyDeployment(context.Background(), release, app); err != nil {
+	if err := deployer.applyDeployment(context.Background(), release, app, nil); err != nil {
 		t.Fatalf("applyDeployment() error = %v", err)
 	}
 
@@ -269,7 +269,7 @@ func TestApplyDeploymentWebApp(t *testing.T) {
 		Replicas: 2,
 	}
 
-	if err := deployer.applyDeployment(context.Background(), release, app); err != nil {
+	if err := deployer.applyDeployment(context.Background(), release, app, nil); err != nil {
 		t.Fatalf("applyDeployment() error = %v", err)
 	}
 
@@ -326,7 +326,7 @@ func TestDeployWorkerSkipsService(t *testing.T) {
 	// 使用 Deploy（而非 applyDeployment）来验证 Service 逻辑
 	// 注意: Deploy 会调用 waitForRollout，fake client 的 Deployment 没有 Status，
 	// 所以这里直接测试 applyDeployment + 检查 Service 不存在
-	if err := deployer.applyDeployment(context.Background(), release, app); err != nil {
+	if err := deployer.applyDeployment(context.Background(), release, app, nil); err != nil {
 		t.Fatalf("applyDeployment() error = %v", err)
 	}
 

--- a/apps/paas-engine/internal/adapter/repository/app_repo.go
+++ b/apps/paas-engine/internal/adapter/repository/app_repo.go
@@ -92,6 +92,10 @@ func appToModel(a *domain.App) (*AppModel, error) {
 	if err != nil {
 		return nil, err
 	}
+	configBundlesJSON, err := json.Marshal(a.ConfigBundles)
+	if err != nil {
+		return nil, err
+	}
 	return &AppModel{
 		Name:              a.Name,
 		Description:       a.Description,
@@ -102,6 +106,7 @@ func appToModel(a *domain.App) (*AppModel, error) {
 		EnvFromSecrets:    string(envFromSecretsJSON),
 		EnvFromConfigMaps: string(envFromConfigMapsJSON),
 		Envs:              string(envsJSON),
+		ConfigBundles:     string(configBundlesJSON),
 		CreatedAt:         a.CreatedAt,
 		UpdatedAt:         a.UpdatedAt,
 	}, nil
@@ -132,6 +137,12 @@ func modelToApp(m *AppModel) (*domain.App, error) {
 			return nil, err
 		}
 	}
+	var configBundles []string
+	if m.ConfigBundles != "" {
+		if err := json.Unmarshal([]byte(m.ConfigBundles), &configBundles); err != nil {
+			return nil, err
+		}
+	}
 	return &domain.App{
 		Name:              m.Name,
 		Description:       m.Description,
@@ -142,6 +153,7 @@ func modelToApp(m *AppModel) (*domain.App, error) {
 		EnvFromSecrets:    envFromSecrets,
 		EnvFromConfigMaps: envFromConfigMaps,
 		Envs:              envs,
+		ConfigBundles:     configBundles,
 		CreatedAt:         m.CreatedAt,
 		UpdatedAt:         m.UpdatedAt,
 	}, nil

--- a/apps/paas-engine/internal/adapter/repository/config_bundle_repo.go
+++ b/apps/paas-engine/internal/adapter/repository/config_bundle_repo.go
@@ -1,0 +1,134 @@
+package repository
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+
+	"github.com/chiwei-platform/paas-engine/internal/domain"
+	"github.com/chiwei-platform/paas-engine/internal/port"
+	"gorm.io/gorm"
+)
+
+var _ port.ConfigBundleRepository = (*ConfigBundleRepo)(nil)
+
+type ConfigBundleRepo struct {
+	db *gorm.DB
+}
+
+func NewConfigBundleRepo(db *gorm.DB) *ConfigBundleRepo {
+	return &ConfigBundleRepo{db: db}
+}
+
+func (r *ConfigBundleRepo) Save(ctx context.Context, bundle *domain.ConfigBundle) error {
+	m, err := bundleToModel(bundle)
+	if err != nil {
+		return err
+	}
+	result := r.db.WithContext(ctx).Create(m)
+	if result.Error != nil {
+		if isUniqueConstraintError(result.Error) {
+			return domain.ErrAlreadyExists
+		}
+		return result.Error
+	}
+	return nil
+}
+
+func (r *ConfigBundleRepo) FindByName(ctx context.Context, name string) (*domain.ConfigBundle, error) {
+	var m ConfigBundleModel
+	result := r.db.WithContext(ctx).First(&m, "name = ?", name)
+	if result.Error != nil {
+		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
+			return nil, domain.ErrConfigBundleNotFound
+		}
+		return nil, result.Error
+	}
+	return modelToBundle(&m)
+}
+
+func (r *ConfigBundleRepo) FindAll(ctx context.Context) ([]*domain.ConfigBundle, error) {
+	var models []ConfigBundleModel
+	if err := r.db.WithContext(ctx).Find(&models).Error; err != nil {
+		return nil, err
+	}
+	bundles := make([]*domain.ConfigBundle, 0, len(models))
+	for i := range models {
+		b, err := modelToBundle(&models[i])
+		if err != nil {
+			return nil, err
+		}
+		bundles = append(bundles, b)
+	}
+	return bundles, nil
+}
+
+func (r *ConfigBundleRepo) FindByNames(ctx context.Context, names []string) ([]*domain.ConfigBundle, error) {
+	var models []ConfigBundleModel
+	if err := r.db.WithContext(ctx).Where("name IN ?", names).Find(&models).Error; err != nil {
+		return nil, err
+	}
+	bundles := make([]*domain.ConfigBundle, 0, len(models))
+	for i := range models {
+		b, err := modelToBundle(&models[i])
+		if err != nil {
+			return nil, err
+		}
+		bundles = append(bundles, b)
+	}
+	return bundles, nil
+}
+
+func (r *ConfigBundleRepo) Update(ctx context.Context, bundle *domain.ConfigBundle) error {
+	m, err := bundleToModel(bundle)
+	if err != nil {
+		return err
+	}
+	return r.db.WithContext(ctx).Save(m).Error
+}
+
+func (r *ConfigBundleRepo) Delete(ctx context.Context, name string) error {
+	return r.db.WithContext(ctx).Delete(&ConfigBundleModel{}, "name = ?", name).Error
+}
+
+func bundleToModel(b *domain.ConfigBundle) (*ConfigBundleModel, error) {
+	keysJSON, err := json.Marshal(b.Keys)
+	if err != nil {
+		return nil, err
+	}
+	laneOverridesJSON, err := json.Marshal(b.LaneOverrides)
+	if err != nil {
+		return nil, err
+	}
+	return &ConfigBundleModel{
+		Name:          b.Name,
+		Description:   b.Description,
+		Keys:          string(keysJSON),
+		LaneOverrides: string(laneOverridesJSON),
+		CreatedAt:     b.CreatedAt,
+		UpdatedAt:     b.UpdatedAt,
+	}, nil
+}
+
+func modelToBundle(m *ConfigBundleModel) (*domain.ConfigBundle, error) {
+	var keys map[string]string
+	if m.Keys != "" {
+		if err := json.Unmarshal([]byte(m.Keys), &keys); err != nil {
+			return nil, err
+		}
+	}
+	var laneOverrides map[string]map[string]string
+	if m.LaneOverrides != "" {
+		if err := json.Unmarshal([]byte(m.LaneOverrides), &laneOverrides); err != nil {
+			return nil, err
+		}
+	}
+	return &domain.ConfigBundle{
+		Name:          m.Name,
+		Description:   m.Description,
+		Keys:          keys,
+		LaneOverrides: laneOverrides,
+		CreatedAt:     m.CreatedAt,
+		UpdatedAt:     m.UpdatedAt,
+	}, nil
+}

--- a/apps/paas-engine/internal/adapter/repository/db.go
+++ b/apps/paas-engine/internal/adapter/repository/db.go
@@ -23,6 +23,7 @@ func OpenDB(dsn string) (*gorm.DB, error) {
 		&PipelineRunModel{},
 		&StageRunModel{},
 		&JobRunModel{},
+		&ConfigBundleModel{},
 	); err != nil {
 		return nil, err
 	}

--- a/apps/paas-engine/internal/adapter/repository/model.go
+++ b/apps/paas-engine/internal/adapter/repository/model.go
@@ -13,6 +13,7 @@ type AppModel struct {
 	EnvFromSecrets    string // JSON 序列化的 []string
 	EnvFromConfigMaps string // JSON 序列化的 []string
 	Envs              string // JSON 序列化的 map[string]string
+	ConfigBundles     string // JSON 序列化的 []string
 	CreatedAt         time.Time
 	UpdatedAt         time.Time
 }

--- a/apps/paas-engine/internal/adapter/repository/model.go
+++ b/apps/paas-engine/internal/adapter/repository/model.go
@@ -126,3 +126,15 @@ type JobRunModel struct {
 }
 
 func (JobRunModel) TableName() string { return "job_runs" }
+
+// ConfigBundleModel 是 ConfigBundle 的数据库持久化模型。
+type ConfigBundleModel struct {
+	Name          string `gorm:"primaryKey"`
+	Description   string
+	Keys          string // JSON serialized map[string]string
+	LaneOverrides string // JSON serialized map[string]map[string]string
+	CreatedAt     time.Time
+	UpdatedAt     time.Time
+}
+
+func (ConfigBundleModel) TableName() string { return "config_bundles" }

--- a/apps/paas-engine/internal/domain/app.go
+++ b/apps/paas-engine/internal/domain/app.go
@@ -14,6 +14,7 @@ type App struct {
 	EnvFromSecrets    []string          `json:"env_from_secrets,omitempty"`
 	EnvFromConfigMaps []string          `json:"env_from_config_maps,omitempty"`
 	Envs              map[string]string `json:"envs,omitempty"`
+	ConfigBundles     []string          `json:"config_bundles,omitempty"` // 关联的 ConfigBundle 名称列表
 	CreatedAt         time.Time         `json:"created_at"`
 	UpdatedAt         time.Time         `json:"updated_at"`
 }

--- a/apps/paas-engine/internal/domain/config_bundle.go
+++ b/apps/paas-engine/internal/domain/config_bundle.go
@@ -1,0 +1,15 @@
+package domain
+
+import "time"
+
+// ConfigBundle 表示一组按基础设施实例分组的配置项。
+// 每个 key 是最终注入容器的环境变量名（如 PG_MAIN_HOST）。
+type ConfigBundle struct {
+	Name          string                       `json:"name"`
+	Description   string                       `json:"description,omitempty"`
+	Keys          map[string]string            `json:"keys,omitempty"`
+	LaneOverrides map[string]map[string]string `json:"lane_overrides,omitempty"`
+	ReferencedBy  []string                     `json:"referenced_by,omitempty"`
+	CreatedAt     time.Time                    `json:"created_at"`
+	UpdatedAt     time.Time                    `json:"updated_at"`
+}

--- a/apps/paas-engine/internal/domain/errors.go
+++ b/apps/paas-engine/internal/domain/errors.go
@@ -15,7 +15,8 @@ var (
 	ErrAppNotFound       = fmt.Errorf("app %w", ErrNotFound)
 	ErrBuildNotFound     = fmt.Errorf("build %w", ErrNotFound)
 	ErrReleaseNotFound   = fmt.Errorf("release %w", ErrNotFound)
-	ErrImageRepoNotFound = fmt.Errorf("image repo %w", ErrNotFound)
+	ErrImageRepoNotFound    = fmt.Errorf("image repo %w", ErrNotFound)
+	ErrConfigBundleNotFound = fmt.Errorf("config bundle %w", ErrNotFound)
 
 	ErrNonMainProdDeploy = fmt.Errorf("%w: prod lane only accepts images built from main branch", ErrInvalidInput)
 

--- a/apps/paas-engine/internal/port/kubernetes.go
+++ b/apps/paas-engine/internal/port/kubernetes.go
@@ -8,7 +8,7 @@ import (
 
 // Deployer 负责将 Release 翻译为 K8s Deployment + Service 并下发。
 type Deployer interface {
-	Deploy(ctx context.Context, release *domain.Release, app *domain.App) error
+	Deploy(ctx context.Context, release *domain.Release, app *domain.App, bundleEnvs map[string]string) error
 	Delete(ctx context.Context, release *domain.Release, hasOtherReleases bool) error
 	// GetDeploymentStatus 查询指定 Deployment 的运行时状态（副本数 + Pod 列表）。
 	GetDeploymentStatus(ctx context.Context, name string) (*domain.DeploymentStatus, error)

--- a/apps/paas-engine/internal/port/repository.go
+++ b/apps/paas-engine/internal/port/repository.go
@@ -40,3 +40,12 @@ type ReleaseRepository interface {
 	Update(ctx context.Context, release *domain.Release) error
 	Delete(ctx context.Context, id string) error
 }
+
+type ConfigBundleRepository interface {
+	Save(ctx context.Context, bundle *domain.ConfigBundle) error
+	FindByName(ctx context.Context, name string) (*domain.ConfigBundle, error)
+	FindAll(ctx context.Context) ([]*domain.ConfigBundle, error)
+	FindByNames(ctx context.Context, names []string) ([]*domain.ConfigBundle, error)
+	Update(ctx context.Context, bundle *domain.ConfigBundle) error
+	Delete(ctx context.Context, name string) error
+}

--- a/apps/paas-engine/internal/service/app_service.go
+++ b/apps/paas-engine/internal/service/app_service.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/chiwei-platform/paas-engine/internal/domain"
@@ -9,13 +10,14 @@ import (
 )
 
 type AppService struct {
-	appRepo       port.AppRepository
-	imageRepoRepo port.ImageRepoRepository
-	releaseRepo   port.ReleaseRepository
+	appRepo          port.AppRepository
+	imageRepoRepo    port.ImageRepoRepository
+	releaseRepo      port.ReleaseRepository
+	configBundleRepo port.ConfigBundleRepository
 }
 
-func NewAppService(appRepo port.AppRepository, imageRepoRepo port.ImageRepoRepository, releaseRepo port.ReleaseRepository) *AppService {
-	return &AppService{appRepo: appRepo, imageRepoRepo: imageRepoRepo, releaseRepo: releaseRepo}
+func NewAppService(appRepo port.AppRepository, imageRepoRepo port.ImageRepoRepository, releaseRepo port.ReleaseRepository, configBundleRepo port.ConfigBundleRepository) *AppService {
+	return &AppService{appRepo: appRepo, imageRepoRepo: imageRepoRepo, releaseRepo: releaseRepo, configBundleRepo: configBundleRepo}
 }
 
 type CreateAppRequest struct {
@@ -28,6 +30,7 @@ type CreateAppRequest struct {
 	EnvFromSecrets    []string          `json:"env_from_secrets"`
 	EnvFromConfigMaps []string          `json:"env_from_config_maps"`
 	Envs              map[string]string `json:"envs"`
+	ConfigBundles     []string          `json:"config_bundles"`
 }
 
 func (s *AppService) CreateApp(ctx context.Context, req CreateAppRequest) (*domain.App, error) {
@@ -44,6 +47,12 @@ func (s *AppService) CreateApp(ctx context.Context, req CreateAppRequest) (*doma
 		}
 	}
 
+	if len(req.ConfigBundles) > 0 {
+		if err := s.validateConfigBundles(ctx, req.ConfigBundles); err != nil {
+			return nil, err
+		}
+	}
+
 	now := time.Now()
 	app := &domain.App{
 		Name:              req.Name,
@@ -55,6 +64,7 @@ func (s *AppService) CreateApp(ctx context.Context, req CreateAppRequest) (*doma
 		EnvFromSecrets:    req.EnvFromSecrets,
 		EnvFromConfigMaps: req.EnvFromConfigMaps,
 		Envs:              req.Envs,
+		ConfigBundles:     req.ConfigBundles,
 		CreatedAt:         now,
 		UpdatedAt:         now,
 	}
@@ -105,6 +115,14 @@ func (s *AppService) UpdateApp(ctx context.Context, name string, body []byte) (*
 	if err := ApplyField(fields, "env_from_config_maps", &app.EnvFromConfigMaps); err != nil {
 		return nil, domain.ErrInvalidInput
 	}
+	if err := ApplyField(fields, "config_bundles", &app.ConfigBundles); err != nil {
+		return nil, domain.ErrInvalidInput
+	}
+	if _, ok := fields["config_bundles"]; ok && len(app.ConfigBundles) > 0 {
+		if err := s.validateConfigBundles(ctx, app.ConfigBundles); err != nil {
+			return nil, err
+		}
+	}
 
 	// Map 字段：按 key 合并
 	app.Envs, err = MergeEnvs(app.Envs, fields["envs"])
@@ -139,4 +157,36 @@ func (s *AppService) DeleteApp(ctx context.Context, name string) error {
 		return domain.ErrCannotDelete
 	}
 	return s.appRepo.Delete(ctx, name)
+}
+
+func (s *AppService) validateConfigBundles(ctx context.Context, bundleNames []string) error {
+	if s.configBundleRepo == nil {
+		return nil
+	}
+	bundles, err := s.configBundleRepo.FindByNames(ctx, bundleNames)
+	if err != nil {
+		return err
+	}
+	if len(bundles) != len(bundleNames) {
+		found := make(map[string]bool)
+		for _, b := range bundles {
+			found[b.Name] = true
+		}
+		for _, name := range bundleNames {
+			if !found[name] {
+				return fmt.Errorf("%w: config bundle %q not found", domain.ErrInvalidInput, name)
+			}
+		}
+	}
+	// Check key conflicts across bundles
+	seen := make(map[string]string) // key name → bundle name
+	for _, bundle := range bundles {
+		for key := range bundle.Keys {
+			if other, ok := seen[key]; ok {
+				return fmt.Errorf("%w: key %q defined in both %q and %q", domain.ErrInvalidInput, key, other, bundle.Name)
+			}
+			seen[key] = bundle.Name
+		}
+	}
+	return nil
 }

--- a/apps/paas-engine/internal/service/app_service_test.go
+++ b/apps/paas-engine/internal/service/app_service_test.go
@@ -28,7 +28,7 @@ func (s *stubReleaseRepo) FindAll(_ context.Context, _, _ string) ([]*domain.Rel
 func TestCreateApp_Success(t *testing.T) {
 	appRepo := &stubAppRepo{}
 	imageRepoRepo := &stubImageRepoRepo{repo: &domain.ImageRepo{Name: "myapp"}}
-	svc := NewAppService(appRepo, imageRepoRepo, &stubReleaseRepo{})
+	svc := NewAppService(appRepo, imageRepoRepo, &stubReleaseRepo{}, nil)
 
 	app, err := svc.CreateApp(context.Background(), CreateAppRequest{
 		Name:          "myapp",
@@ -46,7 +46,7 @@ func TestCreateApp_Success(t *testing.T) {
 func TestCreateApp_ImageRepoNotFound(t *testing.T) {
 	appRepo := &stubAppRepo{}
 	imageRepoRepo := &stubImageRepoRepo{err: domain.ErrImageRepoNotFound}
-	svc := NewAppService(appRepo, imageRepoRepo, &stubReleaseRepo{})
+	svc := NewAppService(appRepo, imageRepoRepo, &stubReleaseRepo{}, nil)
 
 	_, err := svc.CreateApp(context.Background(), CreateAppRequest{
 		Name:          "myapp",
@@ -61,7 +61,7 @@ func TestCreateApp_ImageRepoNotFound(t *testing.T) {
 func TestCreateApp_InvalidName(t *testing.T) {
 	appRepo := &stubAppRepo{}
 	imageRepoRepo := &stubImageRepoRepo{}
-	svc := NewAppService(appRepo, imageRepoRepo, &stubReleaseRepo{})
+	svc := NewAppService(appRepo, imageRepoRepo, &stubReleaseRepo{}, nil)
 
 	_, err := svc.CreateApp(context.Background(), CreateAppRequest{
 		Name: "INVALID",
@@ -79,7 +79,7 @@ func TestUpdateApp_Success(t *testing.T) {
 		Port:          8080,
 	}}
 	imageRepoRepo := &stubImageRepoRepo{repo: &domain.ImageRepo{Name: "myapp"}}
-	svc := NewAppService(appRepo, imageRepoRepo, &stubReleaseRepo{})
+	svc := NewAppService(appRepo, imageRepoRepo, &stubReleaseRepo{}, nil)
 
 	app, err := svc.UpdateApp(context.Background(), "myapp", []byte(`{"image_repo":"myapp","port":9090}`))
 	if err != nil {
@@ -99,7 +99,7 @@ func TestUpdateApp_PartialKeepsExisting(t *testing.T) {
 		Envs:          map[string]string{"A": "1"},
 	}}
 	imageRepoRepo := &stubImageRepoRepo{repo: &domain.ImageRepo{Name: "myapp"}}
-	svc := NewAppService(appRepo, imageRepoRepo, &stubReleaseRepo{})
+	svc := NewAppService(appRepo, imageRepoRepo, &stubReleaseRepo{}, nil)
 
 	// 只传 port，其他字段保持不变
 	app, err := svc.UpdateApp(context.Background(), "myapp", []byte(`{"port":9090}`))
@@ -125,7 +125,7 @@ func TestUpdateApp_EnvsMerge(t *testing.T) {
 		Name: "myapp",
 		Envs: map[string]string{"A": "1", "B": "2"},
 	}}
-	svc := NewAppService(appRepo, &stubImageRepoRepo{}, &stubReleaseRepo{})
+	svc := NewAppService(appRepo, &stubImageRepoRepo{}, &stubReleaseRepo{}, nil)
 
 	app, err := svc.UpdateApp(context.Background(), "myapp", []byte(`{"envs":{"C":"3"}}`))
 	if err != nil {
@@ -141,7 +141,7 @@ func TestUpdateApp_EnvsDeleteKey(t *testing.T) {
 		Name: "myapp",
 		Envs: map[string]string{"A": "1", "B": "2"},
 	}}
-	svc := NewAppService(appRepo, &stubImageRepoRepo{}, &stubReleaseRepo{})
+	svc := NewAppService(appRepo, &stubImageRepoRepo{}, &stubReleaseRepo{}, nil)
 
 	app, err := svc.UpdateApp(context.Background(), "myapp", []byte(`{"envs":{"A":null}}`))
 	if err != nil {
@@ -152,5 +152,37 @@ func TestUpdateApp_EnvsDeleteKey(t *testing.T) {
 	}
 	if app.Envs["B"] != "2" {
 		t.Errorf("B = %q, want %q", app.Envs["B"], "2")
+	}
+}
+
+func TestUpdateApp_ConfigBundleConflict(t *testing.T) {
+	appRepo := &stubAppRepo{app: &domain.App{Name: "myapp"}}
+	bundleRepo := newStubConfigBundleRepo()
+	bundleRepo.bundles["pg-main"] = &domain.ConfigBundle{
+		Name: "pg-main",
+		Keys: map[string]string{"DB_HOST": "postgres"},
+	}
+	bundleRepo.bundles["pg-external"] = &domain.ConfigBundle{
+		Name: "pg-external",
+		Keys: map[string]string{"DB_HOST": "external-pg"}, // conflict!
+	}
+	svc := NewAppService(appRepo, &stubImageRepoRepo{}, &stubReleaseRepo{}, bundleRepo)
+
+	_, err := svc.UpdateApp(context.Background(), "myapp",
+		[]byte(`{"config_bundles":["pg-main","pg-external"]}`))
+	if err == nil {
+		t.Error("expected error for key conflict")
+	}
+}
+
+func TestUpdateApp_ConfigBundleNotFound(t *testing.T) {
+	appRepo := &stubAppRepo{app: &domain.App{Name: "myapp"}}
+	bundleRepo := newStubConfigBundleRepo()
+	svc := NewAppService(appRepo, &stubImageRepoRepo{}, &stubReleaseRepo{}, bundleRepo)
+
+	_, err := svc.UpdateApp(context.Background(), "myapp",
+		[]byte(`{"config_bundles":["nonexistent"]}`))
+	if err == nil {
+		t.Error("expected error for missing bundle")
 	}
 }

--- a/apps/paas-engine/internal/service/config_bundle_service.go
+++ b/apps/paas-engine/internal/service/config_bundle_service.go
@@ -1,0 +1,361 @@
+package service
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"time"
+
+	"github.com/chiwei-platform/paas-engine/internal/domain"
+	"github.com/chiwei-platform/paas-engine/internal/port"
+)
+
+// ResolvedConfigEntry 表示一个已解析的配置项，带来源标注。
+type ResolvedConfigEntry struct {
+	Value  string `json:"value"`
+	Source string `json:"source"`
+}
+
+// ConfigBundleService 提供 ConfigBundle 的 CRUD、Key 管理、泳道覆盖和配置解析。
+type ConfigBundleService struct {
+	bundleRepo  port.ConfigBundleRepository
+	appRepo     port.AppRepository
+	releaseRepo port.ReleaseRepository
+}
+
+// NewConfigBundleService 创建 ConfigBundleService 实例。
+func NewConfigBundleService(
+	bundleRepo port.ConfigBundleRepository,
+	appRepo port.AppRepository,
+	releaseRepo port.ReleaseRepository,
+) *ConfigBundleService {
+	return &ConfigBundleService{
+		bundleRepo:  bundleRepo,
+		appRepo:     appRepo,
+		releaseRepo: releaseRepo,
+	}
+}
+
+// CreateBundleRequest 创建 ConfigBundle 的请求体。
+type CreateBundleRequest struct {
+	Name        string            `json:"name"`
+	Description string            `json:"description"`
+	Keys        map[string]string `json:"keys"`
+}
+
+// CreateBundle 创建一个新的 ConfigBundle。
+func (s *ConfigBundleService) CreateBundle(ctx context.Context, req CreateBundleRequest) (*domain.ConfigBundle, error) {
+	if err := domain.ValidateK8sName(req.Name); err != nil {
+		return nil, err
+	}
+	now := time.Now()
+	bundle := &domain.ConfigBundle{
+		Name:        req.Name,
+		Description: req.Description,
+		Keys:        req.Keys,
+		CreatedAt:   now,
+		UpdatedAt:   now,
+	}
+	if err := s.bundleRepo.Save(ctx, bundle); err != nil {
+		return nil, err
+	}
+	return bundle, nil
+}
+
+// GetBundle 查找一个 ConfigBundle，并填充 ReferencedBy（扫描所有 App）。
+func (s *ConfigBundleService) GetBundle(ctx context.Context, name string) (*domain.ConfigBundle, error) {
+	bundle, err := s.bundleRepo.FindByName(ctx, name)
+	if err != nil {
+		return nil, err
+	}
+
+	// 扫描所有 app，找到引用此 bundle 的 app 列表
+	apps, err := s.appRepo.FindAll(ctx)
+	if err != nil {
+		return nil, err
+	}
+	var referencedBy []string
+	for _, app := range apps {
+		for _, b := range app.ConfigBundles {
+			if b == name {
+				referencedBy = append(referencedBy, app.Name)
+				break
+			}
+		}
+	}
+	bundle.ReferencedBy = referencedBy
+	return bundle, nil
+}
+
+// ListBundles 返回所有 ConfigBundle。
+func (s *ConfigBundleService) ListBundles(ctx context.Context) ([]*domain.ConfigBundle, error) {
+	return s.bundleRepo.FindAll(ctx)
+}
+
+// UpdateBundle 对 ConfigBundle 的字段做部分更新，keys 使用 MergeEnvs 语义。
+func (s *ConfigBundleService) UpdateBundle(ctx context.Context, name string, body []byte) (*domain.ConfigBundle, error) {
+	bundle, err := s.bundleRepo.FindByName(ctx, name)
+	if err != nil {
+		return nil, err
+	}
+
+	fields, err := ParseFields(body)
+	if err != nil {
+		return nil, domain.ErrInvalidInput
+	}
+
+	if err := ApplyField(fields, "description", &bundle.Description); err != nil {
+		return nil, domain.ErrInvalidInput
+	}
+
+	bundle.Keys, err = MergeEnvs(bundle.Keys, fields["keys"])
+	if err != nil {
+		return nil, domain.ErrInvalidInput
+	}
+
+	bundle.UpdatedAt = time.Now()
+	if err := s.bundleRepo.Update(ctx, bundle); err != nil {
+		return nil, err
+	}
+	return bundle, nil
+}
+
+// DeleteBundle 删除一个 ConfigBundle，如果有 App 引用则拒绝。
+func (s *ConfigBundleService) DeleteBundle(ctx context.Context, name string) error {
+	if _, err := s.bundleRepo.FindByName(ctx, name); err != nil {
+		return err
+	}
+
+	// 检查是否有 App 引用此 bundle
+	apps, err := s.appRepo.FindAll(ctx)
+	if err != nil {
+		return err
+	}
+	for _, app := range apps {
+		for _, b := range app.ConfigBundles {
+			if b == name {
+				return domain.ErrCannotDelete
+			}
+		}
+	}
+
+	return s.bundleRepo.Delete(ctx, name)
+}
+
+// SetKeys 合并更新 bundle 的 Keys（MergeEnvs 语义）。
+// body 是一个 JSON 对象，直接作为 keys 的 patch（{"KEY":"val"} 或 {"KEY":null} 删除）。
+func (s *ConfigBundleService) SetKeys(ctx context.Context, bundleName string, body []byte) (*domain.ConfigBundle, error) {
+	bundle, err := s.bundleRepo.FindByName(ctx, bundleName)
+	if err != nil {
+		return nil, err
+	}
+
+	bundle.Keys, err = MergeEnvs(bundle.Keys, body)
+	if err != nil {
+		return nil, domain.ErrInvalidInput
+	}
+
+	bundle.UpdatedAt = time.Now()
+	if err := s.bundleRepo.Update(ctx, bundle); err != nil {
+		return nil, err
+	}
+	return bundle, nil
+}
+
+// DeleteKey 从 Keys 中删除一个 key，同时清理所有 LaneOverrides 中该 key。
+func (s *ConfigBundleService) DeleteKey(ctx context.Context, bundleName, keyName string) (*domain.ConfigBundle, error) {
+	bundle, err := s.bundleRepo.FindByName(ctx, bundleName)
+	if err != nil {
+		return nil, err
+	}
+
+	delete(bundle.Keys, keyName)
+
+	// 清理所有 LaneOverrides 中的该 key
+	for lane, overrides := range bundle.LaneOverrides {
+		delete(overrides, keyName)
+		if len(overrides) == 0 {
+			delete(bundle.LaneOverrides, lane)
+		}
+	}
+
+	bundle.UpdatedAt = time.Now()
+	if err := s.bundleRepo.Update(ctx, bundle); err != nil {
+		return nil, err
+	}
+	return bundle, nil
+}
+
+// GenerateKey 生成随机 hex 编码的 key，length 为字节数（<=0 则默认 32）。
+func (s *ConfigBundleService) GenerateKey(ctx context.Context, bundleName, keyName string, length int) (*domain.ConfigBundle, error) {
+	bundle, err := s.bundleRepo.FindByName(ctx, bundleName)
+	if err != nil {
+		return nil, err
+	}
+
+	if length <= 0 {
+		length = 32
+	}
+
+	buf := make([]byte, length)
+	if _, err := rand.Read(buf); err != nil {
+		return nil, err
+	}
+	value := hex.EncodeToString(buf)
+
+	if bundle.Keys == nil {
+		bundle.Keys = make(map[string]string)
+	}
+	bundle.Keys[keyName] = value
+
+	bundle.UpdatedAt = time.Now()
+	if err := s.bundleRepo.Update(ctx, bundle); err != nil {
+		return nil, err
+	}
+	return bundle, nil
+}
+
+// SetLaneOverrides 合并更新某个泳道的覆盖值（MergeEnvs 语义）。
+func (s *ConfigBundleService) SetLaneOverrides(ctx context.Context, bundleName, lane string, body []byte) (*domain.ConfigBundle, error) {
+	bundle, err := s.bundleRepo.FindByName(ctx, bundleName)
+	if err != nil {
+		return nil, err
+	}
+
+	if bundle.LaneOverrides == nil {
+		bundle.LaneOverrides = make(map[string]map[string]string)
+	}
+
+	existing := bundle.LaneOverrides[lane]
+	merged, err := MergeEnvs(existing, body)
+	if err != nil {
+		return nil, domain.ErrInvalidInput
+	}
+	bundle.LaneOverrides[lane] = merged
+
+	bundle.UpdatedAt = time.Now()
+	if err := s.bundleRepo.Update(ctx, bundle); err != nil {
+		return nil, err
+	}
+	return bundle, nil
+}
+
+// DeleteLaneOverrides 删除某个泳道的全部覆盖值。
+func (s *ConfigBundleService) DeleteLaneOverrides(ctx context.Context, bundleName, lane string) (*domain.ConfigBundle, error) {
+	bundle, err := s.bundleRepo.FindByName(ctx, bundleName)
+	if err != nil {
+		return nil, err
+	}
+
+	delete(bundle.LaneOverrides, lane)
+
+	bundle.UpdatedAt = time.Now()
+	if err := s.bundleRepo.Update(ctx, bundle); err != nil {
+		return nil, err
+	}
+	return bundle, nil
+}
+
+// DeleteLaneOverrideKey 删除某个泳道覆盖中的单个 key。
+func (s *ConfigBundleService) DeleteLaneOverrideKey(ctx context.Context, bundleName, lane, keyName string) (*domain.ConfigBundle, error) {
+	bundle, err := s.bundleRepo.FindByName(ctx, bundleName)
+	if err != nil {
+		return nil, err
+	}
+
+	if overrides, ok := bundle.LaneOverrides[lane]; ok {
+		delete(overrides, keyName)
+		if len(overrides) == 0 {
+			delete(bundle.LaneOverrides, lane)
+		}
+	}
+
+	bundle.UpdatedAt = time.Now()
+	if err := s.bundleRepo.Update(ctx, bundle); err != nil {
+		return nil, err
+	}
+	return bundle, nil
+}
+
+// ResolveConfig 解析 App 在指定泳道的完整配置，按层次合并并标注来源。
+// 优先级（低→高）：bundle baseline → bundle lane override → app.Envs → release.Envs → auto-injected
+func (s *ConfigBundleService) ResolveConfig(ctx context.Context, appName, lane string) (map[string]ResolvedConfigEntry, error) {
+	app, err := s.appRepo.FindByName(ctx, appName)
+	if err != nil {
+		return nil, err
+	}
+
+	result := make(map[string]ResolvedConfigEntry)
+
+	// 1. Bundle baseline + lane override
+	if len(app.ConfigBundles) > 0 {
+		bundles, err := s.bundleRepo.FindByNames(ctx, app.ConfigBundles)
+		if err != nil {
+			return nil, err
+		}
+		for _, bundle := range bundles {
+			// baseline
+			for k, v := range bundle.Keys {
+				result[k] = ResolvedConfigEntry{Value: v, Source: bundle.Name}
+			}
+			// lane override
+			if overrides, ok := bundle.LaneOverrides[lane]; ok {
+				for k, v := range overrides {
+					result[k] = ResolvedConfigEntry{Value: v, Source: bundle.Name + "[lane:" + lane + "]"}
+				}
+			}
+		}
+	}
+
+	// 2. App.Envs
+	for k, v := range app.Envs {
+		result[k] = ResolvedConfigEntry{Value: v, Source: "app"}
+	}
+
+	// 3. Release.Envs
+	if lane != "" {
+		release, err := s.releaseRepo.FindByAppAndLane(ctx, appName, lane)
+		if err != nil && !errors.Is(err, domain.ErrReleaseNotFound) {
+			return nil, err
+		}
+		if release != nil {
+			for k, v := range release.Envs {
+				result[k] = ResolvedConfigEntry{Value: v, Source: "release"}
+			}
+			// 4. Auto-injected
+			result["LANE"] = ResolvedConfigEntry{Value: lane, Source: "auto"}
+			if release.Version != "" {
+				result["VERSION"] = ResolvedConfigEntry{Value: release.Version, Source: "auto"}
+			}
+		}
+	}
+
+	return result, nil
+}
+
+// ResolveBundleEnvs 仅解析 bundle 层（baseline + lane override），供 deployer 使用。
+// 如果 App 没有 ConfigBundles，返回 nil。
+func (s *ConfigBundleService) ResolveBundleEnvs(ctx context.Context, app *domain.App, lane string) (map[string]string, error) {
+	if len(app.ConfigBundles) == 0 {
+		return nil, nil
+	}
+
+	bundles, err := s.bundleRepo.FindByNames(ctx, app.ConfigBundles)
+	if err != nil {
+		return nil, err
+	}
+
+	result := make(map[string]string)
+	for _, bundle := range bundles {
+		for k, v := range bundle.Keys {
+			result[k] = v
+		}
+		if overrides, ok := bundle.LaneOverrides[lane]; ok {
+			for k, v := range overrides {
+				result[k] = v
+			}
+		}
+	}
+	return result, nil
+}

--- a/apps/paas-engine/internal/service/config_bundle_service_test.go
+++ b/apps/paas-engine/internal/service/config_bundle_service_test.go
@@ -1,0 +1,341 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/chiwei-platform/paas-engine/internal/domain"
+)
+
+// --- stub for ConfigBundleRepository ---
+
+type stubConfigBundleRepo struct {
+	bundles map[string]*domain.ConfigBundle
+}
+
+func newStubConfigBundleRepo() *stubConfigBundleRepo {
+	return &stubConfigBundleRepo{bundles: make(map[string]*domain.ConfigBundle)}
+}
+
+func (r *stubConfigBundleRepo) Save(_ context.Context, bundle *domain.ConfigBundle) error {
+	if _, exists := r.bundles[bundle.Name]; exists {
+		return domain.ErrAlreadyExists
+	}
+	r.bundles[bundle.Name] = bundle
+	return nil
+}
+
+func (r *stubConfigBundleRepo) FindByName(_ context.Context, name string) (*domain.ConfigBundle, error) {
+	b, ok := r.bundles[name]
+	if !ok {
+		return nil, domain.ErrConfigBundleNotFound
+	}
+	return b, nil
+}
+
+func (r *stubConfigBundleRepo) FindAll(_ context.Context) ([]*domain.ConfigBundle, error) {
+	var result []*domain.ConfigBundle
+	for _, b := range r.bundles {
+		result = append(result, b)
+	}
+	return result, nil
+}
+
+func (r *stubConfigBundleRepo) FindByNames(_ context.Context, names []string) ([]*domain.ConfigBundle, error) {
+	var result []*domain.ConfigBundle
+	for _, name := range names {
+		if b, ok := r.bundles[name]; ok {
+			result = append(result, b)
+		}
+	}
+	return result, nil
+}
+
+func (r *stubConfigBundleRepo) Update(_ context.Context, bundle *domain.ConfigBundle) error {
+	r.bundles[bundle.Name] = bundle
+	return nil
+}
+
+func (r *stubConfigBundleRepo) Delete(_ context.Context, name string) error {
+	delete(r.bundles, name)
+	return nil
+}
+
+// allAppsStubRepo 是一个支持 FindAll 返回多个 App 的 stub，用于 bundle delete 测试。
+type allAppsStubRepo struct {
+	apps []*domain.App
+}
+
+func (r *allAppsStubRepo) Save(_ context.Context, _ *domain.App) error   { return nil }
+func (r *allAppsStubRepo) Update(_ context.Context, _ *domain.App) error { return nil }
+func (r *allAppsStubRepo) Delete(_ context.Context, _ string) error      { return nil }
+func (r *allAppsStubRepo) FindAll(_ context.Context) ([]*domain.App, error) {
+	return r.apps, nil
+}
+func (r *allAppsStubRepo) FindByName(_ context.Context, name string) (*domain.App, error) {
+	for _, a := range r.apps {
+		if a.Name == name {
+			return a, nil
+		}
+	}
+	return nil, domain.ErrAppNotFound
+}
+
+// --- helpers ---
+
+func newConfigBundleService(bundleRepo *stubConfigBundleRepo, appRepo *stubAppRepo, releaseRepo *releaseTestReleaseRepo) *ConfigBundleService {
+	return NewConfigBundleService(bundleRepo, appRepo, releaseRepo)
+}
+
+// --- tests ---
+
+func TestCreateConfigBundle_Success(t *testing.T) {
+	bundleRepo := newStubConfigBundleRepo()
+	svc := NewConfigBundleService(bundleRepo, &stubAppRepo{}, newReleaseTestReleaseRepo())
+
+	bundle, err := svc.CreateBundle(context.Background(), CreateBundleRequest{
+		Name:        "pg-main",
+		Description: "Main PG config",
+		Keys:        map[string]string{"PG_HOST": "localhost", "PG_PORT": "5432"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if bundle.Name != "pg-main" {
+		t.Errorf("Name = %q, want %q", bundle.Name, "pg-main")
+	}
+	if bundle.Keys["PG_HOST"] != "localhost" {
+		t.Errorf("PG_HOST = %q, want %q", bundle.Keys["PG_HOST"], "localhost")
+	}
+	if bundle.Keys["PG_PORT"] != "5432" {
+		t.Errorf("PG_PORT = %q, want %q", bundle.Keys["PG_PORT"], "5432")
+	}
+}
+
+func TestCreateConfigBundle_InvalidName(t *testing.T) {
+	bundleRepo := newStubConfigBundleRepo()
+	svc := NewConfigBundleService(bundleRepo, &stubAppRepo{}, newReleaseTestReleaseRepo())
+
+	_, err := svc.CreateBundle(context.Background(), CreateBundleRequest{
+		Name: "INVALID_NAME",
+	})
+	if !errors.Is(err, domain.ErrInvalidInput) {
+		t.Errorf("expected ErrInvalidInput, got %v", err)
+	}
+}
+
+func TestCreateConfigBundle_Duplicate(t *testing.T) {
+	bundleRepo := newStubConfigBundleRepo()
+	svc := NewConfigBundleService(bundleRepo, &stubAppRepo{}, newReleaseTestReleaseRepo())
+
+	_, err := svc.CreateBundle(context.Background(), CreateBundleRequest{Name: "pg-main"})
+	if err != nil {
+		t.Fatalf("first create failed: %v", err)
+	}
+
+	_, err = svc.CreateBundle(context.Background(), CreateBundleRequest{Name: "pg-main"})
+	if !errors.Is(err, domain.ErrAlreadyExists) {
+		t.Errorf("expected ErrAlreadyExists, got %v", err)
+	}
+}
+
+func TestDeleteConfigBundle_ReferencedByApp(t *testing.T) {
+	bundleRepo := newStubConfigBundleRepo()
+	// Create the bundle first
+	if err := bundleRepo.Save(context.Background(), &domain.ConfigBundle{Name: "pg-main"}); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+
+	// App that references pg-main — use allAppsStubRepo so FindAll returns the app
+	appRepo := &allAppsStubRepo{apps: []*domain.App{
+		{Name: "my-app", ConfigBundles: []string{"pg-main"}},
+	}}
+
+	svc := NewConfigBundleService(bundleRepo, appRepo, newReleaseTestReleaseRepo())
+
+	if err := svc.DeleteBundle(context.Background(), "pg-main"); !errors.Is(err, domain.ErrCannotDelete) {
+		t.Errorf("expected ErrCannotDelete, got %v", err)
+	}
+}
+
+func TestSetKeys_MergesWithExisting(t *testing.T) {
+	bundleRepo := newStubConfigBundleRepo()
+	bundleRepo.bundles["pg-main"] = &domain.ConfigBundle{
+		Name: "pg-main",
+		Keys: map[string]string{"PG_HOST": "localhost"},
+	}
+	svc := NewConfigBundleService(bundleRepo, &stubAppRepo{}, newReleaseTestReleaseRepo())
+
+	bundle, err := svc.SetKeys(context.Background(), "pg-main", []byte(`{"PG_PORT":"5432"}`))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if bundle.Keys["PG_HOST"] != "localhost" {
+		t.Errorf("PG_HOST should be preserved, got %q", bundle.Keys["PG_HOST"])
+	}
+	if bundle.Keys["PG_PORT"] != "5432" {
+		t.Errorf("PG_PORT = %q, want %q", bundle.Keys["PG_PORT"], "5432")
+	}
+}
+
+func TestSetKeys_DeleteKeyWithNull(t *testing.T) {
+	bundleRepo := newStubConfigBundleRepo()
+	bundleRepo.bundles["pg-main"] = &domain.ConfigBundle{
+		Name: "pg-main",
+		Keys: map[string]string{"PG_HOST": "localhost", "PG_PORT": "5432"},
+	}
+	svc := NewConfigBundleService(bundleRepo, &stubAppRepo{}, newReleaseTestReleaseRepo())
+
+	bundle, err := svc.SetKeys(context.Background(), "pg-main", []byte(`{"PG_PORT":null}`))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, ok := bundle.Keys["PG_PORT"]; ok {
+		t.Error("PG_PORT should be deleted")
+	}
+	if bundle.Keys["PG_HOST"] != "localhost" {
+		t.Errorf("PG_HOST should be preserved, got %q", bundle.Keys["PG_HOST"])
+	}
+}
+
+func TestDeleteKey_AlsoRemovesFromLaneOverrides(t *testing.T) {
+	bundleRepo := newStubConfigBundleRepo()
+	bundleRepo.bundles["pg-main"] = &domain.ConfigBundle{
+		Name: "pg-main",
+		Keys: map[string]string{"PG_HOST": "localhost", "PG_PORT": "5432"},
+		LaneOverrides: map[string]map[string]string{
+			"dev": {"PG_PORT": "5433", "PG_HOST": "dev-db"},
+		},
+	}
+	svc := NewConfigBundleService(bundleRepo, &stubAppRepo{}, newReleaseTestReleaseRepo())
+
+	bundle, err := svc.DeleteKey(context.Background(), "pg-main", "PG_PORT")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, ok := bundle.Keys["PG_PORT"]; ok {
+		t.Error("PG_PORT should be deleted from Keys")
+	}
+	if devOverrides, ok := bundle.LaneOverrides["dev"]; ok {
+		if _, ok := devOverrides["PG_PORT"]; ok {
+			t.Error("PG_PORT should be deleted from dev lane override")
+		}
+	}
+	// PG_HOST in override should remain
+	if bundle.LaneOverrides["dev"]["PG_HOST"] != "dev-db" {
+		t.Errorf("PG_HOST override should remain, got %q", bundle.LaneOverrides["dev"]["PG_HOST"])
+	}
+}
+
+func TestSetLaneOverrides_Success(t *testing.T) {
+	bundleRepo := newStubConfigBundleRepo()
+	bundleRepo.bundles["pg-main"] = &domain.ConfigBundle{
+		Name: "pg-main",
+		Keys: map[string]string{"PG_HOST": "localhost"},
+	}
+	svc := NewConfigBundleService(bundleRepo, &stubAppRepo{}, newReleaseTestReleaseRepo())
+
+	bundle, err := svc.SetLaneOverrides(context.Background(), "pg-main", "dev", []byte(`{"PG_HOST":"dev-db"}`))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if bundle.LaneOverrides["dev"]["PG_HOST"] != "dev-db" {
+		t.Errorf("dev override PG_HOST = %q, want %q", bundle.LaneOverrides["dev"]["PG_HOST"], "dev-db")
+	}
+}
+
+func TestGenerateKey_CreatesRandomValue(t *testing.T) {
+	bundleRepo := newStubConfigBundleRepo()
+	bundleRepo.bundles["pg-main"] = &domain.ConfigBundle{
+		Name: "pg-main",
+		Keys: map[string]string{},
+	}
+	svc := NewConfigBundleService(bundleRepo, &stubAppRepo{}, newReleaseTestReleaseRepo())
+
+	bundle, err := svc.GenerateKey(context.Background(), "pg-main", "SECRET_KEY", 32)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	val, ok := bundle.Keys["SECRET_KEY"]
+	if !ok {
+		t.Fatal("SECRET_KEY should exist in Keys")
+	}
+	// 32 bytes hex encoded = 64 chars
+	if len(val) != 64 {
+		t.Errorf("generated key length = %d, want 64 (hex of 32 bytes)", len(val))
+	}
+}
+
+func TestResolveConfig_FullMerge(t *testing.T) {
+	bundleRepo := newStubConfigBundleRepo()
+	bundleRepo.bundles["pg-main"] = &domain.ConfigBundle{
+		Name: "pg-main",
+		Keys: map[string]string{
+			"PG_HOST": "prod-db",
+			"PG_PORT": "5432",
+		},
+		LaneOverrides: map[string]map[string]string{
+			"dev": {"PG_HOST": "dev-db"},
+		},
+	}
+
+	// stubAppRepo returns a single app when FindByName is called,
+	// but FindAll returns nil — good enough for resolve (no ReferencedBy needed here)
+	appRepo := &stubAppRepo{
+		app: &domain.App{
+			Name:          "my-app",
+			ConfigBundles: []string{"pg-main"},
+			Envs:          map[string]string{"APP_ENV": "dev", "PG_PORT": "5999"}, // overrides bundle
+		},
+	}
+
+	releaseRepo := newReleaseTestReleaseRepo()
+	_ = releaseRepo.Save(context.Background(), &domain.Release{
+		ID:      "r1",
+		AppName: "my-app",
+		Lane:    "dev",
+		Envs:    map[string]string{"EXTRA": "from-release"},
+		Version: "1.0.0",
+	})
+
+	svc := NewConfigBundleService(bundleRepo, appRepo, releaseRepo)
+
+	result, err := svc.ResolveConfig(context.Background(), "my-app", "dev")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Bundle baseline: PG_HOST=prod-db, PG_PORT=5432
+	// Bundle dev override: PG_HOST=dev-db  → overrides baseline
+	// App envs: APP_ENV=dev, PG_PORT=5999  → overrides bundle
+	// Release envs: EXTRA=from-release
+	// Auto: LANE=dev, VERSION=1.0.0
+
+	cases := []struct {
+		key    string
+		value  string
+		source string
+	}{
+		{"PG_HOST", "dev-db", "pg-main[lane:dev]"},
+		{"PG_PORT", "5999", "app"},
+		{"APP_ENV", "dev", "app"},
+		{"EXTRA", "from-release", "release"},
+		{"LANE", "dev", "auto"},
+		{"VERSION", "1.0.0", "auto"},
+	}
+
+	for _, c := range cases {
+		entry, ok := result[c.key]
+		if !ok {
+			t.Errorf("key %q not found in result", c.key)
+			continue
+		}
+		if entry.Value != c.value {
+			t.Errorf("result[%q].Value = %q, want %q", c.key, entry.Value, c.value)
+		}
+		if entry.Source != c.source {
+			t.Errorf("result[%q].Source = %q, want %q", c.key, entry.Source, c.source)
+		}
+	}
+}

--- a/apps/paas-engine/internal/service/release_service.go
+++ b/apps/paas-engine/internal/service/release_service.go
@@ -14,11 +14,12 @@ import (
 )
 
 type ReleaseService struct {
-	appRepo       port.AppRepository
-	imageRepoRepo port.ImageRepoRepository
-	buildRepo     port.BuildRepository
-	releaseRepo   port.ReleaseRepository
-	deployer      port.Deployer
+	appRepo         port.AppRepository
+	imageRepoRepo   port.ImageRepoRepository
+	buildRepo       port.BuildRepository
+	releaseRepo     port.ReleaseRepository
+	deployer        port.Deployer
+	configBundleSvc *ConfigBundleService
 }
 
 func NewReleaseService(
@@ -27,13 +28,15 @@ func NewReleaseService(
 	buildRepo port.BuildRepository,
 	releaseRepo port.ReleaseRepository,
 	deployer port.Deployer,
+	configBundleSvc *ConfigBundleService,
 ) *ReleaseService {
 	return &ReleaseService{
-		appRepo:       appRepo,
-		imageRepoRepo: imageRepoRepo,
-		buildRepo:     buildRepo,
-		releaseRepo:   releaseRepo,
-		deployer:      deployer,
+		appRepo:         appRepo,
+		imageRepoRepo:   imageRepoRepo,
+		buildRepo:       buildRepo,
+		releaseRepo:     releaseRepo,
+		deployer:        deployer,
+		configBundleSvc: configBundleSvc,
 	}
 }
 
@@ -123,9 +126,18 @@ func (s *ReleaseService) CreateOrUpdateRelease(ctx context.Context, req CreateRe
 	}
 	release.DeployName = release.ResourceName()
 
+	// Resolve bundle envs
+	var bundleEnvs map[string]string
+	if s.configBundleSvc != nil && len(app.ConfigBundles) > 0 {
+		bundleEnvs, err = s.configBundleSvc.ResolveBundleEnvs(ctx, app, lane)
+		if err != nil {
+			return nil, fmt.Errorf("resolve config bundles: %w", err)
+		}
+	}
+
 	// 下发 K8s 资源
 	if s.deployer != nil {
-		if err := s.deployer.Deploy(ctx, release, app); err != nil {
+		if err := s.deployer.Deploy(ctx, release, app, bundleEnvs); err != nil {
 			release.Status = domain.ReleaseStatusFailed
 			release.Message = err.Error()
 		} else {
@@ -225,8 +237,16 @@ func (s *ReleaseService) UpdateRelease(ctx context.Context, id string, body []by
 	release.UpdatedAt = time.Now()
 	release.DeployName = release.ResourceName()
 
+	var bundleEnvs map[string]string
+	if s.configBundleSvc != nil && len(app.ConfigBundles) > 0 {
+		bundleEnvs, err = s.configBundleSvc.ResolveBundleEnvs(ctx, app, release.Lane)
+		if err != nil {
+			return nil, fmt.Errorf("resolve config bundles: %w", err)
+		}
+	}
+
 	if s.deployer != nil {
-		if err := s.deployer.Deploy(ctx, release, app); err != nil {
+		if err := s.deployer.Deploy(ctx, release, app, bundleEnvs); err != nil {
 			release.Status = domain.ReleaseStatusFailed
 			release.Message = err.Error()
 		} else {

--- a/apps/paas-engine/internal/service/release_service_test.go
+++ b/apps/paas-engine/internal/service/release_service_test.go
@@ -58,7 +58,7 @@ type stubDeployer struct {
 	status    *domain.DeploymentStatus
 }
 
-func (s *stubDeployer) Deploy(_ context.Context, _ *domain.Release, _ *domain.App) error {
+func (s *stubDeployer) Deploy(_ context.Context, _ *domain.Release, _ *domain.App, _ map[string]string) error {
 	return s.deployErr
 }
 func (s *stubDeployer) Delete(_ context.Context, _ *domain.Release, _ bool) error { return nil }
@@ -90,7 +90,7 @@ func TestCreateRelease_DeployFailure_SetsMessage(t *testing.T) {
 		deployErr: errors.New("wait for rollout: deployment myapp-prod failed: pod myapp-prod-abc is in CrashLoopBackOff: exit code 1"),
 	}
 
-	svc := NewReleaseService(appRepo, imageRepoRepo, &stubBuildRepo{}, releaseRepo, deployer)
+	svc := NewReleaseService(appRepo, imageRepoRepo, &stubBuildRepo{}, releaseRepo, deployer, nil)
 
 	release, err := svc.CreateOrUpdateRelease(context.Background(), CreateReleaseRequest{
 		AppName:  "myapp",
@@ -125,7 +125,7 @@ func TestCreateRelease_DeploySuccess_ClearsMessage(t *testing.T) {
 	releaseRepo := newReleaseTestReleaseRepo()
 	deployer := &stubDeployer{}
 
-	svc := NewReleaseService(appRepo, imageRepoRepo, &stubBuildRepo{}, releaseRepo, deployer)
+	svc := NewReleaseService(appRepo, imageRepoRepo, &stubBuildRepo{}, releaseRepo, deployer, nil)
 
 	release, err := svc.CreateOrUpdateRelease(context.Background(), CreateReleaseRequest{
 		AppName:  "myapp",
@@ -158,7 +158,7 @@ func TestGetReleaseStatus(t *testing.T) {
 	}
 	deployer := &stubDeployer{status: expectedStatus}
 
-	svc := NewReleaseService(appRepo, nil, nil, releaseRepo, deployer)
+	svc := NewReleaseService(appRepo, nil, nil, releaseRepo, deployer, nil)
 
 	// 先存一个 release
 	rel := &domain.Release{ID: "r1", AppName: "myapp", Lane: "prod", DeployName: "myapp-prod"}
@@ -179,7 +179,7 @@ func TestGetReleaseStatus(t *testing.T) {
 func TestGetReleaseStatus_NotFound(t *testing.T) {
 	releaseRepo := newReleaseTestReleaseRepo()
 	deployer := &stubDeployer{}
-	svc := NewReleaseService(nil, nil, nil, releaseRepo, deployer)
+	svc := NewReleaseService(nil, nil, nil, releaseRepo, deployer, nil)
 
 	_, err := svc.GetReleaseStatus(context.Background(), "nonexistent")
 	if !errors.Is(err, domain.ErrReleaseNotFound) {

--- a/docs/superpowers/plans/2026-03-30-unified-config-system.md
+++ b/docs/superpowers/plans/2026-03-30-unified-config-system.md
@@ -1,0 +1,1837 @@
+# Unified Config System (ConfigBundle) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add ConfigBundle to PaaS Engine — a unified config management system that replaces fragmented env vars + K8s Secret/ConfigMap with grouped, lane-overridable, API-managed configuration bundles.
+
+**Architecture:** New domain aggregate `ConfigBundle` with CRUD API, integrated into deploy flow via K8s Secret generation. App references bundles by name, deployer resolves bundle→lane override→app.Envs→release.Envs and writes a single auto-managed K8s Secret per app-lane. Existing env/secret fields preserved for backward compatibility during migration.
+
+**Tech Stack:** Go, chi router, GORM/PostgreSQL, K8s client-go
+
+---
+
+## File Map
+
+| Action | File | Responsibility |
+|--------|------|---------------|
+| Create | `internal/domain/config_bundle.go` | ConfigBundle + ConfigKey domain types |
+| Modify | `internal/domain/errors.go` | Add ErrConfigBundleNotFound |
+| Modify | `internal/port/repository.go` | Add ConfigBundleRepository interface |
+| Create | `internal/adapter/repository/config_bundle_repo.go` | GORM implementation |
+| Modify | `internal/adapter/repository/model.go` | Add ConfigBundleModel |
+| Modify | `internal/adapter/repository/db.go` | AutoMigrate new model |
+| Create | `internal/service/config_bundle_service.go` | CRUD, keys, lane overrides, generate, resolve |
+| Create | `internal/service/config_bundle_service_test.go` | Tests with stub repos |
+| Modify | `internal/domain/app.go` | Add ConfigBundles field |
+| Modify | `internal/adapter/repository/app_repo.go` | Handle ConfigBundles serialization |
+| Modify | `internal/service/app_service.go` | Conflict detection on bundle binding |
+| Modify | `internal/service/app_service_test.go` | Tests for conflict detection |
+| Create | `internal/adapter/http/config_bundle_handler.go` | HTTP handlers for ConfigBundle API |
+| Modify | `internal/adapter/http/router.go` | Add /config-bundles routes + /resolved-config |
+| Modify | `internal/port/kubernetes.go` | Add bundleEnvs param to Deployer.Deploy |
+| Modify | `internal/adapter/kubernetes/deployer.go` | K8s Secret creation + envFrom injection |
+| Modify | `internal/adapter/kubernetes/deployer_test.go` | Update tests |
+| Modify | `internal/service/release_service.go` | Resolve bundle envs before deploy |
+| Modify | `internal/service/release_service_test.go` | Update stub deployer + add tests |
+| Modify | `internal/config/config.go` | (No change needed for v1) |
+| Modify | `cmd/paas-engine/main.go` | Wire ConfigBundleRepo + Service + Handler |
+
+---
+
+### Task 1: Domain Model + Port Interface
+
+**Files:**
+- Create: `internal/domain/config_bundle.go`
+- Modify: `internal/domain/errors.go`
+- Modify: `internal/port/repository.go`
+
+- [ ] **Step 1: Create ConfigBundle domain type**
+
+```go
+// internal/domain/config_bundle.go
+package domain
+
+import "time"
+
+// ConfigBundle 表示一组按基础设施实例分组的配置项。
+// 每个 key 是最终注入容器的环境变量名（如 PG_MAIN_HOST）。
+type ConfigBundle struct {
+	Name          string                       `json:"name"`
+	Description   string                       `json:"description,omitempty"`
+	Keys          map[string]string            `json:"keys,omitempty"`            // env var name → value
+	LaneOverrides map[string]map[string]string `json:"lane_overrides,omitempty"`  // lane → {key: value}
+	ReferencedBy  []string                     `json:"referenced_by,omitempty"`   // app names (populated on read)
+	CreatedAt     time.Time                    `json:"created_at"`
+	UpdatedAt     time.Time                    `json:"updated_at"`
+}
+```
+
+- [ ] **Step 2: Add error sentinel**
+
+In `internal/domain/errors.go`, add after `ErrImageRepoNotFound`:
+
+```go
+ErrConfigBundleNotFound = fmt.Errorf("config bundle %w", ErrNotFound)
+```
+
+- [ ] **Step 3: Add ConfigBundleRepository interface**
+
+In `internal/port/repository.go`, add:
+
+```go
+type ConfigBundleRepository interface {
+	Save(ctx context.Context, bundle *domain.ConfigBundle) error
+	FindByName(ctx context.Context, name string) (*domain.ConfigBundle, error)
+	FindAll(ctx context.Context) ([]*domain.ConfigBundle, error)
+	FindByNames(ctx context.Context, names []string) ([]*domain.ConfigBundle, error)
+	Update(ctx context.Context, bundle *domain.ConfigBundle) error
+	Delete(ctx context.Context, name string) error
+}
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd apps/paas-engine
+git add internal/domain/config_bundle.go internal/domain/errors.go internal/port/repository.go
+git commit -m "feat(config): add ConfigBundle domain model and repository port"
+```
+
+---
+
+### Task 2: Repository Layer (DB Model + GORM Repo + Migration)
+
+**Files:**
+- Modify: `internal/adapter/repository/model.go`
+- Create: `internal/adapter/repository/config_bundle_repo.go`
+- Modify: `internal/adapter/repository/db.go`
+
+- [ ] **Step 1: Add ConfigBundleModel to model.go**
+
+In `internal/adapter/repository/model.go`, add after `JobRunModel`:
+
+```go
+// ConfigBundleModel 是 ConfigBundle 的数据库持久化模型。
+type ConfigBundleModel struct {
+	Name          string `gorm:"primaryKey"`
+	Description   string
+	Keys          string // JSON 序列化的 map[string]string
+	LaneOverrides string // JSON 序列化的 map[string]map[string]string
+	CreatedAt     time.Time
+	UpdatedAt     time.Time
+}
+
+func (ConfigBundleModel) TableName() string { return "config_bundles" }
+```
+
+- [ ] **Step 2: Create config_bundle_repo.go**
+
+```go
+// internal/adapter/repository/config_bundle_repo.go
+package repository
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+
+	"github.com/chiwei-platform/paas-engine/internal/domain"
+	"github.com/chiwei-platform/paas-engine/internal/port"
+	"gorm.io/gorm"
+)
+
+var _ port.ConfigBundleRepository = (*ConfigBundleRepo)(nil)
+
+type ConfigBundleRepo struct {
+	db *gorm.DB
+}
+
+func NewConfigBundleRepo(db *gorm.DB) *ConfigBundleRepo {
+	return &ConfigBundleRepo{db: db}
+}
+
+func (r *ConfigBundleRepo) Save(ctx context.Context, bundle *domain.ConfigBundle) error {
+	m, err := bundleToModel(bundle)
+	if err != nil {
+		return err
+	}
+	result := r.db.WithContext(ctx).Create(m)
+	if result.Error != nil {
+		if isUniqueConstraintError(result.Error) {
+			return domain.ErrAlreadyExists
+		}
+		return result.Error
+	}
+	return nil
+}
+
+func (r *ConfigBundleRepo) FindByName(ctx context.Context, name string) (*domain.ConfigBundle, error) {
+	var m ConfigBundleModel
+	result := r.db.WithContext(ctx).First(&m, "name = ?", name)
+	if result.Error != nil {
+		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
+			return nil, domain.ErrConfigBundleNotFound
+		}
+		return nil, result.Error
+	}
+	return modelToBundle(&m)
+}
+
+func (r *ConfigBundleRepo) FindAll(ctx context.Context) ([]*domain.ConfigBundle, error) {
+	var models []ConfigBundleModel
+	if err := r.db.WithContext(ctx).Find(&models).Error; err != nil {
+		return nil, err
+	}
+	bundles := make([]*domain.ConfigBundle, 0, len(models))
+	for i := range models {
+		b, err := modelToBundle(&models[i])
+		if err != nil {
+			return nil, err
+		}
+		bundles = append(bundles, b)
+	}
+	return bundles, nil
+}
+
+func (r *ConfigBundleRepo) FindByNames(ctx context.Context, names []string) ([]*domain.ConfigBundle, error) {
+	if len(names) == 0 {
+		return nil, nil
+	}
+	var models []ConfigBundleModel
+	if err := r.db.WithContext(ctx).Where("name IN ?", names).Find(&models).Error; err != nil {
+		return nil, err
+	}
+	bundles := make([]*domain.ConfigBundle, 0, len(models))
+	for i := range models {
+		b, err := modelToBundle(&models[i])
+		if err != nil {
+			return nil, err
+		}
+		bundles = append(bundles, b)
+	}
+	return bundles, nil
+}
+
+func (r *ConfigBundleRepo) Update(ctx context.Context, bundle *domain.ConfigBundle) error {
+	m, err := bundleToModel(bundle)
+	if err != nil {
+		return err
+	}
+	return r.db.WithContext(ctx).Save(m).Error
+}
+
+func (r *ConfigBundleRepo) Delete(ctx context.Context, name string) error {
+	return r.db.WithContext(ctx).Delete(&ConfigBundleModel{}, "name = ?", name).Error
+}
+
+func bundleToModel(b *domain.ConfigBundle) (*ConfigBundleModel, error) {
+	keysJSON, err := json.Marshal(b.Keys)
+	if err != nil {
+		return nil, err
+	}
+	laneOverridesJSON, err := json.Marshal(b.LaneOverrides)
+	if err != nil {
+		return nil, err
+	}
+	return &ConfigBundleModel{
+		Name:          b.Name,
+		Description:   b.Description,
+		Keys:          string(keysJSON),
+		LaneOverrides: string(laneOverridesJSON),
+		CreatedAt:     b.CreatedAt,
+		UpdatedAt:     b.UpdatedAt,
+	}, nil
+}
+
+func modelToBundle(m *ConfigBundleModel) (*domain.ConfigBundle, error) {
+	var keys map[string]string
+	if m.Keys != "" {
+		if err := json.Unmarshal([]byte(m.Keys), &keys); err != nil {
+			return nil, err
+		}
+	}
+	var laneOverrides map[string]map[string]string
+	if m.LaneOverrides != "" {
+		if err := json.Unmarshal([]byte(m.LaneOverrides), &laneOverrides); err != nil {
+			return nil, err
+		}
+	}
+	return &domain.ConfigBundle{
+		Name:          m.Name,
+		Description:   m.Description,
+		Keys:          keys,
+		LaneOverrides: laneOverrides,
+		CreatedAt:     m.CreatedAt,
+		UpdatedAt:     m.UpdatedAt,
+	}, nil
+}
+```
+
+- [ ] **Step 3: Add ConfigBundleModel to AutoMigrate in db.go**
+
+In `internal/adapter/repository/db.go`, add `&ConfigBundleModel{}` to the AutoMigrate call:
+
+```go
+if err := db.AutoMigrate(
+	&AppModel{},
+	&ImageRepoModel{},
+	&BuildModel{},
+	&ReleaseModel{},
+	&CIConfigModel{},
+	&PipelineRunModel{},
+	&StageRunModel{},
+	&JobRunModel{},
+	&ConfigBundleModel{},
+); err != nil {
+```
+
+- [ ] **Step 4: Run build to verify compilation**
+
+```bash
+cd apps/paas-engine && go build ./...
+```
+
+Expected: BUILD SUCCESS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/adapter/repository/config_bundle_repo.go internal/adapter/repository/model.go internal/adapter/repository/db.go
+git commit -m "feat(config): add ConfigBundle repository with GORM persistence"
+```
+
+---
+
+### Task 3: ConfigBundle Service — CRUD (TDD)
+
+**Files:**
+- Create: `internal/service/config_bundle_service.go`
+- Create: `internal/service/config_bundle_service_test.go`
+
+- [ ] **Step 1: Write stub repo for tests**
+
+Create `internal/service/config_bundle_service_test.go`:
+
+```go
+package service
+
+import (
+	"context"
+	"testing"
+
+	"github.com/chiwei-platform/paas-engine/internal/domain"
+)
+
+// --- stub ConfigBundle repo ---
+
+type stubConfigBundleRepo struct {
+	bundles map[string]*domain.ConfigBundle
+}
+
+func newStubConfigBundleRepo() *stubConfigBundleRepo {
+	return &stubConfigBundleRepo{bundles: make(map[string]*domain.ConfigBundle)}
+}
+
+func (r *stubConfigBundleRepo) Save(_ context.Context, b *domain.ConfigBundle) error {
+	if _, exists := r.bundles[b.Name]; exists {
+		return domain.ErrAlreadyExists
+	}
+	r.bundles[b.Name] = b
+	return nil
+}
+
+func (r *stubConfigBundleRepo) FindByName(_ context.Context, name string) (*domain.ConfigBundle, error) {
+	if b, ok := r.bundles[name]; ok {
+		return b, nil
+	}
+	return nil, domain.ErrConfigBundleNotFound
+}
+
+func (r *stubConfigBundleRepo) FindAll(_ context.Context) ([]*domain.ConfigBundle, error) {
+	result := make([]*domain.ConfigBundle, 0, len(r.bundles))
+	for _, b := range r.bundles {
+		result = append(result, b)
+	}
+	return result, nil
+}
+
+func (r *stubConfigBundleRepo) FindByNames(_ context.Context, names []string) ([]*domain.ConfigBundle, error) {
+	result := make([]*domain.ConfigBundle, 0)
+	for _, name := range names {
+		if b, ok := r.bundles[name]; ok {
+			result = append(result, b)
+		}
+	}
+	return result, nil
+}
+
+func (r *stubConfigBundleRepo) Update(_ context.Context, b *domain.ConfigBundle) error {
+	r.bundles[b.Name] = b
+	return nil
+}
+
+func (r *stubConfigBundleRepo) Delete(_ context.Context, name string) error {
+	delete(r.bundles, name)
+	return nil
+}
+
+// --- CRUD tests ---
+
+func TestCreateConfigBundle_Success(t *testing.T) {
+	repo := newStubConfigBundleRepo()
+	appRepo := &stubAppRepo{}
+	svc := NewConfigBundleService(repo, appRepo, &stubReleaseRepo{})
+
+	bundle, err := svc.CreateBundle(context.Background(), CreateBundleRequest{
+		Name:        "pg-main",
+		Description: "主 PostgreSQL",
+		Keys:        map[string]string{"PG_MAIN_HOST": "postgres", "PG_MAIN_PORT": "5432"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if bundle.Name != "pg-main" {
+		t.Errorf("Name = %q, want %q", bundle.Name, "pg-main")
+	}
+	if bundle.Keys["PG_MAIN_HOST"] != "postgres" {
+		t.Errorf("Keys[PG_MAIN_HOST] = %q, want %q", bundle.Keys["PG_MAIN_HOST"], "postgres")
+	}
+}
+
+func TestCreateConfigBundle_InvalidName(t *testing.T) {
+	repo := newStubConfigBundleRepo()
+	svc := NewConfigBundleService(repo, &stubAppRepo{}, &stubReleaseRepo{})
+
+	_, err := svc.CreateBundle(context.Background(), CreateBundleRequest{
+		Name: "INVALID_NAME",
+	})
+	if err == nil {
+		t.Error("expected error for invalid name")
+	}
+}
+
+func TestCreateConfigBundle_Duplicate(t *testing.T) {
+	repo := newStubConfigBundleRepo()
+	svc := NewConfigBundleService(repo, &stubAppRepo{}, &stubReleaseRepo{})
+
+	_, _ = svc.CreateBundle(context.Background(), CreateBundleRequest{Name: "pg-main"})
+	_, err := svc.CreateBundle(context.Background(), CreateBundleRequest{Name: "pg-main"})
+	if err == nil {
+		t.Error("expected error for duplicate")
+	}
+}
+
+func TestDeleteConfigBundle_ReferencedByApp(t *testing.T) {
+	repo := newStubConfigBundleRepo()
+	repo.bundles["pg-main"] = &domain.ConfigBundle{Name: "pg-main"}
+	appRepo := &stubAppRepo{apps: []*domain.App{
+		{Name: "myapp", ConfigBundles: []string{"pg-main"}},
+	}}
+	svc := NewConfigBundleService(repo, appRepo, &stubReleaseRepo{})
+
+	err := svc.DeleteBundle(context.Background(), "pg-main")
+	if err == nil {
+		t.Error("expected error when bundle is referenced by app")
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+cd apps/paas-engine && go test ./internal/service/ -run TestCreate.*ConfigBundle -v 2>&1 | head -20
+```
+
+Expected: FAIL (NewConfigBundleService not defined)
+
+- [ ] **Step 3: Implement ConfigBundle service CRUD**
+
+Create `internal/service/config_bundle_service.go`:
+
+```go
+package service
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/chiwei-platform/paas-engine/internal/domain"
+	"github.com/chiwei-platform/paas-engine/internal/port"
+)
+
+type ConfigBundleService struct {
+	bundleRepo  port.ConfigBundleRepository
+	appRepo     port.AppRepository
+	releaseRepo port.ReleaseRepository
+}
+
+func NewConfigBundleService(
+	bundleRepo port.ConfigBundleRepository,
+	appRepo port.AppRepository,
+	releaseRepo port.ReleaseRepository,
+) *ConfigBundleService {
+	return &ConfigBundleService{
+		bundleRepo:  bundleRepo,
+		appRepo:     appRepo,
+		releaseRepo: releaseRepo,
+	}
+}
+
+type CreateBundleRequest struct {
+	Name        string            `json:"name"`
+	Description string            `json:"description"`
+	Keys        map[string]string `json:"keys"`
+}
+
+func (s *ConfigBundleService) CreateBundle(ctx context.Context, req CreateBundleRequest) (*domain.ConfigBundle, error) {
+	if err := domain.ValidateK8sName(req.Name); err != nil {
+		return nil, err
+	}
+	now := time.Now()
+	bundle := &domain.ConfigBundle{
+		Name:        req.Name,
+		Description: req.Description,
+		Keys:        req.Keys,
+		CreatedAt:   now,
+		UpdatedAt:   now,
+	}
+	if err := s.bundleRepo.Save(ctx, bundle); err != nil {
+		return nil, err
+	}
+	return bundle, nil
+}
+
+func (s *ConfigBundleService) GetBundle(ctx context.Context, name string) (*domain.ConfigBundle, error) {
+	bundle, err := s.bundleRepo.FindByName(ctx, name)
+	if err != nil {
+		return nil, err
+	}
+	// Populate referenced_by
+	apps, err := s.appRepo.FindAll(ctx)
+	if err != nil {
+		return nil, err
+	}
+	for _, app := range apps {
+		for _, bn := range app.ConfigBundles {
+			if bn == name {
+				bundle.ReferencedBy = append(bundle.ReferencedBy, app.Name)
+				break
+			}
+		}
+	}
+	return bundle, nil
+}
+
+func (s *ConfigBundleService) ListBundles(ctx context.Context) ([]*domain.ConfigBundle, error) {
+	return s.bundleRepo.FindAll(ctx)
+}
+
+func (s *ConfigBundleService) UpdateBundle(ctx context.Context, name string, body []byte) (*domain.ConfigBundle, error) {
+	bundle, err := s.bundleRepo.FindByName(ctx, name)
+	if err != nil {
+		return nil, err
+	}
+
+	fields, err := ParseFields(body)
+	if err != nil {
+		return nil, domain.ErrInvalidInput
+	}
+
+	if err := ApplyField(fields, "description", &bundle.Description); err != nil {
+		return nil, domain.ErrInvalidInput
+	}
+
+	// Keys: merge semantics (same as envs)
+	bundle.Keys, err = MergeEnvs(bundle.Keys, fields["keys"])
+	if err != nil {
+		return nil, domain.ErrInvalidInput
+	}
+
+	bundle.UpdatedAt = time.Now()
+	if err := s.bundleRepo.Update(ctx, bundle); err != nil {
+		return nil, err
+	}
+	return bundle, nil
+}
+
+func (s *ConfigBundleService) DeleteBundle(ctx context.Context, name string) error {
+	if _, err := s.bundleRepo.FindByName(ctx, name); err != nil {
+		return err
+	}
+	// Check no app references this bundle
+	apps, err := s.appRepo.FindAll(ctx)
+	if err != nil {
+		return err
+	}
+	for _, app := range apps {
+		for _, bn := range app.ConfigBundles {
+			if bn == name {
+				return fmt.Errorf("%w: bundle %q is referenced by app %q", domain.ErrCannotDelete, name, app.Name)
+			}
+		}
+	}
+	return s.bundleRepo.Delete(ctx, name)
+}
+
+// --- Key management ---
+
+func (s *ConfigBundleService) SetKeys(ctx context.Context, name string, body []byte) (*domain.ConfigBundle, error) {
+	bundle, err := s.bundleRepo.FindByName(ctx, name)
+	if err != nil {
+		return nil, err
+	}
+	bundle.Keys, err = MergeEnvs(bundle.Keys, json.RawMessage(body))
+	if err != nil {
+		return nil, domain.ErrInvalidInput
+	}
+	bundle.UpdatedAt = time.Now()
+	if err := s.bundleRepo.Update(ctx, bundle); err != nil {
+		return nil, err
+	}
+	return bundle, nil
+}
+
+func (s *ConfigBundleService) DeleteKey(ctx context.Context, bundleName, keyName string) (*domain.ConfigBundle, error) {
+	bundle, err := s.bundleRepo.FindByName(ctx, bundleName)
+	if err != nil {
+		return nil, err
+	}
+	delete(bundle.Keys, keyName)
+	// Also remove from lane overrides
+	for lane := range bundle.LaneOverrides {
+		delete(bundle.LaneOverrides[lane], keyName)
+		if len(bundle.LaneOverrides[lane]) == 0 {
+			delete(bundle.LaneOverrides, lane)
+		}
+	}
+	bundle.UpdatedAt = time.Now()
+	if err := s.bundleRepo.Update(ctx, bundle); err != nil {
+		return nil, err
+	}
+	return bundle, nil
+}
+
+func (s *ConfigBundleService) GenerateKey(ctx context.Context, bundleName, keyName string, length int) (*domain.ConfigBundle, error) {
+	bundle, err := s.bundleRepo.FindByName(ctx, bundleName)
+	if err != nil {
+		return nil, err
+	}
+	if length <= 0 {
+		length = 32
+	}
+	b := make([]byte, length)
+	if _, err := rand.Read(b); err != nil {
+		return nil, fmt.Errorf("generate random: %w", err)
+	}
+	if bundle.Keys == nil {
+		bundle.Keys = make(map[string]string)
+	}
+	bundle.Keys[keyName] = hex.EncodeToString(b)
+	bundle.UpdatedAt = time.Now()
+	if err := s.bundleRepo.Update(ctx, bundle); err != nil {
+		return nil, err
+	}
+	return bundle, nil
+}
+
+// --- Lane overrides ---
+
+func (s *ConfigBundleService) SetLaneOverrides(ctx context.Context, bundleName, lane string, body []byte) (*domain.ConfigBundle, error) {
+	bundle, err := s.bundleRepo.FindByName(ctx, bundleName)
+	if err != nil {
+		return nil, err
+	}
+	if bundle.LaneOverrides == nil {
+		bundle.LaneOverrides = make(map[string]map[string]string)
+	}
+	existing := bundle.LaneOverrides[lane]
+	merged, err := MergeEnvs(existing, json.RawMessage(body))
+	if err != nil {
+		return nil, domain.ErrInvalidInput
+	}
+	if merged == nil || len(merged) == 0 {
+		delete(bundle.LaneOverrides, lane)
+	} else {
+		bundle.LaneOverrides[lane] = merged
+	}
+	bundle.UpdatedAt = time.Now()
+	if err := s.bundleRepo.Update(ctx, bundle); err != nil {
+		return nil, err
+	}
+	return bundle, nil
+}
+
+func (s *ConfigBundleService) DeleteLaneOverrides(ctx context.Context, bundleName, lane string) (*domain.ConfigBundle, error) {
+	bundle, err := s.bundleRepo.FindByName(ctx, bundleName)
+	if err != nil {
+		return nil, err
+	}
+	delete(bundle.LaneOverrides, lane)
+	bundle.UpdatedAt = time.Now()
+	if err := s.bundleRepo.Update(ctx, bundle); err != nil {
+		return nil, err
+	}
+	return bundle, nil
+}
+
+func (s *ConfigBundleService) DeleteLaneOverrideKey(ctx context.Context, bundleName, lane, keyName string) (*domain.ConfigBundle, error) {
+	bundle, err := s.bundleRepo.FindByName(ctx, bundleName)
+	if err != nil {
+		return nil, err
+	}
+	if overrides, ok := bundle.LaneOverrides[lane]; ok {
+		delete(overrides, keyName)
+		if len(overrides) == 0 {
+			delete(bundle.LaneOverrides, lane)
+		}
+	}
+	bundle.UpdatedAt = time.Now()
+	if err := s.bundleRepo.Update(ctx, bundle); err != nil {
+		return nil, err
+	}
+	return bundle, nil
+}
+
+// --- Resolve config ---
+
+// ResolvedConfigEntry 表示一个已解析的配置项，带来源标注。
+type ResolvedConfigEntry struct {
+	Value  string `json:"value"`
+	Source string `json:"source"`
+}
+
+// ResolveConfig 合并 app 的所有配置来源，返回最终的环境变量 map。
+// 优先级（低→高）：bundle baseline → bundle lane override → app.Envs → release.Envs → auto-injected
+func (s *ConfigBundleService) ResolveConfig(ctx context.Context, appName, lane string) (map[string]ResolvedConfigEntry, error) {
+	app, err := s.appRepo.FindByName(ctx, appName)
+	if err != nil {
+		return nil, err
+	}
+	if lane == "" {
+		lane = domain.DefaultLane
+	}
+
+	resolved := make(map[string]ResolvedConfigEntry)
+
+	// 1. Bundle baseline + lane overrides
+	if len(app.ConfigBundles) > 0 {
+		bundles, err := s.bundleRepo.FindByNames(ctx, app.ConfigBundles)
+		if err != nil {
+			return nil, err
+		}
+		for _, bundle := range bundles {
+			for k, v := range bundle.Keys {
+				resolved[k] = ResolvedConfigEntry{Value: v, Source: bundle.Name}
+			}
+			if overrides, ok := bundle.LaneOverrides[lane]; ok {
+				for k, v := range overrides {
+					resolved[k] = ResolvedConfigEntry{Value: v, Source: fmt.Sprintf("%s[lane:%s]", bundle.Name, lane)}
+				}
+			}
+		}
+	}
+
+	// 2. App.Envs
+	for k, v := range app.Envs {
+		resolved[k] = ResolvedConfigEntry{Value: v, Source: "app"}
+	}
+
+	// 3. Release.Envs
+	release, err := s.releaseRepo.FindByAppAndLane(ctx, appName, lane)
+	if err == nil && release != nil {
+		for k, v := range release.Envs {
+			resolved[k] = ResolvedConfigEntry{Value: v, Source: "release"}
+		}
+		if release.Version != "" {
+			resolved["VERSION"] = ResolvedConfigEntry{Value: release.Version, Source: "auto"}
+		}
+	}
+
+	// 4. Auto-injected
+	resolved["LANE"] = ResolvedConfigEntry{Value: lane, Source: "auto"}
+
+	return resolved, nil
+}
+
+// ResolveBundleEnvs 仅解析 bundle 层的配置（baseline + lane override），用于部署注入。
+// 不包含 app.Envs 和 release.Envs（由 deployer 单独处理）。
+func (s *ConfigBundleService) ResolveBundleEnvs(ctx context.Context, app *domain.App, lane string) (map[string]string, error) {
+	if len(app.ConfigBundles) == 0 {
+		return nil, nil
+	}
+	bundles, err := s.bundleRepo.FindByNames(ctx, app.ConfigBundles)
+	if err != nil {
+		return nil, err
+	}
+	resolved := make(map[string]string)
+	for _, bundle := range bundles {
+		for k, v := range bundle.Keys {
+			resolved[k] = v
+		}
+		if overrides, ok := bundle.LaneOverrides[lane]; ok {
+			for k, v := range overrides {
+				resolved[k] = v
+			}
+		}
+	}
+	return resolved, nil
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+cd apps/paas-engine && go test ./internal/service/ -run TestCreate.*ConfigBundle -v
+```
+
+Expected: PASS
+
+- [ ] **Step 5: Add tests for key management and lane overrides**
+
+Append to `internal/service/config_bundle_service_test.go`:
+
+```go
+func TestSetKeys_MergesWithExisting(t *testing.T) {
+	repo := newStubConfigBundleRepo()
+	repo.bundles["pg-main"] = &domain.ConfigBundle{
+		Name: "pg-main",
+		Keys: map[string]string{"PG_MAIN_HOST": "postgres", "PG_MAIN_PORT": "5432"},
+	}
+	svc := NewConfigBundleService(repo, &stubAppRepo{}, &stubReleaseRepo{})
+
+	bundle, err := svc.SetKeys(context.Background(), "pg-main", []byte(`{"PG_MAIN_USER":"chiwei"}`))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if bundle.Keys["PG_MAIN_HOST"] != "postgres" {
+		t.Errorf("existing key should be preserved")
+	}
+	if bundle.Keys["PG_MAIN_USER"] != "chiwei" {
+		t.Errorf("new key should be added")
+	}
+}
+
+func TestSetKeys_DeleteKeyWithNull(t *testing.T) {
+	repo := newStubConfigBundleRepo()
+	repo.bundles["pg-main"] = &domain.ConfigBundle{
+		Name: "pg-main",
+		Keys: map[string]string{"PG_MAIN_HOST": "postgres", "PG_MAIN_PORT": "5432"},
+	}
+	svc := NewConfigBundleService(repo, &stubAppRepo{}, &stubReleaseRepo{})
+
+	bundle, err := svc.SetKeys(context.Background(), "pg-main", []byte(`{"PG_MAIN_PORT":null}`))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, ok := bundle.Keys["PG_MAIN_PORT"]; ok {
+		t.Error("PG_MAIN_PORT should be deleted")
+	}
+	if bundle.Keys["PG_MAIN_HOST"] != "postgres" {
+		t.Error("PG_MAIN_HOST should be preserved")
+	}
+}
+
+func TestDeleteKey_AlsoRemovesFromLaneOverrides(t *testing.T) {
+	repo := newStubConfigBundleRepo()
+	repo.bundles["pg-main"] = &domain.ConfigBundle{
+		Name: "pg-main",
+		Keys: map[string]string{"PG_MAIN_HOST": "postgres", "PG_MAIN_PORT": "5432"},
+		LaneOverrides: map[string]map[string]string{
+			"dev": {"PG_MAIN_HOST": "dev-postgres"},
+		},
+	}
+	svc := NewConfigBundleService(repo, &stubAppRepo{}, &stubReleaseRepo{})
+
+	bundle, err := svc.DeleteKey(context.Background(), "pg-main", "PG_MAIN_HOST")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, ok := bundle.Keys["PG_MAIN_HOST"]; ok {
+		t.Error("key should be deleted")
+	}
+	if _, ok := bundle.LaneOverrides["dev"]; ok {
+		t.Error("lane override should be cleaned up")
+	}
+}
+
+func TestSetLaneOverrides_Success(t *testing.T) {
+	repo := newStubConfigBundleRepo()
+	repo.bundles["pg-main"] = &domain.ConfigBundle{
+		Name: "pg-main",
+		Keys: map[string]string{"PG_MAIN_HOST": "postgres"},
+	}
+	svc := NewConfigBundleService(repo, &stubAppRepo{}, &stubReleaseRepo{})
+
+	bundle, err := svc.SetLaneOverrides(context.Background(), "pg-main", "dev", []byte(`{"PG_MAIN_HOST":"dev-pg"}`))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if bundle.LaneOverrides["dev"]["PG_MAIN_HOST"] != "dev-pg" {
+		t.Errorf("lane override not set")
+	}
+}
+
+func TestGenerateKey_CreatesRandomValue(t *testing.T) {
+	repo := newStubConfigBundleRepo()
+	repo.bundles["inter-service-auth"] = &domain.ConfigBundle{
+		Name: "inter-service-auth",
+		Keys: map[string]string{},
+	}
+	svc := NewConfigBundleService(repo, &stubAppRepo{}, &stubReleaseRepo{})
+
+	bundle, err := svc.GenerateKey(context.Background(), "inter-service-auth", "AUTH_SECRET", 32)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	val := bundle.Keys["AUTH_SECRET"]
+	if len(val) != 64 { // 32 bytes = 64 hex chars
+		t.Errorf("generated value length = %d, want 64", len(val))
+	}
+}
+
+func TestResolveConfig_FullMerge(t *testing.T) {
+	bundleRepo := newStubConfigBundleRepo()
+	bundleRepo.bundles["pg-main"] = &domain.ConfigBundle{
+		Name: "pg-main",
+		Keys: map[string]string{"PG_MAIN_HOST": "postgres", "PG_MAIN_PORT": "5432"},
+		LaneOverrides: map[string]map[string]string{
+			"dev": {"PG_MAIN_HOST": "dev-postgres"},
+		},
+	}
+	bundleRepo.bundles["redis"] = &domain.ConfigBundle{
+		Name: "redis",
+		Keys: map[string]string{"REDIS_HOST": "redis"},
+	}
+
+	appRepo := &stubAppRepo{app: &domain.App{
+		Name:          "myapp",
+		ConfigBundles: []string{"pg-main", "redis"},
+		Envs:          map[string]string{"APP_NAME": "myapp"},
+	}}
+
+	releaseRepo := newReleaseTestReleaseRepo()
+	_ = releaseRepo.Save(context.Background(), &domain.Release{
+		ID:      "r1",
+		AppName: "myapp",
+		Lane:    "dev",
+		Envs:    map[string]string{"DEBUG": "true"},
+		Version: "1.0.0",
+	})
+
+	svc := NewConfigBundleService(bundleRepo, appRepo, releaseRepo)
+
+	resolved, err := svc.ResolveConfig(context.Background(), "myapp", "dev")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Bundle baseline
+	if resolved["PG_MAIN_PORT"].Value != "5432" || resolved["PG_MAIN_PORT"].Source != "pg-main" {
+		t.Errorf("PG_MAIN_PORT: got %+v", resolved["PG_MAIN_PORT"])
+	}
+	// Lane override
+	if resolved["PG_MAIN_HOST"].Value != "dev-postgres" || resolved["PG_MAIN_HOST"].Source != "pg-main[lane:dev]" {
+		t.Errorf("PG_MAIN_HOST: got %+v", resolved["PG_MAIN_HOST"])
+	}
+	// Second bundle
+	if resolved["REDIS_HOST"].Value != "redis" || resolved["REDIS_HOST"].Source != "redis" {
+		t.Errorf("REDIS_HOST: got %+v", resolved["REDIS_HOST"])
+	}
+	// App envs
+	if resolved["APP_NAME"].Value != "myapp" || resolved["APP_NAME"].Source != "app" {
+		t.Errorf("APP_NAME: got %+v", resolved["APP_NAME"])
+	}
+	// Release envs
+	if resolved["DEBUG"].Value != "true" || resolved["DEBUG"].Source != "release" {
+		t.Errorf("DEBUG: got %+v", resolved["DEBUG"])
+	}
+	// Auto-injected
+	if resolved["VERSION"].Value != "1.0.0" {
+		t.Errorf("VERSION: got %+v", resolved["VERSION"])
+	}
+	if resolved["LANE"].Value != "dev" {
+		t.Errorf("LANE: got %+v", resolved["LANE"])
+	}
+}
+```
+
+- [ ] **Step 6: Run all ConfigBundle tests**
+
+```bash
+cd apps/paas-engine && go test ./internal/service/ -run TestCreate.*ConfigBundle\|TestSet.*\|TestDelete.*Key\|TestGenerate.*\|TestResolve.* -v
+```
+
+Expected: ALL PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add internal/service/config_bundle_service.go internal/service/config_bundle_service_test.go
+git commit -m "feat(config): add ConfigBundle service with CRUD, keys, lane overrides, resolve"
+```
+
+---
+
+### Task 4: App Model — Add ConfigBundles Field
+
+**Files:**
+- Modify: `internal/domain/app.go`
+- Modify: `internal/adapter/repository/model.go`
+- Modify: `internal/adapter/repository/app_repo.go`
+- Modify: `internal/service/app_service.go`
+- Modify: `internal/service/app_service_test.go`
+
+- [ ] **Step 1: Add ConfigBundles to domain App**
+
+In `internal/domain/app.go`, add after the `Envs` field:
+
+```go
+ConfigBundles []string `json:"config_bundles,omitempty"`
+```
+
+- [ ] **Step 2: Add ConfigBundles to AppModel**
+
+In `internal/adapter/repository/model.go`, add to `AppModel` after `Envs`:
+
+```go
+ConfigBundles string // JSON 序列化的 []string
+```
+
+- [ ] **Step 3: Update appToModel/modelToApp in app_repo.go**
+
+In `appToModel`, add after `envFromConfigMapsJSON`:
+
+```go
+configBundlesJSON, err := json.Marshal(a.ConfigBundles)
+if err != nil {
+	return nil, err
+}
+```
+
+And add the field to the returned model:
+
+```go
+ConfigBundles: string(configBundlesJSON),
+```
+
+In `modelToApp`, add after the `envFromConfigMaps` unmarshaling:
+
+```go
+var configBundles []string
+if m.ConfigBundles != "" {
+	if err := json.Unmarshal([]byte(m.ConfigBundles), &configBundles); err != nil {
+		return nil, err
+	}
+}
+```
+
+And add to the returned App:
+
+```go
+ConfigBundles: configBundles,
+```
+
+- [ ] **Step 4: Update AppService to handle config_bundles + conflict detection**
+
+In `internal/service/app_service.go`:
+
+Add `configBundleRepo` to the struct and constructor:
+
+```go
+type AppService struct {
+	appRepo          port.AppRepository
+	imageRepoRepo    port.ImageRepoRepository
+	releaseRepo      port.ReleaseRepository
+	configBundleRepo port.ConfigBundleRepository
+}
+
+func NewAppService(appRepo port.AppRepository, imageRepoRepo port.ImageRepoRepository, releaseRepo port.ReleaseRepository, configBundleRepo port.ConfigBundleRepository) *AppService {
+	return &AppService{appRepo: appRepo, imageRepoRepo: imageRepoRepo, releaseRepo: releaseRepo, configBundleRepo: configBundleRepo}
+}
+```
+
+Add `ConfigBundles` to `CreateAppRequest`:
+
+```go
+ConfigBundles []string `json:"config_bundles"`
+```
+
+In `CreateApp`, add before saving:
+
+```go
+if len(req.ConfigBundles) > 0 {
+	if err := s.validateConfigBundles(ctx, req.ConfigBundles); err != nil {
+		return nil, err
+	}
+}
+app.ConfigBundles = req.ConfigBundles
+```
+
+In `UpdateApp`, add after the existing ApplyField calls:
+
+```go
+if err := ApplyField(fields, "config_bundles", &app.ConfigBundles); err != nil {
+	return nil, domain.ErrInvalidInput
+}
+if _, ok := fields["config_bundles"]; ok && len(app.ConfigBundles) > 0 {
+	if err := s.validateConfigBundles(ctx, app.ConfigBundles); err != nil {
+		return nil, err
+	}
+}
+```
+
+Add the validation method:
+
+```go
+// validateConfigBundles checks that all referenced bundles exist and have no key conflicts.
+func (s *AppService) validateConfigBundles(ctx context.Context, bundleNames []string) error {
+	if s.configBundleRepo == nil {
+		return nil
+	}
+	bundles, err := s.configBundleRepo.FindByNames(ctx, bundleNames)
+	if err != nil {
+		return err
+	}
+	if len(bundles) != len(bundleNames) {
+		// Find missing bundle
+		found := make(map[string]bool)
+		for _, b := range bundles {
+			found[b.Name] = true
+		}
+		for _, name := range bundleNames {
+			if !found[name] {
+				return fmt.Errorf("%w: config bundle %q not found", domain.ErrInvalidInput, name)
+			}
+		}
+	}
+	// Check key conflicts across bundles
+	seen := make(map[string]string) // key name → bundle name
+	for _, bundle := range bundles {
+		for key := range bundle.Keys {
+			if other, ok := seen[key]; ok {
+				return fmt.Errorf("%w: key %q defined in both %q and %q", domain.ErrInvalidInput, key, other, bundle.Name)
+			}
+			seen[key] = bundle.Name
+		}
+	}
+	return nil
+}
+```
+
+Add `"fmt"` to imports if not already present.
+
+- [ ] **Step 5: Update existing AppService tests to pass new parameter**
+
+In `internal/service/app_service_test.go`, update all `NewAppService` calls to add a 4th parameter. Add a `stubConfigBundleRepo` field to tests that need it, or pass `nil`:
+
+```go
+// Update all existing calls from:
+svc := NewAppService(appRepo, imageRepoRepo, &stubReleaseRepo{})
+// To:
+svc := NewAppService(appRepo, imageRepoRepo, &stubReleaseRepo{}, nil)
+```
+
+Also update `stubAppRepo` in `internal/service/log_service_test.go` (the shared stub) to support an `apps` field:
+
+```go
+type stubAppRepo struct {
+	app  *domain.App
+	apps []*domain.App // for FindAll with multiple apps
+	err  error
+}
+```
+
+And update its `FindAll` method:
+
+```go
+func (s *stubAppRepo) FindAll(_ context.Context) ([]*domain.App, error) {
+	if s.apps != nil {
+		return s.apps, nil
+	}
+	if s.app != nil {
+		return []*domain.App{s.app}, nil
+	}
+	return nil, nil
+}
+```
+
+Note: this stub is defined in `log_service_test.go` and shared across all service test files.
+
+- [ ] **Step 6: Add conflict detection tests**
+
+Append to `internal/service/app_service_test.go`:
+
+```go
+func TestUpdateApp_ConfigBundleConflict(t *testing.T) {
+	appRepo := &stubAppRepo{app: &domain.App{Name: "myapp"}}
+	bundleRepo := newStubConfigBundleRepo()
+	bundleRepo.bundles["pg-main"] = &domain.ConfigBundle{
+		Name: "pg-main",
+		Keys: map[string]string{"DB_HOST": "postgres"},
+	}
+	bundleRepo.bundles["pg-external"] = &domain.ConfigBundle{
+		Name: "pg-external",
+		Keys: map[string]string{"DB_HOST": "external-pg"}, // conflict!
+	}
+	svc := NewAppService(appRepo, &stubImageRepoRepo{}, &stubReleaseRepo{}, bundleRepo)
+
+	_, err := svc.UpdateApp(context.Background(), "myapp",
+		[]byte(`{"config_bundles":["pg-main","pg-external"]}`))
+	if err == nil {
+		t.Error("expected error for key conflict")
+	}
+}
+
+func TestUpdateApp_ConfigBundleNotFound(t *testing.T) {
+	appRepo := &stubAppRepo{app: &domain.App{Name: "myapp"}}
+	bundleRepo := newStubConfigBundleRepo()
+	svc := NewAppService(appRepo, &stubImageRepoRepo{}, &stubReleaseRepo{}, bundleRepo)
+
+	_, err := svc.UpdateApp(context.Background(), "myapp",
+		[]byte(`{"config_bundles":["nonexistent"]}`))
+	if err == nil {
+		t.Error("expected error for missing bundle")
+	}
+}
+```
+
+- [ ] **Step 7: Run all app and config bundle tests**
+
+```bash
+cd apps/paas-engine && go test ./internal/service/ -v
+```
+
+Expected: ALL PASS
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add internal/domain/app.go internal/adapter/repository/model.go internal/adapter/repository/app_repo.go internal/service/app_service.go internal/service/app_service_test.go internal/service/config_bundle_service_test.go internal/service/log_service_test.go
+git commit -m "feat(config): add ConfigBundles field to App with conflict detection"
+```
+
+---
+
+### Task 5: HTTP Handlers + Routes
+
+**Files:**
+- Create: `internal/adapter/http/config_bundle_handler.go`
+- Modify: `internal/adapter/http/router.go`
+
+- [ ] **Step 1: Create config_bundle_handler.go**
+
+```go
+// internal/adapter/http/config_bundle_handler.go
+package http
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+
+	"github.com/chiwei-platform/paas-engine/internal/service"
+	"github.com/go-chi/chi/v5"
+)
+
+type ConfigBundleHandler struct {
+	svc *service.ConfigBundleService
+}
+
+func NewConfigBundleHandler(svc *service.ConfigBundleService) *ConfigBundleHandler {
+	return &ConfigBundleHandler{svc: svc}
+}
+
+func (h *ConfigBundleHandler) Create(w http.ResponseWriter, r *http.Request) {
+	var req service.CreateBundleRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, err)
+		return
+	}
+	bundle, err := h.svc.CreateBundle(r.Context(), req)
+	if err != nil {
+		writeError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusCreated, bundle)
+}
+
+func (h *ConfigBundleHandler) List(w http.ResponseWriter, r *http.Request) {
+	bundles, err := h.svc.ListBundles(r.Context())
+	if err != nil {
+		writeError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, bundles)
+}
+
+func (h *ConfigBundleHandler) Get(w http.ResponseWriter, r *http.Request) {
+	name := chi.URLParam(r, "bundle")
+	bundle, err := h.svc.GetBundle(r.Context(), name)
+	if err != nil {
+		writeError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, bundle)
+}
+
+func (h *ConfigBundleHandler) Update(w http.ResponseWriter, r *http.Request) {
+	name := chi.URLParam(r, "bundle")
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		writeError(w, err)
+		return
+	}
+	bundle, err := h.svc.UpdateBundle(r.Context(), name, body)
+	if err != nil {
+		writeError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, bundle)
+}
+
+func (h *ConfigBundleHandler) Delete(w http.ResponseWriter, r *http.Request) {
+	name := chi.URLParam(r, "bundle")
+	if err := h.svc.DeleteBundle(r.Context(), name); err != nil {
+		writeError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]string{"deleted": name})
+}
+
+func (h *ConfigBundleHandler) SetKeys(w http.ResponseWriter, r *http.Request) {
+	name := chi.URLParam(r, "bundle")
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		writeError(w, err)
+		return
+	}
+	bundle, err := h.svc.SetKeys(r.Context(), name, body)
+	if err != nil {
+		writeError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, bundle)
+}
+
+func (h *ConfigBundleHandler) DeleteKey(w http.ResponseWriter, r *http.Request) {
+	bundleName := chi.URLParam(r, "bundle")
+	keyName := chi.URLParam(r, "key")
+	bundle, err := h.svc.DeleteKey(r.Context(), bundleName, keyName)
+	if err != nil {
+		writeError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, bundle)
+}
+
+func (h *ConfigBundleHandler) GenerateKey(w http.ResponseWriter, r *http.Request) {
+	bundleName := chi.URLParam(r, "bundle")
+	keyName := chi.URLParam(r, "key")
+
+	length := 32
+	if r.ContentLength > 0 {
+		var req struct {
+			Length int `json:"length"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err == nil && req.Length > 0 {
+			length = req.Length
+		}
+	}
+
+	bundle, err := h.svc.GenerateKey(r.Context(), bundleName, keyName, length)
+	if err != nil {
+		writeError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, bundle)
+}
+
+func (h *ConfigBundleHandler) SetLaneOverrides(w http.ResponseWriter, r *http.Request) {
+	bundleName := chi.URLParam(r, "bundle")
+	lane := chi.URLParam(r, "lane")
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		writeError(w, err)
+		return
+	}
+	bundle, err := h.svc.SetLaneOverrides(r.Context(), bundleName, lane, body)
+	if err != nil {
+		writeError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, bundle)
+}
+
+func (h *ConfigBundleHandler) DeleteLaneOverrides(w http.ResponseWriter, r *http.Request) {
+	bundleName := chi.URLParam(r, "bundle")
+	lane := chi.URLParam(r, "lane")
+	bundle, err := h.svc.DeleteLaneOverrides(r.Context(), bundleName, lane)
+	if err != nil {
+		writeError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, bundle)
+}
+
+func (h *ConfigBundleHandler) DeleteLaneOverrideKey(w http.ResponseWriter, r *http.Request) {
+	bundleName := chi.URLParam(r, "bundle")
+	lane := chi.URLParam(r, "lane")
+	keyName := chi.URLParam(r, "key")
+	bundle, err := h.svc.DeleteLaneOverrideKey(r.Context(), bundleName, lane, keyName)
+	if err != nil {
+		writeError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, bundle)
+}
+
+// ResolveConfig is mounted on the App handler, but calls ConfigBundleService.
+func (h *ConfigBundleHandler) ResolveConfig(w http.ResponseWriter, r *http.Request) {
+	appName := chi.URLParam(r, "app")
+	lane := r.URL.Query().Get("lane")
+	resolved, err := h.svc.ResolveConfig(r.Context(), appName, lane)
+	if err != nil {
+		writeError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, resolved)
+}
+
+}
+```
+
+Note: the `strconv` import is not needed in this file — do not include it.
+
+- [ ] **Step 2: Add routes to router.go**
+
+In `internal/adapter/http/router.go`, update the `NewRouter` function signature to accept the new handler:
+
+```go
+func NewRouter(
+	appH *AppHandler,
+	releaseH *ReleaseHandler,
+	logH *LogHandler,
+	imageRepoH *ImageRepoHandler,
+	opsH *OpsHandler,
+	pipelineH *PipelineHandler,
+	configBundleH *ConfigBundleHandler,
+	apiToken string,
+) http.Handler {
+```
+
+Add routes inside the `/api/paas` route group, after the existing CI Pipeline block:
+
+```go
+// Config Bundles
+r.Route("/config-bundles", func(r chi.Router) {
+	r.Post("/", configBundleH.Create)
+	r.Get("/", configBundleH.List)
+	r.Route("/{bundle}", func(r chi.Router) {
+		r.Get("/", configBundleH.Get)
+		r.Put("/", configBundleH.Update)
+		r.Delete("/", configBundleH.Delete)
+		r.Put("/keys", configBundleH.SetKeys)
+		r.Delete("/keys/{key}", configBundleH.DeleteKey)
+		r.Post("/keys/{key}/generate", configBundleH.GenerateKey)
+		r.Route("/lanes/{lane}", func(r chi.Router) {
+			r.Put("/", configBundleH.SetLaneOverrides)
+			r.Delete("/", configBundleH.DeleteLaneOverrides)
+			r.Delete("/{key}", configBundleH.DeleteLaneOverrideKey)
+		})
+	})
+})
+```
+
+Also add the resolved-config endpoint inside the existing `/{app}` route group (after `r.Get("/logs", logH.GetLogs)`):
+
+```go
+r.Get("/resolved-config", configBundleH.ResolveConfig)
+```
+
+- [ ] **Step 3: Build to verify compilation**
+
+```bash
+cd apps/paas-engine && go build ./...
+```
+
+Expected: FAIL — main.go needs to be updated to pass configBundleH (done in Task 7).
+
+This is expected. We'll fix it in Task 7 (wiring). For now, just verify the handler + router code compiles in isolation:
+
+```bash
+cd apps/paas-engine && go vet ./internal/adapter/http/...
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add internal/adapter/http/config_bundle_handler.go internal/adapter/http/router.go
+git commit -m "feat(config): add ConfigBundle HTTP handlers and routes"
+```
+
+---
+
+### Task 6: Deployer — K8s Secret Management
+
+**Files:**
+- Modify: `internal/port/kubernetes.go`
+- Modify: `internal/adapter/kubernetes/deployer.go`
+- Modify: `internal/adapter/kubernetes/deployer_test.go`
+- Modify: `internal/service/release_service.go`
+- Modify: `internal/service/release_service_test.go`
+
+- [ ] **Step 1: Update Deployer interface**
+
+In `internal/port/kubernetes.go`, change the `Deploy` signature:
+
+```go
+Deploy(ctx context.Context, release *domain.Release, app *domain.App, bundleEnvs map[string]string) error
+```
+
+- [ ] **Step 2: Update K8sDeployer.Deploy to create K8s Secret + envFrom**
+
+In `internal/adapter/kubernetes/deployer.go`:
+
+Update `Deploy` method signature:
+
+```go
+func (d *K8sDeployer) Deploy(ctx context.Context, release *domain.Release, app *domain.App, bundleEnvs map[string]string) error {
+```
+
+Update `applyDeployment` signature and call:
+
+```go
+func (d *K8sDeployer) applyDeployment(ctx context.Context, release *domain.Release, app *domain.App, bundleEnvs map[string]string) error {
+```
+
+In `Deploy`, update the call:
+
+```go
+if err := d.applyDeployment(ctx, release, app, bundleEnvs); err != nil {
+```
+
+In `applyDeployment`, add K8s Secret creation before building the container. Replace the envFrom and env construction:
+
+```go
+// Bundle envs → auto-managed K8s Secret
+var bundleSecretName string
+if len(bundleEnvs) > 0 {
+	bundleSecretName = name + "-config"
+	if err := d.applySecret(ctx, bundleSecretName, bundleEnvs); err != nil {
+		return fmt.Errorf("apply config secret: %w", err)
+	}
+}
+
+mergedEnvs := mergeEnvs(app.Envs, release.Envs)
+if release.Version != "" {
+	mergedEnvs["VERSION"] = release.Version
+}
+mergedEnvs["LANE"] = release.Lane
+envVars := envsToK8s(mergedEnvs)
+
+// EnvFrom: legacy sources + bundle secret
+envFrom := buildEnvFrom(app.EnvFromSecrets, app.EnvFromConfigMaps)
+if bundleSecretName != "" {
+	envFrom = append(envFrom, corev1.EnvFromSource{
+		SecretRef: &corev1.SecretEnvSource{
+			LocalObjectReference: corev1.LocalObjectReference{Name: bundleSecretName},
+		},
+	})
+}
+
+container := corev1.Container{
+	Name:    app.Name,
+	Image:   release.Image,
+	EnvFrom: envFrom,
+	Env:     envVars,
+}
+```
+
+Add the `applySecret` method:
+
+```go
+func (d *K8sDeployer) applySecret(ctx context.Context, name string, data map[string]string) error {
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: d.namespace,
+			Labels:    map[string]string{"managed-by": "paas-engine"},
+		},
+		StringData: data,
+	}
+
+	existing, err := d.client.CoreV1().Secrets(d.namespace).Get(ctx, name, metav1.GetOptions{})
+	if errors.IsNotFound(err) {
+		_, err = d.client.CoreV1().Secrets(d.namespace).Create(ctx, secret, metav1.CreateOptions{})
+		return err
+	}
+	if err != nil {
+		return err
+	}
+	existing.StringData = data
+	_, err = d.client.CoreV1().Secrets(d.namespace).Update(ctx, existing, metav1.UpdateOptions{})
+	return err
+}
+```
+
+- [ ] **Step 3: Update stub deployer in release_service_test.go**
+
+In `internal/service/release_service_test.go`, update `stubDeployer.Deploy`:
+
+```go
+func (s *stubDeployer) Deploy(_ context.Context, _ *domain.Release, _ *domain.App, _ map[string]string) error {
+	return s.deployErr
+}
+```
+
+- [ ] **Step 4: Update deployer_test.go if applicable**
+
+In `internal/adapter/kubernetes/deployer_test.go`, update any calls to `Deploy` to pass the new `bundleEnvs` parameter (likely `nil` for existing tests):
+
+Search for `.Deploy(` calls and add `nil` as the 4th argument.
+
+- [ ] **Step 5: Update ReleaseService to resolve bundle envs before deploying**
+
+In `internal/service/release_service.go`:
+
+Add `configBundleSvc` to the struct and constructor:
+
+```go
+type ReleaseService struct {
+	appRepo         port.AppRepository
+	imageRepoRepo   port.ImageRepoRepository
+	buildRepo       port.BuildRepository
+	releaseRepo     port.ReleaseRepository
+	deployer        port.Deployer
+	configBundleSvc *ConfigBundleService
+}
+
+func NewReleaseService(
+	appRepo port.AppRepository,
+	imageRepoRepo port.ImageRepoRepository,
+	buildRepo port.BuildRepository,
+	releaseRepo port.ReleaseRepository,
+	deployer port.Deployer,
+	configBundleSvc *ConfigBundleService,
+) *ReleaseService {
+	return &ReleaseService{
+		appRepo:         appRepo,
+		imageRepoRepo:   imageRepoRepo,
+		buildRepo:       buildRepo,
+		releaseRepo:     releaseRepo,
+		deployer:        deployer,
+		configBundleSvc: configBundleSvc,
+	}
+}
+```
+
+In `CreateOrUpdateRelease`, before the deployer.Deploy call, resolve bundle envs:
+
+```go
+// Resolve bundle envs
+var bundleEnvs map[string]string
+if s.configBundleSvc != nil && len(app.ConfigBundles) > 0 {
+	bundleEnvs, err = s.configBundleSvc.ResolveBundleEnvs(ctx, app, lane)
+	if err != nil {
+		return nil, fmt.Errorf("resolve config bundles: %w", err)
+	}
+}
+```
+
+Update the deployer.Deploy call:
+
+```go
+if err := s.deployer.Deploy(ctx, release, app, bundleEnvs); err != nil {
+```
+
+Do the same in `UpdateRelease` — add bundle env resolution before the deployer.Deploy call:
+
+```go
+var bundleEnvs map[string]string
+if s.configBundleSvc != nil && len(app.ConfigBundles) > 0 {
+	bundleEnvs, err = s.configBundleSvc.ResolveBundleEnvs(ctx, app, release.Lane)
+	if err != nil {
+		return nil, fmt.Errorf("resolve config bundles: %w", err)
+	}
+}
+
+if s.deployer != nil {
+	if err := s.deployer.Deploy(ctx, release, app, bundleEnvs); err != nil {
+```
+
+- [ ] **Step 6: Update NewReleaseService calls in tests**
+
+In `internal/service/release_service_test.go`, update all `NewReleaseService` calls to add `nil` as the 6th parameter:
+
+```go
+// From:
+svc := NewReleaseService(appRepo, imageRepoRepo, &stubBuildRepo{}, releaseRepo, deployer)
+// To:
+svc := NewReleaseService(appRepo, imageRepoRepo, &stubBuildRepo{}, releaseRepo, deployer, nil)
+```
+
+- [ ] **Step 7: Run all tests**
+
+```bash
+cd apps/paas-engine && go test ./internal/... -v
+```
+
+Expected: ALL PASS
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add internal/port/kubernetes.go internal/adapter/kubernetes/deployer.go internal/adapter/kubernetes/deployer_test.go internal/service/release_service.go internal/service/release_service_test.go
+git commit -m "feat(config): integrate ConfigBundle into deploy flow with K8s Secret injection"
+```
+
+---
+
+### Task 7: Wiring — main.go
+
+**Files:**
+- Modify: `cmd/paas-engine/main.go`
+
+- [ ] **Step 1: Add ConfigBundleRepo, Service, and Handler**
+
+In `cmd/paas-engine/main.go`:
+
+After the existing repo declarations, add:
+
+```go
+configBundleRepo := repository.NewConfigBundleRepo(db)
+```
+
+After the existing service declarations, add:
+
+```go
+configBundleSvc := service.NewConfigBundleService(configBundleRepo, appRepo, releaseRepo)
+```
+
+Update `NewAppService` to pass `configBundleRepo`:
+
+```go
+appSvc := service.NewAppService(appRepo, imageRepoRepo, releaseRepo, configBundleRepo)
+```
+
+Update `NewReleaseService` to pass `configBundleSvc`:
+
+```go
+releaseSvc := service.NewReleaseService(appRepo, imageRepoRepo, buildRepo, releaseRepo, deployer, configBundleSvc)
+```
+
+Update `NewRouter` to pass the new handler:
+
+```go
+handler := httpadapter.NewRouter(
+	httpadapter.NewAppHandler(appSvc, buildSvc),
+	httpadapter.NewReleaseHandler(releaseSvc),
+	httpadapter.NewLogHandler(logSvc),
+	httpadapter.NewImageRepoHandler(imageRepoSvc),
+	httpadapter.NewOpsHandler(opsDbs),
+	httpadapter.NewPipelineHandler(pipelineSvc),
+	httpadapter.NewConfigBundleHandler(configBundleSvc),
+	cfg.APIToken,
+)
+```
+
+- [ ] **Step 2: Build the entire project**
+
+```bash
+cd apps/paas-engine && go build ./...
+```
+
+Expected: BUILD SUCCESS
+
+- [ ] **Step 3: Run all tests**
+
+```bash
+cd apps/paas-engine && go test ./... -v
+```
+
+Expected: ALL PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add cmd/paas-engine/main.go
+git commit -m "feat(config): wire ConfigBundle into application startup"
+```
+
+---
+
+### Task 8: Update Pipeline Service Constructor
+
+**Files:**
+- Modify: `internal/service/pipeline_service.go` (or wherever NewPipelineService is called)
+
+The `NewReleaseService` signature changed (added `configBundleSvc` param). If `NewPipelineService` constructs a `ReleaseService` internally or passes one around, it needs updating.
+
+- [ ] **Step 1: Check if pipeline_service.go needs updates**
+
+Check if `NewReleaseService` is called anywhere besides `main.go`:
+
+```bash
+cd apps/paas-engine && grep -r "NewReleaseService" --include="*.go" .
+```
+
+If only `main.go` calls it, this task is a no-op. If other files call it, update them to pass `nil` for `configBundleSvc`.
+
+- [ ] **Step 2: Run full test suite**
+
+```bash
+cd apps/paas-engine && go test ./... -count=1
+```
+
+Expected: ALL PASS
+
+- [ ] **Step 3: Commit (if changes needed)**
+
+```bash
+git add -A && git commit -m "fix: update NewReleaseService callers for new configBundleSvc param"
+```
+
+---
+
+### Task 9: Final Verification
+
+- [ ] **Step 1: Run go vet**
+
+```bash
+cd apps/paas-engine && go vet ./...
+```
+
+Expected: No issues
+
+- [ ] **Step 2: Run full test suite with race detector**
+
+```bash
+cd apps/paas-engine && go test -race ./...
+```
+
+Expected: ALL PASS, no data races
+
+- [ ] **Step 3: Verify build compiles cleanly**
+
+```bash
+cd apps/paas-engine && go build -o /dev/null ./cmd/paas-engine/
+```
+
+Expected: BUILD SUCCESS
+
+- [ ] **Step 4: Commit any remaining fixes**
+
+If any fixes were needed during verification, commit them.
+
+- [ ] **Step 5: Review all changes**
+
+```bash
+git log --oneline main..HEAD
+git diff --stat main..HEAD
+```
+
+Verify the commit history makes sense and all files are included.

--- a/docs/superpowers/specs/2026-03-30-unified-config-system-design.md
+++ b/docs/superpowers/specs/2026-03-30-unified-config-system-design.md
@@ -1,0 +1,310 @@
+# Unified Config System (ConfigBundle) 设计文档
+
+> 日期: 2026-03-30
+> 状态: Approved
+
+## 背景与动机
+
+当前 PaaS 平台的配置管理存在三个割裂的层面：
+
+| 层面 | 管理方式 | 问题 |
+|------|---------|------|
+| App.Envs | PaaS API 可读写 | 明文存储，不能按泳道覆盖，跨 app 无法复用 |
+| Release.Envs | PaaS API 可读写 | 仅覆盖用途，生命周期绑定 Release |
+| EnvFromSecrets / ConfigMaps | 仅存名称引用 | PaaS 无法管理内容，黑盒，需要 kubectl 手动操作 |
+
+核心痛点：
+1. **复用差** — 同一 DB 密码 5 个 app 各挂一遍，改一次改 5 处
+2. **App envs 不能按泳道覆盖** — dev 想连不同 DB 做不到
+3. **Secret 是黑盒** — PaaS 管不了 K8s Secret 内容
+4. **命名不统一** — 同一个 Redis，tool-service 叫 `TOOL_REDIS_HOST`，其他 app 叫 `REDIS_HOST`
+5. **主要消费者是 Claude** — 操作体验优先，一套 API 搞定一切
+
+## 设计目标
+
+- 所有配置通过 PaaS API 统一管理，消除 kubectl 手动操作
+- 按基础设施实例分组（ConfigBundle），一处修改、多 app 生效
+- 泳道按 key 粒度覆盖，继承基线值
+- 统一命名规范 `{BUNDLE}_{FIELD}`，消除跨 app 命名混乱
+- 支持自动生成随机值（密码、token）
+- 平滑迁移，不停机
+
+## 数据模型
+
+### ConfigBundle（配置包）
+
+```go
+type ConfigBundle struct {
+    Name          string                       // "pg-main", "redis", "rabbitmq"
+    Description   string                       // "主 PostgreSQL 数据库"
+    Keys          []ConfigKey                  // 配置项列表
+    LaneOverrides map[string]map[string]string // lane → {key: value}
+}
+
+type ConfigKey struct {
+    Name     string // 最终的环境变量名，如 "PG_MAIN_HOST"
+    Value    string // 基线值（DB 层 AES-256-GCM 加密）
+    Generate string // 可选："random:32", "random:hex:16" → 创建时自动生成
+}
+```
+
+### App 引用方式
+
+```go
+type App struct {
+    Name          string
+    ConfigBundles []string          // ["pg-main", "redis", "rabbitmq"]
+    Envs          map[string]string // app 专属配置（过渡期保留）
+    // EnvFromSecrets / EnvFromConfigMaps → 迁移完成后废弃
+}
+```
+
+### 注入优先级（低 → 高）
+
+```
+ConfigBundle baseline → ConfigBundle lane override → App.Envs → Release.Envs
+```
+
+后者覆盖前者。自动注入 `LANE` 和 `VERSION`。
+
+### 数据库表结构
+
+**config_bundles 表：**
+```sql
+CREATE TABLE config_bundles (
+    name        VARCHAR(63) PRIMARY KEY,
+    description TEXT,
+    created_at  TIMESTAMP,
+    updated_at  TIMESTAMP
+);
+```
+
+**config_keys 表：**
+```sql
+CREATE TABLE config_keys (
+    id          SERIAL PRIMARY KEY,
+    bundle_name VARCHAR(63) REFERENCES config_bundles(name),
+    name        VARCHAR(255) NOT NULL,    -- 环境变量名
+    value       BYTEA NOT NULL,           -- AES-256-GCM 加密
+    generate    VARCHAR(50),              -- 自动生成规则
+    created_at  TIMESTAMP,
+    updated_at  TIMESTAMP,
+    UNIQUE(bundle_name, name)
+);
+```
+
+**config_lane_overrides 表：**
+```sql
+CREATE TABLE config_lane_overrides (
+    id          SERIAL PRIMARY KEY,
+    bundle_name VARCHAR(63) REFERENCES config_bundles(name),
+    lane        VARCHAR(63) NOT NULL,
+    key_name    VARCHAR(255) NOT NULL,
+    value       BYTEA NOT NULL,           -- AES-256-GCM 加密
+    created_at  TIMESTAMP,
+    updated_at  TIMESTAMP,
+    UNIQUE(bundle_name, lane, key_name)
+);
+```
+
+## API 设计
+
+### ConfigBundle CRUD
+
+```
+POST   /api/paas/config-bundles/                    创建配置包
+GET    /api/paas/config-bundles/                    列出所有配置包
+GET    /api/paas/config-bundles/{name}              获取配置包（含 referenced_by）
+PUT    /api/paas/config-bundles/{name}              更新配置包（merge 语义）
+DELETE /api/paas/config-bundles/{name}              删除配置包（需无 app 引用）
+```
+
+### Key 管理
+
+```
+PUT    /api/paas/config-bundles/{name}/keys         批量设置 keys（merge 语义）
+DELETE /api/paas/config-bundles/{name}/keys/{key}   删除单个 key
+POST   /api/paas/config-bundles/{name}/keys/{key}/generate   自动生成随机值
+```
+
+### 泳道覆盖
+
+```
+PUT    /api/paas/config-bundles/{name}/lanes/{lane}          设置泳道覆盖（merge 语义）
+DELETE /api/paas/config-bundles/{name}/lanes/{lane}          删除整个泳道覆盖
+DELETE /api/paas/config-bundles/{name}/lanes/{lane}/{key}    删除单个 key 的泳道覆盖
+```
+
+### App 绑定
+
+```
+PUT    /api/paas/apps/{app}/    新增 config_bundles 字段
+```
+
+### 最终配置查询
+
+```
+GET    /api/paas/apps/{app}/resolved-config?lane=dev
+```
+
+返回合并后的完整环境变量，带来源标注：
+
+```json
+{
+    "PG_MAIN_HOST":  {"value": "dev-postgres", "source": "pg-main[lane:dev]"},
+    "PG_MAIN_PORT":  {"value": "5432",         "source": "pg-main"},
+    "REDIS_HOST":    {"value": "redis",        "source": "redis"},
+    "DEBUG":         {"value": "true",         "source": "release"}
+}
+```
+
+### 操作语义示例
+
+**创建配置包：**
+```json
+POST /api/paas/config-bundles/
+{
+    "name": "pg-main",
+    "description": "主 PostgreSQL 数据库",
+    "keys": [
+        {"name": "PG_MAIN_HOST", "value": "postgres"},
+        {"name": "PG_MAIN_PORT", "value": "5432"},
+        {"name": "PG_MAIN_USER", "value": "chiwei"},
+        {"name": "PG_MAIN_PASSWORD", "value": "xxx", "generate": "random:32"},
+        {"name": "PG_MAIN_DATABASE", "value": "chiwei"}
+    ]
+}
+```
+
+**泳道覆盖：**
+```json
+PUT /api/paas/config-bundles/pg-main/lanes/dev
+{
+    "PG_MAIN_HOST": "dev-postgres",
+    "PG_MAIN_DATABASE": "chiwei_dev"
+}
+```
+
+**App 绑定：**
+```json
+PUT /api/paas/apps/agent-service/
+{
+    "config_bundles": ["pg-main", "redis", "rabbitmq", "search-apis"]
+}
+```
+
+### 冲突检测
+
+App 绑定多个 bundle 时，如果两个 bundle 定义了同名 key，绑定时报错。强制包的 key 命名带前缀，从源头避免冲突。
+
+### 影响分析
+
+`GET /api/paas/config-bundles/{name}` 响应包含 `referenced_by` 字段：
+
+```json
+{
+    "name": "pg-main",
+    "referenced_by": ["agent-service", "lark-server", "tool-service"],
+    "keys": [...]
+}
+```
+
+## 部署注入流程
+
+### 注入逻辑
+
+```go
+// 1. resolve 所有 key（bundle → lane override → app.envs → release.envs）
+resolved := resolveConfig(app, release)
+
+// 2. 全部写入一个自动管理的 K8s Secret
+secretName := fmt.Sprintf("%s-%s-config", app.Name, lane)
+createOrUpdateSecret(secretName, resolved)
+
+// 3. container 只需 envFrom
+container := Container{
+    EnvFrom: []EnvFromSource{{SecretRef: secretName}},
+}
+```
+
+不区分 sensitive / non-sensitive，所有值统一走 K8s Secret。原因：
+- 主要消费者是 Claude，通过 `resolved-config` API 查看，不依赖 `kubectl describe`
+- 简化 deployer 逻辑，无需拆分
+
+### Secret 生命周期
+
+- 命名：`{app}-{lane}-config`，如 `agent-service-prod-config`
+- PaaS 全权管理创建、更新、删除
+- 部署时自动同步，Release 删除时对应 Secret 一并清理
+
+## 迁移策略
+
+### Phase 1：建表 + API + 读取黑盒
+
+- 新增 `config_bundles`、`config_keys`、`config_lane_overrides` 三张表
+- 实现 ConfigBundle CRUD API + resolved-config
+- 读取 `app-env`、`main-server-config`、`ai-service-config` 的实际内容，确定完整的 bundle 拆分方案
+
+### Phase 2：数据迁移（双写）
+
+- 把现有配置写入 ConfigBundle
+- Deployer 同时读旧字段和新 ConfigBundle，合并注入
+- 注入顺序：`旧 envFrom` → `旧 App.Envs` → `ConfigBundle resolved` → `Release.Envs`
+- 逐个 app 部署验证，`resolved-config` 对比实际 pod env
+
+### Phase 3：切换（逐 app）
+
+- 确认某个 app 的 ConfigBundle 配置完整后，清空 `env_from_secrets`、`env_from_config_maps`、`envs` 中已迁移的 key
+- 部署验证
+- 逐个 app 完成
+
+### Phase 4：清理
+
+- 所有 app 迁移完毕后，废弃旧字段
+- 清理不再需要的手工 K8s Secret/ConfigMap
+
+### 风险控制
+
+- 不删旧数据 — Phase 3 之前旧字段原样保留
+- resolved-config 对比验证 — diff 为空才算迁移成功
+- 逐 app 切换 — 一个 app 出问题不影响其他
+
+## 统一命名规范
+
+所有 ConfigBundle key 采用 `{BUNDLE}_{FIELD}` 格式，大写下划线：
+
+| Bundle | Keys |
+|--------|------|
+| **pg-main** | `PG_MAIN_HOST`, `PG_MAIN_PORT`, `PG_MAIN_USER`, `PG_MAIN_PASSWORD`, `PG_MAIN_DATABASE` |
+| **redis** | `REDIS_HOST`, `REDIS_PORT`, `REDIS_PASSWORD` |
+| **rabbitmq** | `RABBITMQ_HOST`, `RABBITMQ_PORT`, `RABBITMQ_USER`, `RABBITMQ_PASSWORD`, `RABBITMQ_VHOST` |
+| **lark** | `LARK_APP_ID`, `LARK_APP_SECRET`, `LARK_ENCRYPT_KEY`, `LARK_VERIFICATION_TOKEN` |
+| **forward-proxy** | `FORWARD_PROXY_URL` |
+| **search-apis** | `SEARCH_GOOGLE_API_KEY`, `SEARCH_GOOGLE_CX`, `SEARCH_GOOGLE_HOST`, `SEARCH_SERPAPI_KEY`, `SEARCH_YOU_API_KEY`, `SEARCH_YOU_HOST`, `SEARCH_SILICONFLOW_KEY` |
+| **tos** | `TOS_ACCESS_KEY_ID`, `TOS_ACCESS_KEY_SECRET`, `TOS_BUCKET`, `TOS_ENDPOINT`, `TOS_REGION` |
+| **paas-internal** | `PAAS_TOKEN`, `PAAS_GITHUB_TOKEN`, `PAAS_CI_GIT_REPO`, `PAAS_BUILD_HTTP_PROXY`, `PAAS_BUILD_NO_PROXY`, `PAAS_DEPLOY_NAMESPACE`, `PAAS_INSECURE_REGISTRIES`, `PAAS_KANIKO_CACHE_REPO`, `PAAS_KANIKO_IMAGE`, `PAAS_REGISTRY_MIRRORS`, `PAAS_DATABASE_URL` |
+| **inter-service-auth** | `AUTH_INNER_HTTP_SECRET`, `AUTH_PROXY_HTTP_SECRET` |
+
+### App 侧改造
+
+各 app 代码中读取环境变量的地方需对齐新命名：
+
+| App | 现在读 | 改为读 |
+|-----|--------|--------|
+| tool-service | `TOOL_DATABASE_URL` | 用 `PG_MAIN_*` 各字段拼接 |
+| tool-service | `TOOL_REDIS_HOST` | `REDIS_HOST` |
+| tool-service | `TOOL_TOS_ACCESS_KEY_ID` | `TOS_ACCESS_KEY_ID` |
+| agent-service | `GOOGLE_SEARCH_API_KEY` | `SEARCH_GOOGLE_API_KEY` |
+| agent-service | `POSTGRES_PORT` | `PG_MAIN_PORT` |
+| sandbox-worker | `INNER_HTTP_SECRET` | `AUTH_INNER_HTTP_SECRET` |
+
+### 连接字符串
+
+Bundle 只存分拆字段（HOST/PORT/USER/PASSWORD/DATABASE）。需要连接字符串的 app 在代码启动时自行拼接。
+
+## 不在 v1 范围内
+
+- 配置模板语法（如 `PG_MAIN_URL = "postgres://${PG_MAIN_USER}:${PG_MAIN_PASSWORD}@${PG_MAIN_HOST}:${PG_MAIN_PORT}/${PG_MAIN_DATABASE}"`）
+- 配置变更自动触发重部署
+- 配置版本历史 / 回滚
+- Web UI


### PR DESCRIPTION
## Summary
- 新增 ConfigBundle 领域模型，支持按基础设施实例分组配置（pg-main, redis, rabbitmq 等）
- 完整 CRUD API + Key 管理 + 泳道按 key 粒度覆盖 + 自动生成随机值
- resolved-config 端点一次查看 app 最终配置，每个 key 带来源标注
- 部署时自动生成 K8s Secret，通过 envFrom 注入，与现有 env/secret 机制完全兼容

## Test plan
- [x] go vet / go test -race 全通过
- [x] 独立泳道部署验证：创建 bundle、泳道覆盖、生成密码、resolved-config 全部 OK
- [x] 现有 app 部署行为零变化（未绑定 bundle 时走原有逻辑）

🤖 Generated with [Claude Code](https://claude.com/claude-code)