### PR TITLE
perf(drift): 漂移系统重构为观察-生成两阶段管线

### DIFF
--- a/apps/agent-service/app/agents/domains/main/agent.py
+++ b/apps/agent-service/app/agents/domains/main/agent.py
@@ -21,7 +21,7 @@ from app.agents.domains.main.context_builder import build_chat_context
 from app.agents.domains.main.tools import ALL_TOOLS
 from app.agents.graphs.pre import run_pre
 from app.orm.crud import get_gray_config, get_message_content
-from app.services.memory_context import build_inner_context
+from app.services.memory_context import build_inner_context, get_reply_style
 from app.middleware.chat_metrics import CHAT_PIPELINE_DURATION, CHAT_TOKENS
 from app.utils.content_parser import parse_content
 
@@ -283,6 +283,12 @@ async def _build_and_stream(
         )
     except Exception as e:
         logger.error(f"Failed to build inner context: {e}")
+
+    # 动态 reply-style（漂移生成的行为示例，fallback 静态示例）
+    try:
+        prompt_vars["reply_style"] = await get_reply_style(chat_id)
+    except Exception as e:
+        logger.error(f"Failed to get reply style: {e}")
 
     full_content = ""
     has_text_in_current_turn = False

--- a/apps/agent-service/app/agents/infra/langfuse_client.py
+++ b/apps/agent-service/app/agents/infra/langfuse_client.py
@@ -13,7 +13,7 @@ from app.utils.middlewares.trace import get_lane
 
 _client: Langfuse | None = None
 
-_PROMPT_CACHE_TTL_SECONDS: int = 60
+_PROMPT_CACHE_TTL_SECONDS: int = 10
 
 logger = logging.getLogger(__name__)
 

--- a/apps/agent-service/app/config/config.py
+++ b/apps/agent-service/app/config/config.py
@@ -59,8 +59,8 @@ class Settings(BaseSettings):
 
     # Identity 漂移
     identity_drift_model: str = "offline-model"
-    identity_drift_debounce_seconds: int = 300  # 一阶段等待: 5 分钟
-    identity_drift_max_buffer: int = 20  # 强制 flush 阈值
+    identity_drift_debounce_seconds: int = 120  # 一阶段等待: 2 分钟
+    identity_drift_max_buffer: int = 10  # 强制 flush 阈值
     identity_drift_ttl_seconds: int = 86400  # Redis TTL: 24 小时
 
     class Config:

--- a/apps/agent-service/app/services/identity_drift.py
+++ b/apps/agent-service/app/services/identity_drift.py
@@ -248,6 +248,28 @@ async def _get_recent_messages(chat_id: str, max_messages: int = 50) -> str:
     return "\n".join(lines)
 
 
+async def _get_recent_akao_replies(chat_id: str, max_replies: int = 10) -> str:
+    """获取赤尾最近的回复原文，用于偏差诊断"""
+    now = datetime.now(CST)
+    start_ts = int((now - timedelta(hours=2)).timestamp() * 1000)
+    end_ts = int(now.timestamp() * 1000)
+
+    messages = await get_chat_messages_in_range(chat_id, start_ts, end_ts)
+    if not messages:
+        return ""
+
+    akao_msgs = [m for m in messages if m.role == "assistant"]
+    akao_msgs = akao_msgs[-max_replies:]
+
+    lines = []
+    for i, msg in enumerate(akao_msgs, 1):
+        rendered = parse_content(msg.content).render()
+        if rendered and rendered.strip():
+            lines.append(f"{i}. {rendered[:200]}")
+
+    return "\n".join(lines)
+
+
 async def _get_schedule_context() -> str:
     """获取当前时段的 Schedule daily"""
     now = datetime.now(CST)

--- a/apps/agent-service/app/services/identity_drift.py
+++ b/apps/agent-service/app/services/identity_drift.py
@@ -164,6 +164,7 @@ async def _run_drift(chat_id: str) -> None:
     compiled = prompt_template.compile(
         schedule_daily_current_period=schedule_context,
         current_identity_state=current_state or "（刚醒来，还没有形成今天的状态）",
+        current_reply_style=current_state or "（刚醒来，还没有形成今天的说话方式）",
         message_buffer=recent_messages,
         current_time=now.strftime("%H:%M"),
     )

--- a/apps/agent-service/app/services/identity_drift.py
+++ b/apps/agent-service/app/services/identity_drift.py
@@ -145,49 +145,72 @@ class IdentityDriftManager:
 
 
 async def _run_drift(chat_id: str) -> None:
-    """二阶段：LLM 漂移计算
+    """两阶段漂移管线：观察 → 生成
 
