### PR TITLE
fix(context): 修正今日基调优先级

### DIFF
--- a/apps/agent-service/app/services/memory_context.py
+++ b/apps/agent-service/app/services/memory_context.py
@@ -61,23 +61,24 @@ _MEMORY_RECALL_HINT = (
 
 
 async def _build_today_state() -> str:
-    """构建今日状态：优先 Journal daily，fallback Schedule daily"""
+    """构建今日状态：今天 Schedule > 昨天 Journal
+
+    今天的 Journal 不可能存在（凌晨 04:00 回溯生成昨天的），
+    所以优先用今天的 Schedule（05:00 生成），再 fallback 昨天的 Journal。
+    """
     now = datetime.now(CST)
     today = now.strftime("%Y-%m-%d")
 
-    # 优先用 Journal（模糊化的个人感受）
-    journal = await get_journal("daily", today)
-    if not journal:
-        yesterday = (now - timedelta(days=1)).strftime("%Y-%m-%d")
-        journal = await get_journal("daily", yesterday)
-
-    if journal:
-        return journal.content
-
-    # fallback: Schedule daily
+    # 优先用今天的 Schedule（05:00 已生成）
     schedule = await get_plan_for_period("daily", today, today)
     if schedule and schedule.content:
         return schedule.content
+
+    # fallback: 昨天的 Journal（模糊化的个人感受）
+    yesterday = (now - timedelta(days=1)).strftime("%Y-%m-%d")
+    journal = await get_journal("daily", yesterday)
+    if journal:
+        return journal.content
 
     return ""
 


### PR DESCRIPTION
## Summary
- 修正 `_build_today_state()` fallback 顺序：今天 Schedule > 昨天 Journal
- 今天的 Journal 不可能存在（04:00 回溯生成昨天的），导致昨天 Journal 永远挡住今天 Schedule
- 同时更新了 `drift_generator` Langfuse prompt v2，禁止 markdown 格式包裹颜文字

## Test plan
- [ ] 部署后观察赤尾回复中颜文字是否还有反引号外壳
- [ ] 确认 inner_context 中基调来源切换为今天的 Schedule

🤖 Generated with [Claude Code](https://claude.com/claude-code)