### PR TITLE
chore: unify HTTP framework to Hono

### DIFF
--- a/apps/lark-server/package.json
+++ b/apps/lark-server/package.json
@@ -22,9 +22,6 @@
     "license": "MIT",
     "devDependencies": {
         "@types/ali-oss": "^6.16.11",
-        "@types/koa": "^2.15.0",
-        "@types/koa__cors": "^5.0.0",
-        "@types/koa__router": "^12.0.4",
         "@types/lodash": "^4.17.13",
         "@types/node-cron": "^3.0.11",
         "@types/supertest": "^6.0.3",
@@ -42,8 +39,7 @@
     "dependencies": {
         "@inner/pixiv-client": "workspace:*",
         "@inner/shared": "workspace:*",
-        "@koa/cors": "^5.0.0",
-        "@koa/router": "^12.0.1",
+        "hono": "^4.7.0",
         "@larksuiteoapi/node-sdk": "^1.23.0",
         "@volcengine/tos-sdk": "^0.0.0-preview-2.7.7-20251211024611",
         "ali-oss": "^6.23.0",
@@ -54,8 +50,6 @@
         "feishu-card": "1.0.1",
         "form-data": "^4.0.5",
         "ioredis": "^5.3.2",
-        "koa": "^2.14.2",
-        "koa-body": "^6.0.1",
         "lodash": "^4.17.23",
         "mongodb": "^5.8.0",
         "node-cron": "^4.2.1",

--- a/apps/lark-server/src/api/routes/internal-lark.route.ts
+++ b/apps/lark-server/src/api/routes/internal-lark.route.ts
@@ -1,5 +1,4 @@
-import Router from '@koa/router';
-import { Context } from 'koa';
+import { Hono } from 'hono';
 import { insertEvent } from '@dal/mongo/client';
 import { context } from '@middleware/context';
 import { EventRegistry, registerEventHandlerInstance } from '@lark/events/event-registry';
@@ -15,7 +14,7 @@ function ensureHandlersInitialized(): void {
     }
 }
 
-const router = new Router();
+const app = new Hono();
 
 /**
  * 内部接口：接收 lane-proxy 转发的 Lark 事件
@@ -29,31 +28,27 @@ const router = new Router();
  * Body:
  *   { event_type: string, params: any }
  */
-router.post('/api/internal/lark-event', async (ctx: Context) => {
+app.post('/api/internal/lark-event', async (c) => {
     // 1. 验证 Authorization
-    const authHeader = ctx.get('Authorization') || '';
+    const authHeader = c.req.header('Authorization') || '';
     const token = authHeader.replace('Bearer ', '');
     if (token !== process.env.INNER_HTTP_SECRET) {
-        ctx.status = 401;
-        ctx.body = { error: 'Unauthorized' };
-        return;
+        return c.json({ error: 'Unauthorized' }, 401);
     }
 
     // 2. 从 header 提取上下文
-    const botName = ctx.get('X-App-Name');
-    const traceId = ctx.get('x-trace-id');
-    const lane = ctx.get('x-lane') || undefined;
+    const botName = c.req.header('X-App-Name');
+    const traceId = c.req.header('x-trace-id');
+    const lane = c.req.header('x-lane') || undefined;
 
     // 3. 从 body 提取事件数据
-    const { event_type, params } = ctx.request.body as {
+    const { event_type, params } = await c.req.json() as {
         event_type: string;
         params: unknown;
     };
 
     if (!event_type || !params) {
-        ctx.status = 400;
-        ctx.body = { error: 'Missing event_type or params' };
-        return;
+        return c.json({ error: 'Missing event_type or params' }, 400);
     }
 
     // 4. MongoDB 审计日志（fire-and-forget）
@@ -78,8 +73,7 @@ router.post('/api/internal/lark-event', async (ctx: Context) => {
     });
 
     // 7. 立即返回
-    ctx.status = 200;
-    ctx.body = { ok: true };
+    return c.json({ ok: true }, 200);
 });
 
-export default router;
+export default app;

--- a/apps/lark-server/src/middleware/bot-context.ts
+++ b/apps/lark-server/src/middleware/bot-context.ts
@@ -1,11 +1,11 @@
-import { Context, Next } from 'koa';
+import type { Context, Next } from 'hono';
 import { asyncLocalStorage, context } from './context';
 
-export const botContextMiddleware = async (ctx: Context, next: Next) => {
+export const botContextMiddleware = async (c: Context, next: Next) => {
     // 从 X-App-Name header 获取 bot_name（由 lark-proxy 设置）
-    const botName = (ctx.request.headers['x-app-name'] as string) || undefined;
+    const botName = c.req.header('x-app-name') || undefined;
     // 从 x-lane header 获取泳道标识（由 lark-proxy 设置）
-    const lane = (ctx.request.headers['x-lane'] as string) || undefined;
+    const lane = c.req.header('x-lane') || undefined;
 
     // 将 botName 和 lane 注入到现有的 AsyncLocalStorage 上下文中
     const newStore = context.set({ botName, lane });

--- a/apps/lark-server/src/middleware/error-handler.test.ts
+++ b/apps/lark-server/src/middleware/error-handler.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect, beforeEach, mock } from 'bun:test';
-import type { Context, Next } from 'koa';
+import { Hono } from 'hono';
 import { AppError } from '@inner/shared';
 
 // Mock logger to assert calls
@@ -15,13 +15,6 @@ mock.module('@logger/index', () => ({
 const { errorHandler } = await import('@middleware/error-handler');
 
 describe('middleware/error-handler', () => {
-    const getCtx = (): Context =>
-        ({
-            // minimal ctx fields used by errorHandler
-            status: 200,
-            body: undefined,
-        }) as unknown as Context;
-
     beforeEach(() => {
         mockLogger.warn.mockReset();
         mockLogger.error.mockReset();
@@ -29,15 +22,16 @@ describe('middleware/error-handler', () => {
     });
 
     test('捕获 AppError 并返回统一业务错误响应', async () => {
-        const ctx = getCtx();
-        const next: Next = (async () => {
+        const app = new Hono();
+        app.onError(errorHandler);
+        app.get('/test', () => {
             throw new AppError(400, '无效的参数');
-        }) as Next;
+        });
 
-        await errorHandler(ctx, next);
+        const res = await app.request('/test');
 
-        expect(ctx.status).toBe(400);
-        expect(ctx.body).toEqual({ error: '无效的参数', code: 400 });
+        expect(res.status).toBe(400);
+        expect(await res.json()).toEqual({ error: '无效的参数', code: 400 });
         expect(mockLogger.warn).toHaveBeenCalledWith('Operational error', {
             message: '无效的参数',
         });
@@ -45,15 +39,16 @@ describe('middleware/error-handler', () => {
     });
 
     test('捕获未知错误并返回 500 与通用消息', async () => {
-        const ctx = getCtx();
-        const next: Next = (async () => {
+        const app = new Hono();
+        app.onError(errorHandler);
+        app.get('/test', () => {
             throw new Error('boom');
-        }) as Next;
+        });
 
-        await errorHandler(ctx, next);
+        const res = await app.request('/test');
 
-        expect(ctx.status).toBe(500);
-        expect(ctx.body).toEqual({ error: 'Internal server error', code: 500 });
+        expect(res.status).toBe(500);
+        expect(await res.json()).toEqual({ error: 'Internal server error', code: 500 });
         expect(mockLogger.error).toHaveBeenCalled();
     });
 });

--- a/apps/lark-server/src/middleware/error-handler.ts
+++ b/apps/lark-server/src/middleware/error-handler.ts
@@ -1,9 +1,8 @@
-import type { Context, Next } from 'koa';
 import logger from '@logger/index';
 import { createErrorHandler } from '@inner/shared';
 
 /**
- * 统一错误处理中间件
+ * 统一错误处理（用于 app.onError()）
  * 使用 ts-common 的 createErrorHandler 并注入 logger
  */
 export const errorHandler = createErrorHandler({

--- a/apps/lark-server/src/middleware/metrics.ts
+++ b/apps/lark-server/src/middleware/metrics.ts
@@ -1,6 +1,6 @@
 import { Counter, Histogram, Gauge, Registry, collectDefaultMetrics } from 'prom-client';
-import type { Context, Next } from 'koa';
-import Router from '@koa/router';
+import type { Context, Next } from 'hono';
+import { Hono } from 'hono';
 
 export const register = new Registry();
 collectDefaultMetrics({ register });
@@ -26,9 +26,9 @@ const httpRequestsInFlight = new Gauge({
 });
 
 /**
- * Koa middleware that records Prometheus HTTP metrics.
+ * Hono middleware that records Prometheus HTTP metrics.
  */
-export async function metricsMiddleware(ctx: Context, next: Next): Promise<void> {
+export async function metricsMiddleware(c: Context, next: Next): Promise<void> {
     httpRequestsInFlight.inc();
     const start = performance.now();
     try {
@@ -36,16 +36,15 @@ export async function metricsMiddleware(ctx: Context, next: Next): Promise<void>
     } finally {
         const duration = (performance.now() - start) / 1000;
         httpRequestsInFlight.dec();
-        httpRequestsTotal.inc({ method: ctx.method, path: ctx.path, status: String(ctx.status) });
-        httpRequestDuration.observe({ method: ctx.method, path: ctx.path }, duration);
+        httpRequestsTotal.inc({ method: c.req.method, path: c.req.path, status: String(c.res.status) });
+        httpRequestDuration.observe({ method: c.req.method, path: c.req.path }, duration);
     }
 }
 
 /**
- * Router with /metrics endpoint.
+ * Sub-app with /metrics endpoint.
  */
-export const metricsRouter = new Router();
-metricsRouter.get('/metrics', async (ctx) => {
-    ctx.set('Content-Type', register.contentType);
-    ctx.body = await register.metrics();
+export const metricsApp = new Hono();
+metricsApp.get('/metrics', async (c) => {
+    return c.text(await register.metrics(), 200, { 'Content-Type': register.contentType });
 });

--- a/apps/lark-server/src/middleware/trace.ts
+++ b/apps/lark-server/src/middleware/trace.ts
@@ -1,13 +1,13 @@
-import { Context, Next } from 'koa';
+import type { Context, Next } from 'hono';
 import { asyncLocalStorage } from '@middleware/context';
 import { v4 as uuidv4 } from 'uuid';
 
-export const traceMiddleware = async (ctx: Context, next: Next) => {
-    const traceId = (ctx.request.headers['x-trace-id'] as string) || uuidv4();
+export const traceMiddleware = async (c: Context, next: Next) => {
+    const traceId = c.req.header('x-trace-id') || uuidv4();
 
     // 在AsyncLocalStorage上下文中执行整个后续的中间件链
     await asyncLocalStorage.run({ traceId }, async () => {
-        ctx.set('X-Trace-Id', traceId);
+        c.header('X-Trace-Id', traceId);
         await next();
     });
 };

--- a/apps/lark-server/src/startup/server.test.ts
+++ b/apps/lark-server/src/startup/server.test.ts
@@ -1,24 +1,20 @@
 import { describe, test, expect } from 'bun:test';
-import Koa from 'koa';
-import Router from '@koa/router';
-import request from 'supertest';
+import { Hono } from 'hono';
 
 /**
  * 仅验证健康检查端点与错误处理中间件集成。
- * 使用 supertest 发起请求，不启动真实端口监听。
+ * 使用 Hono 的 app.request() 发起请求，不启动真实端口监听。
  */
 describe('startup/server 集成烟雾测试', () => {
     test('GET /api/health 返回 200 且包含服务字段', async () => {
-        const app: Koa = new Koa();
-        const router = new Router();
-        router.get('/api/health', (ctx) => {
-            ctx.status = 200;
-            ctx.body = { status: 'ok', service: 'lark-server' };
+        const app = new Hono();
+        app.get('/api/health', (c) => {
+            return c.json({ status: 'ok', service: 'lark-server' }, 200);
         });
-        app.use(router.routes());
 
-        const res = await request(app.callback()).get('/api/health');
+        const res = await app.request('/api/health');
         expect(res.status).toBe(200);
-        expect(res.body.service).toBe('lark-server');
+        const body = await res.json();
+        expect(body.service).toBe('lark-server');
     });
 });

--- a/apps/lark-server/src/startup/server.ts
+++ b/apps/lark-server/src/startup/server.ts
@@ -1,12 +1,10 @@
-import Koa from 'koa';
-import Router from '@koa/router';
-import koaBodyModule from 'koa-body';
-const koaBody = (koaBodyModule as any).default ?? koaBodyModule;
-import cors from '@koa/cors';
+import { Hono } from 'hono';
+import { cors } from 'hono/cors';
+import { bodyLimit } from 'hono/body-limit';
 import { errorHandler } from '@middleware/error-handler';
 import { traceMiddleware } from '@middleware/trace';
 import { botContextMiddleware } from '@middleware/bot-context';
-import { metricsMiddleware, metricsRouter } from '@middleware/metrics';
+import { metricsMiddleware, metricsApp } from '@middleware/metrics';
 import { multiBotManager } from '@core/services/bot/multi-bot-manager';
 import internalLarkRoutes from '@api/routes/internal-lark.route';
 
@@ -21,8 +19,7 @@ export interface ServerConfig {
  * HTTP 服务器管理器
  */
 export class HttpServerManager {
-    private app: Koa;
-    private router: Router;
+    private app: Hono;
     private config: ServerConfig;
 
     constructor(
@@ -31,8 +28,8 @@ export class HttpServerManager {
         },
     ) {
         this.config = config;
-        this.app = new Koa();
-        this.router = new Router();
+        this.app = new Hono();
+        this.app.onError(errorHandler); // 统一错误处理（Hono 原生 onError）
         this.setupMiddleware();
     }
 
@@ -40,16 +37,12 @@ export class HttpServerManager {
      * 设置中间件
      */
     private setupMiddleware(): void {
-        this.app.use(metricsMiddleware); // Prometheus metrics（最外层）
-        this.app.use(cors());
-        this.app.use(traceMiddleware); // 先注入 traceId（为后续日志与错误处理提供上下文）
-        this.app.use(errorHandler); // 统一错误处理（依赖 traceId 贯穿）
-        this.app.use(botContextMiddleware); // 注入 botName
-        this.app.use(koaBody({
-            formLimit: '50mb',
-            jsonLimit: '50mb',
-            textLimit: '50mb',
-            multipart: true,
+        this.app.use('*', metricsMiddleware); // Prometheus metrics（最外层）
+        this.app.use('*', cors());
+        this.app.use('*', traceMiddleware); // 先注入 traceId（为后续日志与错误处理提供上下文）
+        this.app.use('*', botContextMiddleware); // 注入 botName
+        this.app.use('*', bodyLimit({
+            maxSize: 50 * 1024 * 1024, // 50mb
         }));
     }
 
@@ -57,10 +50,10 @@ export class HttpServerManager {
      * 注册健康检查端点
      */
     private registerHealthCheck(): void {
-        this.router.get('/api/health', (ctx) => {
+        this.app.get('/api/health', (c) => {
             try {
                 const allBots = multiBotManager.getAllBotConfigs();
-                ctx.body = {
+                return c.json({
                     status: 'ok',
                     timestamp: new Date().toISOString(),
                     service: 'lark-server',
@@ -71,14 +64,12 @@ export class HttpServerManager {
                         init_type: bot.init_type,
                         is_active: bot.is_active,
                     })),
-                };
-                ctx.status = 200;
+                }, 200);
             } catch (error) {
-                ctx.body = {
+                return c.json({
                     status: 'error',
                     message: error instanceof Error ? error.message : 'Unknown error',
-                };
-                ctx.status = 500;
+                }, 500);
             }
         });
     }
@@ -88,13 +79,12 @@ export class HttpServerManager {
      */
     async start(): Promise<void> {
         // 注册 /metrics 和健康检查路由
-        this.app.use(metricsRouter.routes());
+        this.app.route('', metricsApp);
         this.registerHealthCheck();
-        this.app.use(this.router.routes());
-        this.app.use(internalLarkRoutes.routes());
+        this.app.route('', internalLarkRoutes);
 
         // 启动服务器
-        this.app.listen(this.config.port);
+        Bun.serve({ port: this.config.port, fetch: this.app.fetch });
         console.info(`HTTP server started on port ${this.config.port}`);
         this.logAvailableRoutes();
     }
@@ -109,9 +99,9 @@ export class HttpServerManager {
     }
 
     /**
-     * 获取 Koa 应用实例（用于测试）
+     * 获取 Hono 应用实例（用于测试）
      */
-    getApp(): Koa {
+    getApp(): Hono {
         return this.app;
     }
 }

--- a/apps/monitor-dashboard/package.json
+++ b/apps/monitor-dashboard/package.json
@@ -4,13 +4,11 @@
   "version": "1.0.0",
   "type": "module",
   "dependencies": {
+    "@hono/node-server": "^1.13.0",
     "@inner/shared": "workspace:*",
-    "@koa/cors": "^5.0.0",
-    "@koa/router": "^12.0.1",
     "axios": "^1.6.8",
+    "hono": "^4.7.0",
     "jsonwebtoken": "^9.0.2",
-    "koa": "^2.15.0",
-    "koa-bodyparser": "^4.4.1",
     "mongodb": "^6.10.0",
     "pg": "^8.11.5",
     "reflect-metadata": "^0.1.14",
@@ -18,10 +16,6 @@
   },
   "devDependencies": {
     "@types/jsonwebtoken": "^9.0.6",
-    "@types/koa": "^2.15.0",
-    "@types/koa__cors": "^5.0.0",
-    "@types/koa__router": "^12.0.4",
-    "@types/koa-bodyparser": "^4.3.12",
     "@types/node": "^18.19.20",
     "typescript": "^5.9.3"
   }

--- a/apps/monitor-dashboard/pnpm-lock.yaml
+++ b/apps/monitor-dashboard/pnpm-lock.yaml
@@ -1,0 +1,1224 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      '@hono/node-server':
+        specifier: ^1.13.0
+        version: 1.19.12(hono@4.12.10)
+      '@inner/shared':
+        specifier: workspace:*
+        version: link:../../packages/ts-shared
+      axios:
+        specifier: ^1.6.8
+        version: 1.14.0
+      hono:
+        specifier: ^4.7.0
+        version: 4.12.10
+      jsonwebtoken:
+        specifier: ^9.0.2
+        version: 9.0.3
+      mongodb:
+        specifier: ^6.10.0
+        version: 6.21.0
+      pg:
+        specifier: ^8.11.5
+        version: 8.20.0
+      reflect-metadata:
+        specifier: ^0.1.14
+        version: 0.1.14
+      typeorm:
+        specifier: ^0.3.17
+        version: 0.3.28(mongodb@6.21.0)(pg@8.20.0)
+    devDependencies:
+      '@types/jsonwebtoken':
+        specifier: ^9.0.6
+        version: 9.0.10
+      '@types/node':
+        specifier: ^18.19.20
+        version: 18.19.130
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+
+packages:
+
+  '@hono/node-server@1.19.12':
+    resolution: {integrity: sha512-txsUW4SQ1iilgE0l9/e9VQWmELXifEFvmdA1j6WFh/aFPj99hIntrSsq/if0UWyGVkmrRPKA1wCeP+UCr1B9Uw==}
+    engines: {node: '>=18.14.1'}
+    peerDependencies:
+      hono: ^4
+
+  '@isaacs/cliui@8.0.2':
+    resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
+    engines: {node: '>=12'}
+
+  '@mongodb-js/saslprep@1.4.6':
+    resolution: {integrity: sha512-y+x3H1xBZd38n10NZF/rEBlvDOOMQ6LKUTHqr8R9VkJ+mmQOYtJFxIlkkK8fZrtOiL6VixbOBWMbZGBdal3Z1g==}
+
+  '@pkgjs/parseargs@0.11.0':
+    resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
+    engines: {node: '>=14'}
+
+  '@sqltools/formatter@1.2.5':
+    resolution: {integrity: sha512-Uy0+khmZqUrUGm5dmMqVlnvufZRSK0FbYzVgp0UMstm+F5+W2/jnEEQyc9vo1ZR/E5ZI/B1WjjoTqBqwJL6Krw==}
+
+  '@types/jsonwebtoken@9.0.10':
+    resolution: {integrity: sha512-asx5hIG9Qmf/1oStypjanR7iKTv0gXQ1Ov/jfrX6kS/EO0OFni8orbmGCn0672NHR3kXHwpAwR+B368ZGN/2rA==}
+
+  '@types/ms@2.1.0':
+    resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
+
+  '@types/node@18.19.130':
+    resolution: {integrity: sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==}
+
+  '@types/webidl-conversions@7.0.3':
+    resolution: {integrity: sha512-CiJJvcRtIgzadHCYXw7dqEnMNRjhGZlYK05Mj9OyktqV8uVT8fD2BFOB7S1uwBE3Kj2Z+4UyPmFw/Ixgw/LAlA==}
+
+  '@types/whatwg-url@11.0.5':
+    resolution: {integrity: sha512-coYR071JRaHa+xoEvvYqvnIHaVqaYrLPbsufM9BF63HkwI5Lgmy2QR8Q5K/lYDYo5AK82wOvSOS0UsLTpTG7uQ==}
+
+  ansi-regex@5.0.1:
+    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
+    engines: {node: '>=8'}
+
+  ansi-regex@6.2.2:
+    resolution: {integrity: sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==}
+    engines: {node: '>=12'}
+
+  ansi-styles@4.3.0:
+    resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
+    engines: {node: '>=8'}
+
+  ansi-styles@6.2.3:
+    resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
+    engines: {node: '>=12'}
+
+  ansis@4.2.0:
+    resolution: {integrity: sha512-HqZ5rWlFjGiV0tDm3UxxgNRqsOTniqoKZu0pIAfh7TZQMGuZK+hH0drySty0si0QXj1ieop4+SkSfPZBPPkHig==}
+    engines: {node: '>=14'}
+
+  app-root-path@3.1.0:
+    resolution: {integrity: sha512-biN3PwB2gUtjaYy/isrU3aNWI5w+fAfvHkSvCKeQGxhmYpwKFUxudR3Yya+KqVRHBmEDYh+/lTozYCFbmzX4nA==}
+    engines: {node: '>= 6.0.0'}
+
+  asynckit@0.4.0:
+    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
+
+  available-typed-arrays@1.0.7:
+    resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
+    engines: {node: '>= 0.4'}
+
+  axios@1.14.0:
+    resolution: {integrity: sha512-3Y8yrqLSwjuzpXuZ0oIYZ/XGgLwUIBU3uLvbcpb0pidD9ctpShJd43KSlEEkVQg6DS0G9NKyzOvBfUtDKEyHvQ==}
+
+  balanced-match@1.0.2:
+    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+
+  base64-js@1.5.1:
+    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+
+  brace-expansion@2.0.3:
+    resolution: {integrity: sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==}
+
+  bson@6.10.4:
+    resolution: {integrity: sha512-WIsKqkSC0ABoBJuT1LEX+2HEvNmNKKgnTAyd0fL8qzK4SH2i9NXg+t08YtdZp/V9IZ33cxe3iV4yM0qg8lMQng==}
+    engines: {node: '>=16.20.1'}
+
+  buffer-equal-constant-time@1.0.1:
+    resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
+
+  buffer@6.0.3:
+    resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
+
+  call-bind-apply-helpers@1.0.2:
+    resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
+    engines: {node: '>= 0.4'}
+
+  call-bind@1.0.8:
+    resolution: {integrity: sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==}
+    engines: {node: '>= 0.4'}
+
+  call-bound@1.0.4:
+    resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
+    engines: {node: '>= 0.4'}
+
+  cliui@8.0.1:
+    resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
+    engines: {node: '>=12'}
+
+  color-convert@2.0.1:
+    resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
+    engines: {node: '>=7.0.0'}
+
+  color-name@1.1.4:
+    resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
+  combined-stream@1.0.8:
+    resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
+    engines: {node: '>= 0.8'}
+
+  cross-spawn@7.0.6:
+    resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
+    engines: {node: '>= 8'}
+
+  dayjs@1.11.20:
+    resolution: {integrity: sha512-YbwwqR/uYpeoP4pu043q+LTDLFBLApUP6VxRihdfNTqu4ubqMlGDLd6ErXhEgsyvY0K6nCs7nggYumAN+9uEuQ==}
+
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  dedent@1.7.2:
+    resolution: {integrity: sha512-WzMx3mW98SN+zn3hgemf4OzdmyNhhhKz5Ay0pUfQiMQ3e1g+xmTJWp/pKdwKVXhdSkAEGIIzqeuWrL3mV/AXbA==}
+    peerDependencies:
+      babel-plugin-macros: ^3.1.0
+    peerDependenciesMeta:
+      babel-plugin-macros:
+        optional: true
+
+  define-data-property@1.1.4:
+    resolution: {integrity: sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==}
+    engines: {node: '>= 0.4'}
+
+  delayed-stream@1.0.0:
+    resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
+    engines: {node: '>=0.4.0'}
+
+  dotenv@16.6.1:
+    resolution: {integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==}
+    engines: {node: '>=12'}
+
+  dunder-proto@1.0.1:
+    resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
+    engines: {node: '>= 0.4'}
+
+  eastasianwidth@0.2.0:
+    resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
+
+  ecdsa-sig-formatter@1.0.11:
+    resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
+
+  emoji-regex@8.0.0:
+    resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+
+  emoji-regex@9.2.2:
+    resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
+
+  es-define-property@1.0.1:
+    resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
+    engines: {node: '>= 0.4'}
+
+  es-errors@1.3.0:
+    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
+    engines: {node: '>= 0.4'}
+
+  es-object-atoms@1.1.1:
+    resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
+    engines: {node: '>= 0.4'}
+
+  es-set-tostringtag@2.1.0:
+    resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
+    engines: {node: '>= 0.4'}
+
+  escalade@3.2.0:
+    resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
+    engines: {node: '>=6'}
+
+  follow-redirects@1.15.11:
+    resolution: {integrity: sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      debug: '*'
+    peerDependenciesMeta:
+      debug:
+        optional: true
+
+  for-each@0.3.5:
+    resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
+    engines: {node: '>= 0.4'}
+
+  foreground-child@3.3.1:
+    resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
+    engines: {node: '>=14'}
+
+  form-data@4.0.5:
+    resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
+    engines: {node: '>= 6'}
+
+  function-bind@1.1.2:
+    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
+  get-caller-file@2.0.5:
+    resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
+    engines: {node: 6.* || 8.* || >= 10.*}
+
+  get-intrinsic@1.3.0:
+    resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
+    engines: {node: '>= 0.4'}
+
+  get-proto@1.0.1:
+    resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
+    engines: {node: '>= 0.4'}
+
+  glob@10.5.0:
+    resolution: {integrity: sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+    hasBin: true
+
+  gopd@1.2.0:
+    resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
+    engines: {node: '>= 0.4'}
+
+  has-property-descriptors@1.0.2:
+    resolution: {integrity: sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==}
+
+  has-symbols@1.1.0:
+    resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
+    engines: {node: '>= 0.4'}
+
+  has-tostringtag@1.0.2:
+    resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
+    engines: {node: '>= 0.4'}
+
+  hasown@2.0.2:
+    resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
+    engines: {node: '>= 0.4'}
+
+  hono@4.12.10:
+    resolution: {integrity: sha512-mx/p18PLy5og9ufies2GOSUqep98Td9q4i/EF6X7yJgAiIopxqdfIO3jbqsi3jRgTgw88jMDEzVKi+V2EF+27w==}
+    engines: {node: '>=16.9.0'}
+
+  ieee754@1.2.1:
+    resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
+
+  inherits@2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
+  is-callable@1.2.7:
+    resolution: {integrity: sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==}
+    engines: {node: '>= 0.4'}
+
+  is-fullwidth-code-point@3.0.0:
+    resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
+    engines: {node: '>=8'}
+
+  is-typed-array@1.1.15:
+    resolution: {integrity: sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==}
+    engines: {node: '>= 0.4'}
+
+  isarray@2.0.5:
+    resolution: {integrity: sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==}
+
+  isexe@2.0.0:
+    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  jackspeak@3.4.3:
+    resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
+
+  jsonwebtoken@9.0.3:
+    resolution: {integrity: sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==}
+    engines: {node: '>=12', npm: '>=6'}
+
+  jwa@2.0.1:
+    resolution: {integrity: sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==}
+
+  jws@4.0.1:
+    resolution: {integrity: sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==}
+
+  lodash.includes@4.3.0:
+    resolution: {integrity: sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==}
+
+  lodash.isboolean@3.0.3:
+    resolution: {integrity: sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==}
+
+  lodash.isinteger@4.0.4:
+    resolution: {integrity: sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==}
+
+  lodash.isnumber@3.0.3:
+    resolution: {integrity: sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==}
+
+  lodash.isplainobject@4.0.6:
+    resolution: {integrity: sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==}
+
+  lodash.isstring@4.0.1:
+    resolution: {integrity: sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==}
+
+  lodash.once@4.1.1:
+    resolution: {integrity: sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==}
+
+  lru-cache@10.4.3:
+    resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
+
+  math-intrinsics@1.1.0:
+    resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
+    engines: {node: '>= 0.4'}
+
+  memory-pager@1.5.0:
+    resolution: {integrity: sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==}
+
+  mime-db@1.52.0:
+    resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@2.1.35:
+    resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
+    engines: {node: '>= 0.6'}
+
+  minimatch@9.0.9:
+    resolution: {integrity: sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
+  minipass@7.1.3:
+    resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
+  mongodb-connection-string-url@3.0.2:
+    resolution: {integrity: sha512-rMO7CGo/9BFwyZABcKAWL8UJwH/Kc2x0g72uhDWzG48URRax5TCIcJ7Rc3RZqffZzO/Gwff/jyKwCU9TN8gehA==}
+
+  mongodb@6.21.0:
+    resolution: {integrity: sha512-URyb/VXMjJ4da46OeSXg+puO39XH9DeQpWCslifrRn9JWugy0D+DvvBvkm2WxmHe61O/H19JM66p1z7RHVkZ6A==}
+    engines: {node: '>=16.20.1'}
+    peerDependencies:
+      '@aws-sdk/credential-providers': ^3.188.0
+      '@mongodb-js/zstd': ^1.1.0 || ^2.0.0
+      gcp-metadata: ^5.2.0
+      kerberos: ^2.0.1
+      mongodb-client-encryption: '>=6.0.0 <7'
+      snappy: ^7.3.2
+      socks: ^2.7.1
+    peerDependenciesMeta:
+      '@aws-sdk/credential-providers':
+        optional: true
+      '@mongodb-js/zstd':
+        optional: true
+      gcp-metadata:
+        optional: true
+      kerberos:
+        optional: true
+      mongodb-client-encryption:
+        optional: true
+      snappy:
+        optional: true
+      socks:
+        optional: true
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  package-json-from-dist@1.0.1:
+    resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
+
+  path-key@3.1.1:
+    resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
+    engines: {node: '>=8'}
+
+  path-scurry@1.11.1:
+    resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
+    engines: {node: '>=16 || 14 >=14.18'}
+
+  pg-connection-string@2.12.0:
+    resolution: {integrity: sha512-U7qg+bpswf3Cs5xLzRqbXbQl85ng0mfSV/J0nnA31MCLgvEaAo7CIhmeyrmJpOr7o+zm0rXK+hNnT5l9RHkCkQ==}
+
+  pg-int8@1.0.1:
+    resolution: {integrity: sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==}
+    engines: {node: '>=4.0.0'}
+
+  pg-pool@3.13.0:
+    resolution: {integrity: sha512-gB+R+Xud1gLFuRD/QgOIgGOBE2KCQPaPwkzBBGC9oG69pHTkhQeIuejVIk3/cnDyX39av2AxomQiyPT13WKHQA==}
+    peerDependencies:
+      pg: '>=8.0'
+
+  pg-protocol@1.13.0:
+    resolution: {integrity: sha512-zzdvXfS6v89r6v7OcFCHfHlyG/wvry1ALxZo4LqgUoy7W9xhBDMaqOuMiF3qEV45VqsN6rdlcehHrfDtlCPc8w==}
+
+  pg-types@2.2.0:
+    resolution: {integrity: sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==}
+    engines: {node: '>=4'}
+
+  pg@8.20.0:
+    resolution: {integrity: sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==}
+    engines: {node: '>= 16.0.0'}
+    peerDependencies:
+      pg-native: '>=3.0.1'
+    peerDependenciesMeta:
+      pg-native:
+        optional: true
+
+  pgpass@1.0.5:
+    resolution: {integrity: sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==}
+
+  possible-typed-array-names@1.1.0:
+    resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
+    engines: {node: '>= 0.4'}
+
+  postgres-array@2.0.0:
+    resolution: {integrity: sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==}
+    engines: {node: '>=4'}
+
+  postgres-bytea@1.0.1:
+    resolution: {integrity: sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==}
+    engines: {node: '>=0.10.0'}
+
+  postgres-date@1.0.7:
+    resolution: {integrity: sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==}
+    engines: {node: '>=0.10.0'}
+
+  postgres-interval@1.2.0:
+    resolution: {integrity: sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==}
+    engines: {node: '>=0.10.0'}
+
+  proxy-from-env@2.1.0:
+    resolution: {integrity: sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==}
+    engines: {node: '>=10'}
+
+  punycode@2.3.1:
+    resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
+    engines: {node: '>=6'}
+
+  reflect-metadata@0.1.14:
+    resolution: {integrity: sha512-ZhYeb6nRaXCfhnndflDK8qI6ZQ/YcWZCISRAWICW9XYqMUwjZM9Z0DveWX/ABN01oxSHwVxKQmxeYZSsm0jh5A==}
+
+  reflect-metadata@0.2.2:
+    resolution: {integrity: sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==}
+
+  require-directory@2.1.1:
+    resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
+    engines: {node: '>=0.10.0'}
+
+  safe-buffer@5.2.1:
+    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
+
+  semver@7.7.4:
+    resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  set-function-length@1.2.2:
+    resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
+    engines: {node: '>= 0.4'}
+
+  sha.js@2.4.12:
+    resolution: {integrity: sha512-8LzC5+bvI45BjpfXU8V5fdU2mfeKiQe1D1gIMn7XUlF3OTUrpdJpPPH4EMAnF0DsHHdSZqCdSss5qCmJKuiO3w==}
+    engines: {node: '>= 0.10'}
+    hasBin: true
+
+  shebang-command@2.0.0:
+    resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
+    engines: {node: '>=8'}
+
+  shebang-regex@3.0.0:
+    resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
+    engines: {node: '>=8'}
+
+  signal-exit@4.1.0:
+    resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
+    engines: {node: '>=14'}
+
+  sparse-bitfield@3.0.3:
+    resolution: {integrity: sha512-kvzhi7vqKTfkh0PZU+2D2PIllw2ymqJKujUcyPMd9Y75Nv4nPbGJZXNhxsgdQab2BmlDct1YnfQCguEvHr7VsQ==}
+
+  split2@4.2.0:
+    resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
+    engines: {node: '>= 10.x'}
+
+  sql-highlight@6.1.0:
+    resolution: {integrity: sha512-ed7OK4e9ywpE7pgRMkMQmZDPKSVdm0oX5IEtZiKnFucSF0zu6c80GZBe38UqHuVhTWJ9xsKgSMjCG2bml86KvA==}
+    engines: {node: '>=14'}
+
+  string-width@4.2.3:
+    resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
+    engines: {node: '>=8'}
+
+  string-width@5.1.2:
+    resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
+    engines: {node: '>=12'}
+
+  strip-ansi@6.0.1:
+    resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
+    engines: {node: '>=8'}
+
+  strip-ansi@7.2.0:
+    resolution: {integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==}
+    engines: {node: '>=12'}
+
+  to-buffer@1.2.2:
+    resolution: {integrity: sha512-db0E3UJjcFhpDhAF4tLo03oli3pwl3dbnzXOUIlRKrp+ldk/VUxzpWYZENsw2SZiuBjHAk7DfB0VU7NKdpb6sw==}
+    engines: {node: '>= 0.4'}
+
+  tr46@5.1.1:
+    resolution: {integrity: sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==}
+    engines: {node: '>=18'}
+
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  typed-array-buffer@1.0.3:
+    resolution: {integrity: sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==}
+    engines: {node: '>= 0.4'}
+
+  typeorm@0.3.28:
+    resolution: {integrity: sha512-6GH7wXhtfq2D33ZuRXYwIsl/qM5685WZcODZb7noOOcRMteM9KF2x2ap3H0EBjnSV0VO4gNAfJT5Ukp0PkOlvg==}
+    engines: {node: '>=16.13.0'}
+    hasBin: true
+    peerDependencies:
+      '@google-cloud/spanner': ^5.18.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
+      '@sap/hana-client': ^2.14.22
+      better-sqlite3: ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0 || ^12.0.0
+      ioredis: ^5.0.4
+      mongodb: ^5.8.0 || ^6.0.0
+      mssql: ^9.1.1 || ^10.0.0 || ^11.0.0 || ^12.0.0
+      mysql2: ^2.2.5 || ^3.0.1
+      oracledb: ^6.3.0
+      pg: ^8.5.1
+      pg-native: ^3.0.0
+      pg-query-stream: ^4.0.0
+      redis: ^3.1.1 || ^4.0.0 || ^5.0.14
+      sql.js: ^1.4.0
+      sqlite3: ^5.0.3
+      ts-node: ^10.7.0
+      typeorm-aurora-data-api-driver: ^2.0.0 || ^3.0.0
+    peerDependenciesMeta:
+      '@google-cloud/spanner':
+        optional: true
+      '@sap/hana-client':
+        optional: true
+      better-sqlite3:
+        optional: true
+      ioredis:
+        optional: true
+      mongodb:
+        optional: true
+      mssql:
+        optional: true
+      mysql2:
+        optional: true
+      oracledb:
+        optional: true
+      pg:
+        optional: true
+      pg-native:
+        optional: true
+      pg-query-stream:
+        optional: true
+      redis:
+        optional: true
+      sql.js:
+        optional: true
+      sqlite3:
+        optional: true
+      ts-node:
+        optional: true
+      typeorm-aurora-data-api-driver:
+        optional: true
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  undici-types@5.26.5:
+    resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
+
+  uuid@11.1.0:
+    resolution: {integrity: sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==}
+    hasBin: true
+
+  webidl-conversions@7.0.0:
+    resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
+    engines: {node: '>=12'}
+
+  whatwg-url@14.2.0:
+    resolution: {integrity: sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==}
+    engines: {node: '>=18'}
+
+  which-typed-array@1.1.20:
+    resolution: {integrity: sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==}
+    engines: {node: '>= 0.4'}
+
+  which@2.0.2:
+    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
+    engines: {node: '>= 8'}
+    hasBin: true
+
+  wrap-ansi@7.0.0:
+    resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
+    engines: {node: '>=10'}
+
+  wrap-ansi@8.1.0:
+    resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
+    engines: {node: '>=12'}
+
+  xtend@4.0.2:
+    resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
+    engines: {node: '>=0.4'}
+
+  y18n@5.0.8:
+    resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
+    engines: {node: '>=10'}
+
+  yargs-parser@21.1.1:
+    resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
+    engines: {node: '>=12'}
+
+  yargs@17.7.2:
+    resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
+    engines: {node: '>=12'}
+
+snapshots:
+
+  '@hono/node-server@1.19.12(hono@4.12.10)':
+    dependencies:
+      hono: 4.12.10
+
+  '@isaacs/cliui@8.0.2':
+    dependencies:
+      string-width: 5.1.2
+      string-width-cjs: string-width@4.2.3
+      strip-ansi: 7.2.0
+      strip-ansi-cjs: strip-ansi@6.0.1
+      wrap-ansi: 8.1.0
+      wrap-ansi-cjs: wrap-ansi@7.0.0
+
+  '@mongodb-js/saslprep@1.4.6':
+    dependencies:
+      sparse-bitfield: 3.0.3
+
+  '@pkgjs/parseargs@0.11.0':
+    optional: true
+
+  '@sqltools/formatter@1.2.5': {}
+
+  '@types/jsonwebtoken@9.0.10':
+    dependencies:
+      '@types/ms': 2.1.0
+      '@types/node': 18.19.130
+
+  '@types/ms@2.1.0': {}
+
+  '@types/node@18.19.130':
+    dependencies:
+      undici-types: 5.26.5
+
+  '@types/webidl-conversions@7.0.3': {}
+
+  '@types/whatwg-url@11.0.5':
+    dependencies:
+      '@types/webidl-conversions': 7.0.3
+
+  ansi-regex@5.0.1: {}
+
+  ansi-regex@6.2.2: {}
+
+  ansi-styles@4.3.0:
+    dependencies:
+      color-convert: 2.0.1
+
+  ansi-styles@6.2.3: {}
+
+  ansis@4.2.0: {}
+
+  app-root-path@3.1.0: {}
+
+  asynckit@0.4.0: {}
+
+  available-typed-arrays@1.0.7:
+    dependencies:
+      possible-typed-array-names: 1.1.0
+
+  axios@1.14.0:
+    dependencies:
+      follow-redirects: 1.15.11
+      form-data: 4.0.5
+      proxy-from-env: 2.1.0
+    transitivePeerDependencies:
+      - debug
+
+  balanced-match@1.0.2: {}
+
+  base64-js@1.5.1: {}
+
+  brace-expansion@2.0.3:
+    dependencies:
+      balanced-match: 1.0.2
+
+  bson@6.10.4: {}
+
+  buffer-equal-constant-time@1.0.1: {}
+
+  buffer@6.0.3:
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
+
+  call-bind-apply-helpers@1.0.2:
+    dependencies:
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+
+  call-bind@1.0.8:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      get-intrinsic: 1.3.0
+      set-function-length: 1.2.2
+
+  call-bound@1.0.4:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      get-intrinsic: 1.3.0
+
+  cliui@8.0.1:
+    dependencies:
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      wrap-ansi: 7.0.0
+
+  color-convert@2.0.1:
+    dependencies:
+      color-name: 1.1.4
+
+  color-name@1.1.4: {}
+
+  combined-stream@1.0.8:
+    dependencies:
+      delayed-stream: 1.0.0
+
+  cross-spawn@7.0.6:
+    dependencies:
+      path-key: 3.1.1
+      shebang-command: 2.0.0
+      which: 2.0.2
+
+  dayjs@1.11.20: {}
+
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
+  dedent@1.7.2: {}
+
+  define-data-property@1.1.4:
+    dependencies:
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      gopd: 1.2.0
+
+  delayed-stream@1.0.0: {}
+
+  dotenv@16.6.1: {}
+
+  dunder-proto@1.0.1:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-errors: 1.3.0
+      gopd: 1.2.0
+
+  eastasianwidth@0.2.0: {}
+
+  ecdsa-sig-formatter@1.0.11:
+    dependencies:
+      safe-buffer: 5.2.1
+
+  emoji-regex@8.0.0: {}
+
+  emoji-regex@9.2.2: {}
+
+  es-define-property@1.0.1: {}
+
+  es-errors@1.3.0: {}
+
+  es-object-atoms@1.1.1:
+    dependencies:
+      es-errors: 1.3.0
+
+  es-set-tostringtag@2.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      has-tostringtag: 1.0.2
+      hasown: 2.0.2
+
+  escalade@3.2.0: {}
+
+  follow-redirects@1.15.11: {}
+
+  for-each@0.3.5:
+    dependencies:
+      is-callable: 1.2.7
+
+  foreground-child@3.3.1:
+    dependencies:
+      cross-spawn: 7.0.6
+      signal-exit: 4.1.0
+
+  form-data@4.0.5:
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      es-set-tostringtag: 2.1.0
+      hasown: 2.0.2
+      mime-types: 2.1.35
+
+  function-bind@1.1.2: {}
+
+  get-caller-file@2.0.5: {}
+
+  get-intrinsic@1.3.0:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.1
+      function-bind: 1.1.2
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-symbols: 1.1.0
+      hasown: 2.0.2
+      math-intrinsics: 1.1.0
+
+  get-proto@1.0.1:
+    dependencies:
+      dunder-proto: 1.0.1
+      es-object-atoms: 1.1.1
+
+  glob@10.5.0:
+    dependencies:
+      foreground-child: 3.3.1
+      jackspeak: 3.4.3
+      minimatch: 9.0.9
+      minipass: 7.1.3
+      package-json-from-dist: 1.0.1
+      path-scurry: 1.11.1
+
+  gopd@1.2.0: {}
+
+  has-property-descriptors@1.0.2:
+    dependencies:
+      es-define-property: 1.0.1
+
+  has-symbols@1.1.0: {}
+
+  has-tostringtag@1.0.2:
+    dependencies:
+      has-symbols: 1.1.0
+
+  hasown@2.0.2:
+    dependencies:
+      function-bind: 1.1.2
+
+  hono@4.12.10: {}
+
+  ieee754@1.2.1: {}
+
+  inherits@2.0.4: {}
+
+  is-callable@1.2.7: {}
+
+  is-fullwidth-code-point@3.0.0: {}
+
+  is-typed-array@1.1.15:
+    dependencies:
+      which-typed-array: 1.1.20
+
+  isarray@2.0.5: {}
+
+  isexe@2.0.0: {}
+
+  jackspeak@3.4.3:
+    dependencies:
+      '@isaacs/cliui': 8.0.2
+    optionalDependencies:
+      '@pkgjs/parseargs': 0.11.0
+
+  jsonwebtoken@9.0.3:
+    dependencies:
+      jws: 4.0.1
+      lodash.includes: 4.3.0
+      lodash.isboolean: 3.0.3
+      lodash.isinteger: 4.0.4
+      lodash.isnumber: 3.0.3
+      lodash.isplainobject: 4.0.6
+      lodash.isstring: 4.0.1
+      lodash.once: 4.1.1
+      ms: 2.1.3
+      semver: 7.7.4
+
+  jwa@2.0.1:
+    dependencies:
+      buffer-equal-constant-time: 1.0.1
+      ecdsa-sig-formatter: 1.0.11
+      safe-buffer: 5.2.1
+
+  jws@4.0.1:
+    dependencies:
+      jwa: 2.0.1
+      safe-buffer: 5.2.1
+
+  lodash.includes@4.3.0: {}
+
+  lodash.isboolean@3.0.3: {}
+
+  lodash.isinteger@4.0.4: {}
+
+  lodash.isnumber@3.0.3: {}
+
+  lodash.isplainobject@4.0.6: {}
+
+  lodash.isstring@4.0.1: {}
+
+  lodash.once@4.1.1: {}
+
+  lru-cache@10.4.3: {}
+
+  math-intrinsics@1.1.0: {}
+
+  memory-pager@1.5.0: {}
+
+  mime-db@1.52.0: {}
+
+  mime-types@2.1.35:
+    dependencies:
+      mime-db: 1.52.0
+
+  minimatch@9.0.9:
+    dependencies:
+      brace-expansion: 2.0.3
+
+  minipass@7.1.3: {}
+
+  mongodb-connection-string-url@3.0.2:
+    dependencies:
+      '@types/whatwg-url': 11.0.5
+      whatwg-url: 14.2.0
+
+  mongodb@6.21.0:
+    dependencies:
+      '@mongodb-js/saslprep': 1.4.6
+      bson: 6.10.4
+      mongodb-connection-string-url: 3.0.2
+
+  ms@2.1.3: {}
+
+  package-json-from-dist@1.0.1: {}
+
+  path-key@3.1.1: {}
+
+  path-scurry@1.11.1:
+    dependencies:
+      lru-cache: 10.4.3
+      minipass: 7.1.3
+
+  pg-connection-string@2.12.0: {}
+
+  pg-int8@1.0.1: {}
+
+  pg-pool@3.13.0(pg@8.20.0):
+    dependencies:
+      pg: 8.20.0
+
+  pg-protocol@1.13.0: {}
+
+  pg-types@2.2.0:
+    dependencies:
+      pg-int8: 1.0.1
+      postgres-array: 2.0.0
+      postgres-bytea: 1.0.1
+      postgres-date: 1.0.7
+      postgres-interval: 1.2.0
+
+  pg@8.20.0:
+    dependencies:
+      pg-connection-string: 2.12.0
+      pg-pool: 3.13.0(pg@8.20.0)
+      pg-protocol: 1.13.0
+      pg-types: 2.2.0
+      pgpass: 1.0.5
+
+  pgpass@1.0.5:
+    dependencies:
+      split2: 4.2.0
+
+  possible-typed-array-names@1.1.0: {}
+
+  postgres-array@2.0.0: {}
+
+  postgres-bytea@1.0.1: {}
+
+  postgres-date@1.0.7: {}
+
+  postgres-interval@1.2.0:
+    dependencies:
+      xtend: 4.0.2
+
+  proxy-from-env@2.1.0: {}
+
+  punycode@2.3.1: {}
+
+  reflect-metadata@0.1.14: {}
+
+  reflect-metadata@0.2.2: {}
+
+  require-directory@2.1.1: {}
+
+  safe-buffer@5.2.1: {}
+
+  semver@7.7.4: {}
+
+  set-function-length@1.2.2:
+    dependencies:
+      define-data-property: 1.1.4
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+      get-intrinsic: 1.3.0
+      gopd: 1.2.0
+      has-property-descriptors: 1.0.2
+
+  sha.js@2.4.12:
+    dependencies:
+      inherits: 2.0.4
+      safe-buffer: 5.2.1
+      to-buffer: 1.2.2
+
+  shebang-command@2.0.0:
+    dependencies:
+      shebang-regex: 3.0.0
+
+  shebang-regex@3.0.0: {}
+
+  signal-exit@4.1.0: {}
+
+  sparse-bitfield@3.0.3:
+    dependencies:
+      memory-pager: 1.5.0
+
+  split2@4.2.0: {}
+
+  sql-highlight@6.1.0: {}
+
+  string-width@4.2.3:
+    dependencies:
+      emoji-regex: 8.0.0
+      is-fullwidth-code-point: 3.0.0
+      strip-ansi: 6.0.1
+
+  string-width@5.1.2:
+    dependencies:
+      eastasianwidth: 0.2.0
+      emoji-regex: 9.2.2
+      strip-ansi: 7.2.0
+
+  strip-ansi@6.0.1:
+    dependencies:
+      ansi-regex: 5.0.1
+
+  strip-ansi@7.2.0:
+    dependencies:
+      ansi-regex: 6.2.2
+
+  to-buffer@1.2.2:
+    dependencies:
+      isarray: 2.0.5
+      safe-buffer: 5.2.1
+      typed-array-buffer: 1.0.3
+
+  tr46@5.1.1:
+    dependencies:
+      punycode: 2.3.1
+
+  tslib@2.8.1: {}
+
+  typed-array-buffer@1.0.3:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      is-typed-array: 1.1.15
+
+  typeorm@0.3.28(mongodb@6.21.0)(pg@8.20.0):
+    dependencies:
+      '@sqltools/formatter': 1.2.5
+      ansis: 4.2.0
+      app-root-path: 3.1.0
+      buffer: 6.0.3
+      dayjs: 1.11.20
+      debug: 4.4.3
+      dedent: 1.7.2
+      dotenv: 16.6.1
+      glob: 10.5.0
+      reflect-metadata: 0.2.2
+      sha.js: 2.4.12
+      sql-highlight: 6.1.0
+      tslib: 2.8.1
+      uuid: 11.1.0
+      yargs: 17.7.2
+    optionalDependencies:
+      mongodb: 6.21.0
+      pg: 8.20.0
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
+
+  typescript@5.9.3: {}
+
+  undici-types@5.26.5: {}
+
+  uuid@11.1.0: {}
+
+  webidl-conversions@7.0.0: {}
+
+  whatwg-url@14.2.0:
+    dependencies:
+      tr46: 5.1.1
+      webidl-conversions: 7.0.0
+
+  which-typed-array@1.1.20:
+    dependencies:
+      available-typed-arrays: 1.0.7
+      call-bind: 1.0.8
+      call-bound: 1.0.4
+      for-each: 0.3.5
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-tostringtag: 1.0.2
+
+  which@2.0.2:
+    dependencies:
+      isexe: 2.0.0
+
+  wrap-ansi@7.0.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+
+  wrap-ansi@8.1.0:
+    dependencies:
+      ansi-styles: 6.2.3
+      string-width: 5.1.2
+      strip-ansi: 7.2.0
+
+  xtend@4.0.2: {}
+
+  y18n@5.0.8: {}
+
+  yargs-parser@21.1.1: {}
+
+  yargs@17.7.2:
+    dependencies:
+      cliui: 8.0.1
+      escalade: 3.2.0
+      get-caller-file: 2.0.5
+      require-directory: 2.1.1
+      string-width: 4.2.3
+      y18n: 5.0.8
+      yargs-parser: 21.1.1

--- a/apps/monitor-dashboard/src/index.ts
+++ b/apps/monitor-dashboard/src/index.ts
@@ -1,8 +1,7 @@
 import 'reflect-metadata';
-import Koa from 'koa';
-import Router from '@koa/router';
-import cors from '@koa/cors';
-import bodyParser from 'koa-bodyparser';
+import { Hono } from 'hono';
+import { cors } from 'hono/cors';
+import { serve } from '@hono/node-server';
 
 import { AppDataSource } from './db';
 import { initMongo } from './mongo';
@@ -33,54 +32,45 @@ const bootstrap = async () => {
   await AppDataSource.initialize();
   await initMongo();
 
-  const app = new Koa();
-  const router = new Router({ prefix: '/dashboard' });
+  const app = new Hono();
 
   if (process.env.NODE_ENV !== 'production') {
     app.use(cors());
   }
 
-  app.use(bodyParser({ jsonLimit: '2mb' }));
-
   // Global error handler — return JSON instead of crashing
-  app.use(async (ctx, next) => {
-    try {
-      await next();
-    } catch (err: unknown) {
-      const axiosResp = (err as { response?: { status?: number; data?: unknown } })?.response;
-      const status = axiosResp?.status
-        || (err as { status?: number })?.status
-        || 500;
-      // Prefer upstream error body (e.g. PaaS Engine's {data:{error:"..."}})
-      const raw = axiosResp?.data as Record<string, unknown> | undefined;
-      const upstream = (raw && typeof raw === 'object' && 'data' in raw) ? raw.data as Record<string, unknown> : raw;
-      const message = (upstream && typeof upstream === 'object' && 'error' in upstream)
-        ? upstream.error
-        : err instanceof Error ? err.message : String(err);
-      ctx.status = status;
-      ctx.body = { message, status };
-    }
+  app.onError((err, c) => {
+    const axiosResp = (err as any)?.response;
+    const status = axiosResp?.status || (err as any)?.status || 500;
+    const raw = axiosResp?.data;
+    const upstream = (raw && typeof raw === 'object' && 'data' in raw) ? raw.data : raw;
+    const message = (upstream && typeof upstream === 'object' && 'error' in upstream)
+      ? upstream.error
+      : err.message;
+    return c.json({ message, status }, status);
   });
 
-  app.use(jwtAuth);
-  app.use(auditMiddleware);
+  // Auth & audit middleware on API routes
+  app.use('/dashboard/api/*', jwtAuth);
+  app.use('/dashboard/api/*', auditMiddleware);
 
-  router.use(authRoutes.routes());
-  router.use(configRoutes.routes());
-  router.use(messagesRoutes.routes());
-  router.use(providersRoutes.routes());
-  router.use(modelMappingsRoutes.routes());
-  router.use(mongoRoutes.routes());
-  router.use(migrationsRoutes.routes());
-  router.use(serviceStatusRoutes.routes());
-  router.use(operationsRoutes.routes());
-  router.use(auditLogsRoutes.routes());
-  router.use(activityRoutes.routes());
+  // Mount route sub-apps under /dashboard
+  const dashboard = new Hono();
+  dashboard.route('/', authRoutes);
+  dashboard.route('/', configRoutes);
+  dashboard.route('/', messagesRoutes);
+  dashboard.route('/', providersRoutes);
+  dashboard.route('/', modelMappingsRoutes);
+  dashboard.route('/', mongoRoutes);
+  dashboard.route('/', migrationsRoutes);
+  dashboard.route('/', serviceStatusRoutes);
+  dashboard.route('/', operationsRoutes);
+  dashboard.route('/', auditLogsRoutes);
+  dashboard.route('/', activityRoutes);
 
-  app.use(router.routes());
-  app.use(router.allowedMethods());
+  app.route('/dashboard', dashboard);
 
-  app.listen(PORT, () => {
+  serve({ fetch: app.fetch, port: PORT }, () => {
     console.log(`Monitor dashboard server running on ${PORT}`);
   });
 };

--- a/apps/monitor-dashboard/src/middleware/audit.ts
+++ b/apps/monitor-dashboard/src/middleware/audit.ts
@@ -1,4 +1,5 @@
 import type { MiddlewareHandler } from 'hono';
+import type { AppEnv } from '../types';
 import { AppDataSource } from '../db';
 import { AuditLog } from '../entities/audit-log';
 
@@ -38,7 +39,7 @@ const SKIP_PATHS = new Set([
   '/dashboard/api/health',
 ]);
 
-export const auditMiddleware: MiddlewareHandler = async (c, next) => {
+export const auditMiddleware: MiddlewareHandler<AppEnv> = async (c, next) => {
   if (SKIP_PATHS.has(c.req.path)) {
     return next();
   }
@@ -46,6 +47,14 @@ export const auditMiddleware: MiddlewareHandler = async (c, next) => {
   const start = Date.now();
   let result: 'success' | 'error' | 'denied' = 'success';
   let errorMessage: string | null = null;
+
+  // Pre-read body for audit logging (Hono caches parsed JSON)
+  let requestBody: Record<string, unknown> | null = null;
+  if (['POST', 'PUT', 'PATCH', 'DELETE'].includes(c.req.method)) {
+    try {
+      requestBody = await c.req.json();
+    } catch { /* no body or not JSON */ }
+  }
 
   try {
     await next();
@@ -74,24 +83,15 @@ export const auditMiddleware: MiddlewareHandler = async (c, next) => {
     const params: Record<string, unknown> = {};
 
     // Query params
-    const url = new URL(c.req.url);
-    const queryObj: Record<string, string> = {};
-    url.searchParams.forEach((v, k) => { queryObj[k] = v; });
+    const queryObj = c.req.queries();
     if (Object.keys(queryObj).length) params.query = queryObj;
 
-    // Request body (only for methods that typically have a body)
-    if (['POST', 'PUT', 'PATCH', 'DELETE'].includes(c.req.method)) {
-      try {
-        const reqBody = await c.req.json() as Record<string, unknown>;
-        if (reqBody && typeof reqBody === 'object' && Object.keys(reqBody).length) {
-          const body = { ...reqBody };
-          delete body.password;
-          delete body.api_key;
-          params.body = body;
-        }
-      } catch {
-        // No JSON body or already consumed — skip
-      }
+    // Request body (pre-read before next())
+    if (requestBody && typeof requestBody === 'object' && Object.keys(requestBody).length) {
+      const body = { ...requestBody };
+      delete body.password;
+      delete body.api_key;
+      params.body = body;
     }
 
     // Fire-and-forget audit write

--- a/apps/monitor-dashboard/src/middleware/audit.ts
+++ b/apps/monitor-dashboard/src/middleware/audit.ts
@@ -1,4 +1,4 @@
-import type { Middleware } from 'koa';
+import type { MiddlewareHandler } from 'hono';
 import { AppDataSource } from '../db';
 import { AuditLog } from '../entities/audit-log';
 
@@ -38,8 +38,8 @@ const SKIP_PATHS = new Set([
   '/dashboard/api/health',
 ]);
 
-export const auditMiddleware: Middleware = async (ctx, next) => {
-  if (!ctx.path.startsWith('/dashboard/api') || SKIP_PATHS.has(ctx.path)) {
+export const auditMiddleware: MiddlewareHandler = async (c, next) => {
+  if (SKIP_PATHS.has(c.req.path)) {
     return next();
   }
 
@@ -49,12 +49,17 @@ export const auditMiddleware: Middleware = async (ctx, next) => {
 
   try {
     await next();
-    if (ctx.status === 401 || ctx.status === 403) {
+    const status = c.res.status;
+    if (status === 401 || status === 403) {
       result = 'denied';
-    } else if (ctx.status >= 400) {
+    } else if (status >= 400) {
       result = 'error';
-      const body = ctx.body as Record<string, unknown> | undefined;
-      errorMessage = (body?.message as string) || `HTTP ${ctx.status}`;
+      try {
+        const resBody = await c.res.clone().json() as Record<string, unknown>;
+        errorMessage = (resBody?.message as string) || `HTTP ${status}`;
+      } catch {
+        errorMessage = `HTTP ${status}`;
+      }
     }
   } catch (err) {
     result = 'error';
@@ -62,19 +67,32 @@ export const auditMiddleware: Middleware = async (ctx, next) => {
     throw err;
   } finally {
     const duration = Date.now() - start;
-    const caller = ctx.state.caller || 'unknown';
-    const action = deriveAction(ctx.method, ctx.path);
+    const caller = c.get('caller') || 'unknown';
+    const action = deriveAction(c.req.method, c.req.path);
 
     // Build params — omit sensitive fields
     const params: Record<string, unknown> = {};
-    if (ctx.query && Object.keys(ctx.query).length) params.query = ctx.query;
-    if (ctx.request.body && typeof ctx.request.body === 'object' && Object.keys(ctx.request.body as object).length) {
-      const body = { ...(ctx.request.body as Record<string, unknown>) };
-      delete body.password;
-      delete body.api_key;
-      params.body = body;
+
+    // Query params
+    const url = new URL(c.req.url);
+    const queryObj: Record<string, string> = {};
+    url.searchParams.forEach((v, k) => { queryObj[k] = v; });
+    if (Object.keys(queryObj).length) params.query = queryObj;
+
+    // Request body (only for methods that typically have a body)
+    if (['POST', 'PUT', 'PATCH', 'DELETE'].includes(c.req.method)) {
+      try {
+        const reqBody = await c.req.json() as Record<string, unknown>;
+        if (reqBody && typeof reqBody === 'object' && Object.keys(reqBody).length) {
+          const body = { ...reqBody };
+          delete body.password;
+          delete body.api_key;
+          params.body = body;
+        }
+      } catch {
+        // No JSON body or already consumed — skip
+      }
     }
-    if (ctx.params && Object.keys(ctx.params).length) params.params = ctx.params;
 
     // Fire-and-forget audit write
     try {

--- a/apps/monitor-dashboard/src/middleware/jwt-auth.ts
+++ b/apps/monitor-dashboard/src/middleware/jwt-auth.ts
@@ -1,4 +1,4 @@
-import type { Middleware } from 'koa';
+import type { MiddlewareHandler } from 'hono';
 import jwt from 'jsonwebtoken';
 
 const PUBLIC_PATHS = new Set([
@@ -7,42 +7,35 @@ const PUBLIC_PATHS = new Set([
   '/dashboard/api/health',
 ]);
 
-export const jwtAuth: Middleware = async (ctx, next) => {
-  if (!ctx.path.startsWith('/dashboard/api')) {
-    return next();
-  }
-  if (PUBLIC_PATHS.has(ctx.path)) {
-    ctx.state.caller = 'public';
+export const jwtAuth: MiddlewareHandler = async (c, next) => {
+  if (PUBLIC_PATHS.has(c.req.path)) {
+    c.set('caller', 'public');
     return next();
   }
 
   // --- API Key auth (Claude Code) ---
-  const apiKey = ctx.get('x-api-key');
+  const apiKey = c.req.header('x-api-key');
   const ccToken = process.env.DASHBOARD_CC_TOKEN;
   if (apiKey && ccToken && apiKey === ccToken) {
-    ctx.state.caller = 'claude-code';
+    c.set('caller', 'claude-code');
     return next();
   }
 
   // --- JWT Bearer auth (Web Admin) ---
-  const authHeader = ctx.get('authorization') || ctx.get('Authorization');
+  const authHeader = c.req.header('authorization') || c.req.header('Authorization') || '';
   const token = authHeader.startsWith('Bearer ') ? authHeader.slice(7) : '';
 
   if (!token) {
-    ctx.status = 401;
-    ctx.body = { message: 'Unauthorized' };
-    return;
+    return c.json({ message: 'Unauthorized' }, 401);
   }
 
   try {
     const secret = process.env.DASHBOARD_JWT_SECRET!;
     const payload = jwt.verify(token, secret);
-    ctx.state.user = payload;
-    ctx.state.caller = 'web-admin';
+    c.set('user', payload);
+    c.set('caller', 'web-admin');
   } catch {
-    ctx.status = 401;
-    ctx.body = { message: 'Unauthorized' };
-    return;
+    return c.json({ message: 'Unauthorized' }, 401);
   }
 
   await next();

--- a/apps/monitor-dashboard/src/middleware/jwt-auth.ts
+++ b/apps/monitor-dashboard/src/middleware/jwt-auth.ts
@@ -1,5 +1,6 @@
 import type { MiddlewareHandler } from 'hono';
 import jwt from 'jsonwebtoken';
+import type { AppEnv } from '../types';
 
 const PUBLIC_PATHS = new Set([
   '/dashboard/api/auth/login',
@@ -7,7 +8,7 @@ const PUBLIC_PATHS = new Set([
   '/dashboard/api/health',
 ]);
 
-export const jwtAuth: MiddlewareHandler = async (c, next) => {
+export const jwtAuth: MiddlewareHandler<AppEnv> = async (c, next) => {
   if (PUBLIC_PATHS.has(c.req.path)) {
     c.set('caller', 'public');
     return next();

--- a/apps/monitor-dashboard/src/routes/activity.ts
+++ b/apps/monitor-dashboard/src/routes/activity.ts
@@ -1,7 +1,7 @@
-import Router from '@koa/router';
+import { Hono } from 'hono';
 import { AppDataSource, ConversationMessage, LarkGroupChatInfo, DiaryEntry, WeeklyReview } from '../db';
 
-const router = new Router();
+const app = new Hono();
 
 function msAgo(days: number): string {
   return String(Date.now() - days * 86400000);
@@ -18,8 +18,8 @@ function msToDateStr(ms: string | number): string {
 }
 
 /** GET /api/activity/overview — 群活跃度概览 */
-router.get('/api/activity/overview', async (ctx) => {
-  const days = Number(ctx.query.days) || 7;
+app.get('/api/activity/overview', async (c) => {
+  const days = Number(c.req.query('days')) || 7;
   const since = msAgo(days);
   const todayMs = todayStartMs();
 
@@ -91,7 +91,7 @@ router.get('/api/activity/overview', async (ctx) => {
         .map(([date, count]) => ({ date, count })),
     }));
 
-  ctx.body = {
+  return c.json({
     summary: {
       period_total: rows.length,
       today_total: todayTotal,
@@ -99,11 +99,11 @@ router.get('/api/activity/overview', async (ctx) => {
       today_active_groups: todayChats.size,
     },
     groups,
-  };
+  });
 });
 
 /** GET /api/activity/diary-status — 日记/周记生成状态 */
-router.get('/api/activity/diary-status', async (ctx) => {
+app.get('/api/activity/diary-status', async (c) => {
   const diaryRepo = AppDataSource.getRepository(DiaryEntry);
   const weeklyRepo = AppDataSource.getRepository(WeeklyReview);
 
@@ -165,10 +165,10 @@ router.get('/api/activity/diary-status', async (ctx) => {
     }
   }
 
-  ctx.body = {
+  return c.json({
     diary: [...diaryMap.entries()].map(([chat_id, v]) => ({ chat_id, ...v })),
     weekly: [...weeklyMap.entries()].map(([chat_id, v]) => ({ chat_id, ...v })),
-  };
+  });
 });
 
-export default router;
+export default app;

--- a/apps/monitor-dashboard/src/routes/audit-logs.ts
+++ b/apps/monitor-dashboard/src/routes/audit-logs.ts
@@ -1,20 +1,18 @@
-import Router from '@koa/router';
+import { Hono } from 'hono';
 import { AppDataSource } from '../db';
 import { AuditLog } from '../entities/audit-log';
 
-const router = new Router();
+const app = new Hono();
 
 /** GET /api/audit-logs — 查询审计日志，支持过滤和分页 */
-router.get('/api/audit-logs', async (ctx) => {
-  const {
-    caller,
-    action,
-    result,
-    from,
-    to,
-    page = '1',
-    pageSize = '50',
-  } = ctx.query as Record<string, string | undefined>;
+app.get('/api/audit-logs', async (c) => {
+  const caller = c.req.query('caller');
+  const action = c.req.query('action');
+  const result = c.req.query('result');
+  const from = c.req.query('from');
+  const to = c.req.query('to');
+  const page = c.req.query('page') || '1';
+  const pageSize = c.req.query('pageSize') || '50';
 
   const repo = AppDataSource.getRepository(AuditLog);
   const qb = repo.createQueryBuilder('log');
@@ -32,12 +30,12 @@ router.get('/api/audit-logs', async (ctx) => {
 
   const [items, total] = await qb.getManyAndCount();
 
-  ctx.body = {
+  return c.json({
     items,
     total,
     page: Number(page) || 1,
     pageSize: limit,
-  };
+  });
 });
 
-export default router;
+export default app;

--- a/apps/monitor-dashboard/src/routes/auth.ts
+++ b/apps/monitor-dashboard/src/routes/auth.ts
@@ -1,21 +1,19 @@
-import Router from '@koa/router';
+import { Hono } from 'hono';
 import jwt from 'jsonwebtoken';
 
-const router = new Router();
+const app = new Hono();
 
-router.post('/api/auth/login', async (ctx) => {
-  const { password } = ctx.request.body as { password?: string };
+app.post('/api/auth/login', async (c) => {
+  const { password } = (await c.req.json()) as { password?: string };
 
   if (!password || password !== process.env.DASHBOARD_ADMIN_PASSWORD) {
-    ctx.status = 401;
-    ctx.body = { message: 'Invalid password' };
-    return;
+    return c.json({ message: 'Invalid password' }, 401);
   }
 
   const secret = process.env.DASHBOARD_JWT_SECRET!;
   const token = jwt.sign({ role: 'admin' }, secret, { expiresIn: '7d' });
 
-  ctx.body = { token };
+  return c.json({ token });
 });
 
-export default router;
+export default app;

--- a/apps/monitor-dashboard/src/routes/config.ts
+++ b/apps/monitor-dashboard/src/routes/config.ts
@@ -1,26 +1,26 @@
-import Router from '@koa/router';
+import { Hono } from 'hono';
 
-const router = new Router();
+const app = new Hono();
 
-router.get('/api/config', async (ctx) => {
+app.get('/api/config', async (c) => {
   const grafanaHost = process.env.DASHBOARD_GRAFANA_HOST || '';
   const langfuseHost = process.env.DASHBOARD_LANGFUSE_HOST || '';
   const langfuseProjectId = process.env.DASHBOARD_LANGFUSE_PROJECT_ID || '';
 
-  ctx.body = {
+  return c.json({
     grafanaUrl: grafanaHost,
     kibanaUrl: grafanaHost,
     langfuseUrl: `${langfuseHost}/project/${langfuseProjectId}`,
-  };
+  });
 });
 
-router.get('/api/health', async (ctx) => {
-  ctx.body = {
+app.get('/api/health', async (c) => {
+  return c.json({
     status: 'ok',
     timestamp: new Date().toISOString(),
     service: 'monitor-dashboard',
     version: process.env.VERSION || process.env.GIT_SHA || 'unknown',
-  };
+  });
 });
 
-export default router;
+export default app;

--- a/apps/monitor-dashboard/src/routes/messages.ts
+++ b/apps/monitor-dashboard/src/routes/messages.ts
@@ -1,7 +1,7 @@
-import Router from '@koa/router';
+import { Hono } from 'hono';
 import { AppDataSource, ConversationMessage, LarkUser, LarkGroupChatInfo } from '../db';
 
-const router = new Router();
+const app = new Hono();
 
 const parseNumber = (value: string | undefined, defaultValue: number) => {
   if (!value) {
@@ -11,18 +11,18 @@ const parseNumber = (value: string | undefined, defaultValue: number) => {
   return Number.isNaN(parsed) ? defaultValue : parsed;
 };
 
-router.get('/api/messages', async (ctx) => {
-  const page = Math.max(1, parseNumber(ctx.query.page as string | undefined, 1));
-  const pageSize = Math.min(100, Math.max(1, parseNumber(ctx.query.pageSize as string | undefined, 20)));
-  const chatId = (ctx.query.chatId as string | undefined) || '';
-  const userId = (ctx.query.userId as string | undefined) || '';
-  const role = (ctx.query.role as string | undefined) || '';
-  const botName = (ctx.query.botName as string | undefined) || '';
-  const startTime = (ctx.query.startTime as string | undefined) || '';
-  const endTime = (ctx.query.endTime as string | undefined) || '';
-  const rootMessageId = (ctx.query.rootMessageId as string | undefined) || '';
-  const replyMessageId = (ctx.query.replyMessageId as string | undefined) || '';
-  const messageType = (ctx.query.messageType as string | undefined) || '';
+app.get('/api/messages', async (c) => {
+  const page = Math.max(1, parseNumber(c.req.query('page'), 1));
+  const pageSize = Math.min(100, Math.max(1, parseNumber(c.req.query('pageSize'), 20)));
+  const chatId = c.req.query('chatId') || '';
+  const userId = c.req.query('userId') || '';
+  const role = c.req.query('role') || '';
+  const botName = c.req.query('botName') || '';
+  const startTime = c.req.query('startTime') || '';
+  const endTime = c.req.query('endTime') || '';
+  const rootMessageId = c.req.query('rootMessageId') || '';
+  const replyMessageId = c.req.query('replyMessageId') || '';
+  const messageType = c.req.query('messageType') || '';
 
   const repo = AppDataSource.getRepository(ConversationMessage);
   const qb = repo
@@ -110,34 +110,34 @@ router.get('/api/messages', async (ctx) => {
     return { ...rest, chat_name };
   });
 
-  ctx.body = {
+  return c.json({
     data,
     total,
     page,
     pageSize,
-  };
+  });
 });
 
-router.get('/api/chats', async (ctx) => {
-  const keyword = ((ctx.query.keyword as string) || '').trim();
+app.get('/api/chats', async (c) => {
+  const keyword = (c.req.query('keyword') || '').trim();
   const repo = AppDataSource.getRepository(LarkGroupChatInfo);
   const qb = repo.createQueryBuilder('gc').select(['gc.chat_id AS chat_id', 'gc.name AS name']);
   if (keyword) {
     qb.where('gc.name ILIKE :kw', { kw: `%${keyword}%` });
   }
   qb.orderBy('gc.name', 'ASC').limit(30);
-  ctx.body = await qb.getRawMany();
+  return c.json(await qb.getRawMany());
 });
 
-router.get('/api/users', async (ctx) => {
-  const keyword = ((ctx.query.keyword as string) || '').trim();
+app.get('/api/users', async (c) => {
+  const keyword = (c.req.query('keyword') || '').trim();
   const repo = AppDataSource.getRepository(LarkUser);
   const qb = repo.createQueryBuilder('u').select(['u.union_id AS user_id', 'u.name AS name']);
   if (keyword) {
     qb.where('u.name ILIKE :kw', { kw: `%${keyword}%` });
   }
   qb.orderBy('u.name', 'ASC').limit(30);
-  ctx.body = await qb.getRawMany();
+  return c.json(await qb.getRawMany());
 });
 
-export default router;
+export default app;

--- a/apps/monitor-dashboard/src/routes/migrations.ts
+++ b/apps/monitor-dashboard/src/routes/migrations.ts
@@ -1,16 +1,16 @@
-import Router from '@koa/router';
+import { Hono } from 'hono';
 import { AppDataSource, SchemaMigration } from '../db';
 
-const router = new Router();
+const app = new Hono();
 
-router.get('/api/migrations', async (ctx) => {
+app.get('/api/migrations', async (c) => {
   const repo = AppDataSource.getRepository(SchemaMigration);
   const migrations = await repo.find({ order: { id: 'DESC' } });
-  ctx.body = migrations;
+  return c.json(migrations);
 });
 
-router.post('/api/migrations/run', async (ctx) => {
-  const { version, name, sql, applied_by } = ctx.request.body as {
+app.post('/api/migrations/run', async (c) => {
+  const { version, name, sql, applied_by } = (await c.req.json()) as {
     version?: string;
     name?: string;
     sql?: string;
@@ -18,18 +18,14 @@ router.post('/api/migrations/run', async (ctx) => {
   };
 
   if (!version || !name || !sql) {
-    ctx.status = 400;
-    ctx.body = { message: 'version, name, sql are required' };
-    return;
+    return c.json({ message: 'version, name, sql are required' }, 400);
   }
 
   const repo = AppDataSource.getRepository(SchemaMigration);
 
   const existing = await repo.findOne({ where: { version } });
   if (existing) {
-    ctx.status = 409;
-    ctx.body = { message: `Migration ${version} already applied` };
-    return;
+    return c.json({ message: `Migration ${version} already applied` }, 409);
   }
 
   const startTime = Date.now();
@@ -60,12 +56,10 @@ router.post('/api/migrations/run', async (ctx) => {
   await repo.save(record);
 
   if (status === 'failed') {
-    ctx.status = 500;
-    ctx.body = { message: errorMessage, record };
-    return;
+    return c.json({ message: errorMessage, record }, 500);
   }
 
-  ctx.body = record;
+  return c.json(record);
 });
 
-export default router;
+export default app;

--- a/apps/monitor-dashboard/src/routes/model-mappings.ts
+++ b/apps/monitor-dashboard/src/routes/model-mappings.ts
@@ -1,28 +1,26 @@
-import Router from '@koa/router';
+import { Hono } from 'hono';
 import { AppDataSource, ModelMapping } from '../db';
 
-const router = new Router();
+const app = new Hono();
 
-router.get('/api/model-mappings', async (ctx) => {
+app.get('/api/model-mappings', async (c) => {
   const repo = AppDataSource.getRepository(ModelMapping);
   const mappings = await repo.find({ order: { created_at: 'DESC' } });
-  ctx.body = mappings;
+  return c.json(mappings);
 });
 
-router.get('/api/model-mappings/:id', async (ctx) => {
+app.get('/api/model-mappings/:id', async (c) => {
   const repo = AppDataSource.getRepository(ModelMapping);
-  const mapping = await repo.findOne({ where: { id: ctx.params.id } });
+  const mapping = await repo.findOne({ where: { id: c.req.param('id') } });
   if (!mapping) {
-    ctx.status = 404;
-    ctx.body = { message: 'Not found' };
-    return;
+    return c.json({ message: 'Not found' }, 404);
   }
-  ctx.body = mapping;
+  return c.json(mapping);
 });
 
-router.post('/api/model-mappings', async (ctx) => {
+app.post('/api/model-mappings', async (c) => {
   const { alias, provider_name, real_model_name, description, model_config } =
-    ctx.request.body as {
+    (await c.req.json()) as {
       alias?: string;
       provider_name?: string;
       real_model_name?: string;
@@ -31,17 +29,13 @@ router.post('/api/model-mappings', async (ctx) => {
     };
 
   if (!alias || !provider_name || !real_model_name) {
-    ctx.status = 400;
-    ctx.body = { message: 'alias, provider_name, real_model_name are required' };
-    return;
+    return c.json({ message: 'alias, provider_name, real_model_name are required' }, 400);
   }
 
   const repo = AppDataSource.getRepository(ModelMapping);
   const existing = await repo.findOne({ where: { alias } });
   if (existing) {
-    ctx.status = 400;
-    ctx.body = { message: 'alias already exists' };
-    return;
+    return c.json({ message: 'alias already exists' }, 400);
   }
 
   const mapping = repo.create({
@@ -53,12 +47,12 @@ router.post('/api/model-mappings', async (ctx) => {
   });
 
   await repo.save(mapping);
-  ctx.body = mapping;
+  return c.json(mapping);
 });
 
-router.put('/api/model-mappings/:id', async (ctx) => {
+app.put('/api/model-mappings/:id', async (c) => {
   const { alias, provider_name, real_model_name, description, model_config } =
-    ctx.request.body as {
+    (await c.req.json()) as {
       alias?: string;
       provider_name?: string;
       real_model_name?: string;
@@ -67,19 +61,15 @@ router.put('/api/model-mappings/:id', async (ctx) => {
     };
 
   const repo = AppDataSource.getRepository(ModelMapping);
-  const mapping = await repo.findOne({ where: { id: ctx.params.id } });
+  const mapping = await repo.findOne({ where: { id: c.req.param('id') } });
   if (!mapping) {
-    ctx.status = 404;
-    ctx.body = { message: 'Not found' };
-    return;
+    return c.json({ message: 'Not found' }, 404);
   }
 
   if (alias !== undefined && alias !== mapping.alias) {
     const existing = await repo.findOne({ where: { alias } });
     if (existing) {
-      ctx.status = 400;
-      ctx.body = { message: 'alias already exists' };
-      return;
+      return c.json({ message: 'alias already exists' }, 400);
     }
     mapping.alias = alias;
   }
@@ -97,20 +87,18 @@ router.put('/api/model-mappings/:id', async (ctx) => {
   }
 
   await repo.save(mapping);
-  ctx.body = mapping;
+  return c.json(mapping);
 });
 
-router.delete('/api/model-mappings/:id', async (ctx) => {
+app.delete('/api/model-mappings/:id', async (c) => {
   const repo = AppDataSource.getRepository(ModelMapping);
-  const mapping = await repo.findOne({ where: { id: ctx.params.id } });
+  const mapping = await repo.findOne({ where: { id: c.req.param('id') } });
   if (!mapping) {
-    ctx.status = 404;
-    ctx.body = { message: 'Not found' };
-    return;
+    return c.json({ message: 'Not found' }, 404);
   }
 
   await repo.remove(mapping);
-  ctx.body = { success: true };
+  return c.json({ success: true });
 });
 
-export default router;
+export default app;

--- a/apps/monitor-dashboard/src/routes/mongo.ts
+++ b/apps/monitor-dashboard/src/routes/mongo.ts
@@ -1,7 +1,7 @@
-import Router from '@koa/router';
+import { Hono } from 'hono';
 import { queryLarkEvents } from '../mongo';
 
-const router = new Router();
+const app = new Hono();
 
 const parseNumber = (value: unknown, fallback: number) => {
   if (typeof value === 'number') {
@@ -14,8 +14,8 @@ const parseNumber = (value: unknown, fallback: number) => {
   return fallback;
 };
 
-router.post('/api/mongo/query', async (ctx) => {
-  const body = (ctx.request.body || {}) as {
+app.post('/api/mongo/query', async (c) => {
+  const body = ((await c.req.json()) || {}) as {
     filter?: Record<string, unknown>;
     projection?: Record<string, unknown>;
     sort?: Record<string, unknown>;
@@ -35,16 +35,15 @@ router.post('/api/mongo/query', async (ctx) => {
       limit: pageSize,
     });
 
-    ctx.body = {
+    return c.json({
       data,
       total,
       page,
       pageSize,
-    };
+    });
   } catch (error) {
-    ctx.status = 400;
-    ctx.body = { message: (error as Error).message };
+    return c.json({ message: (error as Error).message }, 400);
   }
 });
 
-export default router;
+export default app;

--- a/apps/monitor-dashboard/src/routes/operations.ts
+++ b/apps/monitor-dashboard/src/routes/operations.ts
@@ -1,160 +1,149 @@
-import Router from '@koa/router';
+import { Hono } from 'hono';
 import { paasClient, larkClient } from '../paas-client';
 
-const router = new Router();
+const app = new Hono();
 
 // ---------- 读操作 ----------
 
 /** GET /api/ops/services — 全部服务 + Release 状态 */
-router.get('/api/ops/services', async (ctx) => {
+app.get('/api/ops/services', async (c) => {
   const [apps, releases] = await Promise.all([
     paasClient.get('/api/paas/apps/'),
     paasClient.get('/api/paas/releases/'),
   ]);
-  ctx.body = { apps, releases };
+  return c.json({ apps, releases });
 });
 
 /** GET /api/ops/services/:app/pods — 指定服务的 Pod 状态 */
-router.get('/api/ops/services/:app/pods', async (ctx) => {
-  const { app } = ctx.params;
-  const lane = (ctx.query.lane as string) || 'prod';
+app.get('/api/ops/services/:app/pods', async (c) => {
+  const appName = c.req.param('app');
+  const lane = c.req.query('lane') || 'prod';
 
   // Step 1: find release ID
-  const releases = (await paasClient.get('/api/paas/releases/', { app, lane })) as Array<{ id: string }>;
+  const releases = (await paasClient.get('/api/paas/releases/', { app: appName, lane })) as Array<{ id: string }>;
   if (!Array.isArray(releases) || releases.length === 0) {
-    ctx.status = 404;
-    ctx.body = { message: `No release found for ${app} in lane ${lane}` };
-    return;
+    return c.json({ message: `No release found for ${appName} in lane ${lane}` }, 404);
   }
 
   // Step 2: get pod status
   const status = await paasClient.get(`/api/paas/releases/${releases[0].id}/status`);
-  ctx.body = status;
+  return c.json(status);
 });
 
 /** GET /api/ops/builds/:app/latest — 最近成功构建 */
-router.get('/api/ops/builds/:app/latest', async (ctx) => {
-  const { app } = ctx.params;
-  const data = await paasClient.get(`/api/paas/apps/${app}/builds/latest`);
-  ctx.body = data;
+app.get('/api/ops/builds/:app/latest', async (c) => {
+  const appName = c.req.param('app');
+  const data = await paasClient.get(`/api/paas/apps/${appName}/builds/latest`);
+  return c.json(data);
 });
 
 /** POST /api/ops/db-query — 只读 SQL 查询 */
-router.post('/api/ops/db-query', async (ctx) => {
-  const { sql, db } = ctx.request.body as { sql?: string; db?: string };
+app.post('/api/ops/db-query', async (c) => {
+  const { sql, db } = (await c.req.json()) as { sql?: string; db?: string };
   if (!sql) {
-    ctx.status = 400;
-    ctx.body = { message: 'sql is required' };
-    return;
+    return c.json({ message: 'sql is required' }, 400);
   }
 
   // Basic safety: block write operations
   const normalized = sql.trim().toUpperCase();
   const forbidden = ['INSERT', 'UPDATE', 'DELETE', 'DROP', 'ALTER', 'TRUNCATE', 'CREATE', 'GRANT', 'REVOKE'];
   if (forbidden.some((kw) => normalized.startsWith(kw))) {
-    ctx.status = 403;
-    ctx.body = { message: 'Only SELECT queries are allowed' };
-    return;
+    return c.json({ message: 'Only SELECT queries are allowed' }, 403);
   }
 
   const data = await paasClient.post('/api/paas/ops/query', {
     sql,
     db: db || 'paas_engine',
   });
-  ctx.body = data;
+  return c.json(data);
 });
 
 /** GET /api/ops/lane-bindings — 列出泳道绑定 */
-router.get('/api/ops/lane-bindings', async (ctx) => {
+app.get('/api/ops/lane-bindings', async (c) => {
   const data = await larkClient.get('/api/lark/lane-bindings');
-  ctx.body = data;
+  return c.json(data);
 });
 
 // ---------- DDL/DML 变更审批 ----------
 
 /** 从请求中提取需要转发的 x-lane header */
-function laneHeaders(ctx: { headers: Record<string, string | string[] | undefined> }): Record<string, string> | undefined {
-  const lane = ctx.headers['x-lane'];
-  return lane ? { 'x-lane': String(lane) } : undefined;
+function laneHeaders(c: { req: { header: (name: string) => string | undefined } }): Record<string, string> | undefined {
+  const lane = c.req.header('x-lane');
+  return lane ? { 'x-lane': lane } : undefined;
 }
 
 /** POST /api/ops/db-mutations — 提交 DDL/DML 变更申请 */
-router.post('/api/ops/db-mutations', async (ctx) => {
-  const data = await paasClient.post('/api/paas/ops/mutations', ctx.request.body, laneHeaders(ctx));
-  ctx.body = data;
+app.post('/api/ops/db-mutations', async (c) => {
+  const data = await paasClient.post('/api/paas/ops/mutations', await c.req.json(), laneHeaders(c));
+  return c.json(data);
 });
 
 /** GET /api/ops/db-mutations — 列出变更申请（可选 ?status=pending） */
-router.get('/api/ops/db-mutations', async (ctx) => {
+app.get('/api/ops/db-mutations', async (c) => {
   const params: Record<string, string> = {};
-  if (ctx.query.status) params.status = ctx.query.status as string;
-  const data = await paasClient.get('/api/paas/ops/mutations', params, laneHeaders(ctx));
-  ctx.body = data;
+  const status = c.req.query('status');
+  if (status) params.status = status;
+  const data = await paasClient.get('/api/paas/ops/mutations', params, laneHeaders(c));
+  return c.json(data);
 });
 
 /** GET /api/ops/db-mutations/:id — 查看单条变更详情 */
-router.get('/api/ops/db-mutations/:id', async (ctx) => {
-  const data = await paasClient.get(`/api/paas/ops/mutations/${ctx.params.id}`, undefined, laneHeaders(ctx));
-  ctx.body = data;
+app.get('/api/ops/db-mutations/:id', async (c) => {
+  const data = await paasClient.get(`/api/paas/ops/mutations/${c.req.param('id')}`, undefined, laneHeaders(c));
+  return c.json(data);
 });
 
 /** POST /api/ops/db-mutations/:id/approve — 审批通过并执行 */
-router.post('/api/ops/db-mutations/:id/approve', async (ctx) => {
-  const data = await paasClient.post(`/api/paas/ops/mutations/${ctx.params.id}/approve`, ctx.request.body, laneHeaders(ctx));
-  ctx.body = data;
+app.post('/api/ops/db-mutations/:id/approve', async (c) => {
+  const data = await paasClient.post(`/api/paas/ops/mutations/${c.req.param('id')}/approve`, await c.req.json(), laneHeaders(c));
+  return c.json(data);
 });
 
 /** POST /api/ops/db-mutations/:id/reject — 拒绝变更 */
-router.post('/api/ops/db-mutations/:id/reject', async (ctx) => {
-  const data = await paasClient.post(`/api/paas/ops/mutations/${ctx.params.id}/reject`, ctx.request.body, laneHeaders(ctx));
-  ctx.body = data;
+app.post('/api/ops/db-mutations/:id/reject', async (c) => {
+  const data = await paasClient.post(`/api/paas/ops/mutations/${c.req.param('id')}/reject`, await c.req.json(), laneHeaders(c));
+  return c.json(data);
 });
 
 // ---------- 写操作 ----------
 
 /** POST /api/ops/lane-bindings — 绑定泳道 */
-router.post('/api/ops/lane-bindings', async (ctx) => {
-  const { route_type, route_key, lane_name } = ctx.request.body as {
+app.post('/api/ops/lane-bindings', async (c) => {
+  const { route_type, route_key, lane_name } = (await c.req.json()) as {
     route_type?: string;
     route_key?: string;
     lane_name?: string;
   };
   if (!route_type || !route_key || !lane_name) {
-    ctx.status = 400;
-    ctx.body = { message: 'route_type, route_key, and lane_name are required' };
-    return;
+    return c.json({ message: 'route_type, route_key, and lane_name are required' }, 400);
   }
   const data = await larkClient.post('/api/lark/lane-bindings', {
     route_type,
     route_key,
     lane_name,
   });
-  ctx.body = data;
+  return c.json(data);
 });
 
 /** DELETE /api/ops/lane-bindings — 解绑泳道 */
-router.delete('/api/ops/lane-bindings', async (ctx) => {
-  const type = ctx.query.type as string;
-  const key = ctx.query.key as string;
+app.delete('/api/ops/lane-bindings', async (c) => {
+  const type = c.req.query('type');
+  const key = c.req.query('key');
   if (!type || !key) {
-    ctx.status = 400;
-    ctx.body = { message: 'type and key query params are required' };
-    return;
+    return c.json({ message: 'type and key query params are required' }, 400);
   }
   const data = await larkClient.del('/api/lark/lane-bindings', { type, key });
-  ctx.body = data;
+  return c.json(data);
 });
 
 /** POST /api/ops/trigger-diary — 触发日记生成 */
-router.post('/api/ops/trigger-diary', async (ctx) => {
-  const { chat_id, target_date } = ctx.request.body as {
+app.post('/api/ops/trigger-diary', async (c) => {
+  const { chat_id, target_date } = (await c.req.json()) as {
     chat_id?: string;
     target_date?: string;
   };
   if (!chat_id) {
-    ctx.status = 400;
-    ctx.body = { message: 'chat_id is required' };
-    return;
+    return c.json({ message: 'chat_id is required' }, 400);
   }
   const params: Record<string, string> = { chat_id };
   if (target_date) params.target_date = target_date;
@@ -162,19 +151,17 @@ router.post('/api/ops/trigger-diary', async (ctx) => {
   const data = await paasClient.post(
     `/api/agent/admin/trigger-diary?${new URLSearchParams(params).toString()}`,
   );
-  ctx.body = data;
+  return c.json(data);
 });
 
 /** POST /api/ops/trigger-weekly-review — 触发周记生成 */
-router.post('/api/ops/trigger-weekly-review', async (ctx) => {
-  const { chat_id, week_start } = ctx.request.body as {
+app.post('/api/ops/trigger-weekly-review', async (c) => {
+  const { chat_id, week_start } = (await c.req.json()) as {
     chat_id?: string;
     week_start?: string;
   };
   if (!chat_id) {
-    ctx.status = 400;
-    ctx.body = { message: 'chat_id is required' };
-    return;
+    return c.json({ message: 'chat_id is required' }, 400);
   }
   const params: Record<string, string> = { chat_id };
   if (week_start) params.week_start = week_start;
@@ -182,7 +169,7 @@ router.post('/api/ops/trigger-weekly-review', async (ctx) => {
   const data = await paasClient.post(
     `/api/agent/admin/trigger-weekly-review?${new URLSearchParams(params).toString()}`,
   );
-  ctx.body = data;
+  return c.json(data);
 });
 
-export default router;
+export default app;

--- a/apps/monitor-dashboard/src/routes/providers.ts
+++ b/apps/monitor-dashboard/src/routes/providers.ts
@@ -1,8 +1,8 @@
-import Router from '@koa/router';
+import { Hono } from 'hono';
 import { AppDataSource, ModelProvider } from '../db';
 import { randomUUID } from 'crypto';
 
-const router = new Router();
+const app = new Hono();
 
 const maskApiKey = (apiKey: string) => {
   if (!apiKey) {
@@ -14,31 +14,29 @@ const maskApiKey = (apiKey: string) => {
 
 const allowedClientTypes = new Set(['openai', 'openai-responses', 'deepseek', 'ark', 'azure-http', 'google']);
 
-router.get('/api/providers', async (ctx) => {
+app.get('/api/providers', async (c) => {
   const repo = AppDataSource.getRepository(ModelProvider);
   const providers = await repo.find({ order: { created_at: 'DESC' } });
-  ctx.body = providers.map((provider) => ({
+  return c.json(providers.map((provider) => ({
     ...provider,
     api_key: maskApiKey(provider.api_key),
-  }));
+  })));
 });
 
-router.get('/api/providers/:id', async (ctx) => {
+app.get('/api/providers/:id', async (c) => {
   const repo = AppDataSource.getRepository(ModelProvider);
-  const provider = await repo.findOne({ where: { provider_id: ctx.params.id } });
+  const provider = await repo.findOne({ where: { provider_id: c.req.param('id') } });
   if (!provider) {
-    ctx.status = 404;
-    ctx.body = { message: 'Not found' };
-    return;
+    return c.json({ message: 'Not found' }, 404);
   }
-  ctx.body = {
+  return c.json({
     ...provider,
     api_key: maskApiKey(provider.api_key),
-  };
+  });
 });
 
-router.post('/api/providers', async (ctx) => {
-  const { name, api_key, base_url, client_type, is_active } = ctx.request.body as {
+app.post('/api/providers', async (c) => {
+  const { name, api_key, base_url, client_type, is_active } = (await c.req.json()) as {
     name?: string;
     api_key?: string;
     base_url?: string;
@@ -47,16 +45,12 @@ router.post('/api/providers', async (ctx) => {
   };
 
   if (!name || !base_url || !api_key) {
-    ctx.status = 400;
-    ctx.body = { message: 'name, base_url, api_key are required' };
-    return;
+    return c.json({ message: 'name, base_url, api_key are required' }, 400);
   }
 
   const resolvedClientType = (client_type || 'openai').toLowerCase();
   if (!allowedClientTypes.has(resolvedClientType)) {
-    ctx.status = 400;
-    ctx.body = { message: 'Invalid client_type' };
-    return;
+    return c.json({ message: 'Invalid client_type' }, 400);
   }
 
   const repo = AppDataSource.getRepository(ModelProvider);
@@ -71,14 +65,14 @@ router.post('/api/providers', async (ctx) => {
 
   await repo.save(provider);
 
-  ctx.body = {
+  return c.json({
     ...provider,
     api_key: maskApiKey(provider.api_key),
-  };
+  });
 });
 
-router.put('/api/providers/:id', async (ctx) => {
-  const { name, api_key, base_url, client_type, is_active } = ctx.request.body as {
+app.put('/api/providers/:id', async (c) => {
+  const { name, api_key, base_url, client_type, is_active } = (await c.req.json()) as {
     name?: string;
     api_key?: string;
     base_url?: string;
@@ -87,11 +81,9 @@ router.put('/api/providers/:id', async (ctx) => {
   };
 
   const repo = AppDataSource.getRepository(ModelProvider);
-  const provider = await repo.findOne({ where: { provider_id: ctx.params.id } });
+  const provider = await repo.findOne({ where: { provider_id: c.req.param('id') } });
   if (!provider) {
-    ctx.status = 404;
-    ctx.body = { message: 'Not found' };
-    return;
+    return c.json({ message: 'Not found' }, 404);
   }
 
   if (name !== undefined) {
@@ -106,9 +98,7 @@ router.put('/api/providers/:id', async (ctx) => {
   if (client_type !== undefined) {
     const resolvedClientType = client_type.toLowerCase();
     if (!allowedClientTypes.has(resolvedClientType)) {
-      ctx.status = 400;
-      ctx.body = { message: 'Invalid client_type' };
-      return;
+      return c.json({ message: 'Invalid client_type' }, 400);
     }
     provider.client_type = resolvedClientType;
   }
@@ -118,23 +108,21 @@ router.put('/api/providers/:id', async (ctx) => {
 
   await repo.save(provider);
 
-  ctx.body = {
+  return c.json({
     ...provider,
     api_key: maskApiKey(provider.api_key),
-  };
+  });
 });
 
-router.delete('/api/providers/:id', async (ctx) => {
+app.delete('/api/providers/:id', async (c) => {
   const repo = AppDataSource.getRepository(ModelProvider);
-  const provider = await repo.findOne({ where: { provider_id: ctx.params.id } });
+  const provider = await repo.findOne({ where: { provider_id: c.req.param('id') } });
   if (!provider) {
-    ctx.status = 404;
-    ctx.body = { message: 'Not found' };
-    return;
+    return c.json({ message: 'Not found' }, 404);
   }
 
   await repo.remove(provider);
-  ctx.body = { success: true };
+  return c.json({ success: true });
 });
 
-export default router;
+export default app;

--- a/apps/monitor-dashboard/src/routes/service-status.ts
+++ b/apps/monitor-dashboard/src/routes/service-status.ts
@@ -1,16 +1,14 @@
-import Router from '@koa/router';
+import { Hono } from 'hono';
 import axios from 'axios';
 
-const router = new Router();
+const app = new Hono();
 
-router.get('/api/service-status', async (ctx) => {
+app.get('/api/service-status', async (c) => {
   const paasApi = process.env.DASHBOARD_PAAS_API;
   const paasToken = process.env.DASHBOARD_PAAS_TOKEN;
 
   if (!paasApi || !paasToken) {
-    ctx.status = 500;
-    ctx.body = { message: 'DASHBOARD_PAAS_API or DASHBOARD_PAAS_TOKEN not configured' };
-    return;
+    return c.json({ message: 'DASHBOARD_PAAS_API or DASHBOARD_PAAS_TOKEN not configured' }, 500);
   }
 
   const headers = { 'X-API-Key': paasToken };
@@ -21,10 +19,10 @@ router.get('/api/service-status', async (ctx) => {
     axios.get(`${paasApi}/api/paas/releases/`, { headers, timeout }),
   ]);
 
-  ctx.body = {
+  return c.json({
     apps: appsRes.data?.data ?? appsRes.data,
     releases: releasesRes.data?.data ?? releasesRes.data,
-  };
+  });
 });
 
-export default router;
+export default app;

--- a/apps/monitor-dashboard/src/types.ts
+++ b/apps/monitor-dashboard/src/types.ts
@@ -1,0 +1,6 @@
+export type AppEnv = {
+  Variables: {
+    caller: string;
+    user: unknown;
+  };
+};

--- a/bun.lock
+++ b/bun.lock
@@ -27,8 +27,6 @@
       "dependencies": {
         "@inner/pixiv-client": "workspace:*",
         "@inner/shared": "workspace:*",
-        "@koa/cors": "^5.0.0",
-        "@koa/router": "^12.0.1",
         "@larksuiteoapi/node-sdk": "^1.23.0",
         "@volcengine/tos-sdk": "^0.0.0-preview-2.7.7-20251211024611",
         "ali-oss": "^6.23.0",
@@ -38,9 +36,8 @@
         "dayjs": "^1.11.13",
         "feishu-card": "1.0.1",
         "form-data": "^4.0.5",
+        "hono": "^4.7.0",
         "ioredis": "^5.3.2",
-        "koa": "^2.14.2",
-        "koa-body": "^6.0.1",
         "lodash": "^4.17.23",
         "mongodb": "^5.8.0",
         "node-cron": "^4.2.1",
@@ -56,9 +53,6 @@
         "@types/ali-oss": "^6.16.11",
         "@types/amqplib": "^0.10.6",
         "@types/bun": "latest",
-        "@types/koa": "^2.15.0",
-        "@types/koa__cors": "^5.0.0",
-        "@types/koa__router": "^12.0.4",
         "@types/lodash": "^4.17.13",
         "@types/node-cron": "^3.0.11",
         "@types/supertest": "^6.0.3",
@@ -152,18 +146,17 @@
         "winston": "^3.11.0",
       },
       "devDependencies": {
-        "@types/koa": "^2.15.0",
         "@types/node": "^18.0.0",
         "@types/uuid": "^10.0.0",
         "typescript": "^5.6.3",
       },
       "peerDependencies": {
-        "koa": "^2.14.2",
+        "hono": "^4.0.0",
         "pg": "^8.11.3",
         "typeorm": "^0.3.17",
       },
       "optionalPeers": [
-        "koa",
+        "hono",
         "pg",
         "typeorm",
       ],
@@ -458,8 +451,6 @@
 
     "@types/bun": ["@types/bun@1.3.10", "https://bnpm.byted.org/@types/bun/-/bun-1.3.10.tgz", { "dependencies": { "bun-types": "1.3.10" } }, "sha512-0+rlrUrOrTSskibryHbvQkDOWRJwJZqZlxrUs1u4oOoTln8+WIXBPmAuCF35SWB2z4Zl3E84Nl/D0P7803nigQ=="],
 
-    "@types/co-body": ["@types/co-body@6.1.3", "https://bnpm.byted.org/@types/co-body/-/co-body-6.1.3.tgz", { "dependencies": { "@types/node": "*", "@types/qs": "*" } }, "sha512-UhuhrQ5hclX6UJctv5m4Rfp52AfG9o9+d9/HwjxhVB5NjXxr5t9oKgJxN8xRHgr35oo8meUEHUPFWiKg6y71aA=="],
-
     "@types/connect": ["@types/connect@3.4.38", "https://bnpm.byted.org/@types/connect/-/connect-3.4.38.tgz", { "dependencies": { "@types/node": "*" } }, "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug=="],
 
     "@types/content-disposition": ["@types/content-disposition@0.5.9", "https://bnpm.byted.org/@types/content-disposition/-/content-disposition-0.5.9.tgz", {}, "sha512-8uYXI3Gw35MhiVYhG3s295oihrxRyytcRHjSjqnqZVDDy/xcGBRny7+Xj1Wgfhv5QzRtN2hB2dVRBUX9XW3UcQ=="],
@@ -473,8 +464,6 @@
     "@types/express": ["@types/express@5.0.6", "https://bnpm.byted.org/@types/express/-/express-5.0.6.tgz", { "dependencies": { "@types/body-parser": "*", "@types/express-serve-static-core": "^5.0.0", "@types/serve-static": "^2" } }, "sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA=="],
 
     "@types/express-serve-static-core": ["@types/express-serve-static-core@5.1.1", "https://bnpm.byted.org/@types/express-serve-static-core/-/express-serve-static-core-5.1.1.tgz", { "dependencies": { "@types/node": "*", "@types/qs": "*", "@types/range-parser": "*", "@types/send": "*" } }, "sha512-v4zIMr/cX7/d2BpAEX3KNKL/JrT1s43s96lLvvdTmza1oEvDudCqK9aF/djc/SWgy8Yh0h30TZx5VpzqFCxk5A=="],
-
-    "@types/formidable": ["@types/formidable@2.0.6", "https://bnpm.byted.org/@types/formidable/-/formidable-2.0.6.tgz", { "dependencies": { "@types/node": "*" } }, "sha512-L4HcrA05IgQyNYJj6kItuIkXrInJvsXTPC5B1i64FggWKKqSL+4hgt7asiSNva75AoLQjq29oPxFfU4GAQ6Z2w=="],
 
     "@types/http-assert": ["@types/http-assert@1.5.6", "https://bnpm.byted.org/@types/http-assert/-/http-assert-1.5.6.tgz", {}, "sha512-TTEwmtjgVbYAzZYWyeHPrrtWnfVkm8tQkP8P21uQifPgMRgjrow3XDEYqucuC8SKZJT7pUnhU/JymvjggxO9vw=="],
 
@@ -580,7 +569,7 @@
 
     "ansi-escapes": ["ansi-escapes@7.3.0", "https://bnpm.byted.org/ansi-escapes/-/ansi-escapes-7.3.0.tgz", { "dependencies": { "environment": "^1.0.0" } }, "sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg=="],
 
-    "ansi-regex": ["ansi-regex@5.0.1", "https://bnpm.byted.org/ansi-regex/-/ansi-regex-5.0.1.tgz", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+    "ansi-regex": ["ansi-regex@6.2.2", "https://bnpm.byted.org/ansi-regex/-/ansi-regex-6.2.2.tgz", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
 
     "ansi-styles": ["ansi-styles@4.3.0", "https://bnpm.byted.org/ansi-styles/-/ansi-styles-4.3.0.tgz", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
@@ -894,7 +883,7 @@
 
     "http-assert": ["http-assert@1.5.0", "https://bnpm.byted.org/http-assert/-/http-assert-1.5.0.tgz", { "dependencies": { "deep-equal": "~1.0.1", "http-errors": "~1.8.0" } }, "sha512-uPpH7OKX4H25hBmU6G1jWNaqJGpTXxey+YOUizJUAgu0AjLUeC8D73hTrhvDS5D+GJN1DN1+hhc/eF/wpxtp0w=="],
 
-    "http-errors": ["http-errors@1.8.1", "https://bnpm.byted.org/http-errors/-/http-errors-1.8.1.tgz", { "dependencies": { "depd": "~1.1.2", "inherits": "2.0.4", "setprototypeof": "1.2.0", "statuses": ">= 1.5.0 < 2", "toidentifier": "1.0.1" } }, "sha512-Kpk9Sm7NmI+RHhnj6OIWDI1d6fIoFAtFt9RLaTMRlg/8w49juAStsrBgp0Dp4OdxdVbRIeKhtCUvoi/RuAhO4g=="],
+    "http-errors": ["http-errors@2.0.1", "https://bnpm.byted.org/http-errors/-/http-errors-2.0.1.tgz", { "dependencies": { "depd": "~2.0.0", "inherits": "~2.0.4", "setprototypeof": "~1.2.0", "statuses": "~2.0.2", "toidentifier": "~1.0.1" } }, "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ=="],
 
     "http-proxy": ["http-proxy@1.18.1", "https://bnpm.byted.org/http-proxy/-/http-proxy-1.18.1.tgz", { "dependencies": { "eventemitter3": "^4.0.0", "follow-redirects": "^1.0.0", "requires-port": "^1.0.0" } }, "sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ=="],
 
@@ -952,7 +941,7 @@
 
     "is-typed-array": ["is-typed-array@1.1.15", "https://bnpm.byted.org/is-typed-array/-/is-typed-array-1.1.15.tgz", { "dependencies": { "which-typed-array": "^1.1.16" } }, "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ=="],
 
-    "isarray": ["isarray@2.0.5", "https://bnpm.byted.org/isarray/-/isarray-2.0.5.tgz", {}, "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="],
+    "isarray": ["isarray@1.0.0", "https://bnpm.byted.org/isarray/-/isarray-1.0.0.tgz", {}, "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="],
 
     "isexe": ["isexe@2.0.0", "https://bnpm.byted.org/isexe/-/isexe-2.0.0.tgz", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
 
@@ -991,8 +980,6 @@
     "keyv": ["keyv@4.5.4", "https://bnpm.byted.org/keyv/-/keyv-4.5.4.tgz", { "dependencies": { "json-buffer": "3.0.1" } }, "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw=="],
 
     "koa": ["koa@2.16.3", "https://bnpm.byted.org/koa/-/koa-2.16.3.tgz", { "dependencies": { "accepts": "^1.3.5", "cache-content-type": "^1.0.0", "content-disposition": "~0.5.2", "content-type": "^1.0.4", "cookies": "~0.9.0", "debug": "^4.3.2", "delegates": "^1.0.0", "depd": "^2.0.0", "destroy": "^1.0.4", "encodeurl": "^1.0.2", "escape-html": "^1.0.3", "fresh": "~0.5.2", "http-assert": "^1.3.0", "http-errors": "^1.6.3", "is-generator-function": "^1.0.7", "koa-compose": "^4.1.0", "koa-convert": "^2.0.0", "on-finished": "^2.3.0", "only": "~0.0.2", "parseurl": "^1.3.2", "statuses": "^1.5.0", "type-is": "^1.6.16", "vary": "^1.1.2" } }, "sha512-zPPuIt+ku1iCpFBRwseMcPYQ1cJL8l60rSmKeOuGfOXyE6YnTBmf2aEFNL2HQGrD0cPcLO/t+v9RTgC+fwEh/g=="],
-
-    "koa-body": ["koa-body@6.0.1", "https://bnpm.byted.org/koa-body/-/koa-body-6.0.1.tgz", { "dependencies": { "@types/co-body": "^6.1.0", "@types/formidable": "^2.0.5", "@types/koa": "^2.13.5", "co-body": "^6.1.0", "formidable": "^2.0.1", "zod": "^3.19.1" } }, "sha512-M8ZvMD8r+kPHy28aWP9VxL7kY8oPWA+C7ZgCljrCMeaU7uX6wsIQgDHskyrAr9sw+jqnIXyv4Mlxri5R4InIJg=="],
 
     "koa-bodyparser": ["koa-bodyparser@4.4.1", "https://bnpm.byted.org/koa-bodyparser/-/koa-bodyparser-4.4.1.tgz", { "dependencies": { "co-body": "^6.0.0", "copy-to": "^2.0.1", "type-is": "^1.6.18" } }, "sha512-kBH3IYPMb+iAXnrxIhXnW+gXV8OTzCu8VPDqvcDHW9SQrbkHmqPQtiZwrltNmSq6/lpipHnT7k7PsjlVD7kK0w=="],
 
@@ -1394,7 +1381,7 @@
 
     "string_decoder": ["string_decoder@1.3.0", "https://bnpm.byted.org/string_decoder/-/string_decoder-1.3.0.tgz", { "dependencies": { "safe-buffer": "~5.2.0" } }, "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA=="],
 
-    "strip-ansi": ["strip-ansi@6.0.1", "https://bnpm.byted.org/strip-ansi/-/strip-ansi-6.0.1.tgz", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+    "strip-ansi": ["strip-ansi@7.1.2", "https://bnpm.byted.org/strip-ansi/-/strip-ansi-7.1.2.tgz", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA=="],
 
     "strip-ansi-cjs": ["strip-ansi@6.0.1", "https://bnpm.byted.org/strip-ansi/-/strip-ansi-6.0.1.tgz", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
@@ -1526,8 +1513,6 @@
 
     "yocto-queue": ["yocto-queue@0.1.0", "https://bnpm.byted.org/yocto-queue/-/yocto-queue-0.1.0.tgz", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
 
-    "zod": ["zod@3.25.76", "https://bnpm.byted.org/zod/-/zod-3.25.76.tgz", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
-
     "@babel/core/semver": ["semver@6.3.1", "https://bnpm.byted.org/semver/-/semver-6.3.1.tgz", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
     "@babel/helper-compilation-targets/lru-cache": ["lru-cache@5.1.1", "https://bnpm.byted.org/lru-cache/-/lru-cache-5.1.1.tgz", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
@@ -1540,11 +1525,7 @@
 
     "@isaacs/cliui/string-width": ["string-width@5.1.2", "https://bnpm.byted.org/string-width/-/string-width-5.1.2.tgz", { "dependencies": { "eastasianwidth": "^0.2.0", "emoji-regex": "^9.2.2", "strip-ansi": "^7.0.1" } }, "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA=="],
 
-    "@isaacs/cliui/strip-ansi": ["strip-ansi@7.1.2", "https://bnpm.byted.org/strip-ansi/-/strip-ansi-7.1.2.tgz", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA=="],
-
     "@isaacs/cliui/wrap-ansi": ["wrap-ansi@8.1.0", "https://bnpm.byted.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz", { "dependencies": { "ansi-styles": "^6.1.0", "string-width": "^5.0.1", "strip-ansi": "^7.0.1" } }, "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ=="],
-
-    "@koa/router/http-errors": ["http-errors@2.0.1", "https://bnpm.byted.org/http-errors/-/http-errors-2.0.1.tgz", { "dependencies": { "depd": "~2.0.0", "inherits": "~2.0.4", "setprototypeof": "~1.2.0", "statuses": "~2.0.2", "toidentifier": "~1.0.1" } }, "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ=="],
 
     "@typescript-eslint/typescript-estree/minimatch": ["minimatch@10.2.3", "https://bnpm.byted.org/minimatch/-/minimatch-10.2.3.tgz", { "dependencies": { "brace-expansion": "^5.0.2" } }, "sha512-Rwi3pnapEqirPSbWbrZaa6N3nmqq4Xer/2XooiOKyV3q12ML06f7MOuc5DVH8ONZIFhwIYQ3yzPH4nt7iWHaTg=="],
 
@@ -1553,6 +1534,8 @@
     "@volcengine/tos-sdk/axios": ["axios@0.30.2", "https://bnpm.byted.org/axios/-/axios-0.30.2.tgz", { "dependencies": { "follow-redirects": "^1.15.4", "form-data": "^4.0.4", "proxy-from-env": "^1.1.0" } }, "sha512-0pE4RQ4UQi1jKY6p7u6i1Tkzqmu+d+/tHS7Q7rKunWLB9WyilBTpHHpXzPNMDj5hTbK0B0PTLSz07yqMBiF6xg=="],
 
     "cli-truncate/string-width": ["string-width@7.2.0", "https://bnpm.byted.org/string-width/-/string-width-7.2.0.tgz", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
+
+    "cliui/strip-ansi": ["strip-ansi@6.0.1", "https://bnpm.byted.org/strip-ansi/-/strip-ansi-6.0.1.tgz", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
     "cliui/wrap-ansi": ["wrap-ansi@7.0.0", "https://bnpm.byted.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
 
@@ -1566,9 +1549,15 @@
 
     "glob/minimatch": ["minimatch@9.0.7", "https://bnpm.byted.org/minimatch/-/minimatch-9.0.7.tgz", { "dependencies": { "brace-expansion": "^5.0.2" } }, "sha512-MOwgjc8tfrpn5QQEvjijjmDVtMw2oL88ugTevzxQnzRLm6l3fVEF2gzU0kYeYYKD8C66+IdGX6peJ4MyUlUnPg=="],
 
-    "http-errors/depd": ["depd@1.1.2", "https://bnpm.byted.org/depd/-/depd-1.1.2.tgz", {}, "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ=="],
+    "http-assert/http-errors": ["http-errors@1.8.1", "https://bnpm.byted.org/http-errors/-/http-errors-1.8.1.tgz", { "dependencies": { "depd": "~1.1.2", "inherits": "2.0.4", "setprototypeof": "1.2.0", "statuses": ">= 1.5.0 < 2", "toidentifier": "1.0.1" } }, "sha512-Kpk9Sm7NmI+RHhnj6OIWDI1d6fIoFAtFt9RLaTMRlg/8w49juAStsrBgp0Dp4OdxdVbRIeKhtCUvoi/RuAhO4g=="],
+
+    "http-errors/statuses": ["statuses@2.0.2", "https://bnpm.byted.org/statuses/-/statuses-2.0.2.tgz", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
 
     "http-proxy/eventemitter3": ["eventemitter3@4.0.7", "https://bnpm.byted.org/eventemitter3/-/eventemitter3-4.0.7.tgz", {}, "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="],
+
+    "koa/http-errors": ["http-errors@1.8.1", "https://bnpm.byted.org/http-errors/-/http-errors-1.8.1.tgz", { "dependencies": { "depd": "~1.1.2", "inherits": "2.0.4", "setprototypeof": "1.2.0", "statuses": ">= 1.5.0 < 2", "toidentifier": "1.0.1" } }, "sha512-Kpk9Sm7NmI+RHhnj6OIWDI1d6fIoFAtFt9RLaTMRlg/8w49juAStsrBgp0Dp4OdxdVbRIeKhtCUvoi/RuAhO4g=="],
+
+    "lark-server/@types/bun": ["@types/bun@1.3.11", "https://bnpm.byted.org/@types/bun/-/bun-1.3.11.tgz", { "dependencies": { "bun-types": "1.3.11" } }, "sha512-5vPne5QvtpjGpsGYXiFyycfpDF2ECyPcTSsFBMa0fraoxiQyMJ3SmuQIGhzPg2WJuWxVBoxWJ2kClYTcw/4fAg=="],
 
     "lark-server/mongodb": ["mongodb@5.9.2", "https://bnpm.byted.org/mongodb/-/mongodb-5.9.2.tgz", { "dependencies": { "bson": "^5.5.0", "mongodb-connection-string-url": "^2.6.0", "socks": "^2.7.1" }, "optionalDependencies": { "@mongodb-js/saslprep": "^1.1.0" }, "peerDependencies": { "@aws-sdk/credential-providers": "^3.188.0", "@mongodb-js/zstd": "^1.0.0", "kerberos": "^1.0.0 || ^2.0.0", "mongodb-client-encryption": ">=2.3.0 <3", "snappy": "^7.2.2" }, "optionalPeers": ["@aws-sdk/credential-providers", "@mongodb-js/zstd", "kerberos", "mongodb-client-encryption", "snappy"] }, "sha512-H60HecKO4Bc+7dhOv4sJlgvenK4fQNqqUIlXxZYQNbfEWSALGAwGoyJd/0Qwk4TttFXUOHJ2ZJQe/52ScaUwtQ=="],
 
@@ -1576,13 +1565,9 @@
 
     "log-update/slice-ansi": ["slice-ansi@7.1.2", "https://bnpm.byted.org/slice-ansi/-/slice-ansi-7.1.2.tgz", { "dependencies": { "ansi-styles": "^6.2.1", "is-fullwidth-code-point": "^5.0.0" } }, "sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w=="],
 
-    "log-update/strip-ansi": ["strip-ansi@7.1.2", "https://bnpm.byted.org/strip-ansi/-/strip-ansi-7.1.2.tgz", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA=="],
-
     "npm-run-path/path-key": ["path-key@4.0.0", "https://bnpm.byted.org/path-key/-/path-key-4.0.0.tgz", {}, "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ=="],
 
     "path-scurry/lru-cache": ["lru-cache@10.4.3", "https://bnpm.byted.org/lru-cache/-/lru-cache-10.4.3.tgz", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
-
-    "raw-body/http-errors": ["http-errors@2.0.1", "https://bnpm.byted.org/http-errors/-/http-errors-2.0.1.tgz", { "dependencies": { "depd": "~2.0.0", "inherits": "~2.0.4", "setprototypeof": "~1.2.0", "statuses": "~2.0.2", "toidentifier": "~1.0.1" } }, "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ=="],
 
     "raw-body/iconv-lite": ["iconv-lite@0.4.24", "https://bnpm.byted.org/iconv-lite/-/iconv-lite-0.4.24.tgz", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3" } }, "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA=="],
 
@@ -1594,7 +1579,15 @@
 
     "stream-http/readable-stream": ["readable-stream@2.3.8", "https://bnpm.byted.org/readable-stream/-/readable-stream-2.3.8.tgz", { "dependencies": { "core-util-is": "~1.0.0", "inherits": "~2.0.3", "isarray": "~1.0.0", "process-nextick-args": "~2.0.0", "safe-buffer": "~5.1.1", "string_decoder": "~1.1.1", "util-deprecate": "~1.0.1" } }, "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA=="],
 
+    "string-width/strip-ansi": ["strip-ansi@6.0.1", "https://bnpm.byted.org/strip-ansi/-/strip-ansi-6.0.1.tgz", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
+    "string-width-cjs/strip-ansi": ["strip-ansi@6.0.1", "https://bnpm.byted.org/strip-ansi/-/strip-ansi-6.0.1.tgz", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
+    "strip-ansi-cjs/ansi-regex": ["ansi-regex@5.0.1", "https://bnpm.byted.org/ansi-regex/-/ansi-regex-5.0.1.tgz", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
     "tinyglobby/picomatch": ["picomatch@4.0.3", "https://bnpm.byted.org/picomatch/-/picomatch-4.0.3.tgz", {}, "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="],
+
+    "to-buffer/isarray": ["isarray@2.0.5", "https://bnpm.byted.org/isarray/-/isarray-2.0.5.tgz", {}, "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="],
 
     "typeorm/reflect-metadata": ["reflect-metadata@0.2.2", "https://bnpm.byted.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz", {}, "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q=="],
 
@@ -1606,25 +1599,27 @@
 
     "wrap-ansi/string-width": ["string-width@7.2.0", "https://bnpm.byted.org/string-width/-/string-width-7.2.0.tgz", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
 
-    "wrap-ansi/strip-ansi": ["strip-ansi@7.1.2", "https://bnpm.byted.org/strip-ansi/-/strip-ansi-7.1.2.tgz", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA=="],
+    "wrap-ansi-cjs/strip-ansi": ["strip-ansi@6.0.1", "https://bnpm.byted.org/strip-ansi/-/strip-ansi-6.0.1.tgz", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
     "@isaacs/cliui/string-width/emoji-regex": ["emoji-regex@9.2.2", "https://bnpm.byted.org/emoji-regex/-/emoji-regex-9.2.2.tgz", {}, "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="],
 
-    "@isaacs/cliui/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "https://bnpm.byted.org/ansi-regex/-/ansi-regex-6.2.2.tgz", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
-
     "@isaacs/cliui/wrap-ansi/ansi-styles": ["ansi-styles@6.2.3", "https://bnpm.byted.org/ansi-styles/-/ansi-styles-6.2.3.tgz", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
-
-    "@koa/router/http-errors/statuses": ["statuses@2.0.2", "https://bnpm.byted.org/statuses/-/statuses-2.0.2.tgz", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
 
     "@typescript-eslint/typescript-estree/minimatch/brace-expansion": ["brace-expansion@5.0.3", "https://bnpm.byted.org/brace-expansion/-/brace-expansion-5.0.3.tgz", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-fy6KJm2RawA5RcHkLa1z/ScpBeA762UF9KmZQxwIbDtRJrgLzM10depAiEQ+CXYcoiqW1/m96OAAoke2nE9EeA=="],
 
     "cli-truncate/string-width/emoji-regex": ["emoji-regex@10.6.0", "https://bnpm.byted.org/emoji-regex/-/emoji-regex-10.6.0.tgz", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
 
-    "cli-truncate/string-width/strip-ansi": ["strip-ansi@7.1.2", "https://bnpm.byted.org/strip-ansi/-/strip-ansi-7.1.2.tgz", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA=="],
+    "cliui/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "https://bnpm.byted.org/ansi-regex/-/ansi-regex-5.0.1.tgz", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
     "color/color-convert/color-name": ["color-name@2.1.0", "https://bnpm.byted.org/color-name/-/color-name-2.1.0.tgz", {}, "sha512-1bPaDNFm0axzE4MEAzKPuqKWeRaT43U/hyxKPBdqTfmPF+d6n7FSoTFxLVULUJOmiLp01KjhIPPH+HrXZJN4Rg=="],
 
     "glob/minimatch/brace-expansion": ["brace-expansion@5.0.3", "https://bnpm.byted.org/brace-expansion/-/brace-expansion-5.0.3.tgz", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-fy6KJm2RawA5RcHkLa1z/ScpBeA762UF9KmZQxwIbDtRJrgLzM10depAiEQ+CXYcoiqW1/m96OAAoke2nE9EeA=="],
+
+    "http-assert/http-errors/depd": ["depd@1.1.2", "https://bnpm.byted.org/depd/-/depd-1.1.2.tgz", {}, "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ=="],
+
+    "koa/http-errors/depd": ["depd@1.1.2", "https://bnpm.byted.org/depd/-/depd-1.1.2.tgz", {}, "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ=="],
+
+    "lark-server/@types/bun/bun-types": ["bun-types@1.3.11", "https://bnpm.byted.org/bun-types/-/bun-types-1.3.11.tgz", { "dependencies": { "@types/node": "*" } }, "sha512-1KGPpoxQWl9f6wcZh57LvrPIInQMn2TQ7jsgxqpRzg+l0QPOFvJVH7HmvHo/AiPgwXy+/Thf6Ov3EdVn1vOabg=="],
 
     "lark-server/mongodb/bson": ["bson@5.5.1", "https://bnpm.byted.org/bson/-/bson-5.5.1.tgz", {}, "sha512-ix0EwukN2EpC0SRWIj/7B5+A6uQMQy6KMREI9qQqvgpkV2frH63T0UDVd1SYedL6dNCmDBYB3QtXi4ISk9YT+g=="],
 
@@ -1634,23 +1629,19 @@
 
     "log-update/slice-ansi/is-fullwidth-code-point": ["is-fullwidth-code-point@5.1.0", "https://bnpm.byted.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz", { "dependencies": { "get-east-asian-width": "^1.3.1" } }, "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ=="],
 
-    "log-update/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "https://bnpm.byted.org/ansi-regex/-/ansi-regex-6.2.2.tgz", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
-
-    "raw-body/http-errors/statuses": ["statuses@2.0.2", "https://bnpm.byted.org/statuses/-/statuses-2.0.2.tgz", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
-
-    "stream-http/readable-stream/isarray": ["isarray@1.0.0", "https://bnpm.byted.org/isarray/-/isarray-1.0.0.tgz", {}, "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="],
-
     "stream-http/readable-stream/safe-buffer": ["safe-buffer@5.1.2", "https://bnpm.byted.org/safe-buffer/-/safe-buffer-5.1.2.tgz", {}, "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="],
 
     "stream-http/readable-stream/string_decoder": ["string_decoder@1.1.1", "https://bnpm.byted.org/string_decoder/-/string_decoder-1.1.1.tgz", { "dependencies": { "safe-buffer": "~5.1.0" } }, "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg=="],
 
+    "string-width-cjs/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "https://bnpm.byted.org/ansi-regex/-/ansi-regex-5.0.1.tgz", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
+    "string-width/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "https://bnpm.byted.org/ansi-regex/-/ansi-regex-5.0.1.tgz", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
+    "wrap-ansi-cjs/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "https://bnpm.byted.org/ansi-regex/-/ansi-regex-5.0.1.tgz", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
     "wrap-ansi/string-width/emoji-regex": ["emoji-regex@10.6.0", "https://bnpm.byted.org/emoji-regex/-/emoji-regex-10.6.0.tgz", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
 
-    "wrap-ansi/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "https://bnpm.byted.org/ansi-regex/-/ansi-regex-6.2.2.tgz", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
-
     "@typescript-eslint/typescript-estree/minimatch/brace-expansion/balanced-match": ["balanced-match@4.0.4", "https://bnpm.byted.org/balanced-match/-/balanced-match-4.0.4.tgz", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
-
-    "cli-truncate/string-width/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "https://bnpm.byted.org/ansi-regex/-/ansi-regex-6.2.2.tgz", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
 
     "glob/minimatch/brace-expansion/balanced-match": ["balanced-match@4.0.4", "https://bnpm.byted.org/balanced-match/-/balanced-match-4.0.4.tgz", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -70,13 +70,11 @@
       "name": "monitor-dashboard",
       "version": "1.0.0",
       "dependencies": {
+        "@hono/node-server": "^1.13.0",
         "@inner/shared": "workspace:*",
-        "@koa/cors": "^5.0.0",
-        "@koa/router": "^12.0.1",
         "axios": "^1.6.8",
+        "hono": "^4.7.0",
         "jsonwebtoken": "^9.0.2",
-        "koa": "^2.15.0",
-        "koa-bodyparser": "^4.4.1",
         "mongodb": "^6.10.0",
         "pg": "^8.11.5",
         "reflect-metadata": "^0.1.14",
@@ -84,10 +82,6 @@
       },
       "devDependencies": {
         "@types/jsonwebtoken": "^9.0.6",
-        "@types/koa": "^2.15.0",
-        "@types/koa-bodyparser": "^4.3.12",
-        "@types/koa__cors": "^5.0.0",
-        "@types/koa__router": "^12.0.4",
         "@types/node": "^18.19.20",
         "typescript": "^5.9.3",
       },
@@ -289,7 +283,7 @@
 
     "@eslint/plugin-kit": ["@eslint/plugin-kit@0.4.1", "https://bnpm.byted.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz", { "dependencies": { "@eslint/core": "^0.17.0", "levn": "^0.4.1" } }, "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA=="],
 
-    "@hapi/bourne": ["@hapi/bourne@3.0.0", "https://bnpm.byted.org/@hapi/bourne/-/bourne-3.0.0.tgz", {}, "sha512-Waj1cwPXJDucOib4a3bAISsKJVb15MKi9IvmTI/7ssVEm6sywXGjVJDhl6/umt1pK1ZS7PacXU3A1PmFKHEZ2w=="],
+    "@hono/node-server": ["@hono/node-server@1.19.12", "https://bnpm.byted.org/@hono/node-server/-/node-server-1.19.12.tgz", { "peerDependencies": { "hono": "^4" } }, "sha512-txsUW4SQ1iilgE0l9/e9VQWmELXifEFvmdA1j6WFh/aFPj99hIntrSsq/if0UWyGVkmrRPKA1wCeP+UCr1B9Uw=="],
 
     "@humanfs/core": ["@humanfs/core@0.19.1", "https://bnpm.byted.org/@humanfs/core/-/core-0.19.1.tgz", {}, "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA=="],
 
@@ -318,10 +312,6 @@
     "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "https://bnpm.byted.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "https://bnpm.byted.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
-
-    "@koa/cors": ["@koa/cors@5.0.0", "https://bnpm.byted.org/@koa/cors/-/cors-5.0.0.tgz", { "dependencies": { "vary": "^1.1.2" } }, "sha512-x/iUDjcS90W69PryLDIMgFyV21YLTnG9zOpPXS7Bkt2b8AsY3zZsIpOLBkYr9fBcF3HbkKaER5hOBZLfpLgYNw=="],
-
-    "@koa/router": ["@koa/router@12.0.2", "https://bnpm.byted.org/@koa/router/-/router-12.0.2.tgz", { "dependencies": { "debug": "^4.3.4", "http-errors": "^2.0.0", "koa-compose": "^4.1.0", "methods": "^1.1.2", "path-to-regexp": "^6.3.0" } }, "sha512-sYcHglGKTxGF+hQ6x67xDfkE9o+NhVlRHBqq6gLywaMc6CojK/5vFZByphdonKinYlMLkEkacm+HEse9HzwgTA=="],
 
     "@larksuiteoapi/node-sdk": ["@larksuiteoapi/node-sdk@1.59.0", "https://bnpm.byted.org/@larksuiteoapi/node-sdk/-/node-sdk-1.59.0.tgz", { "dependencies": { "axios": "~1.13.3", "lodash.identity": "^3.0.0", "lodash.merge": "^4.6.2", "lodash.pickby": "^4.6.0", "protobufjs": "^7.2.6", "qs": "^6.14.2", "ws": "^8.19.0" } }, "sha512-sBpkruTvZDOxnVtoTbepWKRX0j1Y1ZElQYu0x7+v088sI9pcpbVp6ZzCGn62dhrKPatzNyCJyzYCPXPYQWccrA=="],
 
@@ -433,8 +423,6 @@
 
     "@tootallnate/quickjs-emscripten": ["@tootallnate/quickjs-emscripten@0.23.0", "https://bnpm.byted.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz", {}, "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA=="],
 
-    "@types/accepts": ["@types/accepts@1.3.7", "https://bnpm.byted.org/@types/accepts/-/accepts-1.3.7.tgz", { "dependencies": { "@types/node": "*" } }, "sha512-Pay9fq2lM2wXPWbteBsRAGiWH2hig4ZE2asK+mm7kUzlxRTfL961rj89I6zV/E3PcIkDqyuBEcMxFT7rccugeQ=="],
-
     "@types/ali-oss": ["@types/ali-oss@6.23.3", "https://bnpm.byted.org/@types/ali-oss/-/ali-oss-6.23.3.tgz", {}, "sha512-huSf6njkqhSeR37OMJTGMCyUg2d9Zp2AioefhYuUMeh0vNM+WybctrBor7bO/RcCbLCQI6sHn6NtPBIWALYVJg=="],
 
     "@types/amqplib": ["@types/amqplib@0.10.8", "https://bnpm.byted.org/@types/amqplib/-/amqplib-0.10.8.tgz", { "dependencies": { "@types/node": "*" } }, "sha512-vtDp8Pk1wsE/AuQ8/Rgtm6KUZYqcnTgNvEHwzCkX8rL7AGsC6zqAfKAAJhUZXFhM/Pp++tbnUHiam/8vVpPztA=="],
@@ -453,19 +441,13 @@
 
     "@types/connect": ["@types/connect@3.4.38", "https://bnpm.byted.org/@types/connect/-/connect-3.4.38.tgz", { "dependencies": { "@types/node": "*" } }, "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug=="],
 
-    "@types/content-disposition": ["@types/content-disposition@0.5.9", "https://bnpm.byted.org/@types/content-disposition/-/content-disposition-0.5.9.tgz", {}, "sha512-8uYXI3Gw35MhiVYhG3s295oihrxRyytcRHjSjqnqZVDDy/xcGBRny7+Xj1Wgfhv5QzRtN2hB2dVRBUX9XW3UcQ=="],
-
     "@types/cookiejar": ["@types/cookiejar@2.1.5", "https://bnpm.byted.org/@types/cookiejar/-/cookiejar-2.1.5.tgz", {}, "sha512-he+DHOWReW0nghN24E1WUqM0efK4kI9oTqDm6XmK8ZPe2djZ90BSNdGnIyCLzCPw7/pogPlGbzI2wHGGmi4O/Q=="],
-
-    "@types/cookies": ["@types/cookies@0.9.2", "https://bnpm.byted.org/@types/cookies/-/cookies-0.9.2.tgz", { "dependencies": { "@types/connect": "*", "@types/express": "*", "@types/keygrip": "*", "@types/node": "*" } }, "sha512-1AvkDdZM2dbyFybL4fxpuNCaWyv//0AwsuUk2DWeXyM1/5ZKm6W3z6mQi24RZ4l2ucY+bkSHzbDVpySqPGuV8A=="],
 
     "@types/estree": ["@types/estree@1.0.8", "https://bnpm.byted.org/@types/estree/-/estree-1.0.8.tgz", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
 
     "@types/express": ["@types/express@5.0.6", "https://bnpm.byted.org/@types/express/-/express-5.0.6.tgz", { "dependencies": { "@types/body-parser": "*", "@types/express-serve-static-core": "^5.0.0", "@types/serve-static": "^2" } }, "sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA=="],
 
     "@types/express-serve-static-core": ["@types/express-serve-static-core@5.1.1", "https://bnpm.byted.org/@types/express-serve-static-core/-/express-serve-static-core-5.1.1.tgz", { "dependencies": { "@types/node": "*", "@types/qs": "*", "@types/range-parser": "*", "@types/send": "*" } }, "sha512-v4zIMr/cX7/d2BpAEX3KNKL/JrT1s43s96lLvvdTmza1oEvDudCqK9aF/djc/SWgy8Yh0h30TZx5VpzqFCxk5A=="],
-
-    "@types/http-assert": ["@types/http-assert@1.5.6", "https://bnpm.byted.org/@types/http-assert/-/http-assert-1.5.6.tgz", {}, "sha512-TTEwmtjgVbYAzZYWyeHPrrtWnfVkm8tQkP8P21uQifPgMRgjrow3XDEYqucuC8SKZJT7pUnhU/JymvjggxO9vw=="],
 
     "@types/http-errors": ["@types/http-errors@2.0.5", "https://bnpm.byted.org/@types/http-errors/-/http-errors-2.0.5.tgz", {}, "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg=="],
 
@@ -474,18 +456,6 @@
     "@types/json-schema": ["@types/json-schema@7.0.15", "https://bnpm.byted.org/@types/json-schema/-/json-schema-7.0.15.tgz", {}, "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="],
 
     "@types/jsonwebtoken": ["@types/jsonwebtoken@9.0.10", "https://bnpm.byted.org/@types/jsonwebtoken/-/jsonwebtoken-9.0.10.tgz", { "dependencies": { "@types/ms": "*", "@types/node": "*" } }, "sha512-asx5hIG9Qmf/1oStypjanR7iKTv0gXQ1Ov/jfrX6kS/EO0OFni8orbmGCn0672NHR3kXHwpAwR+B368ZGN/2rA=="],
-
-    "@types/keygrip": ["@types/keygrip@1.0.6", "https://bnpm.byted.org/@types/keygrip/-/keygrip-1.0.6.tgz", {}, "sha512-lZuNAY9xeJt7Bx4t4dx0rYCDqGPW8RXhQZK1td7d4H6E9zYbLoOtjBvfwdTKpsyxQI/2jv+armjX/RW+ZNpXOQ=="],
-
-    "@types/koa": ["@types/koa@2.15.0", "https://bnpm.byted.org/@types/koa/-/koa-2.15.0.tgz", { "dependencies": { "@types/accepts": "*", "@types/content-disposition": "*", "@types/cookies": "*", "@types/http-assert": "*", "@types/http-errors": "*", "@types/keygrip": "*", "@types/koa-compose": "*", "@types/node": "*" } }, "sha512-7QFsywoE5URbuVnG3loe03QXuGajrnotr3gQkXcEBShORai23MePfFYdhz90FEtBBpkyIYQbVD+evKtloCgX3g=="],
-
-    "@types/koa-bodyparser": ["@types/koa-bodyparser@4.3.13", "https://bnpm.byted.org/@types/koa-bodyparser/-/koa-bodyparser-4.3.13.tgz", { "dependencies": { "@types/koa": "*" } }, "sha512-yW9afsDnV1ymnhMBfAlzsKZ45sYnvIlTRS+eF5MUZOQ8ePIIj3ajwi+9b4a0vdyYvh6uJKYibU8R1zrUIpCmCA=="],
-
-    "@types/koa-compose": ["@types/koa-compose@3.2.9", "https://bnpm.byted.org/@types/koa-compose/-/koa-compose-3.2.9.tgz", { "dependencies": { "@types/koa": "*" } }, "sha512-BroAZ9FTvPiCy0Pi8tjD1OfJ7bgU1gQf0eR6e1Vm+JJATy9eKOG3hQMFtMciMawiSOVnLMdmUOC46s7HBhSTsA=="],
-
-    "@types/koa__cors": ["@types/koa__cors@5.0.1", "https://bnpm.byted.org/@types/koa__cors/-/koa__cors-5.0.1.tgz", { "dependencies": { "@types/koa": "*" } }, "sha512-xZckuh3B6ycSBAIYnBImG1VDHyBNZsltGAuGb4THuZllccdLgD5DUs4RA7TAUjB58THg00SSZ1e//duQef7WRw=="],
-
-    "@types/koa__router": ["@types/koa__router@12.0.5", "https://bnpm.byted.org/@types/koa__router/-/koa__router-12.0.5.tgz", { "dependencies": { "@types/koa": "*" } }, "sha512-1HeLxuDn4n5it1yZYCSyOYXo++73zT0ffoviXnPxbwbxLbvDFEvWD9ZzpRiIpK4oKR0pi+K+Mk/ZjyROjW3HSw=="],
 
     "@types/lodash": ["@types/lodash@4.17.24", "https://bnpm.byted.org/@types/lodash/-/lodash-4.17.24.tgz", {}, "sha512-gIW7lQLZbue7lRSWEFql49QJJWThrTFFeIMJdp3eH4tKoxm1OvEPg02rm4wCCSHS0cL3/Fizimb35b7k8atwsQ=="],
 
@@ -548,8 +518,6 @@
     "@vitejs/plugin-react": ["@vitejs/plugin-react@4.7.0", "https://bnpm.byted.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz", { "dependencies": { "@babel/core": "^7.28.0", "@babel/plugin-transform-react-jsx-self": "^7.27.1", "@babel/plugin-transform-react-jsx-source": "^7.27.1", "@rolldown/pluginutils": "1.0.0-beta.27", "@types/babel__core": "^7.20.5", "react-refresh": "^0.17.0" }, "peerDependencies": { "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0" } }, "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA=="],
 
     "@volcengine/tos-sdk": ["@volcengine/tos-sdk@0.0.0-preview-2.9.0-enterprise.2-20260122082440", "https://bnpm.byted.org/@volcengine/tos-sdk/-/tos-sdk-0.0.0-preview-2.9.0-enterprise.2-20260122082440.tgz", { "dependencies": { "axios": "0.30.2", "crypto-js": "^4.2.0", "debug": "^4.3.4", "http-proxy-middleware": "^2.0.1", "lodash": "^4.17.21", "qs": "^6.11.2", "tos-crc64-js": "0.0.1", "type-fest": "^1.4.0" } }, "sha512-i3OPzR4RleaXPYR1VSvF8FIoJYRBUjid/lzaCTBJu82kaFzlb/AO8PSjGGDhUXrl8elohmC0P7yilPsGl8d4MQ=="],
-
-    "accepts": ["accepts@1.3.8", "https://bnpm.byted.org/accepts/-/accepts-1.3.8.tgz", { "dependencies": { "mime-types": "~2.1.34", "negotiator": "0.6.3" } }, "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw=="],
 
     "acorn": ["acorn@8.16.0", "https://bnpm.byted.org/acorn/-/acorn-8.16.0.tgz", { "bin": { "acorn": "bin/acorn" } }, "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw=="],
 
@@ -627,10 +595,6 @@
 
     "bun-types": ["bun-types@1.3.10", "https://bnpm.byted.org/bun-types/-/bun-types-1.3.10.tgz", { "dependencies": { "@types/node": "*" } }, "sha512-tcpfCCl6XWo6nCVnpcVrxQ+9AYN1iqMIzgrSKYMB/fjLtV2eyAVEg7AxQJuCq/26R6HpKWykQXuSOq/21RYcbg=="],
 
-    "bytes": ["bytes@3.1.2", "https://bnpm.byted.org/bytes/-/bytes-3.1.2.tgz", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
-
-    "cache-content-type": ["cache-content-type@1.0.1", "https://bnpm.byted.org/cache-content-type/-/cache-content-type-1.0.1.tgz", { "dependencies": { "mime-types": "^2.1.18", "ylru": "^1.2.0" } }, "sha512-IKufZ1o4Ut42YUrZSo8+qnMTrFuKkvyoLXUywKz9GJ5BrhOFGhLdkx9sG4KAnVvbY6kEcSFjLQul+DVmBm2bgA=="],
-
     "call-bind": ["call-bind@1.0.8", "https://bnpm.byted.org/call-bind/-/call-bind-1.0.8.tgz", { "dependencies": { "call-bind-apply-helpers": "^1.0.0", "es-define-property": "^1.0.0", "get-intrinsic": "^1.2.4", "set-function-length": "^1.2.2" } }, "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww=="],
 
     "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "https://bnpm.byted.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } }, "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ=="],
@@ -653,10 +617,6 @@
 
     "cluster-key-slot": ["cluster-key-slot@1.1.2", "https://bnpm.byted.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz", {}, "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA=="],
 
-    "co": ["co@4.6.0", "https://bnpm.byted.org/co/-/co-4.6.0.tgz", {}, "sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ=="],
-
-    "co-body": ["co-body@6.2.0", "https://bnpm.byted.org/co-body/-/co-body-6.2.0.tgz", { "dependencies": { "@hapi/bourne": "^3.0.0", "inflation": "^2.0.0", "qs": "^6.5.2", "raw-body": "^2.3.3", "type-is": "^1.6.16" } }, "sha512-Kbpv2Yd1NdL1V/V4cwLVxraHDV6K8ayohr2rmH0J87Er8+zJjcTa6dAn9QMPC9CRgU8+aNajKbSf1TzDB1yKPA=="],
-
     "color": ["color@5.0.3", "https://bnpm.byted.org/color/-/color-5.0.3.tgz", { "dependencies": { "color-convert": "^3.1.3", "color-string": "^2.1.3" } }, "sha512-ezmVcLR3xAVp8kYOm4GS45ZLLgIE6SPAFoduLr6hTDajwb3KZ2F46gulK3XpcwRFb5KKGCSezCBAY4Dw4HsyXA=="],
 
     "color-convert": ["color-convert@2.0.1", "https://bnpm.byted.org/color-convert/-/color-convert-2.0.1.tgz", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
@@ -677,15 +637,11 @@
 
     "concat-map": ["concat-map@0.0.1", "https://bnpm.byted.org/concat-map/-/concat-map-0.0.1.tgz", {}, "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="],
 
-    "content-disposition": ["content-disposition@0.5.4", "https://bnpm.byted.org/content-disposition/-/content-disposition-0.5.4.tgz", { "dependencies": { "safe-buffer": "5.2.1" } }, "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ=="],
-
     "content-type": ["content-type@1.0.5", "https://bnpm.byted.org/content-type/-/content-type-1.0.5.tgz", {}, "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="],
 
     "convert-source-map": ["convert-source-map@2.0.0", "https://bnpm.byted.org/convert-source-map/-/convert-source-map-2.0.0.tgz", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
 
     "cookiejar": ["cookiejar@2.1.4", "https://bnpm.byted.org/cookiejar/-/cookiejar-2.1.4.tgz", {}, "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw=="],
-
-    "cookies": ["cookies@0.9.1", "https://bnpm.byted.org/cookies/-/cookies-0.9.1.tgz", { "dependencies": { "depd": "~2.0.0", "keygrip": "~1.1.0" } }, "sha512-TG2hpqe4ELx54QER/S3HQ9SRVnQnGBtKUz5bLQWtYAQ+o6GpgMs6sYUvaiJjVxb+UXwhRhAEP3m7LbsIZ77Hmw=="],
 
     "copy-to": ["copy-to@2.0.1", "https://bnpm.byted.org/copy-to/-/copy-to-2.0.1.tgz", {}, "sha512-3DdaFaU/Zf1AnpLiFDeNCD4TOWe3Zl2RZaTzUvWiIk5ERzcCodOE20Vqq4fzCbNoHURFHT4/us/Lfq+S2zyY4w=="],
 
@@ -709,8 +665,6 @@
 
     "dedent": ["dedent@1.7.1", "https://bnpm.byted.org/dedent/-/dedent-1.7.1.tgz", { "peerDependencies": { "babel-plugin-macros": "^3.1.0" }, "optionalPeers": ["babel-plugin-macros"] }, "sha512-9JmrhGZpOlEgOLdQgSm0zxFaYoQon408V1v49aqTWuXENVlnCuY9JBZcXZiCsZQWDjTm5Qf/nIvAy77mXDAjEg=="],
 
-    "deep-equal": ["deep-equal@1.0.1", "https://bnpm.byted.org/deep-equal/-/deep-equal-1.0.1.tgz", {}, "sha512-bHtC0iYvWhyaTzvV3CZgPeZQqCOBGyGsVV7v4eevpdkLHfiSrXUdBG+qAuSz4RI70sszvjQ1QSZ98An1yNwpSw=="],
-
     "deep-is": ["deep-is@0.1.4", "https://bnpm.byted.org/deep-is/-/deep-is-0.1.4.tgz", {}, "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="],
 
     "default-user-agent": ["default-user-agent@1.0.0", "https://bnpm.byted.org/default-user-agent/-/default-user-agent-1.0.0.tgz", { "dependencies": { "os-name": "~1.0.3" } }, "sha512-bDF7bg6OSNcSwFWPu4zYKpVkJZQYVrAANMYB8bc9Szem1D0yKdm4sa/rOCs2aC9+2GMqQ7KnwtZRvDhmLF0dXw=="],
@@ -721,11 +675,7 @@
 
     "delayed-stream": ["delayed-stream@1.0.0", "https://bnpm.byted.org/delayed-stream/-/delayed-stream-1.0.0.tgz", {}, "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="],
 
-    "delegates": ["delegates@1.0.0", "https://bnpm.byted.org/delegates/-/delegates-1.0.0.tgz", {}, "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ=="],
-
     "denque": ["denque@2.1.0", "https://bnpm.byted.org/denque/-/denque-2.1.0.tgz", {}, "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw=="],
-
-    "depd": ["depd@2.0.0", "https://bnpm.byted.org/depd/-/depd-2.0.0.tgz", {}, "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="],
 
     "destroy": ["destroy@1.2.0", "https://bnpm.byted.org/destroy/-/destroy-1.2.0.tgz", {}, "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg=="],
 
@@ -748,8 +698,6 @@
     "emoji-regex": ["emoji-regex@8.0.0", "https://bnpm.byted.org/emoji-regex/-/emoji-regex-8.0.0.tgz", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 
     "enabled": ["enabled@2.0.0", "https://bnpm.byted.org/enabled/-/enabled-2.0.0.tgz", {}, "sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ=="],
-
-    "encodeurl": ["encodeurl@1.0.2", "https://bnpm.byted.org/encodeurl/-/encodeurl-1.0.2.tgz", {}, "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w=="],
 
     "end-of-stream": ["end-of-stream@1.4.5", "https://bnpm.byted.org/end-of-stream/-/end-of-stream-1.4.5.tgz", { "dependencies": { "once": "^1.4.0" } }, "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg=="],
 
@@ -837,13 +785,9 @@
 
     "formstream": ["formstream@1.5.2", "https://bnpm.byted.org/formstream/-/formstream-1.5.2.tgz", { "dependencies": { "destroy": "^1.0.4", "mime": "^2.5.2", "node-hex": "^1.0.1", "pause-stream": "~0.0.11" } }, "sha512-NASf0lgxC1AyKNXQIrXTEYkiX99LhCEXTkiGObXAkpBui86a4u8FjH1o2bGb3PpqI3kafC+yw4zWeK6l6VHTgg=="],
 
-    "fresh": ["fresh@0.5.2", "https://bnpm.byted.org/fresh/-/fresh-0.5.2.tgz", {}, "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q=="],
-
     "fsevents": ["fsevents@2.3.3", "https://bnpm.byted.org/fsevents/-/fsevents-2.3.3.tgz", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
     "function-bind": ["function-bind@1.1.2", "https://bnpm.byted.org/function-bind/-/function-bind-1.1.2.tgz", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
-
-    "generator-function": ["generator-function@2.0.1", "https://bnpm.byted.org/generator-function/-/generator-function-2.0.1.tgz", {}, "sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g=="],
 
     "gensync": ["gensync@1.0.0-beta.2", "https://bnpm.byted.org/gensync/-/gensync-1.0.0-beta.2.tgz", {}, "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg=="],
 
@@ -881,10 +825,6 @@
 
     "hono": ["hono@4.12.5", "https://bnpm.byted.org/hono/-/hono-4.12.5.tgz", {}, "sha512-3qq+FUBtlTHhtYxbxheZgY8NIFnkkC/MR8u5TTsr7YZ3wixryQ3cCwn3iZbg8p8B88iDBBAYSfZDS75t8MN7Vg=="],
 
-    "http-assert": ["http-assert@1.5.0", "https://bnpm.byted.org/http-assert/-/http-assert-1.5.0.tgz", { "dependencies": { "deep-equal": "~1.0.1", "http-errors": "~1.8.0" } }, "sha512-uPpH7OKX4H25hBmU6G1jWNaqJGpTXxey+YOUizJUAgu0AjLUeC8D73hTrhvDS5D+GJN1DN1+hhc/eF/wpxtp0w=="],
-
-    "http-errors": ["http-errors@2.0.1", "https://bnpm.byted.org/http-errors/-/http-errors-2.0.1.tgz", { "dependencies": { "depd": "~2.0.0", "inherits": "~2.0.4", "setprototypeof": "~1.2.0", "statuses": "~2.0.2", "toidentifier": "~1.0.1" } }, "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ=="],
-
     "http-proxy": ["http-proxy@1.18.1", "https://bnpm.byted.org/http-proxy/-/http-proxy-1.18.1.tgz", { "dependencies": { "eventemitter3": "^4.0.0", "follow-redirects": "^1.0.0", "requires-port": "^1.0.0" } }, "sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ=="],
 
     "http-proxy-agent": ["http-proxy-agent@7.0.2", "https://bnpm.byted.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz", { "dependencies": { "agent-base": "^7.1.0", "debug": "^4.3.4" } }, "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig=="],
@@ -907,8 +847,6 @@
 
     "imurmurhash": ["imurmurhash@0.1.4", "https://bnpm.byted.org/imurmurhash/-/imurmurhash-0.1.4.tgz", {}, "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA=="],
 
-    "inflation": ["inflation@2.1.0", "https://bnpm.byted.org/inflation/-/inflation-2.1.0.tgz", {}, "sha512-t54PPJHG1Pp7VQvxyVCJ9mBbjG3Hqryges9bXoOO6GExCPa+//i/d5GSuFtpx3ALLd7lgIAur6zrIlBQyJuMlQ=="],
-
     "inherits": ["inherits@2.0.4", "https://bnpm.byted.org/inherits/-/inherits-2.0.4.tgz", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
 
     "ioredis": ["ioredis@5.9.3", "https://bnpm.byted.org/ioredis/-/ioredis-5.9.3.tgz", { "dependencies": { "@ioredis/commands": "1.5.0", "cluster-key-slot": "^1.1.0", "debug": "^4.3.4", "denque": "^2.1.0", "lodash.defaults": "^4.2.0", "lodash.isarguments": "^3.1.0", "redis-errors": "^1.2.0", "redis-parser": "^3.0.0", "standard-as-callback": "^2.1.0" } }, "sha512-VI5tMCdeoxZWU5vjHWsiE/Su76JGhBvWF1MJnV9ZtGltHk9BmD48oDq8Tj8haZ85aceXZMxLNDQZRVo5QKNgXA=="],
@@ -925,15 +863,11 @@
 
     "is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "https://bnpm.byted.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
 
-    "is-generator-function": ["is-generator-function@1.1.2", "https://bnpm.byted.org/is-generator-function/-/is-generator-function-1.1.2.tgz", { "dependencies": { "call-bound": "^1.0.4", "generator-function": "^2.0.0", "get-proto": "^1.0.1", "has-tostringtag": "^1.0.2", "safe-regex-test": "^1.1.0" } }, "sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA=="],
-
     "is-glob": ["is-glob@4.0.3", "https://bnpm.byted.org/is-glob/-/is-glob-4.0.3.tgz", { "dependencies": { "is-extglob": "^2.1.1" } }, "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg=="],
 
     "is-number": ["is-number@7.0.0", "https://bnpm.byted.org/is-number/-/is-number-7.0.0.tgz", {}, "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="],
 
     "is-plain-obj": ["is-plain-obj@3.0.0", "https://bnpm.byted.org/is-plain-obj/-/is-plain-obj-3.0.0.tgz", {}, "sha512-gwsOE28k+23GP1B6vFl1oVh/WOzmawBrKwo5Ev6wMKzPkaXaCDIQKzLnvsA42DRlbVTWorkgTKIviAKCWkfUwA=="],
-
-    "is-regex": ["is-regex@1.2.1", "https://bnpm.byted.org/is-regex/-/is-regex-1.2.1.tgz", { "dependencies": { "call-bound": "^1.0.2", "gopd": "^1.2.0", "has-tostringtag": "^1.0.2", "hasown": "^2.0.2" } }, "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g=="],
 
     "is-stream": ["is-stream@2.0.1", "https://bnpm.byted.org/is-stream/-/is-stream-2.0.1.tgz", {}, "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg=="],
 
@@ -975,17 +909,7 @@
 
     "jws": ["jws@4.0.1", "https://bnpm.byted.org/jws/-/jws-4.0.1.tgz", { "dependencies": { "jwa": "^2.0.1", "safe-buffer": "^5.0.1" } }, "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA=="],
 
-    "keygrip": ["keygrip@1.1.0", "https://bnpm.byted.org/keygrip/-/keygrip-1.1.0.tgz", { "dependencies": { "tsscmp": "1.0.6" } }, "sha512-iYSchDJ+liQ8iwbSI2QqsQOvqv58eJCEanyJPJi+Khyu8smkcKSFUCbPwzFcL7YVtZ6eONjqRX/38caJ7QjRAQ=="],
-
     "keyv": ["keyv@4.5.4", "https://bnpm.byted.org/keyv/-/keyv-4.5.4.tgz", { "dependencies": { "json-buffer": "3.0.1" } }, "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw=="],
-
-    "koa": ["koa@2.16.3", "https://bnpm.byted.org/koa/-/koa-2.16.3.tgz", { "dependencies": { "accepts": "^1.3.5", "cache-content-type": "^1.0.0", "content-disposition": "~0.5.2", "content-type": "^1.0.4", "cookies": "~0.9.0", "debug": "^4.3.2", "delegates": "^1.0.0", "depd": "^2.0.0", "destroy": "^1.0.4", "encodeurl": "^1.0.2", "escape-html": "^1.0.3", "fresh": "~0.5.2", "http-assert": "^1.3.0", "http-errors": "^1.6.3", "is-generator-function": "^1.0.7", "koa-compose": "^4.1.0", "koa-convert": "^2.0.0", "on-finished": "^2.3.0", "only": "~0.0.2", "parseurl": "^1.3.2", "statuses": "^1.5.0", "type-is": "^1.6.16", "vary": "^1.1.2" } }, "sha512-zPPuIt+ku1iCpFBRwseMcPYQ1cJL8l60rSmKeOuGfOXyE6YnTBmf2aEFNL2HQGrD0cPcLO/t+v9RTgC+fwEh/g=="],
-
-    "koa-bodyparser": ["koa-bodyparser@4.4.1", "https://bnpm.byted.org/koa-bodyparser/-/koa-bodyparser-4.4.1.tgz", { "dependencies": { "co-body": "^6.0.0", "copy-to": "^2.0.1", "type-is": "^1.6.18" } }, "sha512-kBH3IYPMb+iAXnrxIhXnW+gXV8OTzCu8VPDqvcDHW9SQrbkHmqPQtiZwrltNmSq6/lpipHnT7k7PsjlVD7kK0w=="],
-
-    "koa-compose": ["koa-compose@4.1.0", "https://bnpm.byted.org/koa-compose/-/koa-compose-4.1.0.tgz", {}, "sha512-8ODW8TrDuMYvXRwra/Kh7/rJo9BtOfPc6qO8eAfC80CnCvSjSl0bkRM24X6/XBBEyj0v1nRUQ1LyOy3dbqOWXw=="],
-
-    "koa-convert": ["koa-convert@2.0.0", "https://bnpm.byted.org/koa-convert/-/koa-convert-2.0.0.tgz", { "dependencies": { "co": "^4.6.0", "koa-compose": "^4.1.0" } }, "sha512-asOvN6bFlSnxewce2e/DK3p4tltyfC4VM7ZwuTuepI7dEQVcvpyFuBcEARu1+Hxg8DIwytce2n7jrZtRlPrARA=="],
 
     "kuler": ["kuler@2.0.0", "https://bnpm.byted.org/kuler/-/kuler-2.0.0.tgz", {}, "sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A=="],
 
@@ -1041,8 +965,6 @@
 
     "math-intrinsics": ["math-intrinsics@1.1.0", "https://bnpm.byted.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
 
-    "media-typer": ["media-typer@0.3.0", "https://bnpm.byted.org/media-typer/-/media-typer-0.3.0.tgz", {}, "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ=="],
-
     "memory-pager": ["memory-pager@1.5.0", "https://bnpm.byted.org/memory-pager/-/memory-pager-1.5.0.tgz", {}, "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg=="],
 
     "merge-descriptors": ["merge-descriptors@1.0.3", "https://bnpm.byted.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz", {}, "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ=="],
@@ -1087,8 +1009,6 @@
 
     "natural-compare": ["natural-compare@1.4.0", "https://bnpm.byted.org/natural-compare/-/natural-compare-1.4.0.tgz", {}, "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="],
 
-    "negotiator": ["negotiator@0.6.3", "https://bnpm.byted.org/negotiator/-/negotiator-0.6.3.tgz", {}, "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg=="],
-
     "netmask": ["netmask@2.0.2", "https://bnpm.byted.org/netmask/-/netmask-2.0.2.tgz", {}, "sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg=="],
 
     "node-cron": ["node-cron@4.2.1", "https://bnpm.byted.org/node-cron/-/node-cron-4.2.1.tgz", {}, "sha512-lgimEHPE/QDgFlywTd8yTR61ptugX3Qer29efeyWw2rv259HtGBNn1vZVmp8lB9uo9wC0t/AT4iGqXxia+CJFg=="],
@@ -1103,15 +1023,11 @@
 
     "object-inspect": ["object-inspect@1.13.4", "https://bnpm.byted.org/object-inspect/-/object-inspect-1.13.4.tgz", {}, "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="],
 
-    "on-finished": ["on-finished@2.4.1", "https://bnpm.byted.org/on-finished/-/on-finished-2.4.1.tgz", { "dependencies": { "ee-first": "1.1.1" } }, "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg=="],
-
     "once": ["once@1.4.0", "https://bnpm.byted.org/once/-/once-1.4.0.tgz", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
 
     "one-time": ["one-time@1.0.0", "https://bnpm.byted.org/one-time/-/one-time-1.0.0.tgz", { "dependencies": { "fn.name": "1.x.x" } }, "sha512-5DXOiRKwuSEcQ/l0kGCF6Q3jcADFv5tSmRaJck/OqkVFcOzutB134KRSfF0xDrL39MNnqxbHBbUUcjZIhTgb2g=="],
 
     "onetime": ["onetime@6.0.0", "https://bnpm.byted.org/onetime/-/onetime-6.0.0.tgz", { "dependencies": { "mimic-fn": "^4.0.0" } }, "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ=="],
-
-    "only": ["only@0.0.2", "https://bnpm.byted.org/only/-/only-0.0.2.tgz", {}, "sha512-Fvw+Jemq5fjjyWz6CpKx6w9s7xxqo3+JCyM0WXWeCSOboZ8ABkyvP8ID4CZuChA/wxSx+XSJmdOm8rGVyJ1hdQ=="],
 
     "optionator": ["optionator@0.9.4", "https://bnpm.byted.org/optionator/-/optionator-0.9.4.tgz", { "dependencies": { "deep-is": "^0.1.3", "fast-levenshtein": "^2.0.6", "levn": "^0.4.1", "prelude-ls": "^1.2.1", "type-check": "^0.4.0", "word-wrap": "^1.2.5" } }, "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g=="],
 
@@ -1131,15 +1047,11 @@
 
     "parent-module": ["parent-module@1.0.1", "https://bnpm.byted.org/parent-module/-/parent-module-1.0.1.tgz", { "dependencies": { "callsites": "^3.0.0" } }, "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g=="],
 
-    "parseurl": ["parseurl@1.3.3", "https://bnpm.byted.org/parseurl/-/parseurl-1.3.3.tgz", {}, "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="],
-
     "path-exists": ["path-exists@4.0.0", "https://bnpm.byted.org/path-exists/-/path-exists-4.0.0.tgz", {}, "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="],
 
     "path-key": ["path-key@3.1.1", "https://bnpm.byted.org/path-key/-/path-key-3.1.1.tgz", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
 
     "path-scurry": ["path-scurry@1.11.1", "https://bnpm.byted.org/path-scurry/-/path-scurry-1.11.1.tgz", { "dependencies": { "lru-cache": "^10.2.0", "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0" } }, "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA=="],
-
-    "path-to-regexp": ["path-to-regexp@6.3.0", "https://bnpm.byted.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz", {}, "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ=="],
 
     "pause-stream": ["pause-stream@0.0.11", "https://bnpm.byted.org/pause-stream/-/pause-stream-0.0.11.tgz", { "dependencies": { "through": "~2.3" } }, "sha512-e3FBlXLmN/D1S+zHzanP4E/4Z60oFAa3O051qt1pxa7DEJWKAyil6upYVXCWadEnuoqa4Pkc9oUx9zsxYeRv8A=="],
 
@@ -1200,8 +1112,6 @@
     "qs": ["qs@6.15.0", "https://bnpm.byted.org/qs/-/qs-6.15.0.tgz", { "dependencies": { "side-channel": "^1.1.0" } }, "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ=="],
 
     "querystringify": ["querystringify@2.2.0", "https://bnpm.byted.org/querystringify/-/querystringify-2.2.0.tgz", {}, "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ=="],
-
-    "raw-body": ["raw-body@2.5.3", "https://bnpm.byted.org/raw-body/-/raw-body-2.5.3.tgz", { "dependencies": { "bytes": "~3.1.2", "http-errors": "~2.0.1", "iconv-lite": "~0.4.24", "unpipe": "~1.0.0" } }, "sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA=="],
 
     "rc-cascader": ["rc-cascader@3.34.0", "https://bnpm.byted.org/rc-cascader/-/rc-cascader-3.34.0.tgz", { "dependencies": { "@babel/runtime": "^7.25.7", "classnames": "^2.3.1", "rc-select": "~14.16.2", "rc-tree": "~5.13.0", "rc-util": "^5.43.0" }, "peerDependencies": { "react": ">=16.9.0", "react-dom": ">=16.9.0" } }, "sha512-KpXypcvju9ptjW9FaN2NFcA2QH9E9LHKq169Y0eWtH4e/wHQ5Wh5qZakAgvb8EKZ736WZ3B0zLLOBsrsja5Dag=="],
 
@@ -1307,8 +1217,6 @@
 
     "safe-buffer": ["safe-buffer@5.2.1", "https://bnpm.byted.org/safe-buffer/-/safe-buffer-5.2.1.tgz", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
 
-    "safe-regex-test": ["safe-regex-test@1.1.0", "https://bnpm.byted.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "is-regex": "^1.2.1" } }, "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw=="],
-
     "safe-stable-stringify": ["safe-stable-stringify@2.5.0", "https://bnpm.byted.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz", {}, "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA=="],
 
     "safer-buffer": ["safer-buffer@2.1.2", "https://bnpm.byted.org/safer-buffer/-/safer-buffer-2.1.2.tgz", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
@@ -1324,8 +1232,6 @@
     "semver": ["semver@7.7.4", "https://bnpm.byted.org/semver/-/semver-7.7.4.tgz", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
     "set-function-length": ["set-function-length@1.2.2", "https://bnpm.byted.org/set-function-length/-/set-function-length-1.2.2.tgz", { "dependencies": { "define-data-property": "^1.1.4", "es-errors": "^1.3.0", "function-bind": "^1.1.2", "get-intrinsic": "^1.2.4", "gopd": "^1.0.1", "has-property-descriptors": "^1.0.2" } }, "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg=="],
-
-    "setprototypeof": ["setprototypeof@1.2.0", "https://bnpm.byted.org/setprototypeof/-/setprototypeof-1.2.0.tgz", {}, "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="],
 
     "sha.js": ["sha.js@2.4.12", "https://bnpm.byted.org/sha.js/-/sha.js-2.4.12.tgz", { "dependencies": { "inherits": "^2.0.4", "safe-buffer": "^5.2.1", "to-buffer": "^1.2.0" }, "bin": { "sha.js": "bin.js" } }, "sha512-8LzC5+bvI45BjpfXU8V5fdU2mfeKiQe1D1gIMn7XUlF3OTUrpdJpPPH4EMAnF0DsHHdSZqCdSss5qCmJKuiO3w=="],
 
@@ -1419,8 +1325,6 @@
 
     "toggle-selection": ["toggle-selection@1.0.6", "https://bnpm.byted.org/toggle-selection/-/toggle-selection-1.0.6.tgz", {}, "sha512-BiZS+C1OS8g/q2RRbJmy59xpyghNBqrr6k5L/uKBGRsTfxmu3ffiRnd8mlGPUVayg8pvfi5urfnu8TU7DVOkLQ=="],
 
-    "toidentifier": ["toidentifier@1.0.1", "https://bnpm.byted.org/toidentifier/-/toidentifier-1.0.1.tgz", {}, "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="],
-
     "tos-crc64-js": ["tos-crc64-js@0.0.1", "https://bnpm.byted.org/tos-crc64-js/-/tos-crc64-js-0.0.1.tgz", {}, "sha512-l2Ndi9BaDH3gmAJ5VIS/1WeqFcucK41WCbw5dije24k2XtUCclYfvhntWIVHe+0S85QcED4vjqm3AO1izlQ30g=="],
 
     "tr46": ["tr46@5.1.1", "https://bnpm.byted.org/tr46/-/tr46-5.1.1.tgz", { "dependencies": { "punycode": "^2.3.1" } }, "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw=="],
@@ -1431,13 +1335,9 @@
 
     "tslib": ["tslib@2.8.1", "https://bnpm.byted.org/tslib/-/tslib-2.8.1.tgz", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
-    "tsscmp": ["tsscmp@1.0.6", "https://bnpm.byted.org/tsscmp/-/tsscmp-1.0.6.tgz", {}, "sha512-LxhtAkPDTkVCMQjt2h6eBVY28KCjikZqZfMcC15YBeNjkgUpdCfBu5HoiOTDu86v6smE8yOjyEktJ8hlbANHQA=="],
-
     "type-check": ["type-check@0.4.0", "https://bnpm.byted.org/type-check/-/type-check-0.4.0.tgz", { "dependencies": { "prelude-ls": "^1.2.1" } }, "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew=="],
 
     "type-fest": ["type-fest@1.4.0", "https://bnpm.byted.org/type-fest/-/type-fest-1.4.0.tgz", {}, "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA=="],
-
-    "type-is": ["type-is@1.6.18", "https://bnpm.byted.org/type-is/-/type-is-1.6.18.tgz", { "dependencies": { "media-typer": "0.3.0", "mime-types": "~2.1.24" } }, "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g=="],
 
     "typed-array-buffer": ["typed-array-buffer@1.0.3", "https://bnpm.byted.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz", { "dependencies": { "call-bound": "^1.0.3", "es-errors": "^1.3.0", "is-typed-array": "^1.1.14" } }, "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw=="],
 
@@ -1448,8 +1348,6 @@
     "undici-types": ["undici-types@5.26.5", "https://bnpm.byted.org/undici-types/-/undici-types-5.26.5.tgz", {}, "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="],
 
     "unescape": ["unescape@1.0.1", "https://bnpm.byted.org/unescape/-/unescape-1.0.1.tgz", { "dependencies": { "extend-shallow": "^2.0.1" } }, "sha512-O0+af1Gs50lyH1nUu3ZyYS1cRh01Q/kUKatTOkSs7jukXE6/NebucDVxyiDsA9AQ4JC1V1jUH9EO8JX2nMDgGQ=="],
-
-    "unpipe": ["unpipe@1.0.0", "https://bnpm.byted.org/unpipe/-/unpipe-1.0.0.tgz", {}, "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="],
 
     "update-browserslist-db": ["update-browserslist-db@1.2.3", "https://bnpm.byted.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz", { "dependencies": { "escalade": "^3.2.0", "picocolors": "^1.1.1" }, "peerDependencies": { "browserslist": ">= 4.21.0" }, "bin": { "update-browserslist-db": "cli.js" } }, "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w=="],
 
@@ -1464,8 +1362,6 @@
     "utility": ["utility@1.18.0", "https://bnpm.byted.org/utility/-/utility-1.18.0.tgz", { "dependencies": { "copy-to": "^2.0.1", "escape-html": "^1.0.3", "mkdirp": "^0.5.1", "mz": "^2.7.0", "unescape": "^1.0.1" } }, "sha512-PYxZDA+6QtvRvm//++aGdmKG/cI07jNwbROz0Ql+VzFV1+Z0Dy55NI4zZ7RHc9KKpBePNFwoErqIuqQv/cjiTA=="],
 
     "uuid": ["uuid@10.0.0", "https://bnpm.byted.org/uuid/-/uuid-10.0.0.tgz", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ=="],
-
-    "vary": ["vary@1.1.2", "https://bnpm.byted.org/vary/-/vary-1.1.2.tgz", {}, "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="],
 
     "vite": ["vite@5.4.21", "https://bnpm.byted.org/vite/-/vite-5.4.21.tgz", { "dependencies": { "esbuild": "^0.21.3", "postcss": "^8.4.43", "rollup": "^4.20.0" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || >=20.0.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.4.0" }, "optionalPeers": ["@types/node", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser"], "bin": { "vite": "bin/vite.js" } }, "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw=="],
 
@@ -1509,8 +1405,6 @@
 
     "yargs-parser": ["yargs-parser@21.1.1", "https://bnpm.byted.org/yargs-parser/-/yargs-parser-21.1.1.tgz", {}, "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="],
 
-    "ylru": ["ylru@1.4.0", "https://bnpm.byted.org/ylru/-/ylru-1.4.0.tgz", {}, "sha512-2OQsPNEmBCvXuFlIni/a+Rn+R2pHW9INm0BxXJ4hVDA8TirqMj+J/Rp9ItLatT/5pZqWwefVrTQcHpixsxnVlA=="],
-
     "yocto-queue": ["yocto-queue@0.1.0", "https://bnpm.byted.org/yocto-queue/-/yocto-queue-0.1.0.tgz", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
 
     "@babel/core/semver": ["semver@6.3.1", "https://bnpm.byted.org/semver/-/semver-6.3.1.tgz", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
@@ -1549,13 +1443,7 @@
 
     "glob/minimatch": ["minimatch@9.0.7", "https://bnpm.byted.org/minimatch/-/minimatch-9.0.7.tgz", { "dependencies": { "brace-expansion": "^5.0.2" } }, "sha512-MOwgjc8tfrpn5QQEvjijjmDVtMw2oL88ugTevzxQnzRLm6l3fVEF2gzU0kYeYYKD8C66+IdGX6peJ4MyUlUnPg=="],
 
-    "http-assert/http-errors": ["http-errors@1.8.1", "https://bnpm.byted.org/http-errors/-/http-errors-1.8.1.tgz", { "dependencies": { "depd": "~1.1.2", "inherits": "2.0.4", "setprototypeof": "1.2.0", "statuses": ">= 1.5.0 < 2", "toidentifier": "1.0.1" } }, "sha512-Kpk9Sm7NmI+RHhnj6OIWDI1d6fIoFAtFt9RLaTMRlg/8w49juAStsrBgp0Dp4OdxdVbRIeKhtCUvoi/RuAhO4g=="],
-
-    "http-errors/statuses": ["statuses@2.0.2", "https://bnpm.byted.org/statuses/-/statuses-2.0.2.tgz", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
-
     "http-proxy/eventemitter3": ["eventemitter3@4.0.7", "https://bnpm.byted.org/eventemitter3/-/eventemitter3-4.0.7.tgz", {}, "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="],
-
-    "koa/http-errors": ["http-errors@1.8.1", "https://bnpm.byted.org/http-errors/-/http-errors-1.8.1.tgz", { "dependencies": { "depd": "~1.1.2", "inherits": "2.0.4", "setprototypeof": "1.2.0", "statuses": ">= 1.5.0 < 2", "toidentifier": "1.0.1" } }, "sha512-Kpk9Sm7NmI+RHhnj6OIWDI1d6fIoFAtFt9RLaTMRlg/8w49juAStsrBgp0Dp4OdxdVbRIeKhtCUvoi/RuAhO4g=="],
 
     "lark-server/@types/bun": ["@types/bun@1.3.11", "https://bnpm.byted.org/@types/bun/-/bun-1.3.11.tgz", { "dependencies": { "bun-types": "1.3.11" } }, "sha512-5vPne5QvtpjGpsGYXiFyycfpDF2ECyPcTSsFBMa0fraoxiQyMJ3SmuQIGhzPg2WJuWxVBoxWJ2kClYTcw/4fAg=="],
 
@@ -1568,8 +1456,6 @@
     "npm-run-path/path-key": ["path-key@4.0.0", "https://bnpm.byted.org/path-key/-/path-key-4.0.0.tgz", {}, "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ=="],
 
     "path-scurry/lru-cache": ["lru-cache@10.4.3", "https://bnpm.byted.org/lru-cache/-/lru-cache-10.4.3.tgz", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
-
-    "raw-body/iconv-lite": ["iconv-lite@0.4.24", "https://bnpm.byted.org/iconv-lite/-/iconv-lite-0.4.24.tgz", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3" } }, "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA=="],
 
     "restore-cursor/onetime": ["onetime@7.0.0", "https://bnpm.byted.org/onetime/-/onetime-7.0.0.tgz", { "dependencies": { "mimic-function": "^5.0.0" } }, "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ=="],
 
@@ -1614,10 +1500,6 @@
     "color/color-convert/color-name": ["color-name@2.1.0", "https://bnpm.byted.org/color-name/-/color-name-2.1.0.tgz", {}, "sha512-1bPaDNFm0axzE4MEAzKPuqKWeRaT43U/hyxKPBdqTfmPF+d6n7FSoTFxLVULUJOmiLp01KjhIPPH+HrXZJN4Rg=="],
 
     "glob/minimatch/brace-expansion": ["brace-expansion@5.0.3", "https://bnpm.byted.org/brace-expansion/-/brace-expansion-5.0.3.tgz", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-fy6KJm2RawA5RcHkLa1z/ScpBeA762UF9KmZQxwIbDtRJrgLzM10depAiEQ+CXYcoiqW1/m96OAAoke2nE9EeA=="],
-
-    "http-assert/http-errors/depd": ["depd@1.1.2", "https://bnpm.byted.org/depd/-/depd-1.1.2.tgz", {}, "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ=="],
-
-    "koa/http-errors/depd": ["depd@1.1.2", "https://bnpm.byted.org/depd/-/depd-1.1.2.tgz", {}, "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ=="],
 
     "lark-server/@types/bun/bun-types": ["bun-types@1.3.11", "https://bnpm.byted.org/bun-types/-/bun-types-1.3.11.tgz", { "dependencies": { "@types/node": "*" } }, "sha512-1KGPpoxQWl9f6wcZh57LvrPIInQMn2TQ7jsgxqpRzg+l0QPOFvJVH7HmvHo/AiPgwXy+/Thf6Ov3EdVn1vOabg=="],
 

--- a/docs/superpowers/plans/2026-04-04-unify-http-framework-hono.md
+++ b/docs/superpowers/plans/2026-04-04-unify-http-framework-hono.md
@@ -1,0 +1,2050 @@
+# 统一 HTTP 框架到 Hono 实现计划
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 将 lark-server 和 monitor-dashboard 从 Koa 迁移到 Hono，统一 monorepo 中所有 TS 服务的 HTTP 框架。
+
+**Architecture:** 分三阶段：先改 `@inner/shared` 中间件（Koa→Hono），再迁移 lark-server（3路由），最后迁移 monitor-dashboard（37路由，保持 Node 运行时通过 `@hono/node-server`）。
+
+**Tech Stack:** Hono, @hono/node-server, prom-client, jsonwebtoken, TypeORM
+
+---
+
+## 文件变更总览
+
+### @inner/shared (packages/ts-shared)
+- Modify: `src/middleware/auth.ts` — Koa→Hono 中间件签名
+- Modify: `src/middleware/error-handler.ts` — Koa→Hono 中间件签名
+- Modify: `src/middleware/trace.ts` — Koa→Hono 中间件签名
+- Modify: `src/middleware/validation.ts` — Koa→Hono 中间件签名
+- Modify: `src/middleware/index.ts` — 更新类型导出
+- Modify: `package.json` — peer dep koa→hono
+
+### lark-server (apps/lark-server)
+- Modify: `src/startup/server.ts` — Koa app→Hono app
+- Modify: `src/middleware/error-handler.ts` — 适配 Hono 签名
+- Modify: `src/middleware/trace.ts` — Koa ctx→Hono c
+- Modify: `src/middleware/bot-context.ts` — Koa ctx→Hono c
+- Modify: `src/middleware/metrics.ts` — Koa ctx→Hono c + 路由
+- Modify: `src/middleware/auth.ts` — re-export 自动跟随 shared
+- Modify: `src/middleware/validation.ts` — re-export 自动跟随 shared
+- Modify: `src/api/routes/internal-lark.route.ts` — Koa Router→Hono
+- Modify: `src/middleware/error-handler.test.ts` — 适配 Hono
+- Modify: `package.json` — 移除 koa deps，加 hono
+
+### monitor-dashboard (apps/monitor-dashboard)
+- Modify: `src/index.ts` — Koa→Hono + @hono/node-server
+- Modify: `src/middleware/jwt-auth.ts` — Koa→Hono
+- Modify: `src/middleware/audit.ts` — Koa→Hono
+- Modify: `src/routes/auth.ts` — ctx→c
+- Modify: `src/routes/config.ts` — ctx→c
+- Modify: `src/routes/messages.ts` — ctx→c
+- Modify: `src/routes/providers.ts` — ctx→c
+- Modify: `src/routes/model-mappings.ts` — ctx→c
+- Modify: `src/routes/mongo.ts` — ctx→c
+- Modify: `src/routes/migrations.ts` — ctx→c
+- Modify: `src/routes/service-status.ts` — ctx→c
+- Modify: `src/routes/operations.ts` — ctx→c
+- Modify: `src/routes/audit-logs.ts` — ctx→c
+- Modify: `src/routes/activity.ts` — ctx→c
+- Modify: `package.json` — 移除 koa deps，加 hono + @hono/node-server
+
+---
+
+## Koa→Hono 转换速查表
+
+所有路由文件遵循相同的机械替换规则：
+
+| Koa | Hono |
+|-----|------|
+| `import Router from '@koa/router'` | `import { Hono } from 'hono'` |
+| `const router = new Router()` | `const app = new Hono()` |
+| `router.get('/path', async (ctx) => {` | `app.get('/path', async (c) => {` |
+| `ctx.body = data` | `return c.json(data)` |
+| `ctx.status = 404; ctx.body = { message: 'x' }; return;` | `return c.json({ message: 'x' }, 404)` |
+| `ctx.params.id` | `c.req.param('id')` |
+| `ctx.query.key as string` | `c.req.query('key')` |
+| `ctx.query as Record<string, string>` | 逐字段 `c.req.query('field')` |
+| `ctx.request.body as T` | `await c.req.json() as T` |
+| `ctx.get('Header')` | `c.req.header('Header')` |
+| `ctx.headers['x-lane']` | `c.req.header('x-lane')` |
+| `ctx.set('Header', val)` | `c.header('Header', val)` |
+| `ctx.state.caller` | `c.get('caller')` |
+| `ctx.method` | `c.req.method` |
+| `ctx.path` | `c.req.path` |
+| `export default router` | `export default app` |
+
+**关键差异：** Koa 用赋值 (`ctx.body = x`)，Hono 用返回 (`return c.json(x)`)。每个 handler 的最后一个 `ctx.body = x` 必须改为 `return c.json(x)`。
+
+---
+
+## Task 1: @inner/shared 中间件迁移
+
+**Files:**
+- Modify: `packages/ts-shared/src/middleware/auth.ts`
+- Modify: `packages/ts-shared/src/middleware/error-handler.ts`
+- Modify: `packages/ts-shared/src/middleware/trace.ts`
+- Modify: `packages/ts-shared/src/middleware/validation.ts`
+- Modify: `packages/ts-shared/src/middleware/index.ts`
+- Modify: `packages/ts-shared/package.json`
+
+- [ ] **Step 1: 更新 package.json 依赖**
+
+将 peer dep `koa` 换为 `hono`，dev dep `@types/koa` 删除：
+
+```json
+{
+  "peerDependencies": {
+    "hono": "^4.0.0",
+    "typeorm": "^0.3.17",
+    "pg": "^8.11.3"
+  },
+  "peerDependenciesMeta": {
+    "hono": { "optional": true },
+    "typeorm": { "optional": true },
+    "pg": { "optional": true }
+  }
+}
+```
+
+devDependencies 中删除 `"@types/koa": "^2.15.0"`。
+
+- [ ] **Step 2: 重写 auth.ts**
+
+```typescript
+import type { Context, Next } from 'hono';
+
+export interface BearerAuthOptions {
+    getExpectedToken?: () => string | undefined;
+    errorResponse?: {
+        missingAuth?: { success: boolean; message: string };
+        invalidToken?: { success: boolean; message: string };
+    };
+}
+
+export function createBearerAuthMiddleware(options: BearerAuthOptions = {}) {
+    const {
+        getExpectedToken = () => process.env.INNER_HTTP_SECRET,
+        errorResponse = {
+            missingAuth: { success: false, message: 'Missing or invalid Authorization header' },
+            invalidToken: { success: false, message: 'Invalid authentication token' },
+        },
+    } = options;
+
+    return async (c: Context, next: Next) => {
+        const authHeader = c.req.header('authorization');
+
+        if (!authHeader || !authHeader.startsWith('Bearer ')) {
+            return c.json(errorResponse.missingAuth, 401);
+        }
+
+        const token = authHeader.substring(7);
+        const expectedToken = getExpectedToken();
+
+        if (token !== expectedToken) {
+            return c.json(errorResponse.invalidToken, 401);
+        }
+
+        await next();
+    };
+}
+
+export const bearerAuthMiddleware = createBearerAuthMiddleware();
+```
+
+- [ ] **Step 3: 重写 error-handler.ts**
+
+```typescript
+import type { Context, Next } from 'hono';
+
+export interface ErrorHandlerOptions {
+    logger?: {
+        warn: (message: string, meta?: Record<string, unknown>) => void;
+        error: (message: string, meta?: Record<string, unknown>) => void;
+    };
+}
+
+export class AppError extends Error {
+    constructor(
+        public statusCode: number,
+        message: string,
+        public isOperational = true,
+    ) {
+        super(message);
+        this.name = 'AppError';
+    }
+}
+
+export function createErrorHandler(options: ErrorHandlerOptions = {}) {
+    const { logger } = options;
+
+    return async (c: Context, next: Next): Promise<void | Response> => {
+        try {
+            await next();
+        } catch (err: unknown) {
+            const error = err as Error;
+
+            if (error instanceof AppError) {
+                logger?.warn('Operational error', { message: error.message });
+                return c.json({ error: error.message, code: error.statusCode }, error.statusCode as any);
+            }
+
+            logger?.error('Unexpected error', {
+                name: error?.name,
+                message: error?.message,
+                stack: error instanceof Error ? error.stack : undefined,
+            });
+            return c.json({ error: 'Internal server error', code: 500 }, 500);
+        }
+    };
+}
+
+export const errorHandler = createErrorHandler();
+```
+
+- [ ] **Step 4: 重写 trace.ts**
+
+`additionalContext` 回调签名从 `(ctx: KoaContext)` 改为 `(c: HonoContext)`：
+
+```typescript
+import type { Context, Next } from 'hono';
+import { asyncLocalStorage, BaseRequestContext } from './context';
+import { v4 as uuidv4 } from 'uuid';
+
+export interface TraceMiddlewareOptions {
+    headerName?: string;
+    responseHeaderName?: string;
+    additionalContext?: (c: Context) => Partial<BaseRequestContext>;
+}
+
+export function createTraceMiddleware(options: TraceMiddlewareOptions = {}) {
+    const {
+        headerName = 'x-trace-id',
+        responseHeaderName = 'X-Trace-Id',
+        additionalContext,
+    } = options;
+
+    return async (c: Context, next: Next) => {
+        const traceId = c.req.header(headerName) || uuidv4();
+
+        const contextData: BaseRequestContext = {
+            traceId,
+            ...(additionalContext ? additionalContext(c) : {}),
+        };
+
+        await asyncLocalStorage.run(contextData, async () => {
+            c.header(responseHeaderName, traceId);
+            await next();
+        });
+    };
+}
+
+export const traceMiddleware = createTraceMiddleware();
+```
+
+- [ ] **Step 5: 重写 validation.ts**
+
+`validateFields` 纯函数不变，只改中间件包装层：
+
+```typescript
+import type { Context, Next } from 'hono';
+
+export class ValidationError extends Error {
+    constructor(message: string, public field: string) {
+        super(message);
+        this.name = 'ValidationError';
+    }
+}
+
+export interface ValidationRule {
+    required?: boolean;
+    type?: 'string' | 'number' | 'boolean';
+    minLength?: number;
+    maxLength?: number;
+    pattern?: RegExp;
+    custom?: (value: unknown) => boolean | string;
+}
+
+export interface ValidationRules {
+    [key: string]: ValidationRule;
+}
+
+function validateType(value: unknown, type: string): boolean {
+    switch (type) {
+        case 'string': return typeof value === 'string';
+        case 'number': return typeof value === 'number' && !isNaN(value);
+        case 'boolean': return typeof value === 'boolean';
+        default: return false;
+    }
+}
+
+function validateFields(data: Record<string, unknown>, rules: ValidationRules): void {
+    for (const [fieldName, rule] of Object.entries(rules)) {
+        const value = data[fieldName];
+        if (rule.required && (value === undefined || value === null || value === '')) {
+            throw new ValidationError(`${fieldName} is required`, fieldName);
+        }
+        if (value === undefined || value === null) continue;
+        if (rule.type && !validateType(value, rule.type)) {
+            throw new ValidationError(`${fieldName} must be of type ${rule.type}`, fieldName);
+        }
+        if (rule.type === 'string' || typeof value === 'string') {
+            const strValue = value as string;
+            if (rule.minLength && strValue.length < rule.minLength) {
+                throw new ValidationError(`${fieldName} must be at least ${rule.minLength} characters`, fieldName);
+            }
+            if (rule.maxLength && strValue.length > rule.maxLength) {
+                throw new ValidationError(`${fieldName} must be at most ${rule.maxLength} characters`, fieldName);
+            }
+        }
+        if (rule.pattern && typeof value === 'string' && !rule.pattern.test(value)) {
+            throw new ValidationError(`${fieldName} format is invalid`, fieldName);
+        }
+        if (rule.custom) {
+            const result = rule.custom(value);
+            if (result !== true) {
+                const message = typeof result === 'string' ? result : `${fieldName} validation failed`;
+                throw new ValidationError(message, fieldName);
+            }
+        }
+    }
+}
+
+export function validateBody(rules: ValidationRules) {
+    return async (c: Context, next: Next) => {
+        try {
+            const body = (await c.req.json().catch(() => ({}))) as Record<string, unknown>;
+            validateFields(body, rules);
+            await next();
+        } catch (error) {
+            if (error instanceof ValidationError) {
+                return c.json({
+                    success: false,
+                    message: `Validation failed: ${error.message}`,
+                    field: error.field,
+                    error_code: 'VALIDATION_ERROR',
+                }, 400);
+            }
+            throw error;
+        }
+    };
+}
+
+export function validateQuery(rules: ValidationRules) {
+    return async (c: Context, next: Next) => {
+        try {
+            const query = Object.fromEntries(
+                new URL(c.req.url).searchParams.entries()
+            ) as Record<string, unknown>;
+            validateFields(query, rules);
+            await next();
+        } catch (error) {
+            if (error instanceof ValidationError) {
+                return c.json({
+                    success: false,
+                    message: `Query validation failed: ${error.message}`,
+                    field: error.field,
+                    error_code: 'VALIDATION_ERROR',
+                }, 400);
+            }
+            throw error;
+        }
+    };
+}
+```
+
+- [ ] **Step 6: 更新 index.ts 导出**
+
+导出名称不变，无需修改 `index.ts`。验证导出列表与原版一致。
+
+- [ ] **Step 7: 安装依赖并验证编译**
+
+```bash
+cd packages/ts-shared && pnpm install && pnpm build
+```
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add packages/ts-shared/
+git commit -m "refactor(shared): migrate middleware from Koa to Hono"
+```
+
+---
+
+## Task 2: lark-server 迁移
+
+**Files:**
+- Modify: `apps/lark-server/package.json`
+- Modify: `apps/lark-server/src/startup/server.ts`
+- Modify: `apps/lark-server/src/middleware/error-handler.ts`
+- Modify: `apps/lark-server/src/middleware/trace.ts`
+- Modify: `apps/lark-server/src/middleware/bot-context.ts`
+- Modify: `apps/lark-server/src/middleware/metrics.ts`
+- Modify: `apps/lark-server/src/middleware/auth.ts`
+- Modify: `apps/lark-server/src/middleware/validation.ts`
+- Modify: `apps/lark-server/src/api/routes/internal-lark.route.ts`
+- Modify: `apps/lark-server/src/middleware/error-handler.test.ts`
+
+- [ ] **Step 1: 更新 package.json**
+
+dependencies 中：
+- 删除: `"koa": "^2.14.2"`, `"koa-body": "^6.0.1"`, `"@koa/cors": "^5.0.0"`, `"@koa/router": "^12.0.1"`
+- 新增: `"hono": "^4.7.0"`
+
+devDependencies 中：
+- 删除: `"@types/koa": "^2.15.0"`, `"@types/koa__cors": "^5.0.0"`, `"@types/koa__router": "^12.0.4"`
+
+- [ ] **Step 2: 重写 middleware/metrics.ts**
+
+```typescript
+import { Counter, Histogram, Gauge, Registry, collectDefaultMetrics } from 'prom-client';
+import type { Context, Next } from 'hono';
+import { Hono } from 'hono';
+
+export const register = new Registry();
+collectDefaultMetrics({ register });
+
+const httpRequestsTotal = new Counter({
+    name: 'http_requests_total',
+    help: 'Total HTTP requests',
+    labelNames: ['method', 'path', 'status'] as const,
+    registers: [register],
+});
+
+const httpRequestDuration = new Histogram({
+    name: 'http_request_duration_seconds',
+    help: 'HTTP request duration in seconds',
+    labelNames: ['method', 'path'] as const,
+    registers: [register],
+});
+
+const httpRequestsInFlight = new Gauge({
+    name: 'http_requests_in_flight',
+    help: 'Number of HTTP requests currently being processed',
+    registers: [register],
+});
+
+export async function metricsMiddleware(c: Context, next: Next): Promise<void> {
+    httpRequestsInFlight.inc();
+    const start = performance.now();
+    try {
+        await next();
+    } finally {
+        const duration = (performance.now() - start) / 1000;
+        httpRequestsInFlight.dec();
+        httpRequestsTotal.inc({ method: c.req.method, path: c.req.path, status: String(c.res.status) });
+        httpRequestDuration.observe({ method: c.req.method, path: c.req.path }, duration);
+    }
+}
+
+export const metricsApp = new Hono();
+metricsApp.get('/metrics', async (c) => {
+    return c.text(await register.metrics(), 200, {
+        'Content-Type': register.contentType,
+    });
+});
+```
+
+- [ ] **Step 3: 重写 middleware/trace.ts**
+
+```typescript
+import type { Context, Next } from 'hono';
+import { asyncLocalStorage } from '@middleware/context';
+import { v4 as uuidv4 } from 'uuid';
+
+export const traceMiddleware = async (c: Context, next: Next) => {
+    const traceId = c.req.header('x-trace-id') || uuidv4();
+
+    await asyncLocalStorage.run({ traceId }, async () => {
+        c.header('X-Trace-Id', traceId);
+        await next();
+    });
+};
+```
+
+- [ ] **Step 4: 重写 middleware/bot-context.ts**
+
+```typescript
+import type { Context, Next } from 'hono';
+import { asyncLocalStorage, context } from './context';
+
+export const botContextMiddleware = async (c: Context, next: Next) => {
+    const botName = c.req.header('x-app-name') || undefined;
+    const lane = c.req.header('x-lane') || undefined;
+
+    const newStore = context.set({ botName, lane });
+    await asyncLocalStorage.run(newStore, next);
+};
+```
+
+- [ ] **Step 5: 重写 middleware/error-handler.ts**
+
+```typescript
+import logger from '@logger/index';
+import { createErrorHandler } from '@inner/shared';
+
+export const errorHandler = createErrorHandler({
+    logger: {
+        warn: (message: string, meta?: Record<string, unknown>) => {
+            logger.warn(message, meta);
+        },
+        error: (message: string, meta?: Record<string, unknown>) => {
+            logger.error(message, meta);
+        },
+    },
+});
+```
+
+注意：删除 `import type { Context, Next } from 'koa'`，此文件不再需要类型导入（`createErrorHandler` 已返回 Hono 中间件）。
+
+- [ ] **Step 6: 重写 api/routes/internal-lark.route.ts**
+
+```typescript
+import { Hono } from 'hono';
+import { insertEvent } from '@dal/mongo/client';
+import { context } from '@middleware/context';
+import { EventRegistry, registerEventHandlerInstance } from '@lark/events/event-registry';
+import { larkEventHandlers } from '@lark/events/handlers';
+
+let initialized = false;
+function ensureHandlersInitialized(): void {
+    if (!initialized) {
+        registerEventHandlerInstance(larkEventHandlers);
+        initialized = true;
+        console.info('Internal lark route: Event handlers initialized');
+    }
+}
+
+const app = new Hono();
+
+app.post('/api/internal/lark-event', async (c) => {
+    const authHeader = c.req.header('Authorization') || '';
+    const token = authHeader.replace('Bearer ', '');
+    if (token !== process.env.INNER_HTTP_SECRET) {
+        return c.json({ error: 'Unauthorized' }, 401);
+    }
+
+    const botName = c.req.header('X-App-Name');
+    const traceId = c.req.header('x-trace-id');
+    const lane = c.req.header('x-lane') || undefined;
+
+    const { event_type, params } = await c.req.json() as {
+        event_type: string;
+        params: unknown;
+    };
+
+    if (!event_type || !params) {
+        return c.json({ error: 'Missing event_type or params' }, 400);
+    }
+
+    insertEvent(params).catch((err) => {
+        console.error('insert event error:', err);
+    });
+
+    ensureHandlersInitialized();
+
+    const contextData = context.createContext(botName || undefined, traceId || undefined, lane);
+    context.run(contextData, async () => {
+        const handler = EventRegistry.getHandlerByEventType(event_type);
+        if (handler) {
+            handler(params).catch((err) => {
+                console.error(`handler ${event_type} failed:`, err);
+            });
+        } else {
+            console.warn(`No handler for event_type: ${event_type}`);
+        }
+    });
+
+    return c.json({ ok: true });
+});
+
+export default app;
+```
+
+- [ ] **Step 7: 重写 startup/server.ts**
+
+```typescript
+import { Hono } from 'hono';
+import { cors } from 'hono/cors';
+import { bodyLimit } from 'hono/body-limit';
+import { errorHandler } from '@middleware/error-handler';
+import { traceMiddleware } from '@middleware/trace';
+import { botContextMiddleware } from '@middleware/bot-context';
+import { metricsMiddleware, metricsApp } from '@middleware/metrics';
+import { multiBotManager } from '@core/services/bot/multi-bot-manager';
+import internalLarkRoutes from '@api/routes/internal-lark.route';
+
+export interface ServerConfig {
+    port: number;
+}
+
+export class HttpServerManager {
+    private app: Hono;
+    private config: ServerConfig;
+
+    constructor(
+        config: ServerConfig = { port: 3000 },
+    ) {
+        this.config = config;
+        this.app = new Hono();
+        this.setupMiddleware();
+    }
+
+    private setupMiddleware(): void {
+        this.app.use('*', metricsMiddleware);
+        this.app.use('*', cors());
+        this.app.use('*', traceMiddleware);
+        this.app.use('*', errorHandler);
+        this.app.use('*', botContextMiddleware);
+        this.app.use('*', bodyLimit({ maxSize: 50 * 1024 * 1024 }));
+    }
+
+    private registerHealthCheck(): void {
+        this.app.get('/api/health', (c) => {
+            try {
+                const allBots = multiBotManager.getAllBotConfigs();
+                return c.json({
+                    status: 'ok',
+                    timestamp: new Date().toISOString(),
+                    service: 'lark-server',
+                    version: process.env.VERSION || process.env.GIT_SHA || 'unknown',
+                    bots: allBots.map((bot) => ({
+                        name: bot.bot_name,
+                        app_id: bot.app_id,
+                        init_type: bot.init_type,
+                        is_active: bot.is_active,
+                    })),
+                });
+            } catch (error) {
+                return c.json({
+                    status: 'error',
+                    message: error instanceof Error ? error.message : 'Unknown error',
+                }, 500);
+            }
+        });
+    }
+
+    async start(): Promise<void> {
+        this.app.route('', metricsApp);
+        this.registerHealthCheck();
+        this.app.route('', internalLarkRoutes);
+
+        // Bun native server
+        Bun.serve({
+            port: this.config.port,
+            fetch: this.app.fetch,
+        });
+        console.info(`HTTP server started on port ${this.config.port}`);
+        this.logAvailableRoutes();
+    }
+
+    private logAvailableRoutes(): void {
+        console.info('Available routes:');
+        console.info('  - /api/health (health check)');
+        console.info('  - /api/internal/lark-event (lane-proxy forwarded events)');
+    }
+
+    getApp(): Hono {
+        return this.app;
+    }
+}
+```
+
+注意：Koa 的 `koa-body` 同时做 body parsing 和 size limit。Hono 不需要显式 body parser（`c.req.json()` 按需解析），只需 `bodyLimit` 控制大小。
+
+- [ ] **Step 8: 更新 middleware/auth.ts 和 validation.ts**
+
+这两个文件只是 re-export shared 的内容，无需修改（import 路径不变）。验证它们仍能正常导出即可。
+
+- [ ] **Step 9: 更新 error-handler.test.ts**
+
+```typescript
+import { describe, test, expect, beforeEach, mock } from 'bun:test';
+import { AppError } from '@inner/shared';
+import { Hono } from 'hono';
+
+const mockLogger = {
+    warn: mock(),
+    error: mock(),
+    info: mock(),
+};
+mock.module('@logger/index', () => ({
+    default: mockLogger,
+}));
+
+const { errorHandler } = await import('@middleware/error-handler');
+
+describe('middleware/error-handler', () => {
+    beforeEach(() => {
+        mockLogger.warn.mockReset();
+        mockLogger.error.mockReset();
+        mockLogger.info.mockReset();
+    });
+
+    test('捕获 AppError 并返回统一业务错误响应', async () => {
+        const app = new Hono();
+        app.use('*', errorHandler);
+        app.get('/test', () => {
+            throw new AppError(400, '无效的参数');
+        });
+
+        const res = await app.request('/test');
+        expect(res.status).toBe(400);
+        expect(await res.json()).toEqual({ error: '无效的参数', code: 400 });
+        expect(mockLogger.warn).toHaveBeenCalledWith('Operational error', {
+            message: '无效的参数',
+        });
+        expect(mockLogger.error).not.toHaveBeenCalled();
+    });
+
+    test('捕获未知错误并返回 500 与通用消息', async () => {
+        const app = new Hono();
+        app.use('*', errorHandler);
+        app.get('/test', () => {
+            throw new Error('boom');
+        });
+
+        const res = await app.request('/test');
+        expect(res.status).toBe(500);
+        expect(await res.json()).toEqual({ error: 'Internal server error', code: 500 });
+        expect(mockLogger.error).toHaveBeenCalled();
+    });
+});
+```
+
+- [ ] **Step 10: 安装依赖并运行测试**
+
+```bash
+cd apps/lark-server && pnpm install && pnpm test
+```
+
+- [ ] **Step 11: 验证编译**
+
+```bash
+cd apps/lark-server && pnpm build
+```
+
+如果编译脚本用 `bun build`，确认无类型错误。
+
+- [ ] **Step 12: Commit**
+
+```bash
+git add apps/lark-server/
+git commit -m "refactor(lark-server): migrate from Koa to Hono"
+```
+
+---
+
+## Task 3: monitor-dashboard 中间件迁移
+
+**Files:**
+- Modify: `apps/monitor-dashboard/package.json`
+- Modify: `apps/monitor-dashboard/src/index.ts`
+- Modify: `apps/monitor-dashboard/src/middleware/jwt-auth.ts`
+- Modify: `apps/monitor-dashboard/src/middleware/audit.ts`
+
+- [ ] **Step 1: 更新 package.json**
+
+dependencies 中：
+- 删除: `"koa": "^2.15.0"`, `"@koa/cors": "^5.0.0"`, `"@koa/router": "^12.0.1"`, `"koa-bodyparser": "^4.4.1"`
+- 新增: `"hono": "^4.7.0"`, `"@hono/node-server": "^1.13.0"`
+
+devDependencies 中：
+- 删除: `"@types/koa": "^2.15.0"`, `"@types/koa__cors": "^5.0.0"`, `"@types/koa__router": "^12.0.4"`, `"@types/koa-bodyparser": "^4.3.12"`
+
+- [ ] **Step 2: 定义 Hono Variables 类型**
+
+在 `apps/monitor-dashboard/src/types.ts` 创建：
+
+```typescript
+export type AppVariables = {
+    caller: string;
+    user: unknown;
+};
+```
+
+这个类型让 `c.get('caller')` 和 `c.set('caller', value)` 有类型安全。
+
+- [ ] **Step 3: 重写 middleware/jwt-auth.ts**
+
+```typescript
+import type { Context, Next } from 'hono';
+import jwt from 'jsonwebtoken';
+
+const PUBLIC_PATHS = new Set([
+  '/dashboard/api/auth/login',
+  '/dashboard/api/config',
+  '/dashboard/api/health',
+]);
+
+export const jwtAuth = async (c: Context, next: Next) => {
+  if (!c.req.path.startsWith('/dashboard/api')) {
+    return next();
+  }
+  if (PUBLIC_PATHS.has(c.req.path)) {
+    c.set('caller', 'public');
+    return next();
+  }
+
+  // API Key auth (Claude Code)
+  const apiKey = c.req.header('x-api-key');
+  const ccToken = process.env.DASHBOARD_CC_TOKEN;
+  if (apiKey && ccToken && apiKey === ccToken) {
+    c.set('caller', 'claude-code');
+    return next();
+  }
+
+  // JWT Bearer auth (Web Admin)
+  const authHeader = c.req.header('authorization') || c.req.header('Authorization') || '';
+  const token = authHeader.startsWith('Bearer ') ? authHeader.slice(7) : '';
+
+  if (!token) {
+    return c.json({ message: 'Unauthorized' }, 401);
+  }
+
+  try {
+    const secret = process.env.DASHBOARD_JWT_SECRET!;
+    const payload = jwt.verify(token, secret);
+    c.set('user', payload);
+    c.set('caller', 'web-admin');
+  } catch {
+    return c.json({ message: 'Unauthorized' }, 401);
+  }
+
+  await next();
+};
+```
+
+- [ ] **Step 4: 重写 middleware/audit.ts**
+
+关键差异：Hono 中 `await next()` 后响应在 `c.res`，读 status 用 `c.res.status`，读 body 需要 clone。`ctx.params` 在全局中间件中不可用，改为从路径解析。`ctx.request.body` 改为 `c.req.json()`（Hono 会缓存已解析的 body）。
+
+```typescript
+import type { Context, Next } from 'hono';
+import { AppDataSource } from '../db';
+import { AuditLog } from '../entities/audit-log';
+
+function deriveAction(method: string, path: string): string {
+  const p = path.replace(/^\/dashboard/, '');
+
+  const patterns: [RegExp, string][] = [
+    [/^\/api\/ops\/services\/[^/]+\/pods$/, 'ops.pods.read'],
+    [/^\/api\/ops\/services$/, 'ops.services.read'],
+    [/^\/api\/ops\/builds\/[^/]+\/latest$/, 'ops.builds.read'],
+    [/^\/api\/ops\/db-query$/, 'ops.db-query'],
+    [/^\/api\/ops\/lane-bindings$/, method === 'GET' ? 'ops.lane-bindings.read' : method === 'POST' ? 'ops.lane-bindings.create' : 'ops.lane-bindings.delete'],
+    [/^\/api\/ops\/trigger-diary$/, 'ops.trigger-diary'],
+    [/^\/api\/ops\/trigger-weekly-review$/, 'ops.trigger-weekly-review'],
+    [/^\/api\/audit-logs$/, 'audit-logs.read'],
+    [/^\/api\/activity\//, 'activity.read'],
+    [/^\/api\/providers/, method === 'GET' ? 'providers.read' : `providers.${method.toLowerCase()}`],
+    [/^\/api\/model-mappings/, method === 'GET' ? 'model-mappings.read' : `model-mappings.${method.toLowerCase()}`],
+    [/^\/api\/messages/, 'messages.read'],
+    [/^\/api\/service-status/, 'service-status.read'],
+    [/^\/api\/migrations/, method === 'POST' ? 'migrations.run' : 'migrations.read'],
+    [/^\/api\/mongo/, 'mongo.query'],
+  ];
+
+  for (const [re, action] of patterns) {
+    if (re.test(p)) return action;
+  }
+  return `${method.toLowerCase()}.${p.replace(/^\/api\//, '').replace(/\//g, '.')}`;
+}
+
+const SKIP_PATHS = new Set([
+  '/dashboard/api/auth/login',
+  '/dashboard/api/config',
+  '/dashboard/api/health',
+]);
+
+export const auditMiddleware = async (c: Context, next: Next) => {
+  if (!c.req.path.startsWith('/dashboard/api') || SKIP_PATHS.has(c.req.path)) {
+    return next();
+  }
+
+  const start = Date.now();
+  let result: 'success' | 'error' | 'denied' = 'success';
+  let errorMessage: string | null = null;
+
+  // Pre-read body for audit logging (Hono caches parsed JSON)
+  let requestBody: Record<string, unknown> | null = null;
+  if (['POST', 'PUT', 'PATCH', 'DELETE'].includes(c.req.method)) {
+    try {
+      requestBody = await c.req.json();
+    } catch { /* no body or not JSON */ }
+  }
+
+  try {
+    await next();
+    const status = c.res.status;
+    if (status === 401 || status === 403) {
+      result = 'denied';
+    } else if (status >= 400) {
+      result = 'error';
+      try {
+        const resBody = await c.res.clone().json() as Record<string, unknown>;
+        errorMessage = (resBody?.message as string) || `HTTP ${status}`;
+      } catch {
+        errorMessage = `HTTP ${status}`;
+      }
+    }
+  } catch (err) {
+    result = 'error';
+    errorMessage = err instanceof Error ? err.message : String(err);
+    throw err;
+  } finally {
+    const duration = Date.now() - start;
+    const caller = c.get('caller') || 'unknown';
+    const action = deriveAction(c.req.method, c.req.path);
+
+    const params: Record<string, unknown> = {};
+    const queryObj = c.req.queries();
+    if (queryObj && Object.keys(queryObj).length) params.query = queryObj;
+    if (requestBody && typeof requestBody === 'object' && Object.keys(requestBody).length) {
+      const body = { ...requestBody };
+      delete body.password;
+      delete body.api_key;
+      params.body = body;
+    }
+
+    try {
+      const repo = AppDataSource.getRepository(AuditLog);
+      await repo.save({
+        caller,
+        action,
+        params: Object.keys(params).length ? params : null,
+        result,
+        error_message: errorMessage,
+        duration_ms: duration,
+      });
+    } catch (auditErr) {
+      console.error('Failed to write audit log:', auditErr);
+    }
+  }
+};
+```
+
+- [ ] **Step 5: 重写 index.ts**
+
+```typescript
+import 'reflect-metadata';
+import { Hono } from 'hono';
+import { cors } from 'hono/cors';
+import { serve } from '@hono/node-server';
+
+import { AppDataSource } from './db';
+import { initMongo } from './mongo';
+import { jwtAuth } from './middleware/jwt-auth';
+import { auditMiddleware } from './middleware/audit';
+
+import authRoutes from './routes/auth';
+import configRoutes from './routes/config';
+import messagesRoutes from './routes/messages';
+import providersRoutes from './routes/providers';
+import modelMappingsRoutes from './routes/model-mappings';
+import mongoRoutes from './routes/mongo';
+import migrationsRoutes from './routes/migrations';
+import serviceStatusRoutes from './routes/service-status';
+import operationsRoutes from './routes/operations';
+import auditLogsRoutes from './routes/audit-logs';
+import activityRoutes from './routes/activity';
+
+const PORT = Number(process.env.DASHBOARD_PORT || 3002);
+
+if (!process.env.DASHBOARD_JWT_SECRET) {
+  console.error('FATAL: DASHBOARD_JWT_SECRET is required but not set');
+  process.exit(1);
+}
+
+const bootstrap = async () => {
+  await AppDataSource.initialize();
+  await initMongo();
+
+  const app = new Hono();
+
+  if (process.env.NODE_ENV !== 'production') {
+    app.use('*', cors());
+  }
+
+  // Global error handler
+  app.use('*', async (c, next) => {
+    try {
+      await next();
+    } catch (err: unknown) {
+      const axiosResp = (err as { response?: { status?: number; data?: unknown } })?.response;
+      const status = axiosResp?.status
+        || (err as { status?: number })?.status
+        || 500;
+      const raw = axiosResp?.data as Record<string, unknown> | undefined;
+      const upstream = (raw && typeof raw === 'object' && 'data' in raw) ? raw.data as Record<string, unknown> : raw;
+      const message = (upstream && typeof upstream === 'object' && 'error' in upstream)
+        ? upstream.error
+        : err instanceof Error ? err.message : String(err);
+      return c.json({ message, status }, status as any);
+    }
+  });
+
+  app.use('/dashboard/api/*', jwtAuth);
+  app.use('/dashboard/api/*', auditMiddleware);
+
+  // Mount all route sub-apps under /dashboard prefix
+  const dashboard = new Hono();
+  dashboard.route('', authRoutes);
+  dashboard.route('', configRoutes);
+  dashboard.route('', messagesRoutes);
+  dashboard.route('', providersRoutes);
+  dashboard.route('', modelMappingsRoutes);
+  dashboard.route('', mongoRoutes);
+  dashboard.route('', migrationsRoutes);
+  dashboard.route('', serviceStatusRoutes);
+  dashboard.route('', operationsRoutes);
+  dashboard.route('', auditLogsRoutes);
+  dashboard.route('', activityRoutes);
+
+  app.route('/dashboard', dashboard);
+
+  serve({ fetch: app.fetch, port: PORT }, () => {
+    console.log(`Monitor dashboard server running on ${PORT}`);
+  });
+};
+
+bootstrap().catch((err) => {
+  console.error('Failed to start monitor dashboard:', err);
+  process.exit(1);
+});
+```
+
+注意：Koa 用 `new Router({ prefix: '/dashboard' })`，Hono 用 `app.route('/dashboard', dashboard)` 实现相同效果。路由文件内的路径保持不变（`/api/xxx`），挂载时自动加 `/dashboard` 前缀。
+
+- [ ] **Step 6: Commit 中间件和入口**
+
+```bash
+git add apps/monitor-dashboard/src/index.ts apps/monitor-dashboard/src/middleware/ apps/monitor-dashboard/src/types.ts apps/monitor-dashboard/package.json
+git commit -m "refactor(dashboard): migrate entry and middleware from Koa to Hono"
+```
+
+---
+
+## Task 4: monitor-dashboard 路由迁移（简单路由）
+
+**Files:**
+- Modify: `apps/monitor-dashboard/src/routes/auth.ts`
+- Modify: `apps/monitor-dashboard/src/routes/config.ts`
+- Modify: `apps/monitor-dashboard/src/routes/service-status.ts`
+- Modify: `apps/monitor-dashboard/src/routes/audit-logs.ts`
+- Modify: `apps/monitor-dashboard/src/routes/mongo.ts`
+- Modify: `apps/monitor-dashboard/src/routes/migrations.ts`
+
+这些路由文件较短（< 70 行），转换直接。
+
+- [ ] **Step 1: 重写 auth.ts**
+
+```typescript
+import { Hono } from 'hono';
+import jwt from 'jsonwebtoken';
+
+const app = new Hono();
+
+app.post('/api/auth/login', async (c) => {
+  const { password } = await c.req.json() as { password?: string };
+
+  if (!password || password !== process.env.DASHBOARD_ADMIN_PASSWORD) {
+    return c.json({ message: 'Invalid password' }, 401);
+  }
+
+  const secret = process.env.DASHBOARD_JWT_SECRET!;
+  const token = jwt.sign({ role: 'admin' }, secret, { expiresIn: '7d' });
+
+  return c.json({ token });
+});
+
+export default app;
+```
+
+- [ ] **Step 2: 重写 config.ts**
+
+```typescript
+import { Hono } from 'hono';
+
+const app = new Hono();
+
+app.get('/api/config', async (c) => {
+  const grafanaHost = process.env.DASHBOARD_GRAFANA_HOST || '';
+  const langfuseHost = process.env.DASHBOARD_LANGFUSE_HOST || '';
+  const langfuseProjectId = process.env.DASHBOARD_LANGFUSE_PROJECT_ID || '';
+
+  return c.json({
+    grafanaUrl: grafanaHost,
+    kibanaUrl: grafanaHost,
+    langfuseUrl: `${langfuseHost}/project/${langfuseProjectId}`,
+  });
+});
+
+app.get('/api/health', async (c) => {
+  return c.json({
+    status: 'ok',
+    timestamp: new Date().toISOString(),
+    service: 'monitor-dashboard',
+    version: process.env.VERSION || process.env.GIT_SHA || 'unknown',
+  });
+});
+
+export default app;
+```
+
+- [ ] **Step 3: 重写 service-status.ts**
+
+```typescript
+import { Hono } from 'hono';
+import axios from 'axios';
+
+const app = new Hono();
+
+app.get('/api/service-status', async (c) => {
+  const paasApi = process.env.DASHBOARD_PAAS_API;
+  const paasToken = process.env.DASHBOARD_PAAS_TOKEN;
+
+  if (!paasApi || !paasToken) {
+    return c.json({ message: 'DASHBOARD_PAAS_API or DASHBOARD_PAAS_TOKEN not configured' }, 500);
+  }
+
+  const headers = { 'X-API-Key': paasToken };
+  const timeout = 10000;
+
+  const [appsRes, releasesRes] = await Promise.all([
+    axios.get(`${paasApi}/api/paas/apps/`, { headers, timeout }),
+    axios.get(`${paasApi}/api/paas/releases/`, { headers, timeout }),
+  ]);
+
+  return c.json({
+    apps: appsRes.data?.data ?? appsRes.data,
+    releases: releasesRes.data?.data ?? releasesRes.data,
+  });
+});
+
+export default app;
+```
+
+- [ ] **Step 4: 重写 audit-logs.ts**
+
+```typescript
+import { Hono } from 'hono';
+import { AppDataSource } from '../db';
+import { AuditLog } from '../entities/audit-log';
+
+const app = new Hono();
+
+app.get('/api/audit-logs', async (c) => {
+  const caller = c.req.query('caller');
+  const action = c.req.query('action');
+  const result = c.req.query('result');
+  const from = c.req.query('from');
+  const to = c.req.query('to');
+  const page = c.req.query('page') || '1';
+  const pageSize = c.req.query('pageSize') || '50';
+
+  const repo = AppDataSource.getRepository(AuditLog);
+  const qb = repo.createQueryBuilder('log');
+
+  if (caller) qb.andWhere('log.caller = :caller', { caller });
+  if (action) qb.andWhere('log.action LIKE :action', { action: `%${action}%` });
+  if (result) qb.andWhere('log.result = :result', { result });
+  if (from) qb.andWhere('log.created_at >= :from', { from });
+  if (to) qb.andWhere('log.created_at <= :to', { to });
+
+  const limit = Math.min(Number(pageSize) || 50, 200);
+  const offset = ((Number(page) || 1) - 1) * limit;
+
+  qb.orderBy('log.created_at', 'DESC').skip(offset).take(limit);
+
+  const [items, total] = await qb.getManyAndCount();
+
+  return c.json({
+    items,
+    total,
+    page: Number(page) || 1,
+    pageSize: limit,
+  });
+});
+
+export default app;
+```
+
+- [ ] **Step 5: 重写 mongo.ts**
+
+```typescript
+import { Hono } from 'hono';
+import { queryLarkEvents } from '../mongo';
+
+const app = new Hono();
+
+const parseNumber = (value: unknown, fallback: number) => {
+  if (typeof value === 'number') return value;
+  if (typeof value === 'string') {
+    const parsed = Number(value);
+    return Number.isNaN(parsed) ? fallback : parsed;
+  }
+  return fallback;
+};
+
+app.post('/api/mongo/query', async (c) => {
+  const body = (await c.req.json().catch(() => ({}))) as {
+    filter?: Record<string, unknown>;
+    projection?: Record<string, unknown>;
+    sort?: Record<string, unknown>;
+    page?: number;
+    pageSize?: number;
+  };
+
+  const page = Math.max(1, parseNumber(body.page, 1));
+  const pageSize = Math.min(100, Math.max(1, parseNumber(body.pageSize, 20)));
+
+  try {
+    const { data, total } = await queryLarkEvents({
+      filter: body.filter ?? {},
+      projection: body.projection ?? {},
+      sort: body.sort ?? { created_at: -1 },
+      skip: (page - 1) * pageSize,
+      limit: pageSize,
+    });
+
+    return c.json({ data, total, page, pageSize });
+  } catch (error) {
+    return c.json({ message: (error as Error).message }, 400);
+  }
+});
+
+export default app;
+```
+
+- [ ] **Step 6: 重写 migrations.ts**
+
+```typescript
+import { Hono } from 'hono';
+import { AppDataSource, SchemaMigration } from '../db';
+
+const app = new Hono();
+
+app.get('/api/migrations', async (c) => {
+  const repo = AppDataSource.getRepository(SchemaMigration);
+  const migrations = await repo.find({ order: { id: 'DESC' } });
+  return c.json(migrations);
+});
+
+app.post('/api/migrations/run', async (c) => {
+  const { version, name, sql, applied_by } = await c.req.json() as {
+    version?: string;
+    name?: string;
+    sql?: string;
+    applied_by?: string;
+  };
+
+  if (!version || !name || !sql) {
+    return c.json({ message: 'version, name, sql are required' }, 400);
+  }
+
+  const repo = AppDataSource.getRepository(SchemaMigration);
+
+  const existing = await repo.findOne({ where: { version } });
+  if (existing) {
+    return c.json({ message: `Migration ${version} already applied` }, 409);
+  }
+
+  const startTime = Date.now();
+  let status: 'success' | 'failed' = 'success';
+  let errorMessage: string | null = null;
+
+  try {
+    await AppDataSource.transaction(async (manager) => {
+      await manager.query(sql);
+    });
+  } catch (err) {
+    status = 'failed';
+    errorMessage = err instanceof Error ? err.message : String(err);
+  }
+
+  const durationMs = Date.now() - startTime;
+
+  const record = repo.create({
+    version,
+    name,
+    sql_content: sql,
+    applied_by: applied_by || 'manual',
+    status,
+    error_message: errorMessage,
+    duration_ms: durationMs,
+  });
+
+  await repo.save(record);
+
+  if (status === 'failed') {
+    return c.json({ message: errorMessage, record }, 500);
+  }
+
+  return c.json(record);
+});
+
+export default app;
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/monitor-dashboard/src/routes/auth.ts apps/monitor-dashboard/src/routes/config.ts apps/monitor-dashboard/src/routes/service-status.ts apps/monitor-dashboard/src/routes/audit-logs.ts apps/monitor-dashboard/src/routes/mongo.ts apps/monitor-dashboard/src/routes/migrations.ts
+git commit -m "refactor(dashboard): migrate simple routes from Koa to Hono"
+```
+
+---
+
+## Task 5: monitor-dashboard 路由迁移（复杂路由）
+
+**Files:**
+- Modify: `apps/monitor-dashboard/src/routes/providers.ts`
+- Modify: `apps/monitor-dashboard/src/routes/model-mappings.ts`
+- Modify: `apps/monitor-dashboard/src/routes/operations.ts`
+- Modify: `apps/monitor-dashboard/src/routes/messages.ts`
+- Modify: `apps/monitor-dashboard/src/routes/activity.ts`
+
+- [ ] **Step 1: 重写 providers.ts**
+
+```typescript
+import { Hono } from 'hono';
+import { AppDataSource, ModelProvider } from '../db';
+import { randomUUID } from 'crypto';
+
+const app = new Hono();
+
+const maskApiKey = (apiKey: string) => {
+  if (!apiKey) return '';
+  const tail = apiKey.slice(-4);
+  return `****${tail}`;
+};
+
+const allowedClientTypes = new Set(['openai', 'openai-responses', 'deepseek', 'ark', 'azure-http', 'google']);
+
+app.get('/api/providers', async (c) => {
+  const repo = AppDataSource.getRepository(ModelProvider);
+  const providers = await repo.find({ order: { created_at: 'DESC' } });
+  return c.json(providers.map((provider) => ({
+    ...provider,
+    api_key: maskApiKey(provider.api_key),
+  })));
+});
+
+app.get('/api/providers/:id', async (c) => {
+  const repo = AppDataSource.getRepository(ModelProvider);
+  const provider = await repo.findOne({ where: { provider_id: c.req.param('id') } });
+  if (!provider) {
+    return c.json({ message: 'Not found' }, 404);
+  }
+  return c.json({
+    ...provider,
+    api_key: maskApiKey(provider.api_key),
+  });
+});
+
+app.post('/api/providers', async (c) => {
+  const { name, api_key, base_url, client_type, is_active } = await c.req.json() as {
+    name?: string;
+    api_key?: string;
+    base_url?: string;
+    client_type?: string;
+    is_active?: boolean;
+  };
+
+  if (!name || !base_url || !api_key) {
+    return c.json({ message: 'name, base_url, api_key are required' }, 400);
+  }
+
+  const resolvedClientType = (client_type || 'openai').toLowerCase();
+  if (!allowedClientTypes.has(resolvedClientType)) {
+    return c.json({ message: 'Invalid client_type' }, 400);
+  }
+
+  const repo = AppDataSource.getRepository(ModelProvider);
+  const provider = repo.create({
+    provider_id: randomUUID(),
+    name,
+    api_key,
+    base_url,
+    client_type: resolvedClientType,
+    is_active: is_active ?? true,
+  });
+
+  await repo.save(provider);
+
+  return c.json({
+    ...provider,
+    api_key: maskApiKey(provider.api_key),
+  });
+});
+
+app.put('/api/providers/:id', async (c) => {
+  const { name, api_key, base_url, client_type, is_active } = await c.req.json() as {
+    name?: string;
+    api_key?: string;
+    base_url?: string;
+    client_type?: string;
+    is_active?: boolean;
+  };
+
+  const repo = AppDataSource.getRepository(ModelProvider);
+  const provider = await repo.findOne({ where: { provider_id: c.req.param('id') } });
+  if (!provider) {
+    return c.json({ message: 'Not found' }, 404);
+  }
+
+  if (name !== undefined) provider.name = name;
+  if (api_key !== undefined && api_key !== '') provider.api_key = api_key;
+  if (base_url !== undefined) provider.base_url = base_url;
+  if (client_type !== undefined) {
+    const resolvedClientType = client_type.toLowerCase();
+    if (!allowedClientTypes.has(resolvedClientType)) {
+      return c.json({ message: 'Invalid client_type' }, 400);
+    }
+    provider.client_type = resolvedClientType;
+  }
+  if (is_active !== undefined) provider.is_active = is_active;
+
+  await repo.save(provider);
+
+  return c.json({
+    ...provider,
+    api_key: maskApiKey(provider.api_key),
+  });
+});
+
+app.delete('/api/providers/:id', async (c) => {
+  const repo = AppDataSource.getRepository(ModelProvider);
+  const provider = await repo.findOne({ where: { provider_id: c.req.param('id') } });
+  if (!provider) {
+    return c.json({ message: 'Not found' }, 404);
+  }
+
+  await repo.remove(provider);
+  return c.json({ success: true });
+});
+
+export default app;
+```
+
+- [ ] **Step 2: 重写 model-mappings.ts**
+
+```typescript
+import { Hono } from 'hono';
+import { AppDataSource, ModelMapping } from '../db';
+
+const app = new Hono();
+
+app.get('/api/model-mappings', async (c) => {
+  const repo = AppDataSource.getRepository(ModelMapping);
+  const mappings = await repo.find({ order: { created_at: 'DESC' } });
+  return c.json(mappings);
+});
+
+app.get('/api/model-mappings/:id', async (c) => {
+  const repo = AppDataSource.getRepository(ModelMapping);
+  const mapping = await repo.findOne({ where: { id: c.req.param('id') } });
+  if (!mapping) {
+    return c.json({ message: 'Not found' }, 404);
+  }
+  return c.json(mapping);
+});
+
+app.post('/api/model-mappings', async (c) => {
+  const { alias, provider_name, real_model_name, description, model_config } =
+    await c.req.json() as {
+      alias?: string;
+      provider_name?: string;
+      real_model_name?: string;
+      description?: string;
+      model_config?: Record<string, unknown> | null;
+    };
+
+  if (!alias || !provider_name || !real_model_name) {
+    return c.json({ message: 'alias, provider_name, real_model_name are required' }, 400);
+  }
+
+  const repo = AppDataSource.getRepository(ModelMapping);
+  const existing = await repo.findOne({ where: { alias } });
+  if (existing) {
+    return c.json({ message: 'alias already exists' }, 400);
+  }
+
+  const mapping = repo.create({
+    alias,
+    provider_name,
+    real_model_name,
+    description: description ?? null,
+    model_config: model_config ?? null,
+  });
+
+  await repo.save(mapping);
+  return c.json(mapping);
+});
+
+app.put('/api/model-mappings/:id', async (c) => {
+  const { alias, provider_name, real_model_name, description, model_config } =
+    await c.req.json() as {
+      alias?: string;
+      provider_name?: string;
+      real_model_name?: string;
+      description?: string;
+      model_config?: Record<string, unknown> | null;
+    };
+
+  const repo = AppDataSource.getRepository(ModelMapping);
+  const mapping = await repo.findOne({ where: { id: c.req.param('id') } });
+  if (!mapping) {
+    return c.json({ message: 'Not found' }, 404);
+  }
+
+  if (alias !== undefined && alias !== mapping.alias) {
+    const existing = await repo.findOne({ where: { alias } });
+    if (existing) {
+      return c.json({ message: 'alias already exists' }, 400);
+    }
+    mapping.alias = alias;
+  }
+  if (provider_name !== undefined) mapping.provider_name = provider_name;
+  if (real_model_name !== undefined) mapping.real_model_name = real_model_name;
+  if (description !== undefined) mapping.description = description;
+  if (model_config !== undefined) mapping.model_config = model_config;
+
+  await repo.save(mapping);
+  return c.json(mapping);
+});
+
+app.delete('/api/model-mappings/:id', async (c) => {
+  const repo = AppDataSource.getRepository(ModelMapping);
+  const mapping = await repo.findOne({ where: { id: c.req.param('id') } });
+  if (!mapping) {
+    return c.json({ message: 'Not found' }, 404);
+  }
+
+  await repo.remove(mapping);
+  return c.json({ success: true });
+});
+
+export default app;
+```
+
+- [ ] **Step 3: 重写 operations.ts**
+
+```typescript
+import { Hono } from 'hono';
+import { paasClient, larkClient } from '../paas-client';
+
+const app = new Hono();
+
+// ---------- 读操作 ----------
+
+app.get('/api/ops/services', async (c) => {
+  const [apps, releases] = await Promise.all([
+    paasClient.get('/api/paas/apps/'),
+    paasClient.get('/api/paas/releases/'),
+  ]);
+  return c.json({ apps, releases });
+});
+
+app.get('/api/ops/services/:app/pods', async (c) => {
+  const appName = c.req.param('app');
+  const lane = c.req.query('lane') || 'prod';
+
+  const releases = (await paasClient.get('/api/paas/releases/', { app: appName, lane })) as Array<{ id: string }>;
+  if (!Array.isArray(releases) || releases.length === 0) {
+    return c.json({ message: `No release found for ${appName} in lane ${lane}` }, 404);
+  }
+
+  const status = await paasClient.get(`/api/paas/releases/${releases[0].id}/status`);
+  return c.json(status);
+});
+
+app.get('/api/ops/builds/:app/latest', async (c) => {
+  const appName = c.req.param('app');
+  const data = await paasClient.get(`/api/paas/apps/${appName}/builds/latest`);
+  return c.json(data);
+});
+
+app.post('/api/ops/db-query', async (c) => {
+  const { sql, db } = await c.req.json() as { sql?: string; db?: string };
+  if (!sql) {
+    return c.json({ message: 'sql is required' }, 400);
+  }
+
+  const normalized = sql.trim().toUpperCase();
+  const forbidden = ['INSERT', 'UPDATE', 'DELETE', 'DROP', 'ALTER', 'TRUNCATE', 'CREATE', 'GRANT', 'REVOKE'];
+  if (forbidden.some((kw) => normalized.startsWith(kw))) {
+    return c.json({ message: 'Only SELECT queries are allowed' }, 403);
+  }
+
+  const data = await paasClient.post('/api/paas/ops/query', {
+    sql,
+    db: db || 'paas_engine',
+  });
+  return c.json(data);
+});
+
+app.get('/api/ops/lane-bindings', async (c) => {
+  const data = await larkClient.get('/api/lark/lane-bindings');
+  return c.json(data);
+});
+
+// ---------- DDL/DML 变更审批 ----------
+
+function laneHeaders(c: { req: { header: (name: string) => string | undefined } }): Record<string, string> | undefined {
+  const lane = c.req.header('x-lane');
+  return lane ? { 'x-lane': lane } : undefined;
+}
+
+app.post('/api/ops/db-mutations', async (c) => {
+  const data = await paasClient.post('/api/paas/ops/mutations', await c.req.json(), laneHeaders(c));
+  return c.json(data);
+});
+
+app.get('/api/ops/db-mutations', async (c) => {
+  const params: Record<string, string> = {};
+  const status = c.req.query('status');
+  if (status) params.status = status;
+  const data = await paasClient.get('/api/paas/ops/mutations', params, laneHeaders(c));
+  return c.json(data);
+});
+
+app.get('/api/ops/db-mutations/:id', async (c) => {
+  const data = await paasClient.get(`/api/paas/ops/mutations/${c.req.param('id')}`, undefined, laneHeaders(c));
+  return c.json(data);
+});
+
+app.post('/api/ops/db-mutations/:id/approve', async (c) => {
+  const data = await paasClient.post(`/api/paas/ops/mutations/${c.req.param('id')}/approve`, await c.req.json(), laneHeaders(c));
+  return c.json(data);
+});
+
+app.post('/api/ops/db-mutations/:id/reject', async (c) => {
+  const data = await paasClient.post(`/api/paas/ops/mutations/${c.req.param('id')}/reject`, await c.req.json(), laneHeaders(c));
+  return c.json(data);
+});
+
+// ---------- 写操作 ----------
+
+app.post('/api/ops/lane-bindings', async (c) => {
+  const { route_type, route_key, lane_name } = await c.req.json() as {
+    route_type?: string;
+    route_key?: string;
+    lane_name?: string;
+  };
+  if (!route_type || !route_key || !lane_name) {
+    return c.json({ message: 'route_type, route_key, and lane_name are required' }, 400);
+  }
+  const data = await larkClient.post('/api/lark/lane-bindings', {
+    route_type,
+    route_key,
+    lane_name,
+  });
+  return c.json(data);
+});
+
+app.delete('/api/ops/lane-bindings', async (c) => {
+  const type = c.req.query('type');
+  const key = c.req.query('key');
+  if (!type || !key) {
+    return c.json({ message: 'type and key query params are required' }, 400);
+  }
+  const data = await larkClient.del('/api/lark/lane-bindings', { type, key });
+  return c.json(data);
+});
+
+app.post('/api/ops/trigger-diary', async (c) => {
+  const { chat_id, target_date } = await c.req.json() as {
+    chat_id?: string;
+    target_date?: string;
+  };
+  if (!chat_id) {
+    return c.json({ message: 'chat_id is required' }, 400);
+  }
+  const params: Record<string, string> = { chat_id };
+  if (target_date) params.target_date = target_date;
+
+  const data = await paasClient.post(
+    `/api/agent/admin/trigger-diary?${new URLSearchParams(params).toString()}`,
+  );
+  return c.json(data);
+});
+
+app.post('/api/ops/trigger-weekly-review', async (c) => {
+  const { chat_id, week_start } = await c.req.json() as {
+    chat_id?: string;
+    week_start?: string;
+  };
+  if (!chat_id) {
+    return c.json({ message: 'chat_id is required' }, 400);
+  }
+  const params: Record<string, string> = { chat_id };
+  if (week_start) params.week_start = week_start;
+
+  const data = await paasClient.post(
+    `/api/agent/admin/trigger-weekly-review?${new URLSearchParams(params).toString()}`,
+  );
+  return c.json(data);
+});
+
+export default app;
+```
+
+- [ ] **Step 4: 重写 messages.ts**
+
+```typescript
+import { Hono } from 'hono';
+import { AppDataSource, ConversationMessage, LarkUser, LarkGroupChatInfo } from '../db';
+
+const app = new Hono();
+
+const parseNumber = (value: string | undefined, defaultValue: number) => {
+  if (!value) return defaultValue;
+  const parsed = Number(value);
+  return Number.isNaN(parsed) ? defaultValue : parsed;
+};
+
+app.get('/api/messages', async (c) => {
+  const page = Math.max(1, parseNumber(c.req.query('page'), 1));
+  const pageSize = Math.min(100, Math.max(1, parseNumber(c.req.query('pageSize'), 20)));
+  const chatId = c.req.query('chatId') || '';
+  const userId = c.req.query('userId') || '';
+  const role = c.req.query('role') || '';
+  const botName = c.req.query('botName') || '';
+  const startTime = c.req.query('startTime') || '';
+  const endTime = c.req.query('endTime') || '';
+  const rootMessageId = c.req.query('rootMessageId') || '';
+  const replyMessageId = c.req.query('replyMessageId') || '';
+  const messageType = c.req.query('messageType') || '';
+
+  const repo = AppDataSource.getRepository(ConversationMessage);
+  const qb = repo
+    .createQueryBuilder('msg')
+    .select([
+      'msg.*',
+      `CASE WHEN msg.role = 'assistant' THEN '赤尾' ELSE COALESCE(lu.name, msg.user_id) END AS user_name`,
+      'gc.name AS group_name',
+    ])
+    .leftJoin('lark_user', 'lu', 'msg.user_id = lu.union_id')
+    .leftJoin('lark_group_chat_info', 'gc', 'msg.chat_id = gc.chat_id');
+
+  if (chatId) qb.andWhere('msg.chat_id = :chatId', { chatId });
+  if (userId) qb.andWhere('msg.user_id = :userId', { userId });
+  if (role) qb.andWhere('msg.role = :role', { role });
+  if (botName) qb.andWhere('msg.bot_name = :botName', { botName });
+  if (startTime) qb.andWhere('msg.create_time >= :startTime', { startTime });
+  if (endTime) qb.andWhere('msg.create_time <= :endTime', { endTime });
+  if (rootMessageId) qb.andWhere('msg.root_message_id = :rootMessageId', { rootMessageId });
+  if (replyMessageId) qb.andWhere('msg.reply_message_id = :replyMessageId', { replyMessageId });
+  if (messageType) qb.andWhere('msg.message_type = :messageType', { messageType });
+
+  const countResult = await qb
+    .clone()
+    .select('COUNT(*)', 'count')
+    .getRawOne();
+  const total = parseInt(countResult?.count ?? '0', 10);
+
+  qb.orderBy('msg.create_time', 'DESC');
+  qb.offset((page - 1) * pageSize).limit(pageSize);
+  const rows = await qb.getRawMany();
+
+  const p2pChatIds = [
+    ...new Set(
+      rows
+        .filter((r) => r.chat_type === 'p2p')
+        .map((r) => r.chat_id)
+    ),
+  ];
+
+  let p2pNameMap: Record<string, string> = {};
+  if (p2pChatIds.length > 0) {
+    const p2pRows: { chat_id: string; user_name: string }[] = await AppDataSource.query(
+      `SELECT DISTINCT ON (cm.chat_id)
+         cm.chat_id,
+         COALESCE(lu.name, cm.user_id) AS user_name
+       FROM conversation_messages cm
+       LEFT JOIN lark_user lu ON cm.user_id = lu.union_id
+       WHERE cm.chat_id = ANY($1) AND cm.role = 'user'
+       ORDER BY cm.chat_id, cm.create_time DESC`,
+      [p2pChatIds]
+    );
+    for (const r of p2pRows) {
+      p2pNameMap[r.chat_id] = r.user_name;
+    }
+  }
+
+  const data = rows.map((row) => {
+    let chat_name: string;
+    if (row.chat_type === 'group') {
+      chat_name = row.group_name || row.chat_id;
+    } else {
+      const userName = p2pNameMap[row.chat_id];
+      chat_name = userName ? `和${userName}的私聊会话` : row.chat_id;
+    }
+    const { group_name, ...rest } = row;
+    return { ...rest, chat_name };
+  });
+
+  return c.json({ data, total, page, pageSize });
+});
+
+app.get('/api/chats', async (c) => {
+  const keyword = (c.req.query('keyword') || '').trim();
+  const repo = AppDataSource.getRepository(LarkGroupChatInfo);
+  const qb = repo.createQueryBuilder('gc').select(['gc.chat_id AS chat_id', 'gc.name AS name']);
+  if (keyword) {
+    qb.where('gc.name ILIKE :kw', { kw: `%${keyword}%` });
+  }
+  qb.orderBy('gc.name', 'ASC').limit(30);
+  return c.json(await qb.getRawMany());
+});
+
+app.get('/api/users', async (c) => {
+  const keyword = (c.req.query('keyword') || '').trim();
+  const repo = AppDataSource.getRepository(LarkUser);
+  const qb = repo.createQueryBuilder('u').select(['u.union_id AS user_id', 'u.name AS name']);
+  if (keyword) {
+    qb.where('u.name ILIKE :kw', { kw: `%${keyword}%` });
+  }
+  qb.orderBy('u.name', 'ASC').limit(30);
+  return c.json(await qb.getRawMany());
+});
+
+export default app;
+```
+
+- [ ] **Step 5: 重写 activity.ts**
+
+```typescript
+import { Hono } from 'hono';
+import { AppDataSource, ConversationMessage, LarkGroupChatInfo, DiaryEntry, WeeklyReview } from '../db';
+
+const app = new Hono();
+
+function msAgo(days: number): string {
+  return String(Date.now() - days * 86400000);
+}
+
+function todayStartMs(): string {
+  const d = new Date();
+  d.setHours(0, 0, 0, 0);
+  return String(d.getTime());
+}
+
+function msToDateStr(ms: string | number): string {
+  return new Date(Number(ms)).toISOString().slice(0, 10);
+}
+
+app.get('/api/activity/overview', async (c) => {
+  const days = Number(c.req.query('days')) || 7;
+  const since = msAgo(days);
+  const todayMs = todayStartMs();
+
+  const repo = AppDataSource.getRepository(ConversationMessage);
+
+  const rows = await repo
+    .createQueryBuilder('cm')
+    .select(['cm.chat_id', 'cm.create_time', 'cm.role'])
+    .where('cm.create_time >= :since', { since })
+    .getMany();
+
+  const todayChats = new Set<string>();
+  let todayTotal = 0;
+  let todayBotReplies = 0;
+  for (const row of rows) {
+    if (Number(row.create_time) >= Number(todayMs)) {
+      todayTotal++;
+      todayChats.add(row.chat_id);
+      if (row.role === 'assistant') todayBotReplies++;
+    }
+  }
+
+  const chatIds = [...new Set(rows.map((r) => r.chat_id))];
+  const groupInfos = chatIds.length > 0
+    ? await AppDataSource.getRepository(LarkGroupChatInfo)
+        .createQueryBuilder('g')
+        .where('g.chat_id IN (:...chatIds)', { chatIds })
+        .getMany()
+    : [];
+  const nameMap = new Map(groupInfos.map((g) => [g.chat_id, g.name]));
+
+  const groupMap = new Map<string, {
+    chat_id: string;
+    group_name: string;
+    message_count: number;
+    bot_replies: number;
+    dailyMap: Map<string, number>;
+  }>();
+
+  for (const row of rows) {
+    let group = groupMap.get(row.chat_id);
+    if (!group) {
+      group = {
+        chat_id: row.chat_id,
+        group_name: nameMap.get(row.chat_id) || row.chat_id,
+        message_count: 0,
+        bot_replies: 0,
+        dailyMap: new Map(),
+      };
+      groupMap.set(row.chat_id, group);
+    }
+    group.message_count++;
+    if (row.role === 'assistant') group.bot_replies++;
+    const dateStr = msToDateStr(row.create_time);
+    group.dailyMap.set(dateStr, (group.dailyMap.get(dateStr) || 0) + 1);
+  }
+
+  const groups = [...groupMap.values()]
+    .filter((group) => group.bot_replies > 0)
+    .sort((a, b) => b.bot_replies - a.bot_replies || b.message_count - a.message_count)
+    .map(({ dailyMap, ...rest }) => ({
+      ...rest,
+      daily_counts: [...dailyMap.entries()]
+        .sort(([a], [b]) => a.localeCompare(b))
+        .map(([date, count]) => ({ date, count })),
+    }));
+
+  return c.json({
+    summary: {
+      period_total: rows.length,
+      today_total: todayTotal,
+      today_bot_replies: todayBotReplies,
+      today_active_groups: todayChats.size,
+    },
+    groups,
+  });
+});
+
+app.get('/api/activity/diary-status', async (c) => {
+  const diaryRepo = AppDataSource.getRepository(DiaryEntry);
+  const weeklyRepo = AppDataSource.getRepository(WeeklyReview);
+
+  const sevenDaysAgo = new Date();
+  sevenDaysAgo.setDate(sevenDaysAgo.getDate() - 7);
+  const sevenDaysAgoStr = sevenDaysAgo.toISOString().slice(0, 10);
+
+  const fourWeeksAgo = new Date();
+  fourWeeksAgo.setDate(fourWeeksAgo.getDate() - 28);
+  const fourWeeksAgoStr = fourWeeksAgo.toISOString().slice(0, 10);
+
+  const diaries = await diaryRepo
+    .createQueryBuilder('de')
+    .select(['de.chat_id', 'de.diary_date', 'de.content'])
+    .getMany();
+
+  const diaryMap = new Map<string, { latest_diary_date: string; latest_diary_content: string; diary_count_7d: number }>();
+  for (const d of diaries) {
+    const existing = diaryMap.get(d.chat_id);
+    const isRecent = d.diary_date >= sevenDaysAgoStr;
+    if (!existing) {
+      diaryMap.set(d.chat_id, {
+        latest_diary_date: d.diary_date,
+        latest_diary_content: d.content,
+        diary_count_7d: isRecent ? 1 : 0,
+      });
+    } else {
+      if (d.diary_date > existing.latest_diary_date) {
+        existing.latest_diary_date = d.diary_date;
+        existing.latest_diary_content = d.content;
+      }
+      if (isRecent) existing.diary_count_7d++;
+    }
+  }
+
+  const weeklies = await weeklyRepo
+    .createQueryBuilder('wr')
+    .select(['wr.chat_id', 'wr.week_start', 'wr.content'])
+    .getMany();
+
+  const weeklyMap = new Map<string, { latest_week_start: string; latest_weekly_content: string; review_count_4w: number }>();
+  for (const w of weeklies) {
+    const existing = weeklyMap.get(w.chat_id);
+    const isRecent = w.week_start >= fourWeeksAgoStr;
+    if (!existing) {
+      weeklyMap.set(w.chat_id, {
+        latest_week_start: w.week_start,
+        latest_weekly_content: w.content,
+        review_count_4w: isRecent ? 1 : 0,
+      });
+    } else {
+      if (w.week_start > existing.latest_week_start) {
+        existing.latest_week_start = w.week_start;
+        existing.latest_weekly_content = w.content;
+      }
+      if (isRecent) existing.review_count_4w++;
+    }
+  }
+
+  return c.json({
+    diary: [...diaryMap.entries()].map(([chat_id, v]) => ({ chat_id, ...v })),
+    weekly: [...weeklyMap.entries()].map(([chat_id, v]) => ({ chat_id, ...v })),
+  });
+});
+
+export default app;
+```
+
+- [ ] **Step 6: 安装依赖并验证编译**
+
+```bash
+cd apps/monitor-dashboard && pnpm install && npx tsc --noEmit
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/monitor-dashboard/src/routes/
+git commit -m "refactor(dashboard): migrate complex routes from Koa to Hono"
+```
+
+---
+
+## Task 6: 清理和最终验证
+
+**Files:**
+- Verify: 全部已改文件
+
+- [ ] **Step 1: 验证 monorepo 零 Koa 依赖**
+
+```bash
+# 检查所有 package.json 中是否还有 koa 相关依赖
+grep -r '"koa' apps/*/package.json packages/*/package.json
+# 期望：无输出
+```
+
+- [ ] **Step 2: 验证所有 import 已清理**
+
+```bash
+# 检查源码中是否还有 koa 相关 import
+grep -rn "from 'koa'" apps/ packages/ --include='*.ts' --exclude-dir=node_modules
+grep -rn "from '@koa/" apps/ packages/ --include='*.ts' --exclude-dir=node_modules
+# 期望：无输出
+```
+
+- [ ] **Step 3: 重新安装依赖**
+
+```bash
+pnpm install
+```
+
+- [ ] **Step 4: lark-server 测试**
+
+```bash
+cd apps/lark-server && pnpm test
+```
+
+- [ ] **Step 5: monitor-dashboard 编译验证**
+
+```bash
+cd apps/monitor-dashboard && npx tsc --noEmit
+```
+
+- [ ] **Step 6: Commit 清理**
+
+如果有遗留的 Koa 引用需要清理：
+
+```bash
+git add -A && git commit -m "chore: remove all remaining Koa references"
+```

--- a/docs/superpowers/specs/2026-04-03-unify-http-framework-design.md
+++ b/docs/superpowers/specs/2026-04-03-unify-http-framework-design.md
@@ -1,0 +1,80 @@
+# 统一 HTTP 框架到 Hono
+
+## 背景
+
+当前 monorepo 中三个 TS 服务使用不同的 HTTP 框架：
+
+| 服务 | 运行时 | 框架 | 路由数 | ctx 渗透深度 |
+|------|--------|------|--------|-------------|
+| lark-server | Bun | Koa | 3 | 浅 (~23处) |
+| lark-proxy | Bun | Hono | 7 | 浅 (~20处) |
+| monitor-dashboard | Node | Koa | 37 | 深 (~155处, 14文件) |
+
+`@inner/shared` 包中有 4 个 Koa 专属中间件（auth、error-handler、trace、validation），lark-proxy 无法复用。
+
+## 决策
+
+- **目标框架：Hono**
+- **monitor-dashboard 运行时：保持 Node**（通过 `@hono/node-server` 适配）
+- **迁移策略：逐服务**（lark-server → monitor-dashboard）
+- **shared 中间件：直接重写为 Hono 版本**
+
+## 迁移范围
+
+### Phase 1：`@inner/shared` 中间件重写
+
+将 4 个 Koa 中间件重写为 Hono 版本：
+
+- `middleware/auth.ts` — Bearer 认证，`ctx.state` → `c.set()`
+- `middleware/error-handler.ts` — 统一错误处理，`ctx.status`/`ctx.body` → `c.json()`
+- `middleware/trace.ts` — TraceId 注入，`ctx.request.headers`/`ctx.set()` → `c.req.header()`/`c.header()`
+- `middleware/validation.ts` — 请求校验，`ctx.request` → `c.req`
+
+同时：
+- 删除 `koa` peer dependency，改为 `hono`
+- 更新类型声明
+
+### Phase 2：lark-server 迁移（3 路由）
+
+- 入口 `new Koa()` → `new Hono()` + `export default { port, fetch }`（Bun 原生模式）
+- 3 个路由从 Koa Router 改为 Hono 路由
+- 7 个中间件从 Koa 模式改为 Hono 模式
+- 移除依赖：koa、@koa/router、@koa/cors、koa-body 及其类型包
+- 验证：health、metrics、lark-event 三个端点正常
+
+### Phase 3：monitor-dashboard 迁移（37 路由）
+
+- 安装 `@hono/node-server`
+- 入口从 `new Koa()` + `app.listen()` → `new Hono()` + `serve({ fetch, port })`
+- 37 个路由处理函数：`ctx.*` → `c.*`
+- 155 处 ctx 引用逐一替换，主要映射：
+  - `ctx.body = x` → `return c.json(x)`
+  - `ctx.status = 404` → `return c.json(body, 404)`
+  - `ctx.params.id` → `c.req.param('id')`
+  - `ctx.query.key` → `c.req.query('key')`
+  - `ctx.request.body` → `await c.req.json()`
+  - `ctx.state.user` → `c.get('user')`
+  - `ctx.get('header')` → `c.req.header('header')`
+- 中间件迁移：cors、bodyParser、errorHandler、jwtAuth、auditMiddleware
+- 移除依赖：koa、@koa/router、@koa/cors、koa-bodyparser 及其类型包
+- 运行时保持 Node
+
+### Phase 4：清理
+
+- 删除 `@inner/shared` 中残留的 Koa 类型和旧代码
+- 确认 monorepo 的 pnpm-lock 中零 Koa 依赖
+- 更新 CLAUDE.md 中关于框架的描述（如有）
+
+## 风险与应对
+
+| 风险 | 应对 |
+|------|------|
+| monitor-dashboard `ctx.state` 中间件间传递 auth 信息 | Hono 用 `c.set()`/`c.get()` + Variables 类型声明替代 |
+| Phase 1 改 shared 后 monitor-dashboard 暂时无法用 shared 中间件 | Phase 3 之前 monitor-dashboard 临时保留自己的 Koa 中间件 |
+| 37 路由逐个改写工作量大 | 机械替换，无技术风险，可并行处理多个路由文件 |
+
+## 不做的事
+
+- 不迁移 monitor-dashboard 运行时（保持 Node）
+- 不重构业务逻辑，只替换框架胶水层
+- 不改 lark-proxy（已是 Hono）

--- a/packages/ts-shared/package.json
+++ b/packages/ts-shared/package.json
@@ -30,18 +30,17 @@
     "winston": "^3.11.0"
   },
   "devDependencies": {
-    "@types/koa": "^2.15.0",
     "@types/node": "^18.0.0",
     "@types/uuid": "^10.0.0",
     "typescript": "^5.6.3"
   },
   "peerDependencies": {
-    "koa": "^2.14.2",
+    "hono": "^4.0.0",
     "typeorm": "^0.3.17",
     "pg": "^8.11.3"
   },
   "peerDependenciesMeta": {
-    "koa": {
+    "hono": {
       "optional": true
     },
     "typeorm": {

--- a/packages/ts-shared/src/middleware/auth.ts
+++ b/packages/ts-shared/src/middleware/auth.ts
@@ -1,4 +1,4 @@
-import type { Context, Next } from 'koa';
+import type { Context, Next } from 'hono';
 
 /**
  * Options for bearer auth middleware
@@ -19,7 +19,7 @@ export interface BearerAuthOptions {
 }
 
 /**
- * Create a bearer authentication middleware for Koa
+ * Create a bearer authentication middleware for Hono
  * Validates Authorization: Bearer <token> header
  */
 export function createBearerAuthMiddleware(options: BearerAuthOptions = {}) {
@@ -37,22 +37,18 @@ export function createBearerAuthMiddleware(options: BearerAuthOptions = {}) {
         },
     } = options;
 
-    return async (ctx: Context, next: Next) => {
-        const authHeader = ctx.request.headers.authorization;
+    return async (c: Context, next: Next) => {
+        const authHeader = c.req.header('authorization');
 
         if (!authHeader || !authHeader.startsWith('Bearer ')) {
-            ctx.status = 401;
-            ctx.body = errorResponse.missingAuth;
-            return;
+            return c.json(errorResponse.missingAuth, 401);
         }
 
         const token = authHeader.substring(7); // Remove 'Bearer ' prefix
         const expectedToken = getExpectedToken();
 
         if (token !== expectedToken) {
-            ctx.status = 401;
-            ctx.body = errorResponse.invalidToken;
-            return;
+            return c.json(errorResponse.invalidToken, 401);
         }
 
         await next();

--- a/packages/ts-shared/src/middleware/error-handler.ts
+++ b/packages/ts-shared/src/middleware/error-handler.ts
@@ -1,8 +1,8 @@
-import type { Context, Next } from 'hono';
+import type { Context } from 'hono';
 import type { StatusCode } from 'hono/utils/http-status';
 
 /**
- * Options for error handler middleware
+ * Options for error handler
  */
 export interface ErrorHandlerOptions {
     /**
@@ -30,44 +30,41 @@ export class AppError extends Error {
 }
 
 /**
- * Create an error handler middleware for Hono
- * Catches downstream errors and returns unified JSON responses
+ * Create an error handler for Hono's app.onError()
+ *
+ * In Hono, errors thrown in route handlers are caught by the compose function
+ * and forwarded to app.onError(), NOT to middleware try/catch. Therefore
+ * error handling must use app.onError(handler) instead of middleware.
  */
 export function createErrorHandler(options: ErrorHandlerOptions = {}) {
     const { logger } = options;
 
-    return async (c: Context, next: Next) => {
-        try {
-            await next();
-        } catch (err: unknown) {
-            const error = err as Error;
-
-            // AppError: expected operational error
-            if (error instanceof AppError) {
-                logger?.warn('Operational error', { message: error.message });
-                return c.json(
-                    {
-                        error: error.message,
-                        code: error.statusCode,
-                    },
-                    error.statusCode as StatusCode,
-                );
-            }
-
-            // Unknown error: avoid leaking internal implementation details
-            logger?.error('Unexpected error', {
-                name: error?.name,
-                message: error?.message,
-                stack: error instanceof Error ? error.stack : undefined,
-            });
+    return (err: Error, c: Context) => {
+        // AppError: expected operational error
+        if (err instanceof AppError) {
+            logger?.warn('Operational error', { message: err.message });
             return c.json(
                 {
-                    error: 'Internal server error',
-                    code: 500,
+                    error: err.message,
+                    code: err.statusCode,
                 },
-                500,
+                err.statusCode as StatusCode,
             );
         }
+
+        // Unknown error: avoid leaking internal implementation details
+        logger?.error('Unexpected error', {
+            name: err?.name,
+            message: err?.message,
+            stack: err instanceof Error ? err.stack : undefined,
+        });
+        return c.json(
+            {
+                error: 'Internal server error',
+                code: 500,
+            },
+            500,
+        );
     };
 }
 

--- a/packages/ts-shared/src/middleware/error-handler.ts
+++ b/packages/ts-shared/src/middleware/error-handler.ts
@@ -1,4 +1,5 @@
-import type { Context, Next } from 'koa';
+import type { Context, Next } from 'hono';
+import type { StatusCode } from 'hono/utils/http-status';
 
 /**
  * Options for error handler middleware
@@ -29,13 +30,13 @@ export class AppError extends Error {
 }
 
 /**
- * Create an error handler middleware for Koa
+ * Create an error handler middleware for Hono
  * Catches downstream errors and returns unified JSON responses
  */
 export function createErrorHandler(options: ErrorHandlerOptions = {}) {
     const { logger } = options;
 
-    return async (ctx: Context, next: Next): Promise<void> => {
+    return async (c: Context, next: Next) => {
         try {
             await next();
         } catch (err: unknown) {
@@ -43,26 +44,29 @@ export function createErrorHandler(options: ErrorHandlerOptions = {}) {
 
             // AppError: expected operational error
             if (error instanceof AppError) {
-                ctx.status = error.statusCode;
-                ctx.body = {
-                    error: error.message,
-                    code: error.statusCode,
-                };
                 logger?.warn('Operational error', { message: error.message });
-                return;
+                return c.json(
+                    {
+                        error: error.message,
+                        code: error.statusCode,
+                    },
+                    error.statusCode as StatusCode,
+                );
             }
 
             // Unknown error: avoid leaking internal implementation details
-            ctx.status = 500;
-            ctx.body = {
-                error: 'Internal server error',
-                code: 500,
-            };
             logger?.error('Unexpected error', {
                 name: error?.name,
                 message: error?.message,
                 stack: error instanceof Error ? error.stack : undefined,
             });
+            return c.json(
+                {
+                    error: 'Internal server error',
+                    code: 500,
+                },
+                500,
+            );
         }
     };
 }

--- a/packages/ts-shared/src/middleware/error-handler.ts
+++ b/packages/ts-shared/src/middleware/error-handler.ts
@@ -1,5 +1,5 @@
 import type { Context } from 'hono';
-import type { StatusCode } from 'hono/utils/http-status';
+import type { ContentfulStatusCode } from 'hono/utils/http-status';
 
 /**
  * Options for error handler
@@ -48,7 +48,7 @@ export function createErrorHandler(options: ErrorHandlerOptions = {}) {
                     error: err.message,
                     code: err.statusCode,
                 },
-                err.statusCode as StatusCode,
+                err.statusCode as ContentfulStatusCode,
             );
         }
 

--- a/packages/ts-shared/src/middleware/trace.ts
+++ b/packages/ts-shared/src/middleware/trace.ts
@@ -1,4 +1,4 @@
-import type { Context, Next } from 'koa';
+import type { Context, Next } from 'hono';
 import { asyncLocalStorage, BaseRequestContext } from './context';
 import { v4 as uuidv4 } from 'uuid';
 
@@ -19,11 +19,11 @@ export interface TraceMiddlewareOptions {
     /**
      * Additional context fields to set
      */
-    additionalContext?: (ctx: Context) => Partial<BaseRequestContext>;
+    additionalContext?: (c: Context) => Partial<BaseRequestContext>;
 }
 
 /**
- * Create a trace middleware for Koa
+ * Create a trace middleware for Hono
  * Extracts or generates trace ID and runs the middleware chain within AsyncLocalStorage context
  */
 export function createTraceMiddleware(options: TraceMiddlewareOptions = {}) {
@@ -33,16 +33,16 @@ export function createTraceMiddleware(options: TraceMiddlewareOptions = {}) {
         additionalContext,
     } = options;
 
-    return async (ctx: Context, next: Next) => {
-        const traceId = (ctx.request.headers[headerName] as string) || uuidv4();
+    return async (c: Context, next: Next) => {
+        const traceId = c.req.header(headerName) || uuidv4();
 
         const contextData: BaseRequestContext = {
             traceId,
-            ...(additionalContext ? additionalContext(ctx) : {}),
+            ...(additionalContext ? additionalContext(c) : {}),
         };
 
         await asyncLocalStorage.run(contextData, async () => {
-            ctx.set(responseHeaderName, traceId);
+            c.header(responseHeaderName, traceId);
             await next();
         });
     };

--- a/packages/ts-shared/src/middleware/validation.ts
+++ b/packages/ts-shared/src/middleware/validation.ts
@@ -1,4 +1,4 @@
-import type { Context, Next } from 'koa';
+import type { Context, Next } from 'hono';
 
 /**
  * Validation error class
@@ -104,21 +104,22 @@ function validateFields(data: Record<string, unknown>, rules: ValidationRules): 
  * Create request body validation middleware
  */
 export function validateBody(rules: ValidationRules) {
-    return async (ctx: Context, next: Next) => {
+    return async (c: Context, next: Next) => {
         try {
-            const body = (ctx.request as { body?: Record<string, unknown> }).body || {};
+            const body = await c.req.json<Record<string, unknown>>().catch(() => ({}));
             validateFields(body, rules);
             await next();
         } catch (error) {
             if (error instanceof ValidationError) {
-                ctx.status = 400;
-                ctx.body = {
-                    success: false,
-                    message: `Validation failed: ${error.message}`,
-                    field: error.field,
-                    error_code: 'VALIDATION_ERROR',
-                };
-                return;
+                return c.json(
+                    {
+                        success: false,
+                        message: `Validation failed: ${error.message}`,
+                        field: error.field,
+                        error_code: 'VALIDATION_ERROR',
+                    },
+                    400,
+                );
             }
             throw error;
         }
@@ -129,21 +130,22 @@ export function validateBody(rules: ValidationRules) {
  * Create query parameter validation middleware
  */
 export function validateQuery(rules: ValidationRules) {
-    return async (ctx: Context, next: Next) => {
+    return async (c: Context, next: Next) => {
         try {
-            const query = (ctx.request.query || {}) as Record<string, unknown>;
+            const query = c.req.query() as Record<string, unknown>;
             validateFields(query, rules);
             await next();
         } catch (error) {
             if (error instanceof ValidationError) {
-                ctx.status = 400;
-                ctx.body = {
-                    success: false,
-                    message: `Query validation failed: ${error.message}`,
-                    field: error.field,
-                    error_code: 'VALIDATION_ERROR',
-                };
-                return;
+                return c.json(
+                    {
+                        success: false,
+                        message: `Query validation failed: ${error.message}`,
+                        field: error.field,
+                        error_code: 'VALIDATION_ERROR',
+                    },
+                    400,
+                );
             }
             throw error;
         }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,0 +1,9 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .: {}


### PR DESCRIPTION
## Summary

- 将 monorepo 中所有 TS 服务的 HTTP 框架统一为 Hono，消除 Koa 多框架维护成本
- `@inner/shared` 4 个共享中间件（auth, error-handler, trace, validation）迁移到 Hono
- `lark-server`（Bun）：3 路由 + 7 中间件全部迁移，62 测试通过
- `monitor-dashboard`（Node）：37 路由 + 3 中间件全部迁移，使用 `@hono/node-server` 适配 Node 运行时
- 发现并处理了 Hono 架构差异：错误处理必须用 `app.onError()` 而非中间件 try/catch

## Test plan

- [x] lark-server: 62 测试通过，0 失败
- [x] monitor-dashboard: TypeScript 零编译错误
- [x] 两个服务部署到 `chore-framework-unif` 泳道，Pod Running，0 restarts
- [x] monorepo 零 Koa 引用（import + package.json）

🤖 Generated with [Claude Code](https://claude.com/claude-code)