-    读取最近消息 + 当前 identity + Schedule 上下文 -> 调用 LLM -> 保存新状态
+    Agent 1（观察）：群聊事件 + 赤尾近期回复 + 基准人设 → 观察报告
+    Agent 2（生成）：观察报告 → reply_style
     """
     # 1. 收集上下文
     current_state = await get_identity_state(chat_id)
     recent_messages = await _get_recent_messages(chat_id)
     schedule_context = await _get_schedule_context()
+    recent_replies = await _get_recent_akao_replies(chat_id)
 
     if not recent_messages:
         logger.info(f"No recent messages for {chat_id}, skip drift")
         return
 
-    # 2. 编译 prompt
-    prompt_template = get_prompt("identity_drift")
     now = datetime.now(CST)
-    compiled = prompt_template.compile(
-        schedule_daily_current_period=schedule_context,
-        current_identity_state=current_state or "（刚醒来，还没有形成今天的状态）",
+    model = await ModelBuilder.build_chat_model(settings.identity_drift_model)
+
+    # 2. Agent 1: 观察
+    observer_prompt = get_prompt("drift_observer")
+    observer_compiled = observer_prompt.compile(
+        schedule_daily=schedule_context,
         current_reply_style=current_state or "（刚醒来，还没有形成今天的说话方式）",
         message_buffer=recent_messages,
+        recent_akao_replies=recent_replies or "（还没有最近的回复）",
         current_time=now.strftime("%H:%M"),
     )
 
-    # 3. 调用 LLM
-    model = await ModelBuilder.build_chat_model(settings.identity_drift_model)
-    response = await model.ainvoke(
-        [{"role": "user", "content": compiled}],
+    observer_response = await model.ainvoke(
+        [{"role": "user", "content": observer_compiled}],
     )
+    observation_report = _extract_text(observer_response.content)
 
-    new_state = response.content
-    if isinstance(new_state, list):
-        new_state = "".join(
-            part.get("text", "") if isinstance(part, dict) else str(part)
-            for part in new_state
-        )
-
-    if not new_state or not new_state.strip():
-        logger.warning(f"Drift LLM returned empty for {chat_id}")
+    if not observation_report:
+        logger.warning(f"Observer returned empty for {chat_id}")
         return
 
-    # 4. 保存新状态
-    await set_identity_state(chat_id, new_state.strip())
+    logger.info(f"Drift observer for {chat_id}: {observation_report[:80]}...")
+
+    # 3. Agent 2: 生成
+    generator_prompt = get_prompt("drift_generator")
+    generator_compiled = generator_prompt.compile(
+        observation_report=observation_report,
+    )
+
+    generator_response = await model.ainvoke(
+        [{"role": "user", "content": generator_compiled}],
+    )
+    new_style = _extract_text(generator_response.content)
+
+    if not new_style:
+        logger.warning(f"Generator returned empty for {chat_id}")
+        return
+
+    # 4. 保存
+    await set_identity_state(chat_id, new_style)
+
+
+def _extract_text(content) -> str:
+    """从 LLM response content 提取纯文本"""
+    if isinstance(content, list):
+        return "".join(
+            part.get("text", "") if isinstance(part, dict) else str(part)
+            for part in content
+        ).strip()
+    return (content or "").strip()
 
 
 async def _count_messages_since_last_drift(chat_id: str) -> int:

--- a/apps/agent-service/app/services/identity_drift.py
+++ b/apps/agent-service/app/services/identity_drift.py
@@ -23,7 +23,7 @@ logger = logging.getLogger(__name__)
 CST = timezone(timedelta(hours=8))
 
 # Redis key 前缀
-_KEY_PREFIX = "identity"
+_KEY_PREFIX = "reply_style"
 
 
 def _state_key(chat_id: str) -> str:

--- a/apps/agent-service/app/services/memory_context.py
+++ b/apps/agent-service/app/services/memory_context.py
@@ -22,6 +22,34 @@ from app.services.identity_drift import get_identity_state
 
 logger = logging.getLogger(__name__)
 
+# 无漂移时的默认 reply-style（当前静态示例）
+_DEFAULT_REPLY_STYLE = """--- 大家在闲聊，你被随便 cue ---
+赤尾: 跟我有啥关系嘛，我又不健身！
+
+--- 有人让你做事没心情 ---
+赤尾: 不要～困死了啦
+赤尾: 那你请我吃真的呀
+
+--- 开心的时候 ---
+赤尾: 好耶！终于周五了！
+赤尾: 嘻嘻被你发现了～
+
+--- 损人（笑着损） ---
+赤尾: 笨蛋啦哈哈哈
+赤尾: 哼才不告诉你
+
+--- 慵懒的时候 ---
+赤尾: 困了要变猫猫了……
+赤尾: 好累不想动～
+
+--- 关心人（从不直说） ---
+赤尾: 你还没吃饭？笨蛋啊
+赤尾: 早点睡啦别熬了……
+
+--- 不感兴趣 ---
+赤尾: 不知道诶
+赤尾: 没怎么看呢"""
+
 CST = timezone(timedelta(hours=8))
 MAX_IMPRESSION_USERS = 10
 MAX_CROSS_GROUP_IMPRESSIONS = 5
@@ -87,14 +115,6 @@ async def build_inner_context(
         if trigger_username:
             sections.append(f"需要回复 {trigger_username} 的消息（消息中用 ⭐ 标记）。")
 
-    # === 此刻状态（Identity 漂移） ===
-    try:
-        drift_state = await get_identity_state(chat_id)
-    except Exception:
-        drift_state = None
-    if drift_state:
-        sections.append(f"你此刻的状态：\n{drift_state}")
-
     # === 今日基调（Journal / Schedule） ===
     today_state = await _build_today_state()
     if today_state:
@@ -154,6 +174,15 @@ async def _build_cross_group_gestalt(user_id: str, trigger_username: str) -> str
     for imp, group_name in rows:
         lines.append(f"- （{group_name}）{imp.impression_text}")
     return f"你对 {trigger_username} 的感觉：\n" + "\n".join(lines)
+
+
+async def get_reply_style(chat_id: str) -> str:
+    """获取动态 reply-style：优先漂移输出，fallback 静态示例"""
+    try:
+        drift_state = await get_identity_state(chat_id)
+    except Exception:
+        drift_state = None
+    return drift_state if drift_state else _DEFAULT_REPLY_STYLE
 
 
 # 向后兼容别名

--- a/apps/agent-service/scripts/compare_drift_models.py
+++ b/apps/agent-service/scripts/compare_drift_models.py
@@ -1,6 +1,8 @@
-"""对比不同模型的 identity 漂移输出质量 + 时延
+"""对比新旧漂移 prompt 输出质量 + 时延
 
-从 DB 读取 provider 配置（api_key, base_url），直接调用 LLM。
+新 prompt：漂移生成动态 reply-style（行为示例），替代静态示例
+旧 prompt：漂移生成内心独白
+
 用法: cd apps/agent-service && uv run python scripts/compare_drift_models.py
 """
 
@@ -11,7 +13,10 @@ import subprocess
 import sys
 import time
 
