### PR TITLE
feat(proactive): 赤尾群聊窥屏主动搭话 MVP

### DIFF
--- a/apps/agent-service/app/agents/domains/main/agent.py
+++ b/apps/agent-service/app/agents/domains/main/agent.py
@@ -273,6 +273,10 @@ async def _build_and_stream(
 
     # 构建统一 inner_context（场景 + 状态 + 印象 + 引导语）
     try:
+        from app.agents.domains.main.context_builder import (
+            _is_proactive_var,
+            _proactive_stimulus_var,
+        )
         prompt_vars["inner_context"] = await build_inner_context(
             chat_id=chat_id,
             chat_type=chat_type,
@@ -280,6 +284,8 @@ async def _build_and_stream(
             trigger_user_id=trigger_user_id,
             trigger_username=trigger_username,
             chat_name=chat_name,
+            is_proactive=_is_proactive_var.get(False),
+            proactive_stimulus=_proactive_stimulus_var.get(""),
         )
     except Exception as e:
         logger.error(f"Failed to build inner context: {e}")

--- a/apps/agent-service/app/agents/domains/main/context_builder.py
+++ b/apps/agent-service/app/agents/domains/main/context_builder.py
@@ -22,6 +22,12 @@ from app.utils.content_parser import parse_content, update_tos_files
 
 logger = logging.getLogger(__name__)
 
+PROACTIVE_USER_ID = "__proactive__"
+
+import contextvars
+_is_proactive_var: contextvars.ContextVar[bool] = contextvars.ContextVar("is_proactive", default=False)
+_proactive_stimulus_var: contextvars.ContextVar[str] = contextvars.ContextVar("proactive_stimulus", default="")
+
 
 async def build_chat_context(
     message_id: str, limit: int = 10
@@ -44,6 +50,22 @@ async def build_chat_context(
         return [], None, "", "", "p2p", "", "", []
 
     chat_type = l1_results[-1].chat_type or "p2p"  # 默认私聊
+
+    # --- Proactive 检测 ---
+    is_proactive = l1_results[-1].user_id == PROACTIVE_USER_ID
+    proactive_stimulus = ""
+    proactive_target_id = ""
+
+    if is_proactive:
+        proactive_msg = l1_results.pop()
+        proactive_stimulus = parse_content(proactive_msg.content).render()
+        proactive_target_id = proactive_msg.reply_message_id or ""
+        if not l1_results:
+            logger.warning("proactive scan: no real messages found after filtering")
+            return [], None, "", "", "group", "", "", []
+
+    _is_proactive_var.set(is_proactive)
+    _proactive_stimulus_var.set(proactive_stimulus)
 
     # 1. 从 content 里批量提取图片 keys，区分已缓存 vs 未缓存
     cached_keys: list[tuple[str, str]]  = []  # (image_key, tos_file)
@@ -115,20 +137,27 @@ async def build_chat_context(
         for key, filename in zip(keys_ordered, filenames):
             image_key_to_filename[key] = filename
 
+    # 提取触发消息的用户名和用户ID
+    if is_proactive:
+        trigger_username = ""
+        trigger_user_id = ""
+        chat_name = l1_results[-1].chat_name or "" if l1_results else ""
+        effective_trigger_id = proactive_target_id or (l1_results[-1].message_id if l1_results else message_id)
+    else:
+        trigger_username = l1_results[-1].username or ""
+        trigger_user_id = l1_results[-1].user_id or ""
+        chat_name = l1_results[-1].chat_name or ""
+        effective_trigger_id = message_id
+
     # 4. 根据 chat_type 使用不同策略组装消息列表
     if chat_type == "group":
         messages = _build_group_messages(
-            l1_results, message_id, image_key_to_url, image_key_to_filename,
+            l1_results, effective_trigger_id, image_key_to_url, image_key_to_filename,
         )
     else:
         messages = _build_p2p_messages(
             l1_results, image_key_to_url, image_key_to_filename,
         )
-
-    # 提取触发消息的用户名和用户ID
-    trigger_username = l1_results[-1].username or ""
-    trigger_user_id = l1_results[-1].user_id or ""
-    chat_name = l1_results[-1].chat_name or ""
 
     # 提取回复链中所有用户ID
     chain_user_ids = list({

--- a/apps/agent-service/app/agents/domains/main/context_builder.py
+++ b/apps/agent-service/app/agents/domains/main/context_builder.py
@@ -53,7 +53,7 @@ async def build_chat_context(
 
     # --- Proactive: 过滤所有合成消息 ---
     proactive_msgs = [m for m in l1_results if m.user_id == PROACTIVE_USER_ID]
-    is_proactive = l1_results[-1].user_id == PROACTIVE_USER_ID
+    is_proactive = len(proactive_msgs) > 0
     proactive_stimulus = ""
     proactive_target_id = ""
 

--- a/apps/agent-service/app/agents/domains/main/context_builder.py
+++ b/apps/agent-service/app/agents/domains/main/context_builder.py
@@ -51,15 +51,19 @@ async def build_chat_context(
 
     chat_type = l1_results[-1].chat_type or "p2p"  # 默认私聊
 
-    # --- Proactive 检测 ---
+    # --- Proactive: 过滤所有合成消息 ---
+    proactive_msgs = [m for m in l1_results if m.user_id == PROACTIVE_USER_ID]
     is_proactive = l1_results[-1].user_id == PROACTIVE_USER_ID
     proactive_stimulus = ""
     proactive_target_id = ""
 
-    if is_proactive:
-        proactive_msg = l1_results.pop()
-        proactive_stimulus = parse_content(proactive_msg.content).render()
-        proactive_target_id = proactive_msg.reply_message_id or ""
+    if proactive_msgs:
+        # 过滤掉所有合成消息
+        l1_results = [m for m in l1_results if m.user_id != PROACTIVE_USER_ID]
+        # 取最新一条合成消息的 stimulus
+        latest_proactive = proactive_msgs[-1]
+        proactive_stimulus = parse_content(latest_proactive.content).render()
+        proactive_target_id = latest_proactive.reply_message_id or ""
         if not l1_results:
             logger.warning("proactive scan: no real messages found after filtering")
             return [], None, "", "", "group", "", "", []

--- a/apps/agent-service/app/clients/rabbitmq.py
+++ b/apps/agent-service/app/clients/rabbitmq.py
@@ -31,8 +31,9 @@ CHAT_RESPONSE = Route("chat_response", "chat.response")
 SAFETY_CHECK = Route("safety_check", "post.safety.check")
 RECALL = Route("recall", "action.recall")
 VECTORIZE = Route("vectorize", "task.vectorize")
+PROACTIVE_EVAL = Route("proactive_eval", "proactive.eval")
 
-ALL_ROUTES = [CHAT_REQUEST, CHAT_RESPONSE, SAFETY_CHECK, RECALL, VECTORIZE]
+ALL_ROUTES = [CHAT_REQUEST, CHAT_RESPONSE, SAFETY_CHECK, RECALL, VECTORIZE, PROACTIVE_EVAL]
 
 # 非 prod 队列空闲自动删除（24h）
 _NON_PROD_EXPIRES_MS = 86_400_000

--- a/apps/agent-service/app/main.py
+++ b/apps/agent-service/app/main.py
@@ -38,12 +38,16 @@ async def lifespan(app: FastAPI):
     if settings.rabbitmq_url:
         from app.workers.chat_consumer import start_chat_consumer
         from app.workers.post_consumer import start_post_consumer
+        from app.workers.proactive_consumer import start_proactive_consumer
 
         consumer_tasks.append(asyncio.create_task(start_post_consumer()))
         logger.info("Post safety consumer started")
 
         consumer_tasks.append(asyncio.create_task(start_chat_consumer()))
         logger.info("Chat request consumer started")
+
+        consumer_tasks.append(asyncio.create_task(start_proactive_consumer()))
+        logger.info("Proactive eval consumer started")
 
     yield
 

--- a/apps/agent-service/app/services/memory_context.py
+++ b/apps/agent-service/app/services/memory_context.py
@@ -90,6 +90,9 @@ async def build_inner_context(
     trigger_user_id: str,
     trigger_username: str,
     chat_name: str = "",
+    *,
+    is_proactive: bool = False,
+    proactive_stimulus: str = "",
 ) -> str:
     """构建统一的聊天注入上下文
 
@@ -107,7 +110,14 @@ async def build_inner_context(
     sections: list[str] = []
 
     # === 场景提示 ===
-    if chat_type == "p2p":
+    if is_proactive:
+        scene = f"你在群聊「{chat_name}」中。" if chat_name else ""
+        scene += "\n你刚刷到了群里的对话。如果你想说点什么就说，不想说也可以不说。"
+        scene += "\n不要刻意解释为什么突然说话，像朋友在群里自然接话就好。"
+        if proactive_stimulus:
+            scene += f"\n（你注意到的：{proactive_stimulus}）"
+        sections.append(scene)
+    elif chat_type == "p2p":
         if trigger_username:
             sections.append(f"你正在和 {trigger_username} 私聊。")
     else:

--- a/apps/agent-service/app/workers/chat_consumer.py
+++ b/apps/agent-service/app/workers/chat_consumer.py
@@ -46,6 +46,7 @@ async def handle_chat_request(message: AbstractIncomingMessage) -> None:
         user_id = body.get("user_id")
         lane = body.get("lane")
         bot_name = body.get("bot_name")
+        is_proactive = body.get("is_proactive", False)
 
         # Measure MQ queue wait time
         queue_wait_ms = 0.0
@@ -80,6 +81,8 @@ async def handle_chat_request(message: AbstractIncomingMessage) -> None:
             "root_id": root_id,
             "user_id": user_id,
             "lane": lane,
+            "is_proactive": is_proactive,
+            "bot_name": bot_name,
         }
 
         try:
@@ -195,6 +198,11 @@ async def handle_chat_request(message: AbstractIncomingMessage) -> None:
                 },
             )
 
+            # Piggyback: 回复完后顺手刷一眼群聊（proactive 回复不触发，避免递归）
+            if not is_proactive:
+                import asyncio as _asyncio
+                _asyncio.create_task(_maybe_piggyback_scan())
+
         except Exception as e:
             logger.error(
                 "Chat request failed: session_id=%s, error=%s\n%s",
@@ -212,6 +220,18 @@ async def handle_chat_request(message: AbstractIncomingMessage) -> None:
                 },
                 lane=lane,
             )
+
+
+async def _maybe_piggyback_scan() -> None:
+    """概率触发一次主动搭话扫描（piggyback 模式）"""
+    import random
+    try:
+        if random.random() > 0.6:  # 约 60% 概率触发
+            return
+        from app.workers.proactive_scanner import run_proactive_scan
+        await run_proactive_scan(source="piggyback")
+    except Exception as e:
+        logger.warning(f"piggyback scan failed: {e}")
 
 
 async def start_chat_consumer() -> None:

--- a/apps/agent-service/app/workers/chat_consumer.py
+++ b/apps/agent-service/app/workers/chat_consumer.py
@@ -200,8 +200,7 @@ async def handle_chat_request(message: AbstractIncomingMessage) -> None:
 
             # Piggyback: 回复完后顺手刷一眼群聊（proactive 回复不触发，避免递归）
             if not is_proactive:
-                import asyncio as _asyncio
-                _asyncio.create_task(_maybe_piggyback_scan())
+                await _maybe_piggyback_scan()
 
         except Exception as e:
             logger.error(

--- a/apps/agent-service/app/workers/chat_consumer.py
+++ b/apps/agent-service/app/workers/chat_consumer.py
@@ -226,7 +226,7 @@ async def _maybe_piggyback_scan() -> None:
     """概率触发一次主动搭话扫描（piggyback 模式）"""
     import random
     try:
-        if random.random() > 0.6:  # 约 60% 概率触发
+        if random.random() > 0.6:  # 40% 概率跳过，即 60% 概率触发
             return
         from app.workers.proactive_scanner import run_proactive_scan
         await run_proactive_scan(source="piggyback")

--- a/apps/agent-service/app/workers/proactive_consumer.py
+++ b/apps/agent-service/app/workers/proactive_consumer.py
@@ -24,6 +24,7 @@ async def handle_proactive_event(message: AbstractIncomingMessage) -> None:
     async with message.process(requeue=False):
         body = json.loads(message.body)
         chat_id = body.get("chat_id")
+        logger.info("Proactive event received: chat_id=%s, message_id=%s", chat_id, body.get("message_id"))
         if chat_id:
             manager = ProactiveManager.get_instance()
             await manager.on_event(chat_id)

--- a/apps/agent-service/app/workers/proactive_consumer.py
+++ b/apps/agent-service/app/workers/proactive_consumer.py
@@ -1,0 +1,40 @@
+"""Proactive eval MQ consumer
+
+消费 proactive_eval 队列，将消息事件转发给 ProactiveManager 做 debounce + 判断。
+"""
+
+import json
+import logging
+
+from aio_pika.abc import AbstractIncomingMessage
+
+from app.clients.rabbitmq import (
+    PROACTIVE_EVAL,
+    RabbitMQClient,
+    _current_lane,
+    _lane_queue,
+)
+from app.workers.proactive_manager import ProactiveManager
+
+logger = logging.getLogger(__name__)
+
+
+async def handle_proactive_event(message: AbstractIncomingMessage) -> None:
+    """消费 proactive_eval 队列中的消息"""
+    async with message.process(requeue=False):
+        body = json.loads(message.body)
+        chat_id = body.get("chat_id")
+        if chat_id:
+            manager = ProactiveManager.get_instance()
+            await manager.on_event(chat_id)
+
+
+async def start_proactive_consumer() -> None:
+    """启动 proactive eval consumer"""
+    client = RabbitMQClient.get_instance()
+    await client.connect()
+    await client.declare_topology()
+    lane = _current_lane()
+    queue = _lane_queue(PROACTIVE_EVAL.queue, lane)
+    await client.consume(queue, handle_proactive_event)
+    logger.info("Proactive eval consumer started (queue=%s)", queue)

--- a/apps/agent-service/app/workers/proactive_manager.py
+++ b/apps/agent-service/app/workers/proactive_manager.py
@@ -8,8 +8,12 @@ import asyncio
 import logging
 import time
 
+from sqlalchemy import select, func as sa_func
+
 from app.clients.redis import AsyncRedisClient
-from app.workers.proactive_scanner import TARGET_CHAT_ID, run_proactive_scan
+from app.orm.base import AsyncSessionLocal
+from app.orm.models import ConversationMessage
+from app.workers.proactive_scanner import PROACTIVE_USER_ID, TARGET_CHAT_ID, run_proactive_scan
 
 logger = logging.getLogger(__name__)
 
@@ -26,7 +30,6 @@ class ProactiveManager:
     HOURLY_LIMIT = 6  # 每小时最多主动发言次数
     CONSECUTIVE_LIMIT = 2  # 连续无人回应次数上限
     CONSECUTIVE_COOLDOWN = 3 * 3600  # 连续无回应后冷却 3 小时
-    NO_RESPONSE_COOLDOWN = 150  # 模型说"不想说"后冷却 2.5 分钟
 
     # Redis keys
     HOURLY_COUNT_KEY = "proactive:hourly_count:{chat_id}"  # TTL 1h
@@ -50,8 +53,6 @@ class ProactiveManager:
         """每条群消息调用一次，debounce 后触发扫描"""
         if chat_id not in TARGET_CHAT_IDS:
             return
-        logger.info("proactive on_event: chat_id=%s", chat_id)
-
         redis = AsyncRedisClient.get_instance()
 
         # 冷却中则跳过
@@ -78,7 +79,7 @@ class ProactiveManager:
         finally:
             self._timers.pop(chat_id, None)
 
-        logger.info("proactive debounce fired for %s, executing scan", chat_id)
+        logger.debug("proactive debounce fired for %s", chat_id)
         await self._execute_scan(chat_id)
 
     async def _execute_scan(self, chat_id: str) -> None:
@@ -133,20 +134,14 @@ class ProactiveManager:
         return True
 
     async def _check_and_reset_consecutive(self, chat_id: str) -> None:
-        """扫描前检查：上次主动发言后是否有人回应，有则重置 consecutive 计数"""
+        """扫描前检查：上次主动发言后是否有人回应，有则重置 consecutive 计数和冷却"""
         redis = AsyncRedisClient.get_instance()
         ts_key = self.LAST_PROACTIVE_TS_KEY.format(chat_id=chat_id)
         last_ts = await redis.get(ts_key)
         if last_ts is None:
-            return  # 还没主动发过言，无需检查
+            return
 
         last_ts_ms = int(last_ts)
-
-        # 查询 last_proactive_ts 之后是否有用户消息
-        from sqlalchemy import select, func as sa_func
-        from app.orm.base import AsyncSessionLocal
-        from app.orm.models import ConversationMessage
-        from app.workers.proactive_scanner import PROACTIVE_USER_ID
 
         async with AsyncSessionLocal() as session:
             stmt = (
@@ -163,9 +158,9 @@ class ProactiveManager:
             count = result.scalar() or 0
 
         if count > 0:
-            # 有人说话了，重置连续无回应计数
-            cons_key = self.CONSECUTIVE_KEY.format(chat_id=chat_id)
-            await redis.delete(cons_key)
+            # 有人说话了，重置连续无回应计数 + 清除冷却
+            await redis.delete(self.CONSECUTIVE_KEY.format(chat_id=chat_id))
+            await redis.delete(self.COOLDOWN_KEY.format(chat_id=chat_id))
 
     async def _update_after_submit(self, chat_id: str) -> None:
         """主动发言成功后：递增每小时计数 + 递增连续计数 + 记录时间戳"""

--- a/apps/agent-service/app/workers/proactive_manager.py
+++ b/apps/agent-service/app/workers/proactive_manager.py
@@ -73,10 +73,12 @@ class ProactiveManager:
         try:
             await asyncio.sleep(self.DEBOUNCE_SECONDS)
         except asyncio.CancelledError:
+            logger.debug("proactive debounce cancelled for %s", chat_id)
             return
         finally:
             self._timers.pop(chat_id, None)
 
+        logger.info("proactive debounce fired for %s, executing scan", chat_id)
         await self._execute_scan(chat_id)
 
     async def _execute_scan(self, chat_id: str) -> None:

--- a/apps/agent-service/app/workers/proactive_manager.py
+++ b/apps/agent-service/app/workers/proactive_manager.py
@@ -105,9 +105,6 @@ class ProactiveManager:
 
             if "submitted" in result:
                 await self._update_after_submit(chat_id)
-            elif result.get("decided") == "no_response":
-                # 模型认为不需要说话，短冷却
-                await self._set_cooldown(chat_id, self.NO_RESPONSE_COOLDOWN)
         except Exception:
             logger.exception("proactive _execute_scan error for %s", chat_id)
         finally:

--- a/apps/agent-service/app/workers/proactive_manager.py
+++ b/apps/agent-service/app/workers/proactive_manager.py
@@ -1,0 +1,194 @@
+"""消息级主动搭话管理器 — debounce + 频率控制 + 连续无回应检测
+
+替代 cron 扫描，由 lark-server 每条群消息发 MQ 事件触发。
+debounce 攒消息 → 硬限检查 → 调用 proactive_scanner 判断 + 投递。
+"""
+
+import asyncio
+import logging
+import time
+
+from app.clients.redis import AsyncRedisClient
+from app.workers.proactive_scanner import TARGET_CHAT_ID, run_proactive_scan
+
+logger = logging.getLogger(__name__)
+
+# 只对目标群生效（后续可扩展为集合）
+TARGET_CHAT_IDS = {TARGET_CHAT_ID}
+
+
+class ProactiveManager:
+    """消息级主动搭话管理器 — debounce + 小模型判断"""
+
+    _instance: "ProactiveManager | None" = None
+
+    DEBOUNCE_SECONDS = 15  # 攒消息的等待时间
+    HOURLY_LIMIT = 6  # 每小时最多主动发言次数
+    CONSECUTIVE_LIMIT = 2  # 连续无人回应次数上限
+    CONSECUTIVE_COOLDOWN = 3 * 3600  # 连续无回应后冷却 3 小时
+    NO_RESPONSE_COOLDOWN = 150  # 模型说"不想说"后冷却 2.5 分钟
+
+    # Redis keys
+    HOURLY_COUNT_KEY = "proactive:hourly_count:{chat_id}"  # TTL 1h
+    CONSECUTIVE_KEY = "proactive:consecutive_noreply:{chat_id}"
+    COOLDOWN_KEY = "proactive:cooldown:{chat_id}"  # TTL varies
+    LAST_PROACTIVE_TS_KEY = "proactive:last_ts:{chat_id}"
+
+    def __init__(self) -> None:
+        self._timers: dict[str, asyncio.Task] = {}
+        self._scanning: set[str] = set()  # 防止并发扫描
+
+    @classmethod
+    def get_instance(cls) -> "ProactiveManager":
+        if cls._instance is None:
+            cls._instance = cls()
+        return cls._instance
+
+    # ── 公开入口 ───────────────────────────────────────────────────────────
+
+    async def on_event(self, chat_id: str) -> None:
+        """每条群消息调用一次，debounce 后触发扫描"""
+        if chat_id not in TARGET_CHAT_IDS:
+            return
+
+        redis = AsyncRedisClient.get_instance()
+
+        # 冷却中则跳过
+        if await redis.exists(self.COOLDOWN_KEY.format(chat_id=chat_id)):
+            return
+
+        # 取消已有计时器（重置 debounce）
+        if chat_id in self._timers:
+            self._timers[chat_id].cancel()
+
+        self._timers[chat_id] = asyncio.create_task(
+            self._debounce_timer(chat_id)
+        )
+
+    # ── 内部方法 ───────────────────────────────────────────────────────────
+
+    async def _debounce_timer(self, chat_id: str) -> None:
+        """等待 DEBOUNCE_SECONDS 后执行扫描"""
+        try:
+            await asyncio.sleep(self.DEBOUNCE_SECONDS)
+        except asyncio.CancelledError:
+            return
+        finally:
+            self._timers.pop(chat_id, None)
+
+        await self._execute_scan(chat_id)
+
+    async def _execute_scan(self, chat_id: str) -> None:
+        """实际扫描：硬限检查 → 连续无回应检测 → 调用 scanner"""
+        if chat_id in self._scanning:
+            logger.debug("proactive scan already running for %s, skip", chat_id)
+            return
+
+        self._scanning.add(chat_id)
+        try:
+            # 1. 每小时频次检查
+            if not await self._check_hourly_limit(chat_id):
+                logger.info("proactive: hourly limit reached for %s", chat_id)
+                return
+
+            # 2. 连续无回应检查 + 重置
+            if not await self._check_consecutive_limit(chat_id):
+                logger.info("proactive: consecutive no-reply limit for %s", chat_id)
+                return
+            await self._check_and_reset_consecutive(chat_id)
+
+            # 3. 调用 scanner
+            result = await run_proactive_scan(source="message_event")
+
+            if "submitted" in result:
+                await self._update_after_submit(chat_id)
+            elif result.get("decided") == "no_response":
+                # 模型认为不需要说话，短冷却
+                await self._set_cooldown(chat_id, self.NO_RESPONSE_COOLDOWN)
+        except Exception:
+            logger.exception("proactive _execute_scan error for %s", chat_id)
+        finally:
+            self._scanning.discard(chat_id)
+
+    async def _check_hourly_limit(self, chat_id: str) -> bool:
+        """检查每小时发言次数是否在限制内（不递增）"""
+        redis = AsyncRedisClient.get_instance()
+        key = self.HOURLY_COUNT_KEY.format(chat_id=chat_id)
+        val = await redis.get(key)
+        if val is not None and int(val) >= self.HOURLY_LIMIT:
+            return False
+        return True
+
+    async def _check_consecutive_limit(self, chat_id: str) -> bool:
+        """检查连续无回应次数是否在限制内"""
+        redis = AsyncRedisClient.get_instance()
+        key = self.CONSECUTIVE_KEY.format(chat_id=chat_id)
+        val = await redis.get(key)
+        if val is not None and int(val) >= self.CONSECUTIVE_LIMIT:
+            # 触发长冷却
+            await self._set_cooldown(chat_id, self.CONSECUTIVE_COOLDOWN)
+            # 重置计数器
+            await redis.delete(key)
+            return False
+        return True
+
+    async def _check_and_reset_consecutive(self, chat_id: str) -> None:
+        """扫描前检查：上次主动发言后是否有人回应，有则重置 consecutive 计数"""
+        redis = AsyncRedisClient.get_instance()
+        ts_key = self.LAST_PROACTIVE_TS_KEY.format(chat_id=chat_id)
+        last_ts = await redis.get(ts_key)
+        if last_ts is None:
+            return  # 还没主动发过言，无需检查
+
+        last_ts_ms = int(last_ts)
+
+        # 查询 last_proactive_ts 之后是否有用户消息
+        from sqlalchemy import select, func as sa_func
+        from app.orm.base import AsyncSessionLocal
+        from app.orm.models import ConversationMessage
+        from app.workers.proactive_scanner import PROACTIVE_USER_ID
+
+        async with AsyncSessionLocal() as session:
+            stmt = (
+                select(sa_func.count())
+                .select_from(ConversationMessage)
+                .where(
+                    ConversationMessage.chat_id == chat_id,
+                    ConversationMessage.role == "user",
+                    ConversationMessage.user_id != PROACTIVE_USER_ID,
+                    ConversationMessage.create_time > last_ts_ms,
+                )
+            )
+            result = await session.execute(stmt)
+            count = result.scalar() or 0
+
+        if count > 0:
+            # 有人说话了，重置连续无回应计数
+            cons_key = self.CONSECUTIVE_KEY.format(chat_id=chat_id)
+            await redis.delete(cons_key)
+
+    async def _update_after_submit(self, chat_id: str) -> None:
+        """主动发言成功后：递增每小时计数 + 递增连续计数 + 记录时间戳"""
+        redis = AsyncRedisClient.get_instance()
+        now_ms = int(time.time() * 1000)
+
+        # 每小时计数 INCR（首次设置 1h TTL）
+        hourly_key = self.HOURLY_COUNT_KEY.format(chat_id=chat_id)
+        new_val = await redis.incr(hourly_key)
+        if new_val == 1:
+            await redis.expire(hourly_key, 3600)
+
+        # 连续无回应计数 INCR
+        cons_key = self.CONSECUTIVE_KEY.format(chat_id=chat_id)
+        await redis.incr(cons_key)
+
+        # 记录最后主动发言时间戳
+        ts_key = self.LAST_PROACTIVE_TS_KEY.format(chat_id=chat_id)
+        await redis.set(ts_key, str(now_ms), ex=86400)  # 24h TTL
+
+    async def _set_cooldown(self, chat_id: str, seconds: int) -> None:
+        """设置冷却期"""
+        redis = AsyncRedisClient.get_instance()
+        key = self.COOLDOWN_KEY.format(chat_id=chat_id)
+        await redis.set(key, "1", ex=seconds)
+        logger.info("proactive: cooldown set for %s, %ds", chat_id, seconds)

--- a/apps/agent-service/app/workers/proactive_manager.py
+++ b/apps/agent-service/app/workers/proactive_manager.py
@@ -50,6 +50,7 @@ class ProactiveManager:
         """每条群消息调用一次，debounce 后触发扫描"""
         if chat_id not in TARGET_CHAT_IDS:
             return
+        logger.info("proactive on_event: chat_id=%s", chat_id)
 
         redis = AsyncRedisClient.get_instance()
 

--- a/apps/agent-service/app/workers/proactive_manager.py
+++ b/apps/agent-service/app/workers/proactive_manager.py
@@ -1,45 +1,33 @@
-"""消息级主动搭话管理器 — debounce + 频率控制 + 连续无回应检测
+"""消息级主动搭话管理器 — debounce + 每小时硬限
 
 替代 cron 扫描，由 lark-server 每条群消息发 MQ 事件触发。
-debounce 攒消息 → 硬限检查 → 调用 proactive_scanner 判断 + 投递。
+debounce 攒消息 → hourly limit 检查 → 调用 proactive_scanner 判断 + 投递。
+
+频率克制（"最近主动说了但没人搭理"）交给小模型通过 recent_proactive 上下文判断，
+不做工程硬编码的 cooldown 或 consecutive 计数。
 """
 
 import asyncio
 import logging
-import time
-
-from sqlalchemy import select, func as sa_func
 
 from app.clients.redis import AsyncRedisClient
-from app.orm.base import AsyncSessionLocal
-from app.orm.models import ConversationMessage
-from app.workers.proactive_scanner import PROACTIVE_USER_ID, TARGET_CHAT_ID, run_proactive_scan
+from app.workers.proactive_scanner import TARGET_CHAT_ID, run_proactive_scan
 
 logger = logging.getLogger(__name__)
 
-# 只对目标群生效（后续可扩展为集合）
 TARGET_CHAT_IDS = {TARGET_CHAT_ID}
 
 
 class ProactiveManager:
-    """消息级主动搭话管理器 — debounce + 小模型判断"""
-
     _instance: "ProactiveManager | None" = None
 
-    DEBOUNCE_SECONDS = 15  # 攒消息的等待时间
-    HOURLY_LIMIT = 6  # 每小时最多主动发言次数
-    CONSECUTIVE_LIMIT = 2  # 连续无人回应次数上限
-    CONSECUTIVE_COOLDOWN = 3 * 3600  # 连续无回应后冷却 3 小时
-
-    # Redis keys
+    DEBOUNCE_SECONDS = 15
+    HOURLY_LIMIT = 6
     HOURLY_COUNT_KEY = "proactive:hourly_count:{chat_id}"  # TTL 1h
-    CONSECUTIVE_KEY = "proactive:consecutive_noreply:{chat_id}"
-    COOLDOWN_KEY = "proactive:cooldown:{chat_id}"  # TTL varies
-    LAST_PROACTIVE_TS_KEY = "proactive:last_ts:{chat_id}"
 
     def __init__(self) -> None:
         self._timers: dict[str, asyncio.Task] = {}
-        self._scanning: set[str] = set()  # 防止并发扫描
+        self._scanning: set[str] = set()
 
     @classmethod
     def get_instance(cls) -> "ProactiveManager":
@@ -47,143 +35,47 @@ class ProactiveManager:
             cls._instance = cls()
         return cls._instance
 
-    # ── 公开入口 ───────────────────────────────────────────────────────────
-
     async def on_event(self, chat_id: str) -> None:
         """每条群消息调用一次，debounce 后触发扫描"""
         if chat_id not in TARGET_CHAT_IDS:
             return
-        redis = AsyncRedisClient.get_instance()
-
-        # 冷却中则跳过
-        if await redis.exists(self.COOLDOWN_KEY.format(chat_id=chat_id)):
-            return
-
-        # 取消已有计时器（重置 debounce）
         if chat_id in self._timers:
             self._timers[chat_id].cancel()
-
-        self._timers[chat_id] = asyncio.create_task(
-            self._debounce_timer(chat_id)
-        )
-
-    # ── 内部方法 ───────────────────────────────────────────────────────────
+        self._timers[chat_id] = asyncio.create_task(self._debounce_timer(chat_id))
 
     async def _debounce_timer(self, chat_id: str) -> None:
-        """等待 DEBOUNCE_SECONDS 后执行扫描"""
         try:
             await asyncio.sleep(self.DEBOUNCE_SECONDS)
         except asyncio.CancelledError:
-            logger.debug("proactive debounce cancelled for %s", chat_id)
             return
         finally:
             self._timers.pop(chat_id, None)
-
-        logger.debug("proactive debounce fired for %s", chat_id)
         await self._execute_scan(chat_id)
 
     async def _execute_scan(self, chat_id: str) -> None:
-        """实际扫描：硬限检查 → 连续无回应检测 → 调用 scanner"""
         if chat_id in self._scanning:
-            logger.debug("proactive scan already running for %s, skip", chat_id)
             return
-
         self._scanning.add(chat_id)
         try:
-            # 1. 每小时频次检查
             if not await self._check_hourly_limit(chat_id):
                 logger.info("proactive: hourly limit reached for %s", chat_id)
                 return
-
-            # 2. 连续无回应检查 + 重置
-            if not await self._check_consecutive_limit(chat_id):
-                logger.info("proactive: consecutive no-reply limit for %s", chat_id)
-                return
-            await self._check_and_reset_consecutive(chat_id)
-
-            # 3. 调用 scanner
             result = await run_proactive_scan(source="message_event")
-
             if "submitted" in result:
-                await self._update_after_submit(chat_id)
+                await self._incr_hourly(chat_id)
         except Exception:
             logger.exception("proactive _execute_scan error for %s", chat_id)
         finally:
             self._scanning.discard(chat_id)
 
     async def _check_hourly_limit(self, chat_id: str) -> bool:
-        """检查每小时发言次数是否在限制内（不递增）"""
+        redis = AsyncRedisClient.get_instance()
+        val = await redis.get(self.HOURLY_COUNT_KEY.format(chat_id=chat_id))
+        return val is None or int(val) < self.HOURLY_LIMIT
+
+    async def _incr_hourly(self, chat_id: str) -> None:
         redis = AsyncRedisClient.get_instance()
         key = self.HOURLY_COUNT_KEY.format(chat_id=chat_id)
-        val = await redis.get(key)
-        if val is not None and int(val) >= self.HOURLY_LIMIT:
-            return False
-        return True
-
-    async def _check_consecutive_limit(self, chat_id: str) -> bool:
-        """检查连续无回应次数是否在限制内"""
-        redis = AsyncRedisClient.get_instance()
-        key = self.CONSECUTIVE_KEY.format(chat_id=chat_id)
-        val = await redis.get(key)
-        if val is not None and int(val) >= self.CONSECUTIVE_LIMIT:
-            # 触发长冷却
-            await self._set_cooldown(chat_id, self.CONSECUTIVE_COOLDOWN)
-            # 重置计数器
-            await redis.delete(key)
-            return False
-        return True
-
-    async def _check_and_reset_consecutive(self, chat_id: str) -> None:
-        """扫描前检查：上次主动发言后是否有人回应，有则重置 consecutive 计数和冷却"""
-        redis = AsyncRedisClient.get_instance()
-        ts_key = self.LAST_PROACTIVE_TS_KEY.format(chat_id=chat_id)
-        last_ts = await redis.get(ts_key)
-        if last_ts is None:
-            return
-
-        last_ts_ms = int(last_ts)
-
-        async with AsyncSessionLocal() as session:
-            stmt = (
-                select(sa_func.count())
-                .select_from(ConversationMessage)
-                .where(
-                    ConversationMessage.chat_id == chat_id,
-                    ConversationMessage.role == "user",
-                    ConversationMessage.user_id != PROACTIVE_USER_ID,
-                    ConversationMessage.create_time > last_ts_ms,
-                )
-            )
-            result = await session.execute(stmt)
-            count = result.scalar() or 0
-
-        if count > 0:
-            # 有人说话了，重置连续无回应计数 + 清除冷却
-            await redis.delete(self.CONSECUTIVE_KEY.format(chat_id=chat_id))
-            await redis.delete(self.COOLDOWN_KEY.format(chat_id=chat_id))
-
-    async def _update_after_submit(self, chat_id: str) -> None:
-        """主动发言成功后：递增每小时计数 + 递增连续计数 + 记录时间戳"""
-        redis = AsyncRedisClient.get_instance()
-        now_ms = int(time.time() * 1000)
-
-        # 每小时计数 INCR（首次设置 1h TTL）
-        hourly_key = self.HOURLY_COUNT_KEY.format(chat_id=chat_id)
-        new_val = await redis.incr(hourly_key)
+        new_val = await redis.incr(key)
         if new_val == 1:
-            await redis.expire(hourly_key, 3600)
-
-        # 连续无回应计数 INCR
-        cons_key = self.CONSECUTIVE_KEY.format(chat_id=chat_id)
-        await redis.incr(cons_key)
-
-        # 记录最后主动发言时间戳
-        ts_key = self.LAST_PROACTIVE_TS_KEY.format(chat_id=chat_id)
-        await redis.set(ts_key, str(now_ms), ex=86400)  # 24h TTL
-
-    async def _set_cooldown(self, chat_id: str, seconds: int) -> None:
-        """设置冷却期"""
-        redis = AsyncRedisClient.get_instance()
-        key = self.COOLDOWN_KEY.format(chat_id=chat_id)
-        await redis.set(key, "1", ex=seconds)
-        logger.info("proactive: cooldown set for %s, %ds", chat_id, seconds)
+            await redis.expire(key, 3600)

--- a/apps/agent-service/app/workers/proactive_scanner.py
+++ b/apps/agent-service/app/workers/proactive_scanner.py
@@ -1,0 +1,336 @@
+"""赤尾主动发言扫描器 — 群聊潜水观察 + 小模型判断 + 合成消息投递
+
+核心流程 (run_proactive_scan):
+1. 安静时段检查（23:00~09:00 CST 不扫）
+2. Redis 冷却检查（15 分钟内不重复扫）
+3. 获取上次发言后的未读消息
+4. 收集上下文（reply_style、group_culture、今日主动记录）
+5. 小模型判断是否应该回复
+6. 合成触发消息 + 发布 chat_request
+"""
+
+import json
+import logging
+import time
+import uuid
+from datetime import datetime, timedelta, timezone
+
+from sqlalchemy import select, func as sa_func
+
+from app.agents.infra.langfuse_client import get_prompt
+from app.agents.infra.model_builder import ModelBuilder
+from app.clients.rabbitmq import CHAT_REQUEST, RabbitMQClient
+from app.clients.redis import AsyncRedisClient
+from app.orm.base import AsyncSessionLocal
+from app.orm.crud import get_group_culture_gestalt
+from app.orm.models import ConversationMessage
+from app.services.memory_context import get_reply_style
+from app.utils.content_parser import parse_content
+
+logger = logging.getLogger(__name__)
+
+# ── 常量 ──────────────────────────────────────────────────────────────────
+TARGET_CHAT_ID = "oc_a44255e98af05f1359aeb29eeb503536"
+COOLDOWN_KEY = "proactive:last_scan_time"
+COOLDOWN_MS = 15 * 60 * 1000  # 15 min
+PROACTIVE_USER_ID = "__proactive__"
+QUIET_HOURS = (23, 9)  # >= 23 or < 9
+JUDGE_MODEL_ID = "proactive-judge-model"
+
+CST = timezone(timedelta(hours=8))
+
+
+# ── 冷却与时段 ────────────────────────────────────────────────────────────
+
+
+def _is_quiet_hours(now: datetime | None = None) -> bool:
+    """当前 CST 时间是否在安静时段（23:00~09:00）"""
+    now = now or datetime.now(CST)
+    hour = now.hour
+    start, end = QUIET_HOURS
+    return hour >= start or hour < end
+
+
+async def should_scan() -> bool:
+    """检查 Redis 冷却，15 分钟内扫过则返回 False"""
+    redis = AsyncRedisClient.get_instance()
+    last = await redis.get(COOLDOWN_KEY)
+    if last is None:
+        return True
+    try:
+        elapsed = int(time.time() * 1000) - int(last)
+        return elapsed >= COOLDOWN_MS
+    except (ValueError, TypeError):
+        return True
+
+
+async def _mark_scanned() -> None:
+    """写入当前时间戳到 Redis 冷却 key"""
+    redis = AsyncRedisClient.get_instance()
+    now_ms = int(time.time() * 1000)
+    await redis.set(COOLDOWN_KEY, str(now_ms), ex=COOLDOWN_MS // 1000 + 60)
+
+
+# ── 未读消息获取 ──────────────────────────────────────────────────────────
+
+
+async def get_unseen_messages(limit: int = 30) -> list[ConversationMessage]:
+    """获取赤尾上次发言之后的用户消息
+
+    1. 找 target chat 中 role='assistant' 的最大 create_time（最后一次出现）
+    2. 取 create_time 更晚的 role='user' 且 user_id != PROACTIVE_USER_ID 的消息
+    """
+    async with AsyncSessionLocal() as session:
+        # 子查询：最后一次 assistant 发言时间
+        last_presence_q = (
+            select(sa_func.max(ConversationMessage.create_time))
+            .where(
+                ConversationMessage.chat_id == TARGET_CHAT_ID,
+                ConversationMessage.role == "assistant",
+            )
+            .scalar_subquery()
+        )
+
+        # 主查询：之后的用户消息
+        stmt = (
+            select(ConversationMessage)
+            .where(
+                ConversationMessage.chat_id == TARGET_CHAT_ID,
+                ConversationMessage.role == "user",
+                ConversationMessage.user_id != PROACTIVE_USER_ID,
+                ConversationMessage.create_time > sa_func.coalesce(last_presence_q, 0),
+            )
+            .order_by(ConversationMessage.create_time.asc())
+            .limit(limit)
+        )
+
+        result = await session.execute(stmt)
+        return list(result.scalars().all())
+
+
+# ── 小模型判断 ────────────────────────────────────────────────────────────
+
+
+def _format_messages_for_judge(messages: list[ConversationMessage]) -> str:
+    """将消息格式化为 [HH:MM:SS] user_id[:8]: text"""
+    lines = []
+    for msg in messages:
+        ts = datetime.fromtimestamp(msg.create_time / 1000, tz=CST)
+        time_str = ts.strftime("%H:%M:%S")
+        user_short = msg.user_id[:8] if msg.user_id else "unknown"
+        text = parse_content(msg.content).render()
+        lines.append(f"[{time_str}] {user_short}: {text}")
+    return "\n".join(lines)
+
+
+async def _get_recent_proactive_records() -> list[dict]:
+    """查询今日的主动触发记录（user_id=PROACTIVE_USER_ID）"""
+    today_start = datetime.now(CST).replace(hour=0, minute=0, second=0, microsecond=0)
+    today_start_ms = int(today_start.timestamp() * 1000)
+
+    async with AsyncSessionLocal() as session:
+        stmt = (
+            select(ConversationMessage)
+            .where(
+                ConversationMessage.chat_id == TARGET_CHAT_ID,
+                ConversationMessage.user_id == PROACTIVE_USER_ID,
+                ConversationMessage.create_time >= today_start_ms,
+            )
+            .order_by(ConversationMessage.create_time.desc())
+        )
+        result = await session.execute(stmt)
+        rows = result.scalars().all()
+
+    records = []
+    for msg in rows:
+        ts = datetime.fromtimestamp(msg.create_time / 1000, tz=CST)
+        records.append({
+            "time": ts.strftime("%H:%M"),
+            "summary": parse_content(msg.content).render()[:80],
+        })
+    return records
+
+
+async def judge_response(
+    messages_text: str,
+    reply_style: str,
+    group_culture: str,
+    recent_proactive: list[dict],
+) -> dict:
+    """调用小模型判断是否主动回复
+
+    Returns:
+        {"respond": bool, "target_message_id": str | None, "stimulus": str | None}
+    """
+    try:
+        prompt_template = get_prompt("proactive_judge")
+        compiled = prompt_template.compile(
+            messages=messages_text,
+            reply_style=reply_style,
+            group_culture=group_culture,
+            recent_proactive=json.dumps(recent_proactive, ensure_ascii=False),
+        )
+
+        model = await ModelBuilder.build_chat_model(JUDGE_MODEL_ID)
+        response = await model.ainvoke([{"role": "user", "content": compiled}])
+        raw = _extract_text(response.content)
+
+        return _parse_judge_response(raw)
+    except Exception as e:
+        logger.error("judge_response failed: %s", e, exc_info=True)
+        return {"respond": False}
+
+
+def _parse_judge_response(raw: str) -> dict:
+    """解析 JSON 响应，失败返回 respond=False"""
+    try:
+        # 尝试提取 JSON（LLM 可能在 JSON 前后加文字）
+        start = raw.find("{")
+        end = raw.rfind("}") + 1
+        if start >= 0 and end > start:
+            data = json.loads(raw[start:end])
+            return {
+                "respond": bool(data.get("respond", False)),
+                "target_message_id": data.get("target_message_id"),
+                "stimulus": data.get("stimulus"),
+            }
+    except (json.JSONDecodeError, ValueError):
+        pass
+    return {"respond": False}
+
+
+# ── 合成消息与投递 ─────────────────────────────────────────────────────────
+
+
+async def submit_proactive_request(
+    target_message_id: str | None,
+    stimulus: str | None,
+) -> str:
+    """创建合成触发消息并发布 chat_request
+
+    Returns:
+        生成的 session_id
+    """
+    session_id = str(uuid.uuid4())
+    message_id = f"proactive_{int(time.time() * 1000)}"
+    now_ms = int(time.time() * 1000)
+
+    # 构建合成消息内容
+    content = json.dumps(
+        {"v": 2, "text": stimulus or "", "items": [{"type": "text", "value": stimulus or ""}]},
+        ensure_ascii=False,
+    )
+
+    # 写入数据库
+    async with AsyncSessionLocal() as session:
+        msg = ConversationMessage(
+            message_id=message_id,
+            user_id=PROACTIVE_USER_ID,
+            content=content,
+            role="user",
+            root_message_id=message_id,
+            reply_message_id=target_message_id,
+            chat_id=TARGET_CHAT_ID,
+            chat_type="group",
+            create_time=now_ms,
+            message_type="proactive_trigger",
+            vector_status="skipped",
+            bot_name="chiwei",
+        )
+        session.add(msg)
+        await session.commit()
+
+    # 发布到 chat_request 队列（lane=None 强制走 prod）
+    client = RabbitMQClient.get_instance()
+    await client.publish(
+        CHAT_REQUEST,
+        {
+            "session_id": session_id,
+            "message_id": message_id,
+            "chat_id": TARGET_CHAT_ID,
+            "is_p2p": False,
+            "root_id": message_id,
+            "user_id": PROACTIVE_USER_ID,
+            "bot_name": "chiwei",
+            "is_proactive": True,
+            "lane": None,
+            "enqueued_at": now_ms,
+        },
+        lane=None,
+    )
+
+    logger.info(
+        "Proactive request submitted: session_id=%s, target=%s",
+        session_id,
+        target_message_id,
+    )
+    return session_id
+
+
+# ── 主编排 ────────────────────────────────────────────────────────────────
+
+
+async def run_proactive_scan(source: str = "cron") -> dict:
+    """主动扫描编排
+
+    Returns:
+        {"skipped": str} 或 {"submitted": session_id} 或 {"decided": "no_response"}
+    """
+    # 1. 安静时段
+    if _is_quiet_hours():
+        logger.debug("proactive_scan skipped: quiet hours")
+        return {"skipped": "quiet_hours"}
+
+    # 2. 冷却检查
+    if not await should_scan():
+        logger.debug("proactive_scan skipped: cooldown")
+        return {"skipped": "cooldown"}
+
+    # 3. 标记已扫描
+    await _mark_scanned()
+
+    # 4. 获取未读消息
+    messages = await get_unseen_messages()
+    if not messages:
+        logger.debug("proactive_scan: no unseen messages")
+        return {"skipped": "no_messages"}
+
+    # 5. 收集上下文
+    messages_text = _format_messages_for_judge(messages)
+    reply_style = await get_reply_style(TARGET_CHAT_ID)
+    group_culture = await get_group_culture_gestalt(TARGET_CHAT_ID)
+    recent_proactive = await _get_recent_proactive_records()
+
+    # 6. 小模型判断
+    decision = await judge_response(
+        messages_text=messages_text,
+        reply_style=reply_style,
+        group_culture=group_culture,
+        recent_proactive=recent_proactive,
+    )
+
+    if not decision.get("respond"):
+        logger.info("proactive_scan decided not to respond (source=%s)", source)
+        return {"decided": "no_response"}
+
+    # 7. 投递
+    session_id = await submit_proactive_request(
+        target_message_id=decision.get("target_message_id"),
+        stimulus=decision.get("stimulus"),
+    )
+
+    logger.info("proactive_scan submitted (source=%s, session=%s)", source, session_id)
+    return {"submitted": session_id}
+
+
+# ── 辅助 ──────────────────────────────────────────────────────────────────
+
+
+def _extract_text(content) -> str:
+    """从 LLM 响应中提取文本"""
+    if isinstance(content, list):
+        return "".join(
+            part.get("text", "") if isinstance(part, dict) else str(part)
+            for part in content
+        )
+    return content or ""

--- a/apps/agent-service/app/workers/proactive_scanner.py
+++ b/apps/agent-service/app/workers/proactive_scanner.py
@@ -287,15 +287,9 @@ async def run_proactive_scan(source: str = "cron") -> dict:
         logger.debug("proactive_scan skipped: quiet hours")
         return {"skipped": "quiet_hours"}
 
-    # 2. 冷却检查
-    if not await should_scan():
-        logger.debug("proactive_scan skipped: cooldown")
-        return {"skipped": "cooldown"}
+    # 频率控制已由 ProactiveManager 接管，scanner 不再做冷却检查
 
-    # 3. 标记已扫描
-    await _mark_scanned()
-
-    # 4. 获取未读消息
+    # 2. 获取未读消息
     messages = await get_unseen_messages()
     if not messages:
         logger.debug("proactive_scan: no unseen messages")

--- a/apps/agent-service/app/workers/proactive_scanner.py
+++ b/apps/agent-service/app/workers/proactive_scanner.py
@@ -269,7 +269,7 @@ async def submit_proactive_request(
             "is_p2p": False,
             "root_id": message_id,
             "user_id": PROACTIVE_USER_ID,
-            "bot_name": "chiwei",
+            "bot_name": "bytedance",
             "is_proactive": True,
             "lane": current_lane,
             "enqueued_at": now_ms,

--- a/apps/agent-service/app/workers/proactive_scanner.py
+++ b/apps/agent-service/app/workers/proactive_scanner.py
@@ -111,15 +111,24 @@ async def get_unseen_messages(limit: int = 30) -> list[ConversationMessage]:
 # ── 小模型判断 ────────────────────────────────────────────────────────────
 
 
-def _format_messages_for_judge(messages: list[ConversationMessage]) -> str:
-    """将消息格式化为 [HH:MM:SS] user_id[:8]: text"""
+async def _format_messages_for_judge(messages: list[ConversationMessage]) -> str:
+    """将消息格式化为 [HH:MM:SS] 用户名: text"""
+    from app.orm.crud import get_username
+
+    # 批量查用户名，缓存避免重复查询
+    name_cache: dict[str, str] = {}
+    for msg in messages:
+        if msg.user_id and msg.user_id not in name_cache:
+            name = await get_username(msg.user_id)
+            name_cache[msg.user_id] = name or msg.user_id[:8]
+
     lines = []
     for msg in messages:
         ts = datetime.fromtimestamp(msg.create_time / 1000, tz=CST)
         time_str = ts.strftime("%H:%M:%S")
-        user_short = msg.user_id[:8] if msg.user_id else "unknown"
+        username = name_cache.get(msg.user_id, "unknown")
         text = parse_content(msg.content).render()
-        lines.append(f"[{time_str}] {user_short}: {text}")
+        lines.append(f"[{time_str}] {username}: {text}")
     return "\n".join(lines)
 
 
@@ -304,7 +313,7 @@ async def run_proactive_scan(source: str = "cron") -> dict:
     with langfuse.start_as_current_observation(as_type="trace", name="proactive-scan"):
         with propagate_attributes(session_id=scan_session_id):
             # 5. 收集上下文
-            messages_text = _format_messages_for_judge(messages)
+            messages_text = await _format_messages_for_judge(messages)
             reply_style = await get_reply_style(TARGET_CHAT_ID)
             group_culture = await get_group_culture_gestalt(TARGET_CHAT_ID)
             recent_proactive = await _get_recent_proactive_records()

--- a/apps/agent-service/app/workers/proactive_scanner.py
+++ b/apps/agent-service/app/workers/proactive_scanner.py
@@ -240,7 +240,9 @@ async def submit_proactive_request(
         session.add(msg)
         await session.commit()
 
-    # 发布到 chat_request 队列（lane=None 强制走 prod）
+    # 发布到 chat_request 队列（不指定 lane，跟随当前泳道）
+    from app.clients.rabbitmq import _current_lane
+    current_lane = _current_lane()
     client = RabbitMQClient.get_instance()
     await client.publish(
         CHAT_REQUEST,
@@ -253,10 +255,9 @@ async def submit_proactive_request(
             "user_id": PROACTIVE_USER_ID,
             "bot_name": "chiwei",
             "is_proactive": True,
-            "lane": None,
+            "lane": current_lane,
             "enqueued_at": now_ms,
         },
-        lane=None,
     )
 
     logger.info(

--- a/apps/agent-service/app/workers/proactive_scanner.py
+++ b/apps/agent-service/app/workers/proactive_scanner.py
@@ -105,7 +105,7 @@ async def _format_messages_for_judge(messages: list[ConversationMessage]) -> str
         time_str = ts.strftime("%H:%M:%S")
         username = name_cache.get(msg.user_id, "unknown")
         text = parse_content(msg.content).render()
-        lines.append(f"[{time_str}] {username}: {text}")
+        lines.append(f"[{time_str}] ({msg.message_id}) {username}: {text}")
     return "\n".join(lines)
 
 

--- a/apps/agent-service/app/workers/proactive_scanner.py
+++ b/apps/agent-service/app/workers/proactive_scanner.py
@@ -2,11 +2,12 @@
 
 核心流程 (run_proactive_scan):
 1. 安静时段检查（23:00~09:00 CST 不扫）
-2. Redis 冷却检查（15 分钟内不重复扫）
-3. 获取上次发言后的未读消息
-4. 收集上下文（reply_style、group_culture、今日主动记录）
-5. 小模型判断是否应该回复
-6. 合成触发消息 + 发布 chat_request
+2. 获取上次发言后的未读消息
+3. 收集上下文（reply_style、group_culture、今日主动记录）
+4. 小模型判断是否应该回复
+5. 合成触发消息 + 发布 chat_request
+
+频率控制由 ProactiveManager 负责（debounce、每小时上限、连续无回应冷却）。
 """
 
 import json
@@ -20,7 +21,6 @@ from sqlalchemy import select, func as sa_func
 from app.agents.infra.langfuse_client import get_prompt
 from app.agents.infra.model_builder import ModelBuilder
 from app.clients.rabbitmq import CHAT_REQUEST, RabbitMQClient
-from app.clients.redis import AsyncRedisClient
 from app.orm.base import AsyncSessionLocal
 from app.orm.crud import get_group_culture_gestalt
 from app.orm.models import ConversationMessage
@@ -31,16 +31,11 @@ logger = logging.getLogger(__name__)
 
 # ── 常量 ──────────────────────────────────────────────────────────────────
 TARGET_CHAT_ID = "oc_a44255e98af05f1359aeb29eeb503536"
-COOLDOWN_KEY = "proactive:last_scan_time"
-COOLDOWN_MS = 15 * 60 * 1000  # 15 min
 PROACTIVE_USER_ID = "__proactive__"
 QUIET_HOURS = (23, 9)  # >= 23 or < 9
 JUDGE_MODEL_ID = "proactive-judge-model"
 
 CST = timezone(timedelta(hours=8))
-
-
-# ── 冷却与时段 ────────────────────────────────────────────────────────────
 
 
 def _is_quiet_hours(now: datetime | None = None) -> bool:
@@ -49,26 +44,6 @@ def _is_quiet_hours(now: datetime | None = None) -> bool:
     hour = now.hour
     start, end = QUIET_HOURS
     return hour >= start or hour < end
-
-
-async def should_scan() -> bool:
-    """检查 Redis 冷却，15 分钟内扫过则返回 False"""
-    redis = AsyncRedisClient.get_instance()
-    last = await redis.get(COOLDOWN_KEY)
-    if last is None:
-        return True
-    try:
-        elapsed = int(time.time() * 1000) - int(last)
-        return elapsed >= COOLDOWN_MS
-    except (ValueError, TypeError):
-        return True
-
-
-async def _mark_scanned() -> None:
-    """写入当前时间戳到 Redis 冷却 key"""
-    redis = AsyncRedisClient.get_instance()
-    now_ms = int(time.time() * 1000)
-    await redis.set(COOLDOWN_KEY, str(now_ms), ex=COOLDOWN_MS // 1000 + 60)
 
 
 # ── 未读消息获取 ──────────────────────────────────────────────────────────
@@ -267,7 +242,7 @@ async def submit_proactive_request(
             "message_id": message_id,
             "chat_id": TARGET_CHAT_ID,
             "is_p2p": False,
-            "root_id": message_id,
+            "root_id": target_message_id or "",
             "user_id": PROACTIVE_USER_ID,
             "bot_name": "bytedance",
             "is_proactive": True,
@@ -298,8 +273,6 @@ async def run_proactive_scan(source: str = "cron") -> dict:
         logger.debug("proactive_scan skipped: quiet hours")
         return {"skipped": "quiet_hours"}
 
-    # 频率控制已由 ProactiveManager 接管，scanner 不再做冷却检查
-
     # 2. 获取未读消息
     messages = await get_unseen_messages()
     if not messages:
@@ -314,13 +287,13 @@ async def run_proactive_scan(source: str = "cron") -> dict:
 
     with langfuse.start_as_current_observation(as_type="trace", name="proactive-scan"):
         with propagate_attributes(session_id=scan_session_id):
-            # 5. 收集上下文
+            # 3. 收集上下文
             messages_text = await _format_messages_for_judge(messages)
             reply_style = await get_reply_style(TARGET_CHAT_ID)
             group_culture = await get_group_culture_gestalt(TARGET_CHAT_ID)
             recent_proactive = await _get_recent_proactive_records()
 
-            # 6. 小模型判断
+            # 4. 小模型判断
             decision = await judge_response(
                 messages_text=messages_text,
                 reply_style=reply_style,
@@ -332,7 +305,7 @@ async def run_proactive_scan(source: str = "cron") -> dict:
                 logger.info("proactive_scan decided not to respond (source=%s)", source)
                 return {"decided": "no_response"}
 
-            # 7. 投递
+            # 5. 投递
             session_id = await submit_proactive_request(
                 target_message_id=decision.get("target_message_id"),
                 stimulus=decision.get("stimulus"),

--- a/apps/agent-service/app/workers/proactive_scanner.py
+++ b/apps/agent-service/app/workers/proactive_scanner.py
@@ -171,8 +171,13 @@ async def judge_response(
             recent_proactive=json.dumps(recent_proactive, ensure_ascii=False),
         )
 
+        from langfuse.langchain import CallbackHandler
+
         model = await ModelBuilder.build_chat_model(JUDGE_MODEL_ID)
-        response = await model.ainvoke([{"role": "user", "content": compiled}])
+        response = await model.ainvoke(
+            [{"role": "user", "content": compiled}],
+            config={"callbacks": [CallbackHandler()]},
+        )
         raw = _extract_text(response.content)
 
         return _parse_judge_response(raw)

--- a/apps/agent-service/app/workers/proactive_scanner.py
+++ b/apps/agent-service/app/workers/proactive_scanner.py
@@ -307,7 +307,7 @@ async def run_proactive_scan(source: str = "cron") -> dict:
     langfuse = get_langfuse()
     scan_session_id = str(uuid.uuid4())
 
-    with langfuse.start_as_current_observation(as_type="span", name="proactive-scan"):
+    with langfuse.start_as_current_observation(as_type="trace", name="proactive-scan"):
         with propagate_attributes(session_id=scan_session_id):
             # 5. 收集上下文
             messages_text = _format_messages_for_judge(messages)

--- a/apps/agent-service/app/workers/proactive_scanner.py
+++ b/apps/agent-service/app/workers/proactive_scanner.py
@@ -91,7 +91,7 @@ async def get_unseen_messages(limit: int = 30) -> list[ConversationMessage]:
             .scalar_subquery()
         )
 
-        # 主查询：之后的用户消息
+        # 主查询：之后的用户消息（取最近的 N 条，赤尾看到的是最新对话）
         stmt = (
             select(ConversationMessage)
             .where(
@@ -100,12 +100,14 @@ async def get_unseen_messages(limit: int = 30) -> list[ConversationMessage]:
                 ConversationMessage.user_id != PROACTIVE_USER_ID,
                 ConversationMessage.create_time > sa_func.coalesce(last_presence_q, 0),
             )
-            .order_by(ConversationMessage.create_time.asc())
+            .order_by(ConversationMessage.create_time.desc())
             .limit(limit)
         )
 
         result = await session.execute(stmt)
-        return list(result.scalars().all())
+        rows = list(result.scalars().all())
+        rows.reverse()  # 恢复时间正序
+        return rows
 
 
 # ── 小模型判断 ────────────────────────────────────────────────────────────

--- a/apps/agent-service/app/workers/proactive_scanner.py
+++ b/apps/agent-service/app/workers/proactive_scanner.py
@@ -296,29 +296,37 @@ async def run_proactive_scan(source: str = "cron") -> dict:
         logger.debug("proactive_scan: no unseen messages")
         return {"skipped": "no_messages"}
 
-    # 5. 收集上下文
-    messages_text = _format_messages_for_judge(messages)
-    reply_style = await get_reply_style(TARGET_CHAT_ID)
-    group_culture = await get_group_culture_gestalt(TARGET_CHAT_ID)
-    recent_proactive = await _get_recent_proactive_records()
+    # Langfuse trace 包裹判断 + 投递
+    from langfuse import get_client as get_langfuse, propagate_attributes
 
-    # 6. 小模型判断
-    decision = await judge_response(
-        messages_text=messages_text,
-        reply_style=reply_style,
-        group_culture=group_culture,
-        recent_proactive=recent_proactive,
-    )
+    langfuse = get_langfuse()
+    scan_session_id = str(uuid.uuid4())
 
-    if not decision.get("respond"):
-        logger.info("proactive_scan decided not to respond (source=%s)", source)
-        return {"decided": "no_response"}
+    with langfuse.start_as_current_observation(as_type="span", name="proactive-scan"):
+        with propagate_attributes(session_id=scan_session_id):
+            # 5. 收集上下文
+            messages_text = _format_messages_for_judge(messages)
+            reply_style = await get_reply_style(TARGET_CHAT_ID)
+            group_culture = await get_group_culture_gestalt(TARGET_CHAT_ID)
+            recent_proactive = await _get_recent_proactive_records()
 
-    # 7. 投递
-    session_id = await submit_proactive_request(
-        target_message_id=decision.get("target_message_id"),
-        stimulus=decision.get("stimulus"),
-    )
+            # 6. 小模型判断
+            decision = await judge_response(
+                messages_text=messages_text,
+                reply_style=reply_style,
+                group_culture=group_culture,
+                recent_proactive=recent_proactive,
+            )
+
+            if not decision.get("respond"):
+                logger.info("proactive_scan decided not to respond (source=%s)", source)
+                return {"decided": "no_response"}
+
+            # 7. 投递
+            session_id = await submit_proactive_request(
+                target_message_id=decision.get("target_message_id"),
+                stimulus=decision.get("stimulus"),
+            )
 
     logger.info("proactive_scan submitted (source=%s, session=%s)", source, session_id)
     return {"submitted": session_id}

--- a/apps/agent-service/app/workers/proactive_scanner.py
+++ b/apps/agent-service/app/workers/proactive_scanner.py
@@ -240,7 +240,7 @@ async def submit_proactive_request(
             create_time=now_ms,
             message_type="proactive_trigger",
             vector_status="skipped",
-            bot_name="chiwei",
+            bot_name="bytedance",
         )
         session.add(msg)
         await session.commit()

--- a/apps/agent-service/app/workers/schedule_worker.py
+++ b/apps/agent-service/app/workers/schedule_worker.py
@@ -178,9 +178,10 @@ async def cron_generate_monthly_plan(ctx) -> None:
 
 
 async def cron_generate_weekly_plan(ctx) -> None:
-    """cron 入口：生成本周计划"""
+    """cron 入口：周日 23:00 触发，生成下周计划（target_date 加 1 天进入周一）"""
     try:
-        await generate_weekly_plan()
+        tomorrow = date.today() + timedelta(days=1)
+        await generate_weekly_plan(target_date=tomorrow)
     except Exception as e:
         logger.error(f"Weekly plan generation failed: {e}", exc_info=True)
 

--- a/apps/agent-service/app/workers/unified_worker.py
+++ b/apps/agent-service/app/workers/unified_worker.py
@@ -30,9 +30,9 @@ logger = logging.getLogger(__name__)
 
 
 async def proactive_scan_job(ctx) -> None:
-    """主动搭话扫描（cron 兜底触发）— 每 15 分钟执行，约 40% 概率真正扫描"""
+    """主动搭话扫描（cron 兜底，主触发走消息事件）— 每 30 分钟执行，30% 概率真正扫描"""
     import random
-    if random.random() > 0.4:
+    if random.random() > 0.3:
         return
     await run_proactive_scan(source="cron")
 
@@ -90,6 +90,6 @@ class UnifiedWorkerSettings:
         cron(cron_generate_monthly_plan, day={1}, hour={2}, minute={0}),
         # 8. 基线 reply_style：每天 CST 8:00/14:00/18:00（Schedule 之后）
         cron(cron_generate_base_reply_style, hour={8, 14, 18}, minute={0}),
-        # 9. 主动搭话扫描：每 15 分钟，40% 概率执行
-        cron(proactive_scan_job, minute={0, 15, 30, 45}),
+        # 9. 主动搭话扫描（cron 兜底）：每 30 分钟，30% 概率执行
+        cron(proactive_scan_job, minute={0, 30}),
     ]

--- a/apps/agent-service/app/workers/unified_worker.py
+++ b/apps/agent-service/app/workers/unified_worker.py
@@ -23,9 +23,18 @@ from app.workers.schedule_worker import (
     cron_generate_weekly_plan,
 )
 from app.workers.base_style_worker import cron_generate_base_reply_style
+from app.workers.proactive_scanner import run_proactive_scan
 from app.workers.vectorize_worker import cron_scan_pending_messages
 
 logger = logging.getLogger(__name__)
+
+
+async def proactive_scan_job(ctx) -> None:
+    """主动搭话扫描（cron 兜底触发）— 每 15 分钟执行，约 40% 概率真正扫描"""
+    import random
+    if random.random() > 0.4:
+        return
+    await run_proactive_scan(source="cron")
 
 
 # ==================== 长期任务相关 ====================
@@ -81,4 +90,6 @@ class UnifiedWorkerSettings:
         cron(cron_generate_monthly_plan, day={1}, hour={2}, minute={0}),
         # 8. 基线 reply_style：每天 CST 8:00/14:00/18:00（Schedule 之后）
         cron(cron_generate_base_reply_style, hour={8, 14, 18}, minute={0}),
+        # 9. 主动搭话扫描：每 15 分钟，40% 概率执行
+        cron(proactive_scan_job, minute={0, 15, 30, 45}),
     ]

--- a/apps/agent-service/tests/unit/test_proactive_scanner.py
+++ b/apps/agent-service/tests/unit/test_proactive_scanner.py
@@ -1,0 +1,178 @@
+# tests/unit/test_proactive_scanner.py
+"""proactive_scanner 单元测试
+
+覆盖: should_scan (3 cases), get_unseen_messages (2 cases), judge_response (2 cases)
+"""
+import json
+import time
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+CST = timezone(timedelta(hours=8))
+
+MODULE = "app.workers.proactive_scanner"
+
+
+# ── should_scan ───────────────────────────────────────────────────────────
+
+
+async def test_should_scan_no_previous_scan():
+    """首次扫描（Redis 无 key）→ 返回 True"""
+    mock_redis = AsyncMock()
+    mock_redis.get.return_value = None
+
+    with patch(f"{MODULE}.AsyncRedisClient") as mock_cls:
+        mock_cls.get_instance.return_value = mock_redis
+        from app.workers.proactive_scanner import should_scan
+
+        result = await should_scan()
+
+    assert result is True
+    mock_redis.get.assert_awaited_once()
+
+
+async def test_should_scan_within_cooldown():
+    """冷却期内（5 分钟前扫过）→ 返回 False"""
+    five_min_ago_ms = str(int(time.time() * 1000) - 5 * 60 * 1000)
+    mock_redis = AsyncMock()
+    mock_redis.get.return_value = five_min_ago_ms
+
+    with patch(f"{MODULE}.AsyncRedisClient") as mock_cls:
+        mock_cls.get_instance.return_value = mock_redis
+        from app.workers.proactive_scanner import should_scan
+
+        result = await should_scan()
+
+    assert result is False
+
+
+async def test_should_scan_cooldown_expired():
+    """冷却已过（20 分钟前扫过）→ 返回 True"""
+    twenty_min_ago_ms = str(int(time.time() * 1000) - 20 * 60 * 1000)
+    mock_redis = AsyncMock()
+    mock_redis.get.return_value = twenty_min_ago_ms
+
+    with patch(f"{MODULE}.AsyncRedisClient") as mock_cls:
+        mock_cls.get_instance.return_value = mock_redis
+        from app.workers.proactive_scanner import should_scan
+
+        result = await should_scan()
+
+    assert result is True
+
+
+# ── get_unseen_messages ───────────────────────────────────────────────────
+
+
+async def test_get_unseen_messages_has_messages():
+    """有未读消息时返回 ConversationMessage 列表"""
+    fake_msg = MagicMock(
+        message_id="msg_1",
+        user_id="user_abc",
+        content='{"v": 2, "text": "hello", "items": []}',
+        role="user",
+        create_time=int(time.time() * 1000),
+    )
+
+    mock_scalars = MagicMock()
+    mock_scalars.all.return_value = [fake_msg]
+    mock_result = MagicMock()
+    mock_result.scalars.return_value = mock_scalars
+
+    mock_session = AsyncMock()
+    mock_session.execute.return_value = mock_result
+
+    mock_session_ctx = AsyncMock()
+    mock_session_ctx.__aenter__ = AsyncMock(return_value=mock_session)
+    mock_session_ctx.__aexit__ = AsyncMock(return_value=False)
+
+    with patch(f"{MODULE}.AsyncSessionLocal", return_value=mock_session_ctx):
+        from app.workers.proactive_scanner import get_unseen_messages
+
+        result = await get_unseen_messages()
+
+    assert len(result) == 1
+    assert result[0].message_id == "msg_1"
+
+
+async def test_get_unseen_messages_empty():
+    """无未读消息时返回空列表"""
+    mock_scalars = MagicMock()
+    mock_scalars.all.return_value = []
+    mock_result = MagicMock()
+    mock_result.scalars.return_value = mock_scalars
+
+    mock_session = AsyncMock()
+    mock_session.execute.return_value = mock_result
+
+    mock_session_ctx = AsyncMock()
+    mock_session_ctx.__aenter__ = AsyncMock(return_value=mock_session)
+    mock_session_ctx.__aexit__ = AsyncMock(return_value=False)
+
+    with patch(f"{MODULE}.AsyncSessionLocal", return_value=mock_session_ctx):
+        from app.workers.proactive_scanner import get_unseen_messages
+
+        result = await get_unseen_messages()
+
+    assert result == []
+
+
+# ── judge_response ────────────────────────────────────────────────────────
+
+
+async def test_judge_response_respond_true():
+    """小模型判断应该回复"""
+    judge_result = json.dumps({
+        "respond": True,
+        "target_message_id": "msg_42",
+        "stimulus": "他们在讨论你喜欢的动漫",
+    })
+
+    mock_model = AsyncMock()
+    mock_model.ainvoke.return_value = MagicMock(content=judge_result)
+
+    with (
+        patch(f"{MODULE}.get_prompt") as mock_prompt,
+        patch(f"{MODULE}.ModelBuilder") as mock_mb,
+    ):
+        mock_prompt.return_value.compile.return_value = "compiled prompt"
+        mock_mb.build_chat_model = AsyncMock(return_value=mock_model)
+
+        from app.workers.proactive_scanner import judge_response
+
+        result = await judge_response(
+            messages_text="[10:00:00] user_abc: 你看过新番吗",
+            reply_style="活泼可爱",
+            group_culture="二次元讨论群",
+            recent_proactive=[],
+        )
+
+    assert result["respond"] is True
+    assert result["target_message_id"] == "msg_42"
+    assert result["stimulus"] == "他们在讨论你喜欢的动漫"
+
+
+async def test_judge_response_json_parse_failure():
+    """小模型返回非 JSON → 默认 respond=False"""
+    mock_model = AsyncMock()
+    mock_model.ainvoke.return_value = MagicMock(content="I'm not sure what to say")
+
+    with (
+        patch(f"{MODULE}.get_prompt") as mock_prompt,
+        patch(f"{MODULE}.ModelBuilder") as mock_mb,
+    ):
+        mock_prompt.return_value.compile.return_value = "compiled prompt"
+        mock_mb.build_chat_model = AsyncMock(return_value=mock_model)
+
+        from app.workers.proactive_scanner import judge_response
+
+        result = await judge_response(
+            messages_text="[10:00:00] user_abc: 今天天气不错",
+            reply_style="淡定",
+            group_culture="日常闲聊群",
+            recent_proactive=[],
+        )
+
+    assert result["respond"] is False

--- a/apps/lark-server/src/infrastructure/integrations/lark/events/handlers.ts
+++ b/apps/lark-server/src/infrastructure/integrations/lark/events/handlers.ts
@@ -25,7 +25,7 @@ import {
     GroupChatInfoRepository,
     UserGroupBindingRepository,
 } from 'infrastructure/dal/repositories/repositories';
-import { getBotAppId } from '@core/services/bot/bot-var';
+import { getBotAppId, getBotUnionId } from '@core/services/bot/bot-var';
 import { searchLarkChatInfo, searchLarkChatMember, addChatMember } from '@lark/basic/group';
 import type { LarkEnterChatEvent } from 'types/lark';
 import { LarkBaseChatInfo } from 'infrastructure/dal/entities';
@@ -87,8 +87,9 @@ export class LarkEventHandlers {
                 message_type: message.messageType,
             });
 
-            // Publish proactive eval event for group messages
-            if (!message.isP2P()) {
+            // Publish proactive eval event for group messages that don't @赤尾
+            // @赤尾 的消息走正常回复流程，不需要 proactive 重复触发
+            if (!message.isP2P() && !message.hasMention(getBotUnionId())) {
                 rabbitmqClient.publish(PROACTIVE_EVAL, {
                     chat_id: message.chatId,
                     message_id: message.messageId,

--- a/apps/lark-server/src/infrastructure/integrations/lark/events/handlers.ts
+++ b/apps/lark-server/src/infrastructure/integrations/lark/events/handlers.ts
@@ -25,7 +25,8 @@ import {
     GroupChatInfoRepository,
     UserGroupBindingRepository,
 } from 'infrastructure/dal/repositories/repositories';
-import { getBotAppId, getBotUnionId } from '@core/services/bot/bot-var';
+import { getBotAppId } from '@core/services/bot/bot-var';
+import { multiBotManager } from '@core/services/bot/multi-bot-manager';
 import { searchLarkChatInfo, searchLarkChatMember, addChatMember } from '@lark/basic/group';
 import type { LarkEnterChatEvent } from 'types/lark';
 import { LarkBaseChatInfo } from 'infrastructure/dal/entities';
@@ -87,13 +88,19 @@ export class LarkEventHandlers {
                 message_type: message.messageType,
             });
 
-            // Publish proactive eval event for group messages that don't @赤尾
-            // @赤尾 的消息走正常回复流程，不需要 proactive 重复触发
-            if (!message.isP2P() && !message.hasMention(getBotUnionId())) {
-                rabbitmqClient.publish(PROACTIVE_EVAL, {
-                    chat_id: message.chatId,
-                    message_id: message.messageId,
-                }).catch(err => console.warn('[ProactiveEval] publish failed:', err));
+            // Publish proactive eval event for group messages that don't @任何 persona bot
+            // @persona bot 的消息走正常回复流程，不需要 proactive 重复触发
+            if (!message.isP2P()) {
+                const personaUnionIds = multiBotManager.getAllBotConfigs()
+                    .filter(b => b.bot_role === 'persona')
+                    .map(b => b.robot_union_id);
+                const mentionsPersona = personaUnionIds.some(id => message.hasMention(id));
+                if (!mentionsPersona) {
+                    rabbitmqClient.publish(PROACTIVE_EVAL, {
+                        chat_id: message.chatId,
+                        message_id: message.messageId,
+                    }).catch(err => console.warn('[ProactiveEval] publish failed:', err));
+                }
             }
 
             await runRules(message);

--- a/apps/lark-server/src/infrastructure/integrations/lark/events/handlers.ts
+++ b/apps/lark-server/src/infrastructure/integrations/lark/events/handlers.ts
@@ -32,6 +32,7 @@ import { LarkBaseChatInfo } from 'infrastructure/dal/entities';
 import AppDataSource from 'ormconfig';
 import { laneRouter } from '@infrastructure/lane-router';
 import { context } from '@middleware/context';
+import { rabbitmqClient, PROACTIVE_EVAL } from '@integrations/rabbitmq';
 
 /**
  * Lark事件处理器类
@@ -85,6 +86,14 @@ export class LarkEventHandlers {
                 reply_message_id: message.parentMessageId,
                 message_type: message.messageType,
             });
+
+            // Publish proactive eval event for group messages
+            if (!message.isP2P()) {
+                rabbitmqClient.publish(PROACTIVE_EVAL, {
+                    chat_id: message.chatId,
+                    message_id: message.messageId,
+                }).catch(err => console.warn('[ProactiveEval] publish failed:', err));
+            }
 
             await runRules(message);
         } catch (error) {

--- a/apps/lark-server/src/infrastructure/integrations/rabbitmq.ts
+++ b/apps/lark-server/src/infrastructure/integrations/rabbitmq.ts
@@ -15,8 +15,9 @@ export const CHAT_RESPONSE: Route = { queue: 'chat_response', rk: 'chat.response
 export const SAFETY_CHECK: Route = { queue: 'safety_check', rk: 'post.safety.check' };
 export const RECALL: Route = { queue: 'recall', rk: 'action.recall' };
 export const VECTORIZE: Route = { queue: 'vectorize', rk: 'task.vectorize' };
+export const PROACTIVE_EVAL: Route = { queue: 'proactive_eval', rk: 'proactive.eval' };
 
-const ALL_ROUTES: Route[] = [CHAT_REQUEST, CHAT_RESPONSE, SAFETY_CHECK, RECALL, VECTORIZE];
+const ALL_ROUTES: Route[] = [CHAT_REQUEST, CHAT_RESPONSE, SAFETY_CHECK, RECALL, VECTORIZE, PROACTIVE_EVAL];
 
 const NON_PROD_EXPIRES_MS = 86_400_000;
 const LANE_FALLBACK_TTL_MS = 10_000;

--- a/apps/lark-server/src/workers/chat-response-worker.ts
+++ b/apps/lark-server/src/workers/chat-response-worker.ts
@@ -259,7 +259,7 @@ async function handleChatResponse(msg: ConsumeMessage): Promise<void> {
 
         if (!content) {
             console.warn(`[ChatResponseWorker] Empty content: session_id=${session_id}, part=${part_index}`);
-            if (is_last) {
+            if (is_last && agentResponse) {
                 await repo.update({ session_id }, { status: 'completed' });
             }
             return;

--- a/apps/lark-server/src/workers/chat-response-worker.ts
+++ b/apps/lark-server/src/workers/chat-response-worker.ts
@@ -184,6 +184,8 @@ interface ChatResponsePayload {
     lane?: string;
     part_index?: number;
     is_last?: boolean;
+    is_proactive?: boolean;
+    bot_name?: string;
 }
 
 function sleep(ms: number): Promise<void> {
@@ -213,12 +215,14 @@ async function handleChatResponse(msg: ConsumeMessage): Promise<void> {
         chat_id,
         is_p2p,
         root_id,
+        user_id,
         content,
         full_content,
         status,
         error,
         part_index = 0,
         is_last = false,
+        is_proactive = false,
     } = payload;
 
     console.info(
@@ -233,12 +237,13 @@ async function handleChatResponse(msg: ConsumeMessage): Promise<void> {
     const dbQueryMs = Date.now() - tDbQuery0;
     chatResponseDuration.labels({ stage: 'db_query' }).observe(dbQueryMs / 1000);
 
-    if (!agentResponse) {
-        console.error(`[ChatResponseWorker] No agent_response found: session_id=${session_id}`);
+    // proactive 消息没有 agent_response 记录，从 payload 获取 bot_name
+    const botName = agentResponse?.bot_name || payload.bot_name;
+    if (!botName) {
+        console.error(`[ChatResponseWorker] No bot_name found: session_id=${session_id}, is_proactive=${is_proactive}`);
         rabbitmqClient.ack(msg);
         return;
     }
-    const botName = agentResponse.bot_name;
 
     // 设置 bot context — ack 统一在 context.run 之后，callback 内部禁止 ack/nack
     const contextData = context.createContext(botName || undefined, undefined, payload.lane);
@@ -277,10 +282,17 @@ async function handleChatResponse(msg: ConsumeMessage): Promise<void> {
             const tSend0 = Date.now();
             let aiMessageId: string | undefined;
             if (part_index === 0) {
-                // 第一条作为回复
-                aiMessageId = await replyPost(message_id, postContent);
+                if (is_proactive) {
+                    // proactive: reply to real message if available, else send new
+                    if (root_id) {
+                        aiMessageId = await replyPost(root_id, postContent);
+                    } else {
+                        aiMessageId = await sendPost(chat_id, postContent);
+                    }
+                } else {
+                    aiMessageId = await replyPost(message_id, postContent);
+                }
             } else {
-                // 后续消息带延迟后发送
                 await sleep(SEND_DELAY_MS);
                 aiMessageId = await sendPost(chat_id, postContent);
             }
@@ -301,38 +313,39 @@ async function handleChatResponse(msg: ConsumeMessage): Promise<void> {
                 chat_id: chat_id,
                 chat_type: is_p2p ? 'p2p' : 'group',
                 create_time: String(now),
-                root_message_id: root_id || message_id,
-                reply_message_id: message_id,
+                root_message_id: is_proactive ? (root_id || effectiveMessageId) : (root_id || message_id),
+                reply_message_id: is_proactive ? (root_id || undefined) : message_id,
             });
 
-            // 每条消息追加到 agent_responses.replies jsonb 数组（参数化）
-            const replyEntry = [
-                {
-                    message_id: effectiveMessageId,
-                    content_type: 'post',
-                    sent_at: new Date().toISOString(),
-                },
-            ];
-            await repo
-                .createQueryBuilder()
-                .update(AgentResponse)
-                .set({
-                    replies: () =>
-                        `COALESCE(replies, '[]'::jsonb) || :replyEntry::jsonb`,
-                })
-                .setParameter('replyEntry', JSON.stringify(replyEntry))
-                .where('session_id = :sid', { sid: session_id })
-                .execute();
-
-            // is_last 时更新 response_text 和状态
-            if (is_last) {
-                await repo.update(
-                    { session_id },
+            // proactive 没有 agent_response 记录，跳过 replies 追加和状态更新
+            if (agentResponse) {
+                const replyEntry = [
                     {
-                        response_text: full_content || content,
-                        status: 'completed',
+                        message_id: effectiveMessageId,
+                        content_type: 'post',
+                        sent_at: new Date().toISOString(),
                     },
-                );
+                ];
+                await repo
+                    .createQueryBuilder()
+                    .update(AgentResponse)
+                    .set({
+                        replies: () =>
+                            `COALESCE(replies, '[]'::jsonb) || :replyEntry::jsonb`,
+                    })
+                    .setParameter('replyEntry', JSON.stringify(replyEntry))
+                    .where('session_id = :sid', { sid: session_id })
+                    .execute();
+
+                if (is_last) {
+                    await repo.update(
+                        { session_id },
+                        {
+                            response_text: full_content || content,
+                            status: 'completed',
+                        },
+                    );
+                }
             }
             const dbWriteMs = Date.now() - tDbWrite0;
             chatResponseDuration.labels({ stage: 'db_write' }).observe(dbWriteMs / 1000);

--- a/docs/superpowers/plans/2026-04-01-proactive-chat.md
+++ b/docs/superpowers/plans/2026-04-01-proactive-chat.md
@@ -1,0 +1,1204 @@
+# 赤尾群聊窥屏 MVP 实现计划
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 让赤尾能在群聊中主动插话——基于"顺手刷"和"cron 兜底"两层触发，用小模型判断是否想说话，复用现有 chat_request 链路发送。
+
+**Architecture:** 新增 `proactive_scanner.py` 作为核心模块，负责扫描 → 小模型判断 → 构造合成消息 → 投递 chat_request。两个触发入口：chat_consumer 处理完后的 piggyback、unified_worker 的 cron job。context_builder 和 memory_context 加 proactive 分支，chat-response-worker 调整发送方式。
+
+**Tech Stack:** Python (agent-service)、TypeScript (lark-server)、ARQ cron、RabbitMQ、Redis、PostgreSQL、gemini-2.0-flash (小模型判断)
+
+**Spec:** `docs/superpowers/specs/2026-04-01-proactive-chat-design.md`
+
+---
+
+### Task 1: 创建 proactive_scanner.py — 核心扫描与判断模块
+
+**Files:**
+- Create: `apps/agent-service/app/workers/proactive_scanner.py`
+- Test: `apps/agent-service/tests/workers/test_proactive_scanner.py`
+
+这是整个功能的核心新文件。包含：冷却检查、拉取未读消息、小模型判断、合成消息构造、chat_request 投递。
+
+- [ ] **Step 1: 写测试 — should_scan 冷却逻辑**
+
+```python
+# tests/workers/test_proactive_scanner.py
+import time
+import pytest
+from unittest.mock import AsyncMock, patch
+
+from app.workers.proactive_scanner import should_scan, COOLDOWN_KEY
+
+
+@pytest.mark.asyncio
+async def test_should_scan_returns_true_when_no_recent_scan():
+    mock_redis = AsyncMock()
+    mock_redis.get.return_value = None
+    with patch("app.workers.proactive_scanner.AsyncRedisClient.get_instance", return_value=mock_redis):
+        assert await should_scan() is True
+
+
+@pytest.mark.asyncio
+async def test_should_scan_returns_false_within_cooldown():
+    mock_redis = AsyncMock()
+    mock_redis.get.return_value = str(int(time.time() * 1000))  # just now
+    with patch("app.workers.proactive_scanner.AsyncRedisClient.get_instance", return_value=mock_redis):
+        assert await should_scan() is False
+
+
+@pytest.mark.asyncio
+async def test_should_scan_returns_true_after_cooldown():
+    mock_redis = AsyncMock()
+    mock_redis.get.return_value = str(int(time.time() * 1000) - 20 * 60 * 1000)  # 20min ago
+    with patch("app.workers.proactive_scanner.AsyncRedisClient.get_instance", return_value=mock_redis):
+        assert await should_scan() is True
+```
+
+- [ ] **Step 2: 运行测试确认失败**
+
+Run: `cd apps/agent-service && python -m pytest tests/workers/test_proactive_scanner.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'app.workers.proactive_scanner'`
+
+- [ ] **Step 3: 实现 proactive_scanner.py 骨架 + should_scan**
+
+```python
+# apps/agent-service/app/workers/proactive_scanner.py
+"""赤尾群聊窥屏 — 主动搭话扫描器
+
+两层触发（piggyback / cron）共用同一套扫描 → 判断 → 投递流程。
+MVP 硬编码目标群 oc_a44255e98af05f1359aeb29eeb503536。
+"""
+
+import json
+import logging
+import random
+import time
+import uuid
+from datetime import datetime, timedelta, timezone
+
+from app.clients.redis import AsyncRedisClient
+from app.config import settings
+
+logger = logging.getLogger(__name__)
+
+CST = timezone(timedelta(hours=8))
+TARGET_CHAT_ID = "oc_a44255e98af05f1359aeb29eeb503536"
+COOLDOWN_KEY = "proactive:last_scan_time"
+COOLDOWN_MS = 15 * 60 * 1000  # 15 分钟
+PROACTIVE_USER_ID = "__proactive__"
+QUIET_HOURS = (23, 9)  # 23:00-09:00 不触发
+
+
+async def should_scan() -> bool:
+    """检查冷却：15 分钟内已扫描过则跳过"""
+    redis = AsyncRedisClient.get_instance()
+    last_scan = await redis.get(COOLDOWN_KEY)
+    if last_scan:
+        elapsed_ms = int(time.time() * 1000) - int(last_scan)
+        if elapsed_ms < COOLDOWN_MS:
+            return False
+    return True
+
+
+def _is_quiet_hours() -> bool:
+    """23:00-09:00 CST 不触发"""
+    hour = datetime.now(CST).hour
+    return hour >= QUIET_HOURS[0] or hour < QUIET_HOURS[1]
+
+
+async def _mark_scanned() -> None:
+    """记录扫描时间戳到 Redis"""
+    redis = AsyncRedisClient.get_instance()
+    await redis.set(COOLDOWN_KEY, str(int(time.time() * 1000)), ex=COOLDOWN_MS // 1000 + 60)
+```
+
+- [ ] **Step 4: 运行测试确认通过**
+
+Run: `cd apps/agent-service && python -m pytest tests/workers/test_proactive_scanner.py -v`
+Expected: 3 tests PASS
+
+- [ ] **Step 5: 写测试 — get_unseen_messages**
+
+```python
+# 追加到 tests/workers/test_proactive_scanner.py
+from datetime import datetime, timezone
+from app.workers.proactive_scanner import get_unseen_messages, TARGET_CHAT_ID
+
+
+@pytest.mark.asyncio
+async def test_get_unseen_messages_returns_messages_after_last_presence():
+    mock_session = AsyncMock()
+    mock_result = AsyncMock()
+    # 模拟有 2 条新消息
+    mock_result.scalars.return_value.all.return_value = [
+        AsyncMock(message_id="m1", content='{"text":"hello"}', user_id="u1",
+                  create_time=1000, role="user", chat_id=TARGET_CHAT_ID),
+        AsyncMock(message_id="m2", content='{"text":"world"}', user_id="u2",
+                  create_time=2000, role="user", chat_id=TARGET_CHAT_ID),
+    ]
+    mock_session.execute.return_value = mock_result
+
+    # 模拟 last_presence_time
+    mock_presence_result = AsyncMock()
+    mock_presence_result.scalar.return_value = 500  # 赤尾上次在 t=500 说话
+
+    mock_session.execute.side_effect = [mock_presence_result, mock_result]
+
+    with patch("app.workers.proactive_scanner.AsyncSessionLocal") as mock_session_cls:
+        mock_session_cls.return_value.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+        messages = await get_unseen_messages()
+
+    assert len(messages) == 2
+
+
+@pytest.mark.asyncio
+async def test_get_unseen_messages_returns_empty_when_no_new_messages():
+    mock_session = AsyncMock()
+    mock_presence_result = AsyncMock()
+    mock_presence_result.scalar.return_value = 5000
+
+    mock_msg_result = AsyncMock()
+    mock_msg_result.scalars.return_value.all.return_value = []
+
+    mock_session.execute.side_effect = [mock_presence_result, mock_msg_result]
+
+    with patch("app.workers.proactive_scanner.AsyncSessionLocal") as mock_session_cls:
+        mock_session_cls.return_value.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+        messages = await get_unseen_messages()
+
+    assert messages == []
+```
+
+- [ ] **Step 6: 实现 get_unseen_messages**
+
+```python
+# 追加到 proactive_scanner.py
+from sqlalchemy import select, func, and_, desc
+from app.orm.base import AsyncSessionLocal
+from app.orm.models import ConversationMessage
+
+
+async def get_unseen_messages(limit: int = 30) -> list[ConversationMessage]:
+    """拉取目标群中赤尾'不在场'期间的新消息"""
+    async with AsyncSessionLocal() as session:
+        # 赤尾在该群最后一次说话的时间
+        last_presence = await session.execute(
+            select(func.max(ConversationMessage.create_time)).where(
+                and_(
+                    ConversationMessage.chat_id == TARGET_CHAT_ID,
+                    ConversationMessage.role == "assistant",
+                )
+            )
+        )
+        last_presence_time = last_presence.scalar() or 0
+
+        # 拉取之后的用户消息
+        result = await session.execute(
+            select(ConversationMessage)
+            .where(
+                and_(
+                    ConversationMessage.chat_id == TARGET_CHAT_ID,
+                    ConversationMessage.role == "user",
+                    ConversationMessage.create_time > last_presence_time,
+                    ConversationMessage.user_id != PROACTIVE_USER_ID,
+                )
+            )
+            .order_by(ConversationMessage.create_time.asc())
+            .limit(limit)
+        )
+        return list(result.scalars().all())
+```
+
+- [ ] **Step 7: 运行测试确认通过**
+
+Run: `cd apps/agent-service && python -m pytest tests/workers/test_proactive_scanner.py -v`
+Expected: 5 tests PASS
+
+- [ ] **Step 8: 写测试 — judge_response 小模型判断**
+
+```python
+# 追加到 tests/workers/test_proactive_scanner.py
+from app.workers.proactive_scanner import judge_response
+
+
+@pytest.mark.asyncio
+async def test_judge_response_returns_respond_true():
+    mock_model = AsyncMock()
+    mock_model.ainvoke.return_value = AsyncMock(
+        content='{"respond": true, "target_message_id": "m1", "stimulus": "他们在聊番剧"}'
+    )
+    with patch("app.workers.proactive_scanner.ModelBuilder.build_chat_model",
+               new_callable=AsyncMock, return_value=mock_model):
+        result = await judge_response(
+            messages_text="[10:00] 小明: 最近有啥好看的番吗",
+            reply_style="元气活泼",
+            group_culture="二次元浓度拉满的群",
+            recent_proactive=[],
+        )
+    assert result["respond"] is True
+    assert result["stimulus"] == "他们在聊番剧"
+
+
+@pytest.mark.asyncio
+async def test_judge_response_returns_respond_false():
+    mock_model = AsyncMock()
+    mock_model.ainvoke.return_value = AsyncMock(
+        content='{"respond": false}'
+    )
+    with patch("app.workers.proactive_scanner.ModelBuilder.build_chat_model",
+               new_callable=AsyncMock, return_value=mock_model):
+        result = await judge_response(
+            messages_text="[10:00] 小明: 我去吃饭了",
+            reply_style="懒洋洋的",
+            group_culture="日常闲聊群",
+            recent_proactive=[],
+        )
+    assert result["respond"] is False
+```
+
+- [ ] **Step 9: 实现 judge_response**
+
+```python
+# 追加到 proactive_scanner.py
+from app.agents.infra.model_builder import ModelBuilder
+from app.agents.infra.langfuse_client import get_prompt
+from app.utils.content_parser import parse_content
+
+JUDGE_MODEL_ID = "proactive-judge-model"  # DB 中配置的小模型 ID
+
+
+async def judge_response(
+    messages_text: str,
+    reply_style: str,
+    group_culture: str,
+    recent_proactive: list[dict],
+) -> dict:
+    """用小模型判断赤尾想不想在群里说话
+
+    Returns:
+        {"respond": bool, "target_message_id": str?, "stimulus": str?}
+    """
+    recent_str = ""
+    if recent_proactive:
+        lines = [f"- {r['time']}: {r['summary']}" for r in recent_proactive]
+        recent_str = "你今天已经主动在这个群说过的话：\n" + "\n".join(lines)
+
+    prompt_template = get_prompt("proactive_judge")
+    prompt_text = prompt_template.compile(
+        messages=messages_text,
+        reply_style=reply_style,
+        group_culture=group_culture,
+        recent_proactive=recent_str,
+    )
+
+    model = await ModelBuilder.build_chat_model(JUDGE_MODEL_ID)
+    response = await model.ainvoke([{"role": "user", "content": prompt_text}])
+
+    raw = response.content
+    if isinstance(raw, list):
+        raw = "".join(str(c) for c in raw)
+
+    try:
+        return json.loads(raw.strip())
+    except json.JSONDecodeError:
+        logger.warning(f"judge_response JSON 解析失败: {raw[:200]}")
+        return {"respond": False}
+```
+
+- [ ] **Step 10: 运行测试确认通过**
+
+Run: `cd apps/agent-service && python -m pytest tests/workers/test_proactive_scanner.py -v`
+Expected: 7 tests PASS
+
+- [ ] **Step 11: 实现 submit_proactive_request — 合成消息 + 投递**
+
+```python
+# 追加到 proactive_scanner.py
+from app.clients.rabbitmq import CHAT_REQUEST, RabbitMQClient
+
+
+async def submit_proactive_request(
+    target_message_id: str | None,
+    stimulus: str,
+) -> None:
+    """构造合成消息并投递 proactive chat_request"""
+    now_ms = int(time.time() * 1000)
+    synthetic_id = f"proactive_{uuid.uuid4().hex[:16]}"
+
+    # 插入合成消息到 conversation_messages
+    async with AsyncSessionLocal() as session:
+        session.add(ConversationMessage(
+            message_id=synthetic_id,
+            chat_id=TARGET_CHAT_ID,
+            chat_type="group",
+            role="user",
+            user_id=PROACTIVE_USER_ID,
+            content=json.dumps({"text": stimulus}),
+            root_message_id=target_message_id or synthetic_id,
+            reply_message_id=target_message_id,
+            create_time=now_ms,
+            message_type="proactive_trigger",
+            vector_status="skipped",
+            bot_name="chiwei",
+        ))
+        await session.commit()
+
+    # 投递 chat_request
+    client = RabbitMQClient.get_instance()
+    await client.publish(
+        CHAT_REQUEST,
+        {
+            "session_id": str(uuid.uuid4()),
+            "message_id": synthetic_id,
+            "chat_id": TARGET_CHAT_ID,
+            "is_p2p": False,
+            "root_id": target_message_id or "",
+            "user_id": PROACTIVE_USER_ID,
+            "bot_name": "chiwei",
+            "lane": "prod",
+            "is_proactive": True,
+            "enqueued_at": now_ms,
+        },
+        lane=None,  # 强制 prod
+    )
+    logger.info(
+        "proactive_request_submitted",
+        extra={
+            "synthetic_id": synthetic_id,
+            "target_message_id": target_message_id,
+            "stimulus": stimulus[:100],
+        },
+    )
+```
+
+- [ ] **Step 12: 实现主入口 run_proactive_scan — 完整流程编排**
+
+```python
+# 追加到 proactive_scanner.py
+from app.orm.crud import get_group_culture_gestalt
+from app.services.memory_context import get_reply_style
+
+
+async def _get_recent_proactive_records() -> list[dict]:
+    """获取今天赤尾在目标群的主动发言触发记录（查询合成触发消息）"""
+    today_start = datetime.now(CST).replace(hour=0, minute=0, second=0, microsecond=0)
+    today_start_ms = int(today_start.timestamp() * 1000)
+
+    async with AsyncSessionLocal() as session:
+        result = await session.execute(
+            select(ConversationMessage)
+            .where(
+                and_(
+                    ConversationMessage.chat_id == TARGET_CHAT_ID,
+                    ConversationMessage.user_id == PROACTIVE_USER_ID,
+                    ConversationMessage.create_time > today_start_ms,
+                )
+            )
+            .order_by(ConversationMessage.create_time.desc())
+            .limit(10)
+        )
+        rows = result.scalars().all()
+
+    records = []
+    for r in rows:
+        t = datetime.fromtimestamp(r.create_time / 1000, tz=CST)
+        parsed = parse_content(r.content)
+        records.append({
+            "time": t.strftime("%H:%M"),
+            "summary": parsed.render()[:80],
+        })
+    return records
+
+
+async def _format_messages_for_judge(messages: list[ConversationMessage]) -> str:
+    """将消息格式化为小模型判断用的文本"""
+    lines = []
+    for msg in messages:
+        t = datetime.fromtimestamp(msg.create_time / 1000, tz=CST)
+        time_str = t.strftime("%H:%M:%S")
+        parsed = parse_content(msg.content)
+        text = parsed.render()
+        lines.append(f"[{time_str}] {msg.user_id[:8]}: {text}")
+    return "\n".join(lines)
+
+
+async def run_proactive_scan(source: str = "cron") -> None:
+    """主入口：执行一次完整的窥屏扫描
+
+    Args:
+        source: 触发来源，"cron" 或 "piggyback"，仅用于日志
+    """
+    if _is_quiet_hours():
+        return
+
+    if not await should_scan():
+        logger.debug("proactive_scan skipped: cooldown")
+        return
+
+    await _mark_scanned()
+
+    # 1. 拉取未读消息
+    unseen = await get_unseen_messages()
+    if not unseen:
+        logger.debug("proactive_scan: no unseen messages")
+        return
+
+    # 2. 收集上下文
+    reply_style = await get_reply_style(TARGET_CHAT_ID)
+    group_culture = await get_group_culture_gestalt(TARGET_CHAT_ID)
+    recent_proactive = await _get_recent_proactive_records()
+    messages_text = await _format_messages_for_judge(unseen)
+
+    # 3. 小模型判断
+    judgment = await judge_response(
+        messages_text=messages_text,
+        reply_style=reply_style,
+        group_culture=group_culture,
+        recent_proactive=recent_proactive,
+    )
+
+    if not judgment.get("respond"):
+        logger.info(
+            "proactive_scan: decided not to respond",
+            extra={"source": source, "unseen_count": len(unseen)},
+        )
+        return
+
+    # 4. 投递
+    await submit_proactive_request(
+        target_message_id=judgment.get("target_message_id"),
+        stimulus=judgment.get("stimulus", ""),
+    )
+    logger.info(
+        "proactive_scan: response submitted",
+        extra={
+            "source": source,
+            "target_message_id": judgment.get("target_message_id"),
+            "stimulus": judgment.get("stimulus", "")[:100],
+        },
+    )
+```
+
+- [ ] **Step 13: 运行全部测试**
+
+Run: `cd apps/agent-service && python -m pytest tests/workers/test_proactive_scanner.py -v`
+Expected: All PASS
+
+- [ ] **Step 14: Commit**
+
+```bash
+cd apps/agent-service
+git add app/workers/proactive_scanner.py tests/workers/test_proactive_scanner.py
+git commit -m "feat(proactive): 新增 proactive_scanner 核心模块
+
+扫描 → 小模型判断 → 合成消息 → 投递 chat_request 的完整流程。
+MVP 硬编码目标群，含冷却检查和深夜静默。"
+```
+
+---
+
+### Task 2: 注册 Cron Job — unified_worker.py
+
+**Files:**
+- Modify: `apps/agent-service/app/workers/unified_worker.py:9-84`
+
+- [ ] **Step 1: 添加 import 和 cron job wrapper**
+
+在 `unified_worker.py` 顶部 import 区域（约第 26 行之后）添加：
+
+```python
+from app.workers.proactive_scanner import run_proactive_scan
+```
+
+添加 cron job wrapper 函数（在 `on_startup` 之前，约第 32 行之前）：
+
+```python
+async def proactive_scan_job(ctx) -> None:
+    """主动搭话扫描（cron 兜底触发）
+
+    每 15 分钟执行一次，约 40% 概率真正扫描（平均有效间隔约 35 分钟）。
+    """
+    import random
+    if random.random() > 0.4:
+        return
+    await run_proactive_scan(source="cron")
+```
+
+- [ ] **Step 2: 在 cron_jobs 列表中注册**
+
+在 `cron_jobs` 列表（约第 65-84 行）末尾追加：
+
+```python
+            cron(proactive_scan_job, minute={0, 15, 30, 45}),  # 每 15 分钟，40% 概率执行
+```
+
+- [ ] **Step 3: 运行 lint/type check 确认无语法错误**
+
+Run: `cd apps/agent-service && python -c "from app.workers.unified_worker import UnifiedWorkerSettings; print('OK')"`
+Expected: `OK`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/agent-service/app/workers/unified_worker.py
+git commit -m "feat(proactive): 注册 cron job，每 15 分钟 40% 概率触发扫描"
+```
+
+---
+
+### Task 3: Piggyback 触发 — chat_consumer.py
+
+**Files:**
+- Modify: `apps/agent-service/app/workers/chat_consumer.py:36-215`
+
+- [ ] **Step 1: 在 handle_chat_request 末尾添加 piggyback 触发**
+
+在 `handle_chat_request` 函数中，约第 48 行后（解析 body 之后）添加读取 `is_proactive`：
+
+```python
+        is_proactive = body.get("is_proactive", False)
+```
+
+在第 196 行（日志记录之后、except 之前）添加 piggyback 触发：
+
+```python
+            # Piggyback: 回复完后顺手刷一眼群聊（proactive 回复不触发，避免递归）
+            if not is_proactive:
+                import asyncio
+                asyncio.create_task(_maybe_piggyback_scan())
+
+```
+
+- [ ] **Step 2: 添加 _maybe_piggyback_scan 辅助函数**
+
+在文件末尾（`start_chat_consumer` 之前）添加：
+
+```python
+async def _maybe_piggyback_scan() -> None:
+    """概率触发一次主动搭话扫描（piggyback 模式）"""
+    import random
+    try:
+        if random.random() > 0.6:  # 约 60% 概率触发
+            return
+        from app.workers.proactive_scanner import run_proactive_scan
+        await run_proactive_scan(source="piggyback")
+    except Exception as e:
+        logger.warning(f"piggyback scan failed: {e}")
+
+```
+
+- [ ] **Step 3: 运行 import 确认**
+
+Run: `cd apps/agent-service && python -c "from app.workers.chat_consumer import handle_chat_request; print('OK')"`
+Expected: `OK`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/agent-service/app/workers/chat_consumer.py
+git commit -m "feat(proactive): chat_consumer 添加 piggyback 触发，60% 概率顺手刷群"
+```
+
+---
+
+### Task 4: context_builder 适配 proactive 模式
+
+**Files:**
+- Modify: `apps/agent-service/app/agents/domains/main/context_builder.py:26-148`
+- Test: `apps/agent-service/tests/agents/test_proactive_context.py`
+
+- [ ] **Step 1: 写测试 — proactive 模式下过滤合成消息**
+
+```python
+# tests/agents/test_proactive_context.py
+import pytest
+from unittest.mock import AsyncMock, patch, MagicMock
+from datetime import datetime, timezone
+from app.agents.domains.main.context_builder import build_chat_context
+
+
+def _make_quick_result(message_id, user_id, content, role, create_time_ms, chat_id="oc_test", chat_type="group", chat_name="测试群", username="test_user", reply_message_id=None):
+    """创建 QuickSearchResult mock"""
+    from app.services.quick_search import QuickSearchResult
+    return QuickSearchResult(
+        message_id=message_id,
+        content=content,
+        user_id=user_id,
+        create_time=datetime.fromtimestamp(create_time_ms / 1000, tz=timezone.utc),
+        role=role,
+        username=username,
+        chat_type=chat_type,
+        chat_name=chat_name,
+        reply_message_id=reply_message_id,
+        chat_id=chat_id,
+    )
+
+
+@pytest.mark.asyncio
+async def test_proactive_filters_out_synthetic_message():
+    """proactive 模式下应过滤掉合成消息，返回 is_proactive 标记"""
+    results = [
+        _make_quick_result("m1", "user1", '{"text":"hello"}', "user", 1000, username="小明"),
+        _make_quick_result("m2", "user2", '{"text":"聊番剧"}', "user", 2000, username="小红"),
+        _make_quick_result("proactive_abc", "__proactive__", '{"text":"他们在聊番剧"}', "user", 3000, username=None, reply_message_id="m2"),
+    ]
+
+    with patch("app.agents.domains.main.context_builder.quick_search", new_callable=AsyncMock, return_value=results):
+        with patch("app.agents.domains.main.context_builder.check_group_allows_download", new_callable=AsyncMock, return_value=False):
+            msgs, registry, chat_id, trigger_username, chat_type, trigger_user_id, chat_name, chain_user_ids = await build_chat_context("proactive_abc")
+
+    # 合成消息应被过滤，trigger 信息来自真实消息
+    assert len(msgs) == 1  # group 模式返回单条 HumanMessage
+    assert trigger_username == ""  # proactive 无 trigger user
+    assert trigger_user_id == ""
+```
+
+- [ ] **Step 2: 运行测试确认失败**
+
+Run: `cd apps/agent-service && python -m pytest tests/agents/test_proactive_context.py -v`
+Expected: FAIL — trigger_username 不为空（当前代码取 l1_results[-1] 即合成消息）
+
+- [ ] **Step 3: 修改 build_chat_context 添加 proactive 分支**
+
+在 `build_chat_context` 函数中（约第 39 行之后，`l1_results` 获取之后），添加 proactive 检测和处理逻辑。在 `chat_type = l1_results[-1].chat_type or "p2p"` 之后（第 46 行后）添加：
+
+```python
+    # --- Proactive 检测 ---
+    is_proactive = l1_results[-1].user_id == PROACTIVE_USER_ID
+    proactive_stimulus = ""
+    proactive_target_id = ""
+
+    if is_proactive:
+        proactive_msg = l1_results.pop()
+        proactive_stimulus = parse_content(proactive_msg.content).render()
+        proactive_target_id = proactive_msg.reply_message_id or ""
+
+        if not l1_results:
+            logger.warning("proactive scan: no real messages found after filtering")
+            return [], None, "", "", "group", "", "", []
+```
+
+在文件顶部添加常量（import 区域之后）：
+
+```python
+PROACTIVE_USER_ID = "__proactive__"
+```
+
+- [ ] **Step 4: 调整 trigger 信息提取逻辑**
+
+修改第 128-137 行的 trigger 信息提取，改为区分 proactive 和普通模式：
+
+```python
+    # 提取触发消息的用户名和用户ID
+    if is_proactive:
+        trigger_username = ""
+        trigger_user_id = ""
+        chat_name = l1_results[-1].chat_name or "" if l1_results else ""
+        # proactive 时 trigger_id 指向引起兴趣的消息（获得 ⭐ 标记）
+        effective_trigger_id = proactive_target_id or (l1_results[-1].message_id if l1_results else message_id)
+    else:
+        trigger_username = l1_results[-1].username or ""
+        trigger_user_id = l1_results[-1].user_id or ""
+        chat_name = l1_results[-1].chat_name or ""
+        effective_trigger_id = message_id
+```
+
+修改第 119 行群聊消息构建调用，使用 `effective_trigger_id`：
+
+```python
+    if chat_type == "group":
+        messages = _build_group_messages(
+            l1_results, effective_trigger_id, image_key_to_url, image_key_to_filename,
+        )
+```
+
+修改返回值，附带 proactive 信息（在返回 tuple 末尾不变，但通过模块级变量传递 stimulus）：
+
+在函数开头声明模块级存储（用于传递给 memory_context）：
+
+```python
+# 模块级缓存，用于 proactive stimulus 传递（同一 async context 内安全）
+import contextvars
+_proactive_stimulus_var: contextvars.ContextVar[str] = contextvars.ContextVar(
+    "proactive_stimulus", default=""
+)
+_is_proactive_var: contextvars.ContextVar[bool] = contextvars.ContextVar(
+    "is_proactive", default=False
+)
+```
+
+在 proactive 检测后设置：
+
+```python
+    _is_proactive_var.set(is_proactive)
+    _proactive_stimulus_var.set(proactive_stimulus)
+```
+
+- [ ] **Step 5: 运行测试确认通过**
+
+Run: `cd apps/agent-service && python -m pytest tests/agents/test_proactive_context.py -v`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/agent-service/app/agents/domains/main/context_builder.py tests/agents/test_proactive_context.py
+git commit -m "feat(proactive): context_builder 添加 proactive 分支，过滤合成消息"
+```
+
+---
+
+### Task 5: memory_context 添加 proactive 场景提示
+
+**Files:**
+- Modify: `apps/agent-service/app/services/memory_context.py:86-146`
+- Test: `apps/agent-service/tests/services/test_proactive_memory_context.py`
+
+- [ ] **Step 1: 写测试**
+
+```python
+# tests/services/test_proactive_memory_context.py
+import pytest
+from unittest.mock import AsyncMock, patch
+
+from app.services.memory_context import build_inner_context
+
+
+@pytest.mark.asyncio
+async def test_proactive_scene_hint_injected():
+    """proactive 模式下应注入窥屏场景提示"""
+    with patch("app.services.memory_context.get_plan_for_period", new_callable=AsyncMock, return_value=None), \
+         patch("app.services.memory_context.get_journal", new_callable=AsyncMock, return_value=None), \
+         patch("app.services.memory_context.get_group_culture_gestalt", new_callable=AsyncMock, return_value="二次元群"), \
+         patch("app.services.memory_context.get_impressions_for_users", new_callable=AsyncMock, return_value=[]):
+
+        result = await build_inner_context(
+            chat_id="oc_test",
+            chat_type="group",
+            user_ids=["u1"],
+            trigger_user_id="",
+            trigger_username="",
+            chat_name="测试群",
+            is_proactive=True,
+            proactive_stimulus="他们在聊新番",
+        )
+
+    assert "刷到了群里的对话" in result
+    assert "他们在聊新番" in result
+    assert "需要回复" not in result  # 不应出现"回复某人"的提示
+
+
+@pytest.mark.asyncio
+async def test_normal_mode_no_proactive_hint():
+    """普通模式不应出现窥屏提示"""
+    with patch("app.services.memory_context.get_plan_for_period", new_callable=AsyncMock, return_value=None), \
+         patch("app.services.memory_context.get_journal", new_callable=AsyncMock, return_value=None), \
+         patch("app.services.memory_context.get_group_culture_gestalt", new_callable=AsyncMock, return_value=""), \
+         patch("app.services.memory_context.get_impressions_for_users", new_callable=AsyncMock, return_value=[]):
+
+        result = await build_inner_context(
+            chat_id="oc_test",
+            chat_type="group",
+            user_ids=["u1"],
+            trigger_user_id="u1",
+            trigger_username="小明",
+            chat_name="测试群",
+        )
+
+    assert "刷到了群里的对话" not in result
+```
+
+- [ ] **Step 2: 运行测试确认失败**
+
+Run: `cd apps/agent-service && python -m pytest tests/services/test_proactive_memory_context.py -v`
+Expected: FAIL — `build_inner_context() got an unexpected keyword argument 'is_proactive'`
+
+- [ ] **Step 3: 修改 build_inner_context 签名和逻辑**
+
+修改函数签名（约第 86 行），添加两个可选参数：
+
+```python
+async def build_inner_context(
+    chat_id: str,
+    chat_type: str,
+    user_ids: list[str],
+    trigger_user_id: str,
+    trigger_username: str,
+    chat_name: str = "",
+    *,
+    is_proactive: bool = False,
+    proactive_stimulus: str = "",
+) -> str:
+```
+
+修改场景提示部分（约第 109-117 行），添加 proactive 分支：
+
+```python
+    # === 场景提示 ===
+    if is_proactive:
+        scene = f"你在群聊「{chat_name}」中。" if chat_name else ""
+        scene += "\n你刚刷到了群里的对话。如果你想说点什么就说，不想说也可以不说。"
+        scene += "\n不要刻意解释为什么突然说话，像朋友在群里自然接话就好。"
+        if proactive_stimulus:
+            scene += f"\n（你注意到的：{proactive_stimulus}）"
+        sections.append(scene)
+    elif chat_type == "p2p":
+        if trigger_username:
+            sections.append(f"你正在和 {trigger_username} 私聊。")
+    else:
+        if chat_name:
+            sections.append(f"你在群聊「{chat_name}」中。")
+        if trigger_username:
+            sections.append(f"需要回复 {trigger_username} 的消息（消息中用 ⭐ 标记）。")
+```
+
+- [ ] **Step 4: 运行测试确认通过**
+
+Run: `cd apps/agent-service && python -m pytest tests/services/test_proactive_memory_context.py -v`
+Expected: 2 tests PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/agent-service/app/services/memory_context.py tests/services/test_proactive_memory_context.py
+git commit -m "feat(proactive): memory_context 支持 proactive 场景提示注入"
+```
+
+---
+
+### Task 6: agent.py 传递 proactive 参数
+
+**Files:**
+- Modify: `apps/agent-service/app/agents/domains/main/agent.py:229-283`
+
+- [ ] **Step 1: 修改 _build_and_stream 传递 proactive 参数**
+
+在 `_build_and_stream` 函数中（约第 274-283 行），修改 `build_inner_context` 调用，从 context_builder 的 contextvar 读取 proactive 状态：
+
+```python
+    # 构建统一 inner_context（场景 + 状态 + 印象 + 引导语）
+    try:
+        from app.agents.domains.main.context_builder import (
+            _is_proactive_var,
+            _proactive_stimulus_var,
+        )
+
+        prompt_vars["inner_context"] = await build_inner_context(
+            chat_id=chat_id,
+            chat_type=chat_type,
+            user_ids=chain_user_ids,
+            trigger_user_id=trigger_user_id,
+            trigger_username=trigger_username,
+            chat_name=chat_name,
+            is_proactive=_is_proactive_var.get(False),
+            proactive_stimulus=_proactive_stimulus_var.get(""),
+        )
+    except Exception as e:
+        logger.error(f"Failed to build inner context: {e}")
+```
+
+- [ ] **Step 2: 确认 import 无误**
+
+Run: `cd apps/agent-service && python -c "from app.agents.domains.main.agent import stream_chat; print('OK')"`
+Expected: `OK`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/agent-service/app/agents/domains/main/agent.py
+git commit -m "feat(proactive): agent.py 传递 proactive 参数到 inner_context"
+```
+
+---
+
+### Task 7: chat-response-worker 适配 proactive 发送
+
+**Files:**
+- Modify: `apps/lark-server/src/workers/chat-response-worker.ts:173-366`
+
+- [ ] **Step 1: 更新 ChatResponsePayload 接口**
+
+在 `ChatResponsePayload` 接口（约第 173 行）添加 `is_proactive` 和 `bot_name`：
+
+```typescript
+interface ChatResponsePayload {
+    session_id: string;
+    message_id: string;
+    chat_id: string;
+    is_p2p: boolean;
+    root_id?: string;
+    user_id?: string;
+    content: string;
+    full_content?: string;
+    status: 'success' | 'failed';
+    error?: string;
+    lane?: string;
+    part_index?: number;
+    is_last?: boolean;
+    is_proactive?: boolean;  // 新增
+    bot_name?: string;       // 新增，proactive 场景用
+}
+```
+
+- [ ] **Step 2: 修改 handleChatResponse — AgentResponse 查询兼容**
+
+在 `handleChatResponse` 函数中（约第 210 行），解构时添加新字段：
+
+```typescript
+    const {
+        session_id,
+        message_id,
+        chat_id,
+        is_p2p,
+        root_id,
+        user_id,
+        content,
+        full_content,
+        status,
+        error,
+        part_index = 0,
+        is_last = false,
+        is_proactive = false,
+    } = payload;
+```
+
+修改 AgentResponse 查询（约第 228-241 行），兼容 proactive（无 AgentResponse 记录）：
+
+```typescript
+    const repo = AppDataSource.getRepository(AgentResponse);
+
+    // 查询 agent_response 获取 bot_name
+    const tDbQuery0 = Date.now();
+    const agentResponse = await repo.findOneBy({ session_id });
+    const dbQueryMs = Date.now() - tDbQuery0;
+    chatResponseDuration.labels({ stage: 'db_query' }).observe(dbQueryMs / 1000);
+
+    // proactive 消息没有 agent_response 记录，从 payload 获取 bot_name
+    const botName = agentResponse?.bot_name || payload.bot_name;
+    if (!botName) {
+        console.error(`[ChatResponseWorker] No bot_name found: session_id=${session_id}, is_proactive=${is_proactive}`);
+        rabbitmqClient.ack(msg);
+        return;
+    }
+```
+
+- [ ] **Step 3: 修改发送逻辑 — proactive 使用 sendPost 或 replyPost(root_id)**
+
+修改发送消息部分（约第 279-286 行）：
+
+```typescript
+            // 发送消息并捕获 AI 消息 ID
+            const tSend0 = Date.now();
+            let aiMessageId: string | undefined;
+            if (part_index === 0) {
+                if (is_proactive) {
+                    // proactive: reply to real message if available, else send new
+                    if (root_id) {
+                        aiMessageId = await replyPost(root_id, postContent);
+                    } else {
+                        aiMessageId = await sendPost(chat_id, postContent);
+                    }
+                } else {
+                    aiMessageId = await replyPost(message_id, postContent);
+                }
+            } else {
+                // 后续消息带延迟后发送
+                await sleep(SEND_DELAY_MS);
+                aiMessageId = await sendPost(chat_id, postContent);
+            }
+```
+
+- [ ] **Step 4: 修改 storeMessage — proactive 的 reply_message_id**
+
+修改存储部分（约第 295-306 行）：
+
+```typescript
+            await storeMessage({
+                user_id: getBotUnionId(),
+                content: MessageContentUtils.wrapMarkdownAsV2(content),
+                role: 'assistant',
+                message_id: effectiveMessageId,
+                message_type: 'post',
+                chat_id: chat_id,
+                chat_type: is_p2p ? 'p2p' : 'group',
+                create_time: String(now),
+                root_message_id: is_proactive ? (root_id || effectiveMessageId) : (root_id || message_id),
+                reply_message_id: is_proactive ? (root_id || undefined) : message_id,
+            });
+```
+
+- [ ] **Step 5: 修改 AgentResponse 更新逻辑 — proactive 跳过不存在的记录更新**
+
+在追加 replies 和 is_last 更新前添加条件判断：
+
+```typescript
+            // proactive 没有 agent_response 记录，跳过 replies 追加和状态更新
+            if (agentResponse) {
+                const replyEntry = [
+                    {
+                        message_id: effectiveMessageId,
+                        content_type: 'post',
+                        sent_at: new Date().toISOString(),
+                    },
+                ];
+                await repo
+                    .createQueryBuilder()
+                    .update(AgentResponse)
+                    .set({
+                        replies: () =>
+                            `COALESCE(replies, '[]'::jsonb) || :replyEntry::jsonb`,
+                    })
+                    .setParameter('replyEntry', JSON.stringify(replyEntry))
+                    .where('session_id = :sid', { sid: session_id })
+                    .execute();
+
+                if (is_last) {
+                    await repo.update(
+                        { session_id },
+                        {
+                            response_text: full_content || content,
+                            status: 'completed',
+                        },
+                    );
+                }
+            }
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/lark-server/src/workers/chat-response-worker.ts
+git commit -m "feat(proactive): chat-response-worker 适配 proactive 发送模式
+
+proactive 消息用 sendPost/replyPost(root_id) 替代 replyPost(message_id)，
+兼容无 AgentResponse 记录的场景。"
+```
+
+---
+
+### Task 8: chat_consumer 传递 bot_name 到 response
+
+**Files:**
+- Modify: `apps/agent-service/app/workers/chat_consumer.py:74-83`
+
+- [ ] **Step 1: 在 base_response 中添加 bot_name 和 is_proactive**
+
+修改 base_response 构造（约第 74-83 行）：
+
+```python
+        base_response = {
+            "session_id": session_id,
+            "message_id": message_id,
+            "chat_id": chat_id,
+            "is_p2p": is_p2p,
+            "root_id": root_id,
+            "user_id": user_id,
+            "lane": lane,
+            "is_proactive": is_proactive,
+            "bot_name": bot_name,
+        }
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add apps/agent-service/app/workers/chat_consumer.py
+git commit -m "feat(proactive): chat_consumer 传递 is_proactive 和 bot_name 到 response"
+```
+
+---
+
+### Task 9: Langfuse prompt 配置 + 模型配置
+
+**Files:**
+- 无代码文件变更，需要在外部系统配置
+
+- [ ] **Step 1: 在 Langfuse 创建 proactive_judge prompt**
+
+在 Langfuse 中创建名为 `proactive_judge` 的 prompt，内容：
+
+```
+你是赤尾的直觉系统。赤尾是一个元气活泼的女生，正在"刷手机"看群里的消息。
+
+以下是群里最近的对话：
+{messages}
+
+赤尾当前的状态：
+{reply_style}
+
+赤尾对这个群的感觉：
+{group_culture}
+
+{recent_proactive}
+
+请判断赤尾看到这些消息后，会不会想要主动说点什么。判断标准：
+1. 有人提到了赤尾（不是@，是在聊天中提起她）→ 自然想回应
+2. 话题是赤尾会感兴趣的 → 结合她的性格和对这个群的感觉来判断
+
+注意：
+- 大部分时候赤尾不会主动说话，只有真的触动了她才会
+- 如果群里只是普通闲聊、打招呼、与赤尾无关的话题，就不要说
+- 考虑赤尾当前的状态，累了就更不想说话
+
+返回 JSON 格式（不要 markdown 包裹）：
+{{"respond": true/false, "target_message_id": "回复哪条消息的ID（可选）", "stimulus": "赤尾为什么想说话（一句话）"}}
+```
+
+- [ ] **Step 2: 在数据库配置 proactive-judge-model**
+
+通过 PaaS API 或数据库添加模型配置，model_id 为 `proactive-judge-model`，指向 gemini-2.0-flash 或同等小模型。
+
+- [ ] **Step 3: 记录配置完成**
+
+验证：
+Run: `cd apps/agent-service && python -c "from app.agents.infra.langfuse_client import get_prompt; print(get_prompt('proactive_judge'))"`
+Expected: 返回 prompt 对象（不报错）
+
+---
+
+### Task 10: 端到端验证
+
+- [ ] **Step 1: 本地单元测试全部通过**
+
+Run: `cd apps/agent-service && python -m pytest tests/workers/test_proactive_scanner.py tests/agents/test_proactive_context.py tests/services/test_proactive_memory_context.py -v`
+Expected: All PASS
+
+- [ ] **Step 2: Push 并部署到测试泳道**
+
+```bash
+git push origin feat/chiwei-proactive-chat
+make deploy APP=agent-service LANE=feat-proactive GIT_REF=feat/chiwei-proactive-chat
+make deploy APP=lark-server LANE=feat-proactive GIT_REF=feat/chiwei-proactive-chat
+```
+
+- [ ] **Step 3: 绑定 dev bot 测试**
+
+```bash
+/ops bind TYPE=bot KEY=dev LANE=feat-proactive
+```
+
+- [ ] **Step 4: 在目标群发消息测试触发**
+
+1. 在 dev bot 的目标群发一些消息（提到赤尾或她感兴趣的话题）
+2. @赤尾 触发一次普通回复，观察 piggyback 是否触发
+3. 等待 cron 触发（最多 45 分钟）
+4. 检查 agent-service 日志：`make logs APP=agent-service KEYWORD=proactive`
+
+- [ ] **Step 5: 验证发送结果**
+
+确认：
+- 赤尾能在群里主动发消息
+- 回复的消息 reply 到正确的目标消息（或发新消息）
+- 深夜时段不触发
+- 冷却机制生效（15 分钟内不重复扫描）
+
+- [ ] **Step 6: 清理测试环境**
+
+```bash
+/ops unbind TYPE=bot KEY=dev
+make undeploy APP=agent-service LANE=feat-proactive
+make undeploy APP=lark-server LANE=feat-proactive
+```

--- a/docs/superpowers/specs/2026-04-01-proactive-chat-design.md
+++ b/docs/superpowers/specs/2026-04-01-proactive-chat-design.md
@@ -1,0 +1,210 @@
+# 赤尾主动搭话系统设计 — 群聊窥屏 MVP
+
+> 赤尾不是在等你找她。你不找她的时候，她在过自己的日子。
+> 她刷到了一个有意思的东西，想找人分享。
+> — 赤尾宣言 2.1
+
+## 一、背景与目标
+
+赤尾当前的所有对话都是**被动触发**：用户 @赤尾 或命中关键词 → agent-service 处理 → 回复。这意味着赤尾永远不会主动说话，与宣言中"她是一个发光体，不是一面镜子"的定位矛盾。
+
+**MVP 目标**：让赤尾能在群聊中**主动插话**——像一个朋友在群里看到有意思的内容忍不住接一句。
+
+**MVP 范围**：
+- 仅灰度 `oc_a44255e98af05f1359aeb29eeb503536` 一个群
+- 仅做群聊窥屏插话，不做私聊主动搭话（后续迭代）
+- 复用现有 chat_request → agent-service → chat_response 链路
+
+## 二、触发机制
+
+两层触发模拟人"刷手机"的自然节奏：
+
+### 2.1 顺手刷（Piggyback Trigger）
+
+**时机**：赤尾回复完任意一条消息后（不限于目标群）。
+
+**类比**：回完一条微信，手机还在手里，顺手划一下看看群里在聊什么。
+
+**实现位置**：agent-service `chat_consumer` 处理完 chat_request 后，异步触发一次窥屏扫描。
+
+**概率门控**：不是每次都触发。设置一个基础概率（如 50-70%），模拟"有时顺手看看，有时直接放下手机"。概率值可从 Schedule 的当日基调动态微调。
+
+**冷却**：如果 15 分钟内已经执行过一次扫描（无论是 piggyback 还是 cron 触发），跳过本次。这是唯一的硬性工程规则，目的是避免短时间内重复扫描浪费资源，不是频率控制。
+
+### 2.2 闲着翻手机（Cron Fallback）
+
+**时机**：没人找赤尾时的兜底，保证她不会因为没人 @ 就完全不看群。
+
+**调度**：ARQ cron job 每 15 分钟触发一次，但每次执行时以约 40% 概率决定是否真的扫描（平均有效间隔约 35 分钟，但不固定）。加上 piggyback 触发的 15 分钟冷却互斥，实际节奏自然不规律。
+
+**冷却状态**：Redis key `proactive:last_scan_time` 记录上次扫描时间戳，piggyback 和 cron 共用。
+
+**下班静默**：23:00-09:00 不触发。赤尾在睡觉或还没醒，被 @ 可以回（起床气），但不会自己凑上来。
+
+## 三、扫描与判断
+
+两种触发方式共用同一套扫描 → 判断 → 投递流程。
+
+### 3.1 拉取"没看过的消息"
+
+```
+1. target_chat_id = "oc_a44255e98af05f1359aeb29eeb503536"（MVP 硬编码）
+2. last_presence_time = 赤尾在该群的最后一条 assistant 消息的 create_time
+3. new_messages = 该群 last_presence_time 之后的所有 role="user" 的消息
+4. 如果 new_messages 为空 → 跳过
+```
+
+**"不在场"语义**：`last_presence_time` 之后的消息 = 赤尾"没看过"的消息。她上次回复时"在场"，那些消息她已经"看到了"，不会再回头去接。
+
+### 3.2 小模型判断
+
+用小模型（如 gemini-2.0-flash）判断赤尾"想不想说话"。
+
+**输入**：
+| 字段 | 来源 | 作用 |
+|------|------|------|
+| `new_messages` | conversation_message 表 | 群里的新消息 |
+| `reply_style` | Redis `reply_style:__base__` | 赤尾当前基调 |
+| `group_culture` | `group_culture_gestalt` 表 | 群的氛围 |
+| `recent_proactive` | 今天赤尾在该群的主动发言记录 | 让模型自然抑制频率 |
+
+**判断标准**（写在 prompt 中，不是工程规则）：
+1. **有人提到了赤尾**（不是 @，是在聊天中提到她）→ 自然想回应
+2. **话题是赤尾感兴趣的** → 结合人设和群文化判断
+
+**输出**：
+```json
+{
+  "respond": true,
+  "target_message_id": "om_xxx",  // 可选，想回复哪条具体消息
+  "stimulus": "他们在聊最近新出的番，赤尾刚好也看了这个"
+}
+```
+
+**频率控制**：不设硬性计数器或阈值。`recent_proactive` 作为上下文喂给小模型，模型自然判断"今天已经主动说了两次了，算了不凑了"。说得越多，上下文里记录越长，模型越倾向克制。这是赤尾自己的判断，不是工程规则。
+
+### 3.3 硬性降噪规则
+
+仅保留两条无法由模型兜底的硬规则：
+
+| 规则 | 原因 |
+|------|------|
+| 不回"已在场"的消息 | 时序逻辑问题，模型无法感知"我当时在不在" |
+| 下班不触发（23:00-09:00） | 触发层直接跳过，省 token |
+
+## 四、Proactive Chat Request 构造
+
+### 4.1 合成消息
+
+现有 pipeline 强依赖 `message_id` 作为 context_builder 的入口。proactive 场景没有"用户对赤尾说的消息"，因此插入一条合成消息作为触发锚点：
+
+```python
+stimulus_msg = ConversationMessage(
+    message_id=generate_id(),           # 合成 ID（前缀 "proactive_" 便于识别）
+    chat_id=target_chat_id,
+    chat_type="group",
+    role="user",
+    user_id="__proactive__",            # 特殊标记，不是真实用户
+    content=stimulus_text,              # 小模型生成的 stimulus 描述
+    message_type="proactive_trigger",   # 新类型，区分于普通 "text"
+    reply_message_id=target_message_id, # 指向触发兴趣的那条真实消息（可选）
+    create_time=now_ms()
+)
+```
+
+### 4.2 chat_request 消息体
+
+复用现有 `chat.request` 队列，消息体扩展一个字段：
+
+```python
+{
+    "session_id": str(uuid4()),
+    "message_id": stimulus_msg.message_id,
+    "chat_id": target_chat_id,
+    "is_p2p": False,
+    "root_id": target_message_id or "",
+    "user_id": "__proactive__",
+    "bot_name": "chiwei",
+    "lane": "prod",
+    "is_proactive": True,               # 新增字段
+    "enqueued_at": now_ms()
+}
+```
+
+## 五、Pipeline 适配
+
+### 5.1 chat_consumer
+
+识别 `is_proactive` 字段。处理逻辑不变，仅在**处理完成后**触发 piggyback 扫描时跳过（避免"主动回复完又触发一次扫描"的递归）。
+
+### 5.2 context_builder
+
+检测到 `user_id == "__proactive__"` 或 `message_type == "proactive_trigger"` 时：
+
+- **不把合成消息当作对话历史的一部分**
+- 用合成消息的 `reply_message_id` 或 `create_time` 作为锚点，拉取真实的群聊消息作为上下文
+- 其余逻辑（图片处理、quick_search 等）保持不变
+
+### 5.3 inner_context / prompt
+
+`build_inner_context()` 检测到 proactive 模式时，追加场景提示：
+
+```
+[场景] 你刚刷到了群里的对话。如果你想说点什么就说，不想说也可以不说。
+不要刻意解释为什么突然说话，像朋友在群里自然接话就好。
+```
+
+stimulus 内容（小模型生成的"为什么想说话"）注入到 inner_context 中，作为赤尾的内在动机，不直接暴露给用户。
+
+### 5.4 chat-response-worker
+
+检测到 proactive 消息时调整发送方式：
+
+- 如果有 `target_message_id`（root_id）：回复那条具体消息（飞书 reply_message 模式）
+- 如果没有：直接发新消息到群里
+- 如果 agent 返回空内容或明确表示"不想说"：静默丢弃，不发送
+
+## 六、数据流总览
+
+```
+[触发层]
+  顺手刷: chat_consumer 完成 → 概率门控 → 冷却检查 → 通过
+  cron:   ARQ 定时 → 随机抖动 → 深夜检查 → 通过
+      ↓
+[扫描层]
+  拉取目标群 last_presence 后的新消息
+  无新消息 → 结束
+      ↓
+[判断层]
+  小模型（gemini-2.0-flash）
+  输入: 新消息 + reply_style + group_culture + 今日主动记录
+  输出: respond? + target_message_id? + stimulus
+  不想说 → 结束
+      ↓
+[投递层]
+  插入合成 conversation_message（proactive_trigger 类型）
+  构造 chat_request（is_proactive=true）→ RabbitMQ chat.request
+      ↓
+[处理层 — 复用现有链路]
+  chat_consumer → context_builder（proactive 分支）→ main agent
+  → chat_response → chat-response-worker → 飞书
+```
+
+## 七、改动清单
+
+| 组件 | 改动 | 规模 |
+|------|------|------|
+| agent-service/workers/unified_worker.py | 新增 proactive_scan cron job | 新增 |
+| agent-service/workers/chat_consumer.py | 处理完后触发 piggyback；识别 is_proactive 跳过递归 | 小改 |
+| agent-service/workers/proactive_scanner.py | 新文件：扫描 + 小模型判断 + 合成消息 + 投递 | 新增（核心） |
+| agent-service/agents/domains/main/context_builder.py | proactive 模式下的上下文构建分支 | 小改 |
+| agent-service/services/memory_context.py | proactive 场景提示注入 | 小改 |
+| lark-server/workers/chat-response-worker.ts | proactive 消息的发送模式（reply vs 新消息） | 小改 |
+| Langfuse | 无需新 prompt，通过 inner_context 注入场景 | 无代码改动 |
+
+## 八、后续迭代方向（不在 MVP 范围）
+
+- **扩展到更多群**：去掉硬编码，用日记产出 + 近期互动作为资格门槛
+- **私聊主动搭话**：内在状态（Schedule/Journal）产生冲动 → 印象系统选择对象 → 发起对话
+- **消息事件流加速**：lark-server 侧加轻量信号，活跃群提前触发扫描
+- **多模态窥屏**：感知群里的图片、表情包等非文本内容


### PR DESCRIPTION
## Summary
- 赤尾能在群聊中主动插话——基于消息事件触发 + debounce + 小模型判断
- 消息级触发：lark-server 每条群消息发 proactive_eval 事件，agent-service debounce 15s 后评估
- 小模型（gemini-2.0-flash）判断赤尾想不想说话，触发条件：有人提到赤尾 or 话题感兴趣
- 复用 chat_request → agent-service → chat_response → 飞书 完整链路
- 硬限制：每小时 6 次、23:00-09:00 静默
- 顺带修复：周计划 cron 日期计算 bug

## 改动
- **新增**: proactive_scanner.py, proactive_manager.py, proactive_consumer.py
- **修改**: chat_consumer.py, context_builder.py, memory_context.py, agent.py, unified_worker.py, chat-response-worker.ts, handlers.ts, rabbitmq.ts/.py

## Test plan
- [x] 消息事件触发 + debounce 验证
- [x] 小模型判断 + Langfuse trace 验证
- [x] chat-response-worker 发送到飞书验证
- [x] @persona bot 不触发 proactive 验证
- [x] 静默时段验证
- [x] hourly limit 验证

🤖 Generated with [Claude Code](https://claude.com/claude-code)