### PR TITLE
perf(search): filter low-score rerank results and prefer You Search

### DIFF
--- a/apps/agent-service/app/agents/tools/search/reranker.py
+++ b/apps/agent-service/app/agents/tools/search/reranker.py
@@ -15,6 +15,7 @@ logger = logging.getLogger(__name__)
 CHUNK_SIZE = 2000
 CHUNK_OVERLAP = 200
 RESULT_TOP_K = 5
+MIN_RELEVANCE_SCORE = 0.1
 RERANK_MODEL = "Qwen/Qwen3-Reranker-4B"
 
 
@@ -121,16 +122,19 @@ async def rerank_chunks(
 
         ranked = []
         for item in data.get("results", []):
+            score = item.get("relevance_score", 0)
+            if score < MIN_RELEVANCE_SCORE:
+                continue
             idx = item["index"]
             c = all_chunks[idx]
             ranked.append({
                 "title": c["title"],
                 "link": c["link"],
                 "content": c["chunk"],
-                "score": item.get("relevance_score", 0),
+                "score": score,
             })
 
-        return ranked
+        return ranked or _fallback(results, top_k)
 
     except Exception:
         logger.exception("rerank_chunks failed, falling back to truncation")

--- a/apps/agent-service/app/agents/tools/search/reranker.py
+++ b/apps/agent-service/app/agents/tools/search/reranker.py
@@ -134,7 +134,7 @@ async def rerank_chunks(
                 "score": score,
             })
 
-        return ranked or _fallback(results, top_k)
+        return ranked
 
     except Exception:
         logger.exception("rerank_chunks failed, falling back to truncation")

--- a/apps/agent-service/app/agents/tools/search/web.py
+++ b/apps/agent-service/app/agents/tools/search/web.py
@@ -126,11 +126,11 @@ async def search_web(
     start = time.monotonic()
     status = "error"
     try:
-        # 优先 Google Custom Search，fallback You Search
-        if settings.google_search_host and settings.google_search_api_key:
-            organic_results = await _google_search(query, num)
-        elif settings.you_search_host and settings.you_search_api_key:
+        # 优先 You Search，fallback Google Custom Search
+        if settings.you_search_host and settings.you_search_api_key:
             organic_results = await _you_search(query, num, gl, hl)
+        elif settings.google_search_host and settings.google_search_api_key:
+            organic_results = await _google_search(query, num)
         else:
             logger.error("No search provider configured")
             return []


### PR DESCRIPTION
## Summary
- rerank 后过滤 relevance_score < 0.1 的低分 chunk，避免无关结果污染上下文
- 全部低分时返回空列表，让 agent 知道没搜到有用内容
- 搜索源优先级从 Google Custom Search 改为 You Search，提升中文搜索质量

## Test plan
- [x] 部署到 perf-rerank 泳道，绑定 dev bot 验证
- [x] langfuse 日志确认分数过滤生效（低分返回空列表，高分正常保留）

🤖 Generated with [Claude Code](https://claude.com/claude-code)