### PR TITLE
feat(rules): 全量多bot分工 + persona工具指令引导

### DIFF
--- a/apps/lark-proxy/src/lark-adapter.ts
+++ b/apps/lark-proxy/src/lark-adapter.ts
@@ -6,32 +6,21 @@ export function adaptHono(
     dispatcher: Lark.EventDispatcher | Lark.CardActionHandler,
 ): Handler {
     return async (c) => {
-        try {
-            const data = await c.req.json();
-            console.info(`[adaptHono] received request, keys: ${Object.keys(data).join(',')}`);
+        const data = await c.req.json();
 
-            // 处理飞书 url_verification 挑战（配置 webhook URL 时触发）
-            const encryptKey = (dispatcher as any).encryptKey as string;
-            if ('encrypt' in data) {
-                console.info(`[adaptHono] encrypted payload, encryptKey present: ${!!encryptKey}`);
-            }
-            const plain = 'encrypt' in data && encryptKey
-                ? JSON.parse(new AESCipher(encryptKey).decrypt(data.encrypt))
-                : data;
-            if (plain.type === 'url_verification') {
-                console.info(`[adaptHono] responding to url_verification challenge`);
-                return c.json({ challenge: plain.challenge });
-            }
-
-            const headers = Object.fromEntries(c.req.raw.headers);
-            const result = await (dispatcher as any).invoke(
-                Object.assign(Object.create({ headers }), data),
-            );
-            console.info(`[adaptHono] invoke result: ${JSON.stringify(result)?.slice(0, 200)}`);
-            return c.json(result);
-        } catch (err) {
-            console.error(`[adaptHono] error:`, err);
-            return c.json({ error: 'internal' }, 500);
+        // 处理飞书 url_verification 挑战（配置 webhook URL 时触发）
+        const encryptKey = (dispatcher as any).encryptKey as string;
+        const plain = 'encrypt' in data && encryptKey
+            ? JSON.parse(new AESCipher(encryptKey).decrypt(data.encrypt))
+            : data;
+        if (plain.type === 'url_verification') {
+            return c.json({ challenge: plain.challenge });
         }
+
+        const headers = Object.fromEntries(c.req.raw.headers);
+        const result = await (dispatcher as any).invoke(
+            Object.assign(Object.create({ headers }), data),
+        );
+        return c.json(result);
     };
 }

--- a/apps/lark-proxy/src/lark-adapter.ts
+++ b/apps/lark-proxy/src/lark-adapter.ts
@@ -6,21 +6,32 @@ export function adaptHono(
     dispatcher: Lark.EventDispatcher | Lark.CardActionHandler,
 ): Handler {
     return async (c) => {
-        const data = await c.req.json();
+        try {
+            const data = await c.req.json();
+            console.info(`[adaptHono] received request, keys: ${Object.keys(data).join(',')}`);
 
-        // 处理飞书 url_verification 挑战（配置 webhook URL 时触发）
-        const encryptKey = (dispatcher as any).encryptKey as string;
-        const plain = 'encrypt' in data && encryptKey
-            ? JSON.parse(new AESCipher(encryptKey).decrypt(data.encrypt))
-            : data;
-        if (plain.type === 'url_verification') {
-            return c.json({ challenge: plain.challenge });
+            // 处理飞书 url_verification 挑战（配置 webhook URL 时触发）
+            const encryptKey = (dispatcher as any).encryptKey as string;
+            if ('encrypt' in data) {
+                console.info(`[adaptHono] encrypted payload, encryptKey present: ${!!encryptKey}`);
+            }
+            const plain = 'encrypt' in data && encryptKey
+                ? JSON.parse(new AESCipher(encryptKey).decrypt(data.encrypt))
+                : data;
+            if (plain.type === 'url_verification') {
+                console.info(`[adaptHono] responding to url_verification challenge`);
+                return c.json({ challenge: plain.challenge });
+            }
+
+            const headers = Object.fromEntries(c.req.raw.headers);
+            const result = await (dispatcher as any).invoke(
+                Object.assign(Object.create({ headers }), data),
+            );
+            console.info(`[adaptHono] invoke result: ${JSON.stringify(result)?.slice(0, 200)}`);
+            return c.json(result);
+        } catch (err) {
+            console.error(`[adaptHono] error:`, err);
+            return c.json({ error: 'internal' }, 500);
         }
-
-        const headers = Object.fromEntries(c.req.raw.headers);
-        const result = await (dispatcher as any).invoke(
-            Object.assign(Object.create({ headers }), data),
-        );
-        return c.json(result);
     };
 }

--- a/apps/lark-server/src/core/rules/engine.ts
+++ b/apps/lark-server/src/core/rules/engine.ts
@@ -1,5 +1,5 @@
 import { Message } from 'core/models/message';
-import { replyTemplate } from '@lark/basic/message';
+import { replyMessage, replyTemplate } from '@lark/basic/message';
 import { CommandHandler, CommandRule } from './admin/command-handler';
 import { deleteBotMessage } from './admin/delete-message';
 import { genHistoryCard } from './general/gen-history';
@@ -23,6 +23,8 @@ import { sendBalance } from './admin/balance';
 import { context } from '@middleware/context';
 import { multiBotManager } from '@core/services/bot/multi-bot-manager';
 
+const TOOL_BOT_APPLY_URL = process.env.TOOL_BOT_APPLY_URL || '';
+
 // 工具函数：执行规则链
 export async function runRules(message: Message) {
     // 黑名单检查：被拉黑的用户直接忽略
@@ -31,17 +33,10 @@ export async function runRules(message: Message) {
         return;
     }
 
-    // 多 bot 分工：灰度开启时，按 bot 角色过滤规则
-    const multiBotEnabled = message.basicChatInfo?.gray_config?.multi_bot === 'enabled';
-    const botRole = multiBotEnabled
-        ? multiBotManager.getBotConfig(context.getBotName() || '')?.bot_role
-        : undefined;
+    // 多 bot 分工：按 bot 角色过滤规则
+    const botRole = multiBotManager.getBotConfig(context.getBotName() || '')?.bot_role;
 
     for (const { rules, handler, fallthrough, async_rules, category } of chatRules) {
-        // 灰度开启且规则有分类时，只执行匹配角色的规则
-        if (botRole && category && category !== botRole) {
-            continue;
-        }
         // 检查同步规则
         const syncRulesPass = rules.every((rule) => rule(message));
 
@@ -54,6 +49,25 @@ export async function runRules(message: Message) {
 
         // 如果所有规则（同步和异步）都通过
         if (syncRulesPass && asyncRulesPass) {
+            // 角色不匹配时的处理
+            if (botRole && category && category !== botRole) {
+                if (botRole === 'persona' && NeedRobotMention(message)) {
+                    // persona bot 被 @mention 但命中 utility 规则 → 引导用户申请工具 bot
+                    const applyHint = TOOL_BOT_APPLY_URL
+                        ? `，请点击 ${TOOL_BOT_APPLY_URL} 申请将工具人添加到群聊`
+                        : '';
+                    replyMessage(
+                        message.messageId,
+                        `工具类功能已迁移至「赤尾工具人」${applyHint}`,
+                        true,
+                    );
+                    break;
+                }
+                // 其他不匹配（utility bot 跳过 persona 规则，或非 @mention 的 utility）静默跳过
+                if (!fallthrough) break;
+                continue;
+            }
+
             try {
                 await handler(message);
             } catch (e) {
@@ -99,7 +113,6 @@ const chatRules: RuleConfig[] = [
         rules: [EqualText('撤回'), TextMessageLimit, NeedRobotMention],
         handler: deleteBotMessage,
         comment: '撤回消息',
-        category: 'utility',
     },
     {
         rules: [EqualText('水群', '水群趋势'), TextMessageLimit, NeedRobotMention],


### PR DESCRIPTION
## Summary
- 去掉 multi_bot 灰度，全量按 bot_role 分工
- persona bot 收到工具指令 → 回复引导申请工具 bot（URL 走 TOOL_BOT_APPLY_URL 环境变量）
- 撤回不分 category，所有 bot 都处理
- utility bot 不触发聊天

🤖 Generated with [Claude Code](https://claude.com/claude-code)