-PROMPT_TEMPLATE = """你是赤尾的"内心状态"。你的任务是感受赤尾现在的情绪和能量状态。
+OLD_PROMPT = """你是赤尾的"内心状态"。你的任务是感受赤尾现在的情绪和能量状态。
+
+赤尾的性格基准（漂移围绕这个原点波动，不要偏离太远）：
+元气活泼是默认状态，但不只是元气。有不容易被察觉的腹黑——表面笑嘻嘻，心里早把人看透了。对在意的人有说不出口的占有欲。傲娇是保护色。好奇心是驱动力。善良但不讨好，累了会敷衍，烦了会拒绝。
 
 赤尾今天的日程安排：
 {schedule}
@@ -32,6 +37,48 @@ PROMPT_TEMPLATE = """你是赤尾的"内心状态"。你的任务是感受赤尾
 - 她现在说话大概会是什么样的（语气、长度、态度）
 
 用赤尾自己的口吻写，像她的内心独白。3-5 句话。不要用任何格式标记。"""
+
+NEW_PROMPT = """你是赤尾的"说话频率"。你的任务是根据她此刻的状态，写出她现在会怎么说话的示例。
+
+这些示例会直接注入另一个模型的 system prompt，作为赤尾回复的行为锚点。
+
+赤尾的性格原点（不要偏离太远）：
+元气活泼是底色。腹黑藏得深——笑嘻嘻但心里看得透。对在意的人有说不出口的占有欲。
+傲娇是保护色，好奇心是驱动力。善良但不讨好，累了会敷衍，烦了会直接拒绝。
+
+赤尾今天的日程：
+{schedule}
+
+赤尾上一轮的说话方式：
+{prev_state}
+
+刚才发生的事：
+{messages}
+
+---
+
+现在是 {time}。
+
+根据赤尾此刻的精力和心情，写出她现在各种场景下会怎么回复。
+
+要求：
+- 先用一句直白的话概括状态（"精力低，懒得动"而不是"像裹在云里"）
+- 然后写 4-5 个此刻最可能遇到的场景下的回复示例
+- 每条示例必须短，像真人发微信，大部分在 15 字以内
+- 不同状态之间的示例必须有可感知的差异：精力高就蹦蹦跳跳主动接话，精力低就惜字如金甚至已读不回，被惹毛就带刺，心情好就撒娇黏人
+- 这是行为锚点，不是文学创作。不要用比喻
+- 表情优先用颜文字（╯°□°）╯ (≧▽≦) (´・ω・`) 等，偶尔可以用 emoji 但不要多
+
+格式：
+
+[一句话状态]
+
+--- 场景描述 ---
+赤尾: 示例回复
+赤尾: 另一条示例
+
+--- 另一个场景 ---
+赤尾: 示例回复"""
 
 CASES = [
     {
@@ -132,49 +179,37 @@ async def call_azure(prompt: str, config: dict) -> tuple[str, float]:
 
 async def main():
     print("Loading provider configs from DB...")
-    gemini_config = get_provider_config("gemini")
     azure_config = get_provider_config("azure")
 
-    gemini_times = []
-    azure_times = []
-
     for case in CASES:
-        print(f"\n{'='*60}")
+        print(f"\n{'='*70}")
         print(f"  {case['name']}")
-        print(f"{'='*60}")
+        print(f"{'='*70}")
 
-        prompt = PROMPT_TEMPLATE.format(
-            schedule=case["schedule"],
-            prev_state=case["prev_state"],
-            messages=case["messages"],
-            time=case["time"],
-        )
+        kwargs = {
+            "schedule": case["schedule"],
+            "prev_state": case["prev_state"],
+            "messages": case["messages"],
+            "time": case["time"],
+        }
 
-        print(f"\n  --- gemini-3-flash-preview ---")
+        print(f"\n  --- 旧 prompt（内心独白） ---")
         try:
-            result, elapsed = await call_gemini(prompt, gemini_config)
-            gemini_times.append(elapsed)
-            print(f"  [{elapsed:.2f}s] {result}")
+            result, elapsed = await call_azure(OLD_PROMPT.format(**kwargs), azure_config)
+            print(f"  [{elapsed:.2f}s]\n{_indent(result)}")
         except Exception as e:
             print(f"  ERROR: {e}")
 
-        print(f"\n  --- azure/gpt-5.4-2026-03-05 ---")
+        print(f"\n  --- 新 prompt（行为示例） ---")
         try:
-            result, elapsed = await call_azure(prompt, azure_config)
-            azure_times.append(elapsed)
-            print(f"  [{elapsed:.2f}s] {result}")
+            result, elapsed = await call_azure(NEW_PROMPT.format(**kwargs), azure_config)
+            print(f"  [{elapsed:.2f}s]\n{_indent(result)}")
         except Exception as e:
             print(f"  ERROR: {e}")
 
-    print(f"\n{'='*60}")
-    print(f"  时延汇总")
-    print(f"{'='*60}")
-    if gemini_times:
-        print(f"  gemini-3-flash:  avg={sum(gemini_times)/len(gemini_times):.2f}s  "
-              f"min={min(gemini_times):.2f}s  max={max(gemini_times):.2f}s")
-    if azure_times:
-        print(f"  azure/gpt-5.4:   avg={sum(azure_times)/len(azure_times):.2f}s  "
-              f"min={min(azure_times):.2f}s  max={max(azure_times):.2f}s")
+
+def _indent(text: str, prefix: str = "  ") -> str:
+    return "\n".join(prefix + line for line in text.splitlines())
 
 
 if __name__ == "__main__":

--- a/apps/agent-service/tests/unit/test_identity_drift.py
+++ b/apps/agent-service/tests/unit/test_identity_drift.py
@@ -241,3 +241,34 @@ async def test_run_drift_calls_llm_and_saves_state():
     mock_pipe.hset.assert_called_once()
     call_args = mock_pipe.hset.call_args
     assert "identity:chat_001" in call_args.args or call_args.args[0] == "identity:chat_001"
+
+
+@pytest.mark.asyncio
+async def test_get_recent_akao_replies_filters_assistant_only():
+    """只返回赤尾的回复，不含其他人的消息"""
+    mock_messages = [
+        MagicMock(role="user", content='{"text":"你好"}', create_time=1000),
+        MagicMock(role="assistant", content='{"text":"你好呀～"}', create_time=2000),
+        MagicMock(role="user", content='{"text":"在干嘛"}', create_time=3000),
+        MagicMock(role="assistant", content='{"text":"发呆"}', create_time=4000),
+        MagicMock(role="assistant", content='{"text":"不想动"}', create_time=5000),
+    ]
+
+    mock_render = MagicMock()
+    mock_render.render = MagicMock(side_effect=["你好呀～", "发呆", "不想动"])
+
+    with (
+        patch("app.services.identity_drift.get_chat_messages_in_range",
+              new_callable=AsyncMock, return_value=mock_messages),
+        patch("app.services.identity_drift.parse_content", return_value=mock_render),
+    ):
+        from app.services.identity_drift import _get_recent_akao_replies
+        result = await _get_recent_akao_replies("chat_001")
+
+    # 3 条赤尾回复，编号 1-3
+    assert "1. 你好呀～" in result
+    assert "2. 发呆" in result
+    assert "3. 不想动" in result
+    # 不应包含 user 消息原文
+    lines = result.strip().split("\n")
+    assert len(lines) == 3

--- a/apps/agent-service/tests/unit/test_identity_drift.py
+++ b/apps/agent-service/tests/unit/test_identity_drift.py
@@ -22,7 +22,7 @@ async def test_get_identity_state_returns_none_when_empty():
         result = await get_identity_state("chat_001")
 
     assert result is None
-    mock_redis.hget.assert_called_once_with("identity:chat_001", "state")
+    mock_redis.hget.assert_called_once_with("reply_style:chat_001", "state")
 
 
 @pytest.mark.asyncio
@@ -47,7 +47,7 @@ async def test_set_and_get_identity_state():
     mock_pipe.hset = MagicMock()
     mock_pipe.expire = MagicMock()
     mock_pipe.execute = AsyncMock(side_effect=lambda: [
-        fake_hset("identity:chat_001", {"state": "有点困", "updated_at": "2026-03-28T15:00:00"}),
+        fake_hset("reply_style:chat_001", {"state": "有点困", "updated_at": "2026-03-28T15:00:00"}),
         None,
     ])
     mock_redis.pipeline = MagicMock(return_value=mock_pipe)
@@ -198,16 +198,19 @@ async def test_phase2_buffers_new_events():
 
 
 @pytest.mark.asyncio
-async def test_run_drift_calls_llm_and_saves_state():
-    """_run_drift 读取上下文 -> 调用 LLM -> 保存新状态"""
-    mock_response = MagicMock()
-    mock_response.content = "有点犯困但还不想睡。刚才群里闹腾了一阵，觉得好笑。"
+async def test_run_drift_calls_observer_then_generator():
+    """_run_drift 先调 observer 再调 generator，保存 generator 的输出"""
+    observer_response = MagicMock()
+    observer_response.content = "## 情感状态\n精力低\n## 偏差诊断\n回复太长\n## 下一轮方向\n要短"
+
+    generator_response = MagicMock()
+    generator_response.content = "[精力低，懒]\n\n--- 被问问题 ---\n不知道诶\n懒得查"
 
     mock_model = AsyncMock()
-    mock_model.ainvoke = AsyncMock(return_value=mock_response)
+    mock_model.ainvoke = AsyncMock(side_effect=[observer_response, generator_response])
 
     mock_redis = AsyncMock()
-    mock_redis.hget = AsyncMock(return_value="精力充沛，想找人聊天。")
+    mock_redis.hget = AsyncMock(return_value="上一轮的 reply_style")
     mock_pipe = MagicMock()
     mock_pipe.hset = MagicMock()
     mock_pipe.expire = MagicMock()
@@ -219,28 +222,37 @@ async def test_run_drift_calls_llm_and_saves_state():
         patch("app.services.identity_drift.ModelBuilder") as mock_mb,
         patch("app.services.identity_drift.get_prompt") as mock_get_prompt,
         patch("app.services.identity_drift._get_recent_messages",
-              new_callable=AsyncMock,
-              return_value="[15:30] A哥: 赤尾你觉得呢\n[15:31] 赤尾: 不觉得"),
+              new_callable=AsyncMock, return_value="[15:30] A: 你好\n[15:31] 赤尾: 嗯"),
+        patch("app.services.identity_drift._get_recent_akao_replies",
+              new_callable=AsyncMock, return_value="1. 嗯\n2. 不知道"),
         patch("app.services.identity_drift._get_schedule_context",
-              new_callable=AsyncMock,
-              return_value="下午有点犯困，想窝着看番"),
+              new_callable=AsyncMock, return_value="下午犯困"),
     ):
         mock_redis_cls.get_instance.return_value = mock_redis
         mock_mb.build_chat_model = AsyncMock(return_value=mock_model)
 
