### PR TITLE
fix(memory-v3): 修复 Life Engine browsing 死循环 + glimpse 搭话断路

### DIFF
--- a/apps/agent-service/app/services/life_engine.py
+++ b/apps/agent-service/app/services/life_engine.py
@@ -62,17 +62,19 @@ class LifeEngine:
             current_state = row.current_state
             response_mood = row.response_mood
             skip_until = row.skip_until
+            activity_type = row.activity_type or ""
         else:
             current_state = "刚醒来，还有点迷糊"
             response_mood = "迷迷糊糊的"
             skip_until = None
+            activity_type = ""
 
         # skip_until 检查
         if skip_until and now < skip_until:
             return
 
         # LLM 决策
-        new = await self._think(current_state, response_mood, now, persona_id)
+        new = await self._think(current_state, response_mood, now, persona_id, activity_type)
 
         await _save_state(
             persona_id=persona_id,
@@ -103,6 +105,7 @@ class LifeEngine:
         response_mood: str,
         now: datetime,
         persona_id: str,
+        activity_type: str = "",
     ) -> dict:
         """调用 LLM 决定下一步状态"""
         from app.agents.infra.langfuse_client import get_prompt
@@ -120,7 +123,7 @@ class LifeEngine:
         schedule_text = schedule.content if schedule else "（今天还没有安排）"
 
         today_frags = await get_today_fragments(
-            persona_id, grains=["conversation", "glimpse"]
+            persona_id, grains=["conversation"]
         )
         frag_text = (
             "\n".join(f.content[:100] for f in today_frags[-5:])
@@ -134,6 +137,7 @@ class LifeEngine:
             persona_lite=persona_lite,
             current_time=now.strftime("%H:%M"),
             current_state=current_state,
+            activity_type=activity_type,
             response_mood=response_mood,
             schedule=schedule_text,
             recent_experiences=frag_text,

--- a/apps/agent-service/app/workers/unified_worker.py
+++ b/apps/agent-service/app/workers/unified_worker.py
@@ -48,9 +48,16 @@ async def task_executor_job(ctx) -> None:
 
 
 async def on_startup(ctx) -> None:
-    """Worker 启动时配置日志 + 生成基线 reply_style"""
+    """Worker 启动时配置日志 + 初始化 MQ + 生成基线 reply_style"""
     setup_logging(log_dir="/logs/agent-service", log_file="arq-worker.log")
     logger.info("arq-worker started, file logging enabled")
+
+    # Life Engine browsing → glimpse → 搭话 需要通过 MQ publish
+    from app.clients.rabbitmq import RabbitMQClient
+    client = RabbitMQClient.get_instance()
+    await client.connect()
+    await client.declare_topology()
+
     asyncio.create_task(cron_generate_base_reply_style(None))
 
 


### PR DESCRIPTION
1. arq-worker 启动时初始化 RabbitMQ，修复 glimpse proactive "must call
   declare_topology() first" 错误
2. tick() 读取并回传 activity_type 给 LLM prompt（配合 Langfuse v5）
3. recent_experiences 只读 conversation 碎片，不读 glimpse，打破
   "browsing → glimpse → recent_experiences 全是 glimpse → 继续 browsing"
   的自我强化反馈环

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
