### PR TITLE
fix: make logs JSON 解析报错

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -255,10 +255,13 @@ logs:
 		PARAMS="$$PARAMS&since=$(SINCE)"; \
 	fi; \
 	echo ">>> 查询日志: $$PARAMS"; \
-	RESP=$$(curl -sf "$(PAAS_API)/api/paas/logs?$$PARAMS" \
-		-H 'X-API-Key: $(PAAS_TOKEN)' $(CURL_LANE)); \
-	if [ -z "$$RESP" ]; then echo "(请求失败或无响应)"; exit 1; fi; \
-	echo "$$RESP" | python3 -c "import sys,json; print(json.loads(sys.stdin.buffer.read(),strict=False).get('data',{}).get('logs','(无日志)'))"
+	curl -sf "$(PAAS_API)/api/paas/logs?$$PARAMS" \
+		-H 'X-API-Key: $(PAAS_TOKEN)' $(CURL_LANE) | \
+	python3 -c "\
+import sys,json; \
+raw=sys.stdin.buffer.read(); \
+exit(print('(请求失败或无响应)') or 1) if not raw else None; \
+print(json.loads(raw,strict=False).get('data',{}).get('logs','(无日志)'))"
 
 # ---------- 泳道绑定 ----------
 


### PR DESCRIPTION
## Summary
- `make logs` 将 curl 响应存入 shell 变量再 echo，日志含 `"`、`$`、反引号等特殊字符时 JSON 被破坏，导致 `json.loads` 报错
- 改为 curl 直接管道到 python3，避免 shell 对 JSON 数据的二次解释

## Test plan
- [x] `make logs APP=arq-worker SINCE=1h` 正常返回
- [x] `make logs APP=arq-worker REGEXP="journal|schedule|daily_plan|diary" SINCE=12h` 之前报错，现在正常
- [x] 含空格的 KEYWORD/REGEXP 正常 URL 编码，无报错

🤖 Generated with [Claude Code](https://claude.com/claude-code)