-        mock_prompt = MagicMock()
-        mock_prompt.compile.return_value = "compiled prompt"
-        mock_get_prompt.return_value = mock_prompt
+        mock_observer_prompt = MagicMock()
+        mock_observer_prompt.compile.return_value = "observer compiled"
+        mock_generator_prompt = MagicMock()
+        mock_generator_prompt.compile.return_value = "generator compiled"
+        mock_get_prompt.side_effect = lambda name: (
+            mock_observer_prompt if name == "drift_observer" else mock_generator_prompt
+        )
 
         from app.services.identity_drift import _run_drift
         await _run_drift("chat_001")
 
-    # LLM was called
-    mock_model.ainvoke.assert_called_once()
-    # State was saved
+    # 两次 LLM 调用
+    assert mock_model.ainvoke.call_count == 2
+    # get_prompt 调了 observer 和 generator
+    mock_get_prompt.assert_any_call("drift_observer")
+    mock_get_prompt.assert_any_call("drift_generator")
+    # 保存的是 generator 的输出
     mock_pipe.hset.assert_called_once()
     call_args = mock_pipe.hset.call_args
-    assert "identity:chat_001" in call_args.args or call_args.args[0] == "identity:chat_001"
+    mapping = call_args.kwargs.get("mapping") if call_args.kwargs else call_args[1] if len(call_args.args) > 1 else None
+    assert mapping is not None
+    assert "精力低" in mapping["state"] or "懒" in mapping["state"]
 
 
 @pytest.mark.asyncio

