### PR TITLE
chore: audit bot_config, rename bytedance→chiwei

### DIFF
--- a/apps/agent-service/app/workers/proactive_scanner.py
+++ b/apps/agent-service/app/workers/proactive_scanner.py
@@ -226,7 +226,7 @@ async def submit_proactive_request(
             create_time=now_ms,
             message_type="proactive_trigger",
             vector_status="skipped",
-            bot_name="bytedance",
+            bot_name="chiwei",
         )
         session.add(msg)
         await session.commit()
@@ -244,7 +244,7 @@ async def submit_proactive_request(
             "is_p2p": False,
             "root_id": target_message_id or "",
             "user_id": PROACTIVE_USER_ID,
-            "bot_name": "bytedance",
+            "bot_name": "chiwei",
             "is_proactive": True,
             "lane": current_lane,
             "enqueued_at": now_ms,

--- a/apps/agent-service/app/workers/vectorize_worker.py
+++ b/apps/agent-service/app/workers/vectorize_worker.py
@@ -116,7 +116,7 @@ async def vectorize_message(message: ConversationMessage) -> bool:
     image_base64_list: list[str] = []
     if image_keys:
         # bot_name 默认 bytedance（兼容历史数据）
-        bot_name = message.bot_name or "bytedance"
+        bot_name = message.bot_name or "chiwei"
         tasks = [
             image_client.download_image_as_base64(key, message.message_id, bot_name)
             for key in image_keys

--- a/apps/lark-server/src/infrastructure/crontab/decorators.ts
+++ b/apps/lark-server/src/infrastructure/crontab/decorators.ts
@@ -107,14 +107,14 @@ export interface CrontabOptions {
  *
  * @example
  * class MyService {
- *   @Crontab('0 18 * * *', { taskName: 'daily-task', botName: 'bytedance' })
+ *   @Crontab('0 18 * * *', { taskName: 'daily-task', botName: 'chiwei' })
  *   async runDailyTask() {
  *   }
  * }
  */
 export function Crontab(cronExpression: string, options: CrontabOptions) {
     return function (target: any, propertyKey: string, descriptor: PropertyDescriptor): PropertyDescriptor {
-        const { taskName, botName = 'bytedance' } = options;
+        const { taskName, botName = 'chiwei' } = options;
 
         // 保存类级别的元数据
         const existingMetadata = crontabMethodsMetadata.get(target) || [];

--- a/apps/lark-server/src/infrastructure/crontab/services/daily-photo.ts
+++ b/apps/lark-server/src/infrastructure/crontab/services/daily-photo.ts
@@ -15,7 +15,7 @@ export class DailyPhotoService {
      * 发图给订阅群聊
      * 每天 18:00 执行
      */
-    @Crontab('0 18 * * *', { taskName: 'daily-photo', botName: 'bytedance' })
+    @Crontab('0 18 * * *', { taskName: 'daily-photo', botName: 'chiwei' })
     async sendDailyPhoto(): Promise<void> {
         let images = await fetchUploadedImages({
             status: StatusMode.VISIBLE,
@@ -42,7 +42,7 @@ export class DailyPhotoService {
      * 发新图给特定群聊
      * 每天 19:30 执行
      */
-    @Crontab('30 19 * * *', { taskName: 'daily-new-photo', botName: 'bytedance' })
+    @Crontab('30 19 * * *', { taskName: 'daily-new-photo', botName: 'chiwei' })
     async dailySendNewPhoto(): Promise<void> {
         try {
             const card = await searchAndBuildDailyPhotoCard(dayjs().add(-1, 'day').valueOf());

--- a/apps/lark-server/src/infrastructure/crontab/services/emoji.ts
+++ b/apps/lark-server/src/infrastructure/crontab/services/emoji.ts
@@ -60,7 +60,7 @@ export class EmojiService {
      * 同步emoji数据到数据库
      * 每小时执行一次
      */
-    @Crontab('0 * * * *', { taskName: 'emoji-sync', botName: 'bytedance' })
+    @Crontab('0 * * * *', { taskName: 'emoji-sync', botName: 'chiwei' })
     async syncEmojiData(): Promise<void> {
         try {
             console.info('Starting emoji data sync...');

--- a/apps/lark-server/src/infrastructure/integrations/memory.ts
+++ b/apps/lark-server/src/infrastructure/integrations/memory.ts
@@ -21,7 +21,7 @@ function isEmptyContent(content: string | undefined | null): boolean {
  */
 export async function storeMessage(message: ChatMessage): Promise<void> {
     try {
-        const botName = message.bot_name || context.getBotName() || 'bytedance';
+        const botName = message.bot_name || context.getBotName() || 'chiwei';
         const isEmpty = isEmptyContent(message.content);
 
         // INSERT ... ON CONFLICT (message_id) DO NOTHING


### PR DESCRIPTION
## Summary
- 删除废弃 bot：bezhai（0条消息）、fly-dev（0条消息）— DB 变更 #30 待审批
- 主力 bot 从 `bytedance` 改名为 `chiwei`，代码中 8 处硬编码全部替换 — DB 变更 #31-33 待审批
- 保留 fly、dev、tool 三个 bot

## 涉及服务
- lark-server（定时任务默认 bot、memory fallback）
- agent-service（proactive_scanner、vectorize_worker fallback）

## 部署顺序
1. 合并此 PR，部署 lark-server + agent-service
2. Dashboard 审批 DB 变更 #30→#31→#32→#33
3. 飞书开发者后台改 Webhook URL：`/webhook/bytedance/event` → `/webhook/chiwei/event`

## Test plan
- [ ] 部署后验证 `/webhook/bytedance/event` 仍可用（DB 未改前）
- [ ] DB 变更 #31 执行后验证 `/webhook/chiwei/event` 可用
- [ ] 飞书后台改 URL 后端到端测试消息收发

🤖 Generated with [Claude Code](https://claude.com/claude-code)