### PR TITLE
fix: arq worker 按泳道隔离队列，避免多泳道抢 job

### DIFF
--- a/apps/agent-service/app/workers/unified_worker.py
+++ b/apps/agent-service/app/workers/unified_worker.py
@@ -64,6 +64,8 @@ class UnifiedWorkerSettings:
 
     on_startup = on_startup
 
+    queue_name = f"arq:queue:{settings.lane}" if settings.lane else "arq:queue"
+
     redis_settings = RedisSettings(
         host=settings.redis_host or "localhost",
         port=6379,


### PR DESCRIPTION
共享 Redis 时不同泳道的 arq-worker 监听同一队列会互相抢 job，
导致 prod 抢到未注册函数报错。按 settings.lane 分配独立队列名。

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