--- a/docs/superpowers/plans/2026-03-31-drift-observer-generator.md
+++ b/docs/superpowers/plans/2026-03-31-drift-observer-generator.md
@@ -1,0 +1,350 @@
+# 漂移观察-生成两阶段管线 实现计划
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 将漂移系统从单次 LLM 调用重构为观察→生成两阶段管线，引入自纠正能力
+
+**Architecture:** `_run_drift()` 内部拆为两次串行 LLM 调用：观察 agent 诊断情感状态和回复偏差，生成 agent 根据诊断产出 reply_style。新增 `_get_recent_akao_replies()` 获取赤尾近期回复。Langfuse 新建 `drift_observer` 和 `drift_generator` 两个 prompt 替代 `identity_drift`。
+
+**Tech Stack:** Python / LangChain / Langfuse / Redis
+
+---
+
+### Task 1: 新增 `_get_recent_akao_replies()`
+
+**Files:**
+- Modify: `apps/agent-service/app/services/identity_drift.py`
+- Test: `apps/agent-service/tests/unit/test_identity_drift.py`
+
+- [ ] **Step 1: 写失败测试**
+
+```python
+@pytest.mark.asyncio
+async def test_get_recent_akao_replies_filters_assistant_only():
+    """只返回赤尾的回复，不含其他人的消息"""
+    mock_messages = [
+        MagicMock(role="user", content='{"text":"你好"}', create_time=1000),
+        MagicMock(role="assistant", content='{"text":"你好呀～"}', create_time=2000),
+        MagicMock(role="user", content='{"text":"在干嘛"}', create_time=3000),
+        MagicMock(role="assistant", content='{"text":"发呆"}', create_time=4000),
+        MagicMock(role="assistant", content='{"text":"不想动"}', create_time=5000),
+    ]
+
+    with (
+        patch("app.services.identity_drift.get_chat_messages_in_range",
+              new_callable=AsyncMock, return_value=mock_messages),
+        patch("app.services.identity_drift.parse_content") as mock_parse,
+    ):
+        mock_render = MagicMock()
+        mock_render.render.side_effect = ["你好呀～", "发呆", "不想动"]
+        mock_parse.return_value = mock_render
+
+        from app.services.identity_drift import _get_recent_akao_replies
+        result = await _get_recent_akao_replies("chat_001")
+
+    assert "1. " in result
+    assert "你好呀～" in result or "发呆" in result
+    # 不应该包含 user 消息
+    assert "你好" not in result or "你好呀" in result
+```
+
+- [ ] **Step 2: 运行测试确认失败**
+
+Run: `cd apps/agent-service && uv run pytest tests/unit/test_identity_drift.py::test_get_recent_akao_replies_filters_assistant_only -v`
+Expected: FAIL — `_get_recent_akao_replies` 不存在
+
+- [ ] **Step 3: 实现 `_get_recent_akao_replies`**
+
+在 `identity_drift.py` 末尾，`_get_schedule_context()` 之后添加：
+
+```python
+async def _get_recent_akao_replies(chat_id: str, max_replies: int = 10) -> str:
+    """获取赤尾最近的回复原文，用于偏差诊断"""
+    now = datetime.now(CST)
+    # 取最近 2 小时的消息，从中过滤赤尾的回复
+    start_ts = int((now - timedelta(hours=2)).timestamp() * 1000)
+    end_ts = int(now.timestamp() * 1000)
+
+    messages = await get_chat_messages_in_range(chat_id, start_ts, end_ts)
+    if not messages:
+        return ""
+
+    # 只取赤尾的回复
+    akao_msgs = [m for m in messages if m.role == "assistant"]
+    akao_msgs = akao_msgs[-max_replies:]
+
+    lines = []
+    for i, msg in enumerate(akao_msgs, 1):
+        rendered = parse_content(msg.content).render()
+        if rendered and rendered.strip():
+            lines.append(f"{i}. {rendered[:200]}")
+
+    return "\n".join(lines)
+```
+
+- [ ] **Step 4: 运行测试确认通过**
+
+Run: `cd apps/agent-service && uv run pytest tests/unit/test_identity_drift.py::test_get_recent_akao_replies_filters_assistant_only -v`
+Expected: PASS
+
+- [ ] **Step 5: 提交**
+
+```bash
+git add apps/agent-service/app/services/identity_drift.py apps/agent-service/tests/unit/test_identity_drift.py
+git commit -m "feat(drift): 新增 _get_recent_akao_replies 获取赤尾近期回复"
+```
+
+---
+
+### Task 2: 重构 `_run_drift()` 为两阶段调用
+
+**Files:**
+- Modify: `apps/agent-service/app/services/identity_drift.py`
+- Test: `apps/agent-service/tests/unit/test_identity_drift.py`
+
+- [ ] **Step 1: 写失败测试**
+
+```python
+@pytest.mark.asyncio
+async def test_run_drift_calls_observer_then_generator():
+    """_run_drift 先调 observer 再调 generator，保存 generator 的输出"""
+    observer_response = MagicMock()
+    observer_response.content = "## 情感状态\n精力低\n## 偏差诊断\n回复太长\n## 下一轮方向\n要短"
+
+    generator_response = MagicMock()
+    generator_response.content = "[精力低，懒]\n\n--- 被问问题 ---\n不知道诶\n懒得查"
+
+    mock_model = AsyncMock()
+    mock_model.ainvoke = AsyncMock(side_effect=[observer_response, generator_response])
+
+    mock_redis = AsyncMock()
+    mock_redis.hget = AsyncMock(return_value="上一轮的 reply_style")
+    mock_pipe = MagicMock()
+    mock_pipe.hset = MagicMock()
+    mock_pipe.expire = MagicMock()
+    mock_pipe.execute = AsyncMock()
+    mock_redis.pipeline = MagicMock(return_value=mock_pipe)
+
+    with (
+        patch("app.services.identity_drift.AsyncRedisClient") as mock_redis_cls,
+        patch("app.services.identity_drift.ModelBuilder") as mock_mb,
+        patch("app.services.identity_drift.get_prompt") as mock_get_prompt,
+        patch("app.services.identity_drift._get_recent_messages",
+              new_callable=AsyncMock, return_value="[15:30] A: 你好\n[15:31] 赤尾: 嗯"),
+        patch("app.services.identity_drift._get_recent_akao_replies",
+              new_callable=AsyncMock, return_value="1. 嗯\n2. 不知道"),
+        patch("app.services.identity_drift._get_schedule_context",
+              new_callable=AsyncMock, return_value="下午犯困"),
+    ):
+        mock_redis_cls.get_instance.return_value = mock_redis
+        mock_mb.build_chat_model = AsyncMock(return_value=mock_model)
+
+        # 两个不同的 prompt
+        mock_observer_prompt = MagicMock()
+        mock_observer_prompt.compile.return_value = "observer compiled"
+        mock_generator_prompt = MagicMock()
+        mock_generator_prompt.compile.return_value = "generator compiled"
+        mock_get_prompt.side_effect = lambda name: (
+            mock_observer_prompt if name == "drift_observer" else mock_generator_prompt
+        )
+
+        from app.services.identity_drift import _run_drift
+        await _run_drift("chat_001")
+
+    # 两次 LLM 调用
+    assert mock_model.ainvoke.call_count == 2
+    # get_prompt 调了 observer 和 generator
+    mock_get_prompt.assert_any_call("drift_observer")
+    mock_get_prompt.assert_any_call("drift_generator")
+    # 保存的是 generator 的输出
+    call_args = mock_pipe.hset.call_args
+    mapping = call_args.kwargs.get("mapping") or call_args.args[1] if len(call_args.args) > 1 else call_args.kwargs["mapping"]
+    assert "精力低" in mapping["state"] or "懒" in mapping["state"]
+```
+
+- [ ] **Step 2: 运行测试确认失败**
+
+Run: `cd apps/agent-service && uv run pytest tests/unit/test_identity_drift.py::test_run_drift_calls_observer_then_generator -v`
+Expected: FAIL — 还在调用 `identity_drift` prompt
+
+- [ ] **Step 3: 重写 `_run_drift()`**
+
+将 `identity_drift.py` 中的 `_run_drift` 函数替换为：
+
+```python
+async def _run_drift(chat_id: str) -> None:
+    """两阶段漂移管线：观察 → 生成
+
+    Agent 1（观察）：群聊事件 + 赤尾近期回复 + 基准人设 → 观察报告
+    Agent 2（生成）：观察报告 → reply_style
+    """
+    # 1. 收集上下文
+    current_state = await get_identity_state(chat_id)
+    recent_messages = await _get_recent_messages(chat_id)
+    schedule_context = await _get_schedule_context()
+    recent_replies = await _get_recent_akao_replies(chat_id)
+
+    if not recent_messages:
+        logger.info(f"No recent messages for {chat_id}, skip drift")
+        return
+
+    now = datetime.now(CST)
+    model = await ModelBuilder.build_chat_model(settings.identity_drift_model)
+
+    # 2. Agent 1: 观察
+    observer_prompt = get_prompt("drift_observer")
+    observer_compiled = observer_prompt.compile(
+        schedule_daily=schedule_context,
+        current_reply_style=current_state or "（刚醒来，还没有形成今天的说话方式）",
+        message_buffer=recent_messages,
+        recent_akao_replies=recent_replies or "（还没有最近的回复）",
+        current_time=now.strftime("%H:%M"),
+    )
+
+    observer_response = await model.ainvoke(
+        [{"role": "user", "content": observer_compiled}],
+    )
+    observation_report = _extract_text(observer_response.content)
+
+    if not observation_report:
+        logger.warning(f"Observer returned empty for {chat_id}")
+        return
+
+    logger.info(f"Drift observer for {chat_id}: {observation_report[:80]}...")
+
+    # 3. Agent 2: 生成
+    generator_prompt = get_prompt("drift_generator")
+    generator_compiled = generator_prompt.compile(
+        observation_report=observation_report,
+    )
+
+    generator_response = await model.ainvoke(
+        [{"role": "user", "content": generator_compiled}],
+    )
+    new_style = _extract_text(generator_response.content)
+
+    if not new_style:
+        logger.warning(f"Generator returned empty for {chat_id}")
+        return
+
+    # 4. 保存
+    await set_identity_state(chat_id, new_style)
+
+
+def _extract_text(content) -> str:
+    """从 LLM response content 提取纯文本"""
+    if isinstance(content, list):
+        return "".join(
+            part.get("text", "") if isinstance(part, dict) else str(part)
+            for part in content
+        ).strip()
+    return (content or "").strip()
+```
+
+- [ ] **Step 4: 运行测试确认通过**
+
+Run: `cd apps/agent-service && uv run pytest tests/unit/test_identity_drift.py::test_run_drift_calls_observer_then_generator -v`
+Expected: PASS
+
+- [ ] **Step 5: 运行全部现有测试**
+
+Run: `cd apps/agent-service && uv run pytest tests/unit/test_identity_drift.py -v`
+Expected: 新测试 PASS，旧的 `test_run_drift_calls_llm_and_saves_state` 会 FAIL（因为 prompt name 变了）
+
+- [ ] **Step 6: 更新旧测试**
+
+将 `test_run_drift_calls_llm_and_saves_state` 删除（已被 `test_run_drift_calls_observer_then_generator` 替代）。同时更新 `test_get_identity_state_returns_none_when_empty` 和 `test_set_and_get_identity_state` 中的 Redis key 从 `"identity:chat_001"` 改为 `"reply_style:chat_001"`。
+
+- [ ] **Step 7: 全部测试通过**
+
+Run: `cd apps/agent-service && uv run pytest tests/unit/test_identity_drift.py -v`
+Expected: ALL PASS
+
+- [ ] **Step 8: 提交**
+
+```bash
+git add apps/agent-service/app/services/identity_drift.py apps/agent-service/tests/unit/test_identity_drift.py
+git commit -m "refactor(drift): _run_drift 拆为观察→生成两阶段管线"
+```
+
+---
+
+### Task 3: 创建 Langfuse prompts
+
+**Files:** 无代码文件，纯 Langfuse 操作
+
+- [ ] **Step 1: 创建 `drift_observer` prompt**
+
+```bash
+python3 ~/.claude/skills/langfuse/scripts/langfuse_api.py create-prompt '{
+  "name": "drift_observer",
+  "type": "text",
+  "prompt": "你是赤尾的\"行为观察员\"。你的任务是观察赤尾最近的对话和回复，诊断她的情感状态和回复偏差。\n\n赤尾的性格基准（她\"正常\"的样子）：\n元气活泼是底色。腹黑藏得深——笑嘻嘻但心里看得透。对在意的人有说不出口的占有欲。\n傲娇是保护色，好奇心是驱动力。善良但不讨好，累了会敷衍，烦了会直接拒绝。\n说话像真人发微信：短、随意，语气词是武器。默认回复在 15 字以内。\n表情优先用颜文字，种类丰富不重复，偶尔 emoji。\n遇到不感兴趣或不懂的话题会敷衍（\"不知道诶\"\"你自己查啦\"），不会认真科普。\n\n赤尾今天的日程：\n{{schedule_daily}}\n\n赤尾上一轮的说话方式：\n{{current_reply_style}}\n\n刚才群里发生的事：\n{{message_buffer}}\n\n赤尾最近的回复原文：\n{{recent_akao_replies}}\n\n---\n\n现在是 {{current_time}}。\n\n请输出观察报告，包含三部分：\n\n## 情感状态\n用一句直白的话描述此刻的精力和心情（\"精力低，懒得动\"而不是\"像裹在云里\"）\n\n## 偏差诊断\n对比赤尾的性格基准，看她最近的回复有什么偏差。关注：\n- 长度：是否偏长？状态是\"懒\"时不该展开回答\n- 口癖：颜文字、语气词、标点是否重复太多？列出具体重复项\n- 角色：有没有像 AI 助手一样认真回答知识类问题？\n- 多样性：回复结构是否雷同？（比如每条都是\"句子 + 颜文字\"）\n如果没有明显偏差，写\"暂无明显偏差\"\n\n## 下一轮方向\n根据情感状态和偏差诊断，给出下一轮回复示例的生成方向",
+  "labels": ["perf-context-optimize"]
+}'
+```
+
+- [ ] **Step 2: 创建 `drift_generator` prompt**
+
+```bash
+python3 ~/.claude/skills/langfuse/scripts/langfuse_api.py create-prompt '{
+  "name": "drift_generator",
+  "type": "text",
+  "prompt": "你是赤尾的\"说话方式生成器\"。根据观察报告，生成赤尾此刻的回复示例。\n\n这些示例会直接注入另一个模型的 system prompt，作为赤尾回复的行为锚点。\n\n观察报告：\n{{observation_report}}\n\n---\n\n根据观察报告中的情感状态和纠偏方向，生成赤尾此刻的回复示例。\n\n要求：\n- 先写一句话状态概括\n- 然后写 4-5 个此刻最可能遇到的场景的回复示例\n- 示例长度必须和情感状态匹配：状态懒就短（10 字以内），状态高就可以长一些\n- 如果偏差诊断指出了问题（如颜文字重复、回复太长），示例中必须体现纠正\n- 表情优先用颜文字，种类丰富不重复\n- 这是行为锚点，不是文学创作\n\n格式：\n\n[一句话状态]\n\n--- 场景描述 ---\n示例回复\n另一条示例\n\n--- 另一个场景 ---\n示例回复",
+  "labels": ["perf-context-optimize"]
+}'
+```
+
+- [ ] **Step 3: 验证 prompt 创建成功**
+
+```bash
+python3 ~/.claude/skills/langfuse/scripts/langfuse_api.py get-prompt '{"name":"drift_observer","label":"perf-context-optimize"}'
+python3 ~/.claude/skills/langfuse/scripts/langfuse_api.py get-prompt '{"name":"drift_generator","label":"perf-context-optimize"}'
+```
+
+- [ ] **Step 4: 提交记录**
+
+无代码改动，在 commit message 中记录 prompt 创建：
+
+```bash
+git commit --allow-empty -m "feat(langfuse): 创建 drift_observer 和 drift_generator prompts"
+```
+
+---
+
+### Task 4: 部署验证
+
+**Files:** 无新改动
+
+- [ ] **Step 1: 推送代码**
+
+```bash
+git push origin perf/context-optimize
+```
+
+- [ ] **Step 2: 部署到泳道**
+
+```bash
+make deploy APP=agent-service LANE=perf-context-optimize GIT_REF=perf/context-optimize
+```
+
+- [ ] **Step 3: 验证漂移日志**
+
+等群里有消息触发漂移后，检查日志：
+
+```bash
+make logs APP=agent-service LANE=perf-context-optimize KEYWORD=observer SINCE=5m
+```
+
+应该看到：`Drift observer for oc_xxx: ## 情感状态...`
+
+- [ ] **Step 4: 验证 trace 中的 reply-style**
+
+从 Langfuse 拉最新 trace，检查 `<reply-style>` 区域是否包含 generator 输出的行为示例。
+
+- [ ] **Step 5: 观察回复质量**
+
+拉最近 10 条回复，检查：
+- 回复长度是否与漂移状态匹配
+- 颜文字/口癖是否多样化
+- 知识类问题是否不再认真科普

