### PR TITLE
fix(proactive): 暂时禁用主动搭话触发机制

### DIFF
--- a/apps/agent-service/app/workers/chat_consumer.py
+++ b/apps/agent-service/app/workers/chat_consumer.py
@@ -198,9 +198,9 @@ async def handle_chat_request(message: AbstractIncomingMessage) -> None:
                 },
             )
 
-            # Piggyback: 回复完后顺手刷一眼群聊（proactive 回复不触发，避免递归）
-            if not is_proactive:
-                await _maybe_piggyback_scan()
+            # Piggyback: 回复完后顺手刷一眼群聊（proactive 回复不触发，避免递归）[DISABLED]
+            # if not is_proactive:
+            #     await _maybe_piggyback_scan()
 
         except Exception as e:
             logger.error(

--- a/apps/agent-service/app/workers/unified_worker.py
+++ b/apps/agent-service/app/workers/unified_worker.py
@@ -90,6 +90,6 @@ class UnifiedWorkerSettings:
         cron(cron_generate_monthly_plan, day={1}, hour={2}, minute={0}),
         # 8. 基线 reply_style：每天 CST 8:00/14:00/18:00（Schedule 之后）
         cron(cron_generate_base_reply_style, hour={8, 14, 18}, minute={0}),
-        # 9. 主动搭话扫描（cron 兜底）：每 30 分钟，30% 概率执行
-        cron(proactive_scan_job, minute={0, 30}),
+        # 9. 主动搭话扫描（cron 兜底）：每 30 分钟，30% 概率执行 [DISABLED]
+        # cron(proactive_scan_job, minute={0, 30}),
     ]

--- a/apps/lark-server/src/infrastructure/integrations/lark/events/handlers.ts
+++ b/apps/lark-server/src/infrastructure/integrations/lark/events/handlers.ts
@@ -88,20 +88,20 @@ export class LarkEventHandlers {
                 message_type: message.messageType,
             });
 
-            // Publish proactive eval event for group messages that don't @任何 persona bot
+            // [DISABLED] Publish proactive eval event for group messages that don't @任何 persona bot
             // @persona bot 的消息走正常回复流程，不需要 proactive 重复触发
-            if (!message.isP2P()) {
-                const personaUnionIds = multiBotManager.getAllBotConfigs()
-                    .filter(b => b.bot_role === 'persona')
-                    .map(b => b.robot_union_id);
-                const mentionsPersona = personaUnionIds.some(id => message.hasMention(id));
-                if (!mentionsPersona) {
-                    rabbitmqClient.publish(PROACTIVE_EVAL, {
-                        chat_id: message.chatId,
-                        message_id: message.messageId,
-                    }).catch(err => console.warn('[ProactiveEval] publish failed:', err));
-                }
-            }
+            // if (!message.isP2P()) {
+            //     const personaUnionIds = multiBotManager.getAllBotConfigs()
+            //         .filter(b => b.bot_role === 'persona')
+            //         .map(b => b.robot_union_id);
+            //     const mentionsPersona = personaUnionIds.some(id => message.hasMention(id));
+            //     if (!mentionsPersona) {
+            //         rabbitmqClient.publish(PROACTIVE_EVAL, {
+            //             chat_id: message.chatId,
+            //             message_id: message.messageId,
+            //         }).catch(err => console.warn('[ProactiveEval] publish failed:', err));
+            //     }
+            // }
 
             await runRules(message);
         } catch (error) {


### PR DESCRIPTION
注释掉三处触发点：
- lark-server: 群消息事件不再发布到 proactive_eval 队列
- agent-service: 移除 cron 兜底扫描（每 30 分钟）
- agent-service: 移除回复后 piggyback 触发

Co-Authored-By: Claude Haiku <noreply@anthropic.com>
