### PR TITLE
fix(infra): 修复 make logs URL 编码和 Dashboard lane-bindings 404

### DIFF
--- a/.claude/skills/ship/SKILL.md
+++ b/.claude/skills/ship/SKILL.md
@@ -48,9 +48,14 @@ git push -u origin <branch>
 # 创建 PR（已存在则跳过）
 ghc pr create --fill 2>/dev/null || true
 
-# 直接合码
-ghc pr merge --squash --delete-branch
+# 合码（不带 --delete-branch，避免 worktree 下切 main 失败）
+ghc pr merge --squash
+
+# 删除远端分支（合码成功后）
+git push origin --delete <branch>
 ```
+
+**禁止使用 `--delete-branch`**：在 worktree 中该参数会尝试本地切换到 main，导致 `致命错误：'main' 已经检出到 ...`。PR 实际已合并但命令报错，模型会误以为失败而重试。
 
 **合并冲突处理**：遇到冲突时，展示冲突文件和冲突内容，等用户指示如何解决。解决后重新 push 并重试。不要自行选择保留哪个版本。
 

--- a/Makefile
+++ b/Makefile
@@ -240,12 +240,13 @@ END       ?=
 ##       make logs APP=lark-server POD=lark-server-abc          （Pod 前缀）
 ##       make logs APP=lark-server START=2024-01-01T10:00:00Z END=2024-01-01T11:00:00Z
 logs:
-	@PARAMS="limit=$(LIMIT)&direction=$(DIRECTION)"; \
-	if [ -n "$(APP)" ]; then PARAMS="$$PARAMS&app=$(APP)"; fi; \
-	if [ -n "$(KEYWORD)" ]; then PARAMS="$$PARAMS&keyword=$(KEYWORD)"; fi; \
-	if [ -n "$(EXCLUDE)" ]; then PARAMS="$$PARAMS&exclude=$(EXCLUDE)"; fi; \
-	if [ -n "$(REGEXP)" ]; then PARAMS="$$PARAMS&regexp=$(REGEXP)"; fi; \
-	if [ -n "$(POD)" ]; then PARAMS="$$PARAMS&pod=$(POD)"; fi; \
+	@urlencode() { python3 -c "import urllib.parse; print(urllib.parse.quote('''$$1''', safe=''))"; }; \
+	PARAMS="limit=$(LIMIT)&direction=$(DIRECTION)"; \
+	if [ -n "$(APP)" ]; then PARAMS="$$PARAMS&app=$$(urlencode '$(APP)')"; fi; \
+	if [ -n "$(KEYWORD)" ]; then PARAMS="$$PARAMS&keyword=$$(urlencode '$(KEYWORD)')"; fi; \
+	if [ -n "$(EXCLUDE)" ]; then PARAMS="$$PARAMS&exclude=$$(urlencode '$(EXCLUDE)')"; fi; \
+	if [ -n "$(REGEXP)" ]; then PARAMS="$$PARAMS&regexp=$$(urlencode '$(REGEXP)')"; fi; \
+	if [ -n "$(POD)" ]; then PARAMS="$$PARAMS&pod=$$(urlencode '$(POD)')"; fi; \
 	if [ -n "$(filter-out prod,$(LANE))" ]; then PARAMS="$$PARAMS&lane=$(LANE)"; fi; \
 	if [ -n "$(START)" ]; then \
 		PARAMS="$$PARAMS&start=$(START)"; \
@@ -254,9 +255,10 @@ logs:
 		PARAMS="$$PARAMS&since=$(SINCE)"; \
 	fi; \
 	echo ">>> 查询日志: $$PARAMS"; \
-	curl -sf "$(PAAS_API)/api/paas/logs?$$PARAMS" \
-		-H 'X-API-Key: $(PAAS_TOKEN)' $(CURL_LANE) \
-		| python3 -c "import sys,json; print(json.loads(sys.stdin.buffer.read(),strict=False).get('data',{}).get('logs','(无日志)'))"
+	RESP=$$(curl -sf "$(PAAS_API)/api/paas/logs?$$PARAMS" \
+		-H 'X-API-Key: $(PAAS_TOKEN)' $(CURL_LANE)); \
+	if [ -z "$$RESP" ]; then echo "(请求失败或无响应)"; exit 1; fi; \
+	echo "$$RESP" | python3 -c "import sys,json; print(json.loads(sys.stdin.buffer.read(),strict=False).get('data',{}).get('logs','(无日志)'))"
 
 # ---------- 泳道绑定 ----------
 

--- a/apps/monitor-dashboard/src/paas-client.ts
+++ b/apps/monitor-dashboard/src/paas-client.ts
@@ -12,6 +12,18 @@ function getConfig(): { baseURL: string; headers: Record<string, string> } {
   };
 }
 
+function getLarkConfig(): { baseURL: string; headers: Record<string, string> } {
+  const larkApi = process.env.DASHBOARD_LARK_API || 'http://lark-proxy:3003';
+  const paasToken = process.env.DASHBOARD_PAAS_TOKEN;
+  if (!paasToken) {
+    throw new Error('DASHBOARD_PAAS_TOKEN not configured');
+  }
+  return {
+    baseURL: larkApi,
+    headers: { 'X-API-Key': paasToken },
+  };
+}
+
 const TIMEOUT = 15000;
 
 function unwrap(data: unknown): unknown {
@@ -21,28 +33,33 @@ function unwrap(data: unknown): unknown {
   return data;
 }
 
-export const paasClient = {
-  async get(path: string, params?: Record<string, string>) {
-    const { baseURL, headers } = getConfig();
-    const config: AxiosRequestConfig = { headers, timeout: TIMEOUT, params };
-    const res = await axios.get(`${baseURL}${path}`, config);
-    return unwrap(res.data);
-  },
+function createClient(configFn: () => { baseURL: string; headers: Record<string, string> }) {
+  return {
+    async get(path: string, params?: Record<string, string>) {
+      const { baseURL, headers } = configFn();
+      const config: AxiosRequestConfig = { headers, timeout: TIMEOUT, params };
+      const res = await axios.get(`${baseURL}${path}`, config);
+      return unwrap(res.data);
+    },
 
-  async post(path: string, body?: unknown) {
-    const { baseURL, headers } = getConfig();
-    const config: AxiosRequestConfig = {
-      headers: { ...headers, 'Content-Type': 'application/json' },
-      timeout: TIMEOUT,
-    };
-    const res = await axios.post(`${baseURL}${path}`, body, config);
-    return unwrap(res.data);
-  },
+    async post(path: string, body?: unknown) {
+      const { baseURL, headers } = configFn();
+      const config: AxiosRequestConfig = {
+        headers: { ...headers, 'Content-Type': 'application/json' },
+        timeout: TIMEOUT,
+      };
+      const res = await axios.post(`${baseURL}${path}`, body, config);
+      return unwrap(res.data);
+    },
 
-  async del(path: string, params?: Record<string, string>) {
-    const { baseURL, headers } = getConfig();
-    const config: AxiosRequestConfig = { headers, timeout: TIMEOUT, params };
-    const res = await axios.delete(`${baseURL}${path}`, config);
-    return unwrap(res.data);
-  },
-};
+    async del(path: string, params?: Record<string, string>) {
+      const { baseURL, headers } = configFn();
+      const config: AxiosRequestConfig = { headers, timeout: TIMEOUT, params };
+      const res = await axios.delete(`${baseURL}${path}`, config);
+      return unwrap(res.data);
+    },
+  };
+}
+
+export const paasClient = createClient(getConfig);
+export const larkClient = createClient(getLarkConfig);

--- a/apps/monitor-dashboard/src/routes/operations.ts
+++ b/apps/monitor-dashboard/src/routes/operations.ts
@@ -1,5 +1,5 @@
 import Router from '@koa/router';
-import { paasClient } from '../paas-client';
+import { paasClient, larkClient } from '../paas-client';
 
 const router = new Router();
 
@@ -66,7 +66,7 @@ router.post('/api/ops/db-query', async (ctx) => {
 
 /** GET /api/ops/lane-bindings — 列出泳道绑定 */
 router.get('/api/ops/lane-bindings', async (ctx) => {
-  const data = await paasClient.get('/api/lark/lane-bindings');
+  const data = await larkClient.get('/api/lark/lane-bindings');
   ctx.body = data;
 });
 
@@ -84,7 +84,7 @@ router.post('/api/ops/lane-bindings', async (ctx) => {
     ctx.body = { message: 'route_type, route_key, and lane_name are required' };
     return;
   }
-  const data = await paasClient.post('/api/lark/lane-bindings', {
+  const data = await larkClient.post('/api/lark/lane-bindings', {
     route_type,
     route_key,
     lane_name,
@@ -101,7 +101,7 @@ router.delete('/api/ops/lane-bindings', async (ctx) => {
     ctx.body = { message: 'type and key query params are required' };
     return;
   }
-  const data = await paasClient.del('/api/lark/lane-bindings', { type, key });
+  const data = await larkClient.del('/api/lark/lane-bindings', { type, key });
   ctx.body = data;
 });
 


### PR DESCRIPTION
1. Makefile logs target: 对 KEYWORD/EXCLUDE 等参数做 URL 编码，
   含空格/特殊字符时不再导致 curl 请求失败；空响应时报错而非
   Python JSON 解析崩溃

2. monitor-dashboard paas-client: 新增 larkClient 直连
   lark-proxy:3003，修复 paasClient 通过 paas-engine 调
   /api/lark/ 端点 404 的问题

3. ship skill: ghc pr merge 不再使用 --delete-branch，
   避免 worktree 中切 main 失败

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
