### PR TITLE
fix: set explicit cron timeouts for multi-persona jobs

### DIFF
--- a/apps/agent-service/app/workers/unified_worker.py
+++ b/apps/agent-service/app/workers/unified_worker.py
@@ -75,25 +75,29 @@ class UnifiedWorkerSettings:
     functions = []
 
     # 所有定时任务（夜间管线时序，CST）
+    # 注意：ArQ 默认 job_timeout=300s，对多 persona 的 LLM 管线远远不够，
+    # 必须为耗时任务显式设置 timeout（单位：秒）。
     cron_jobs = [
         # 1. 长期任务：每分钟执行一次
         cron(task_executor_job, minute=None),
         # 2. 向量化 pending 消息扫描：每 10 分钟一次
         cron(cron_scan_pending_messages, minute={0, 10, 20, 30, 40, 50}),
         # 3. 日记生成：每天 CST 03:00 → DiaryEntry + PersonImpression + ChatImpression
-        cron(cron_generate_diaries, hour={3}, minute={0}),
+        #    3 persona × N chats × 3 LLM calls，需要充足时间
+        cron(cron_generate_diaries, hour={3}, minute={0}, timeout=3600),
         # 4. Journal daily：每天 CST 04:00（日记之后 1 小时）
-        cron(cron_generate_daily_journal, hour={4}, minute={0}),
+        cron(cron_generate_daily_journal, hour={4}, minute={0}, timeout=600),
         # 5. 周记生成：每周一 CST 04:30（daily journal 之后）
-        cron(cron_generate_weekly_reviews, weekday={0}, hour={4}, minute={30}),
+        cron(cron_generate_weekly_reviews, weekday={0}, hour={4}, minute={30}, timeout=3600),
         # 6. Journal weekly：每周一 CST 04:45（周记之后）
-        cron(cron_generate_weekly_journal, weekday={0}, hour={4}, minute={45}),
+        cron(cron_generate_weekly_journal, weekday={0}, hour={4}, minute={45}, timeout=600),
         # 7. 日程生成：日计划每天 CST 05:00（journal 之后），周计划每周日，月计划每月1号
-        cron(cron_generate_daily_plan, hour={5}, minute={0}),
-        cron(cron_generate_weekly_plan, weekday={6}, hour={23}, minute={0}),
-        cron(cron_generate_monthly_plan, day={1}, hour={2}, minute={0}),
+        #    日计划用 Ideation+Writer+Critic 多 Agent 管线，最耗时
+        cron(cron_generate_daily_plan, hour={5}, minute={0}, timeout=3600),
+        cron(cron_generate_weekly_plan, weekday={6}, hour={23}, minute={0}, timeout=1800),
+        cron(cron_generate_monthly_plan, day={1}, hour={2}, minute={0}, timeout=1800),
         # 8. 基线 reply_style：每天 CST 8:00/14:00/18:00（Schedule 之后）
-        cron(cron_generate_base_reply_style, hour={8, 14, 18}, minute={0}),
+        cron(cron_generate_base_reply_style, hour={8, 14, 18}, minute={0}, timeout=1800),
         # 9. 主动搭话扫描（cron 兜底）：每 30 分钟，30% 概率执行 [DISABLED]
         # cron(proactive_scan_job, minute={0, 30}),
     ]


### PR DESCRIPTION
## Summary
- ArQ 默认 `job_timeout=300s`，多 persona 夜间管线（diary/schedule）远超 5 分钟，被 ArQ 杀掉
- 健康日志确认：03:00 diary cron 和 05:00 schedule cron 各超时 1 次（`j_failed: 0→1→2`）
- 导致只有 1 个 persona 生成了 diary/journal/schedule，其余 2 个缺失
- 修复：为所有耗时 cron job 显式设置合理 timeout（600s~3600s）

## Test plan
- [x] 代码变更仅涉及 `unified_worker.py` 的 cron timeout 参数
- [ ] 部署后观察明天凌晨健康日志 `j_failed` 不再增长
- [ ] 查 DB 确认 3 个 persona 都有 diary/journal/schedule

🤖 Generated with [Claude Code](https://claude.com/claude-code)