### PR TITLE
fix: 每日发图定时任务 botName 从 chiwei 改为 tool

### DIFF
--- a/apps/lark-server/src/infrastructure/crontab/services/daily-photo.ts
+++ b/apps/lark-server/src/infrastructure/crontab/services/daily-photo.ts
@@ -15,7 +15,7 @@ export class DailyPhotoService {
      * 发图给订阅群聊
      * 每天 18:00 执行
      */
-    @Crontab('0 18 * * *', { taskName: 'daily-photo', botName: 'chiwei' })
+    @Crontab('0 18 * * *', { taskName: 'daily-photo', botName: 'tool'})
     async sendDailyPhoto(): Promise<void> {
         let images = await fetchUploadedImages({
             status: StatusMode.VISIBLE,
@@ -42,7 +42,7 @@ export class DailyPhotoService {
      * 发新图给特定群聊
      * 每天 19:30 执行
      */
-    @Crontab('30 19 * * *', { taskName: 'daily-new-photo', botName: 'chiwei' })
+    @Crontab('30 19 * * *', { taskName: 'daily-new-photo', botName: 'tool'})
     async dailySendNewPhoto(): Promise<void> {
         try {
             const card = await searchAndBuildDailyPhotoCard(dayjs().add(-1, 'day').valueOf());


### PR DESCRIPTION
## Summary
- 每日发图两个定时任务 (`daily-photo`, `daily-new-photo`) 的 `botName` 从 `chiwei` 改为 `tool`

🤖 Generated with [Claude Code](https://claude.com/claude-code)