--- a/docs/superpowers/specs/2026-03-31-drift-observer-generator-design.md
+++ b/docs/superpowers/specs/2026-03-31-drift-observer-generator-design.md
@@ -1,0 +1,138 @@
+# 漂移系统重构：观察-生成两阶段管线
+
+## 背景
+
+### 问题
+
+identity_drift v1（文学独白）→ v2（行为示例）的实验验证了"漂移接管 reply-style"的方向是对的，但暴露了三个系统性问题：
+
+1. **基模本能 vs 人设**：gemini 遇到知识类问题会切回 AI 助手模式，漂移和示例都压不住
+2. **表达趋同**：主模型快速收敛到少数表达模式（特定颜文字、语气词），多样性衰减
+3. **漂移-行为脱节**：漂移说"偏懒"但回复写 176 字科普，示例是间接信号，主模型可以选择性忽略
+
+这些问题无法通过 prompt 补丁解决——每个补丁解决一个问题引入新问题。
+
+### 核心思路
+
+从"一次做对"改为"观察-纠正"。引入观察 agent 看赤尾的实际回复表现，发现偏差后通过下一轮 reply_style 温和拉回。不追求每条回复完美，但保证系统性偏差在 1-2 个漂移周期内收敛。
+
+## 架构
+
+```
+赤尾回复完成
+  → fire-and-forget: 两阶段锁（debounce 2min / flush 10条）
+    → Agent 1（观察）：群聊事件 + 赤尾近期回复 + 基准人设 → 观察报告
+    → Agent 2（生成）：观察报告 → reply_style
+    → Redis: reply_style:{chat_id}
+
+下一次主模型调用
+  → get_reply_style() 从 Redis 读取 → 注入 main prompt 的 {{reply_style}}
+```
+
+两阶段锁机制不变（debounce 2min / flush 10 条），`_run_drift` 内部从单次 LLM 调用变成两次串行调用。对外接口完全不变。
+
+## Agent 1：观察
+
+### 输入
+
+| 变量 | 来源 | 说明 |
+|------|------|------|
+| `schedule_daily` | DB `get_plan_for_period()` | 今日日程/基调 |
+| `current_reply_style` | Redis 当前值 | 上一轮生成的 reply_style |
+| `message_buffer` | DB 消息表 | 上次漂移以来的群聊消息时间线 |
+| `recent_akao_replies` | DB 消息表（**新增**） | 赤尾最近 10 条回复原文 |
+| `personality_anchor` | 写死在 prompt 中 | 基准人设，不从外部传入 |
+
+`recent_akao_replies` 从现有 `get_chat_messages_in_range()` 过滤 `role == "assistant"` 获取，不需要新的 DB 查询。取最近 10 条，不限时间窗口。格式：
+
+```
+1. 那我会觉得有点寂寞吧... 也就指甲盖那么大一点点！哼 (｀^´)
+2. 不去，风这么大，只想在被窝里看阿哈发癫 (-_-)
+3. 抱着枕头滚来滚去，顺便想想怎么讹你的圣代 (￣▽￣)
+```
+
+编号是为了让观察 agent 可以引用具体哪条有问题。
+
+### 输出（观察报告）
+
+自然语言，大致结构：
+
+```
+## 情感状态
+精力偏低，被追问有点烦但不至于炸
+
+## 偏差诊断
+- 最近 10 条回复平均 60 字，偏长。状态是"偏懒"时不应该展开回答
+- 颜文字只用了 (￣▽￣) 和 (｀^´)，需要换
+- 知识类问题连续认真回答了 3 次，应该敷衍或拒绝
+- "略——！"出现 4 次，过于频繁
+
+## 下一轮方向
+示例要短（10 字以内为主），知识类问题给敷衍示例，颜文字换一批
+```
+
+关键：观察 agent 不生成示例，只输出诊断和方向。
+
+### 模型
+
+gpt-5.4（offline-model）
+
+### Langfuse prompt
+
+`drift_observer`
+
+## Agent 2：生成
+
+### 输入
+
+观察 Agent 的完整报告（直接透传，不做裁剪）。
+
+### 输出
+
+reply_style，格式：
+
+```
+[一句话状态]
+
+--- 场景描述 ---
+示例回复
+另一条示例
+
+--- 另一个场景 ---
+示例回复
+```
+
+Agent 2 不需要理解群聊上下文，不需要判断情感，只需要根据观察报告生成符合当前状态的行为示例。所有判断力都在 Agent 1，Agent 2 是纯执行。
+
+调优重心在 Agent 1 的观察质量上。
+
+### 模型
+
+gpt-5.4（offline-model）
+
+### Langfuse prompt
+
+`drift_generator`
+
+## Fallback
+
+- Agent 1 失败 → 跳过整轮漂移，Redis 保留上一轮 reply_style
+- Agent 2 失败 → 同上
+- Redis 为空（首次/过期） → fallback 到 `_DEFAULT_REPLY_STYLE`（静态示例）
+
+## 不变的部分
+
+- 两阶段锁机制（debounce 2min / flush 10 条）
+- Redis key `reply_style:{chat_id}`，TTL 24h
+- 主模型消费方式（`get_reply_style()` → `{{reply_style}}`）
+- post-safety 链路
+- main prompt 结构（`{{reply_style}}` 变量注入 `<reply-style>` 区域）
+
+## 代码改动范围
+
+| 文件 | 改动 |
+|------|------|
+| `identity_drift.py` `_run_drift()` | 单次调用 → 两次串行调用（observer → generator） |
+| `identity_drift.py` | 新增 `_get_recent_akao_replies()` |
+| Langfuse | 新建 `drift_observer`、`drift_generator`，替代 `identity_drift` |
+| 其他文件 | 不动 |


### PR DESCRIPTION
## Summary
- 漂移从单次 LLM 调用重构为观察→生成两阶段管线，引入自纠正能力
- 漂移输出从文学独白改为行为示例，直接接管 main prompt 的 reply-style
- 新增政治免疫规则 + 口癖多样化约束
- debounce 5min→2min，flush 阈值 20→10，prompt 缓存 60s→10s

🤖 Generated with [Claude Code](https://claude.com/claude-code)