### PR TITLE
refactor(context): context architecture phase1 — 瘦身 + 落库 + 工具精简

### DIFF
--- a/apps/agent-service/app/agents/core/agent.py
+++ b/apps/agent-service/app/agents/core/agent.py
@@ -38,6 +38,9 @@ _DEFAULT_MAX_RETRIES = 2
 _BACKOFF_BASE = 2  # 秒
 _BACKOFF_MAX = 8  # 秒
 
+# 工具调用次数限制（每次工具调用占 2 步：call + response，故 12 步 ≈ 6 次工具调用）
+_DEFAULT_RECURSION_LIMIT = 12
+
 
 class ChatAgent:
     """核心聊天代理
@@ -88,6 +91,8 @@ class ChatAgent:
             config = {"callbacks": [CallbackHandler(update_trace=True)]}
             if self.trace_name:
                 config["run_name"] = self.trace_name
+        # 限制工具调用轮次，防止失控循环（每次工具调用占 2 步）
+        config.setdefault("recursion_limit", _DEFAULT_RECURSION_LIMIT)
         return config
 
     async def stream(

--- a/apps/agent-service/app/agents/domains/main/tools.py
+++ b/apps/agent-service/app/agents/domains/main/tools.py
@@ -5,11 +5,7 @@ BASE_TOOLS 是子 Agent 可复用的基础工具集（不含委派工具）。
 """
 
 from app.agents.tools.delegation.research import deep_research
-from app.agents.tools.history.chat_history import check_chat_history
-from app.agents.tools.history.members import list_group_members
-from app.agents.tools.history.search import search_group_history
 from app.agents.tools.image import generate_image, read_images
-from app.agents.tools.recall import recall
 from app.agents.tools.sandbox_bash import sandbox_bash
 from app.agents.tools.search.image import search_images
 from app.agents.tools.search.web import search_web
@@ -19,12 +15,8 @@ from app.agents.tools.skill import load_skill
 BASE_TOOLS = [
     search_web,
     search_images,
-    search_group_history,
-    list_group_members,
     generate_image,
     read_images,
-    recall,
-    check_chat_history,
 ]
 
 # 主 Agent 完整工具集（基础 + 委派 + 技能）

--- a/apps/agent-service/app/agents/domains/main/tools.py
+++ b/apps/agent-service/app/agents/domains/main/tools.py
@@ -6,6 +6,7 @@ BASE_TOOLS 是子 Agent 可复用的基础工具集（不含委派工具）。
 
 from app.agents.tools.delegation.research import deep_research
 from app.agents.tools.image import generate_image, read_images
+from app.agents.tools.recall import recall
 from app.agents.tools.sandbox_bash import sandbox_bash
 from app.agents.tools.search.image import search_images
 from app.agents.tools.search.web import search_web
@@ -17,6 +18,7 @@ BASE_TOOLS = [
     search_images,
     generate_image,
     read_images,
+    recall,
 ]
 
 # 主 Agent 完整工具集（基础 + 委派 + 技能）

--- a/apps/agent-service/app/orm/memory_crud.py
+++ b/apps/agent-service/app/orm/memory_crud.py
@@ -163,6 +163,40 @@ async def insert_glimpse_state(
         await session.commit()
 
 
+async def save_reply_style(
+    persona_id: str,
+    style_text: str,
+    source: str,
+    observation: str | None = None,
+) -> None:
+    """写入 reply_style 审计日志（append-only）"""
+    from app.orm.memory_models import ReplyStyleLog
+
+    async with AsyncSessionLocal() as session:
+        session.add(ReplyStyleLog(
+            persona_id=persona_id,
+            style_text=style_text,
+            source=source,
+            observation=observation,
+        ))
+        await session.commit()
+
+
+async def get_latest_reply_style(persona_id: str) -> str | None:
+    """获取最新的 reply_style"""
+    from app.orm.memory_models import ReplyStyleLog
+
+    async with AsyncSessionLocal() as session:
+        result = await session.execute(
+            select(ReplyStyleLog.style_text)
+            .where(ReplyStyleLog.persona_id == persona_id)
+            .order_by(ReplyStyleLog.created_at.desc())
+            .limit(1)
+        )
+        row = result.scalar_one_or_none()
+        return row
+
+
 async def get_last_bot_reply_time(chat_id: str) -> int:
     """查指定群最近一次 assistant 回复的 create_time（毫秒），无则返回 0"""
     from sqlalchemy import func as sa_func

--- a/apps/agent-service/app/orm/memory_models.py
+++ b/apps/agent-service/app/orm/memory_models.py
@@ -93,3 +93,18 @@ class MemoryEntity(Base):
     display_name: Mapped[str | None] = mapped_column(String(100), nullable=True)
 
     __table_args__ = (UniqueConstraint("entity_type", "external_id"),)
+
+
+class ReplyStyleLog(Base):
+    """Reply Style 审计日志 — 每次漂移 INSERT 一行，append-only"""
+
+    __tablename__ = "reply_style_log"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    persona_id: Mapped[str] = mapped_column(String(50), nullable=False, index=True)
+    style_text: Mapped[str] = mapped_column(Text, nullable=False)
+    observation: Mapped[str | None] = mapped_column(Text, nullable=True)
+    source: Mapped[str] = mapped_column(String(20), nullable=False)  # 'base' / 'drift' / 'manual'
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now()
+    )

--- a/apps/agent-service/app/services/bot_context.py
+++ b/apps/agent-service/app/services/bot_context.py
@@ -7,10 +7,10 @@ from langchain_core.messages import AIMessage, HumanMessage
 from app.orm.crud import get_bot_persona
 
 
-async def get_reply_style(chat_id: str, persona_id: str, default_style: str) -> str:
+async def get_reply_style(persona_id: str, default_style: str) -> str:
     """转发到 memory_context.get_reply_style（lazy import 避免循环）"""
     from app.services.memory_context import get_reply_style as _impl
-    return await _impl(chat_id, persona_id, default_style)
+    return await _impl(persona_id, default_style)
 
 
 if TYPE_CHECKING:
@@ -114,7 +114,7 @@ class BotContext:
 
         default_style = self._persona.default_reply_style if self._persona else ""
         self._reply_style = await get_reply_style(
-            self.chat_id, self._persona_id, default_style
+            self._persona_id, default_style
         )
 
     @property

--- a/apps/agent-service/app/services/identity_drift.py
+++ b/apps/agent-service/app/services/identity_drift.py
@@ -13,7 +13,6 @@ from datetime import datetime, timedelta, timezone
 
 from app.agents.infra.langfuse_client import get_prompt
 from app.agents.infra.model_builder import ModelBuilder
-from app.clients.redis import AsyncRedisClient
 from app.config.config import settings
 from app.orm.crud import get_chat_messages_in_range, get_plan_for_period, get_username
 from app.utils.content_parser import parse_content
@@ -21,17 +20,6 @@ from app.utils.content_parser import parse_content
 logger = logging.getLogger(__name__)
 
 CST = timezone(timedelta(hours=8))
-
-# Redis key 前缀
-_KEY_PREFIX = "reply_style"
-
-
-def _state_key(chat_id: str, persona_id: str) -> str:
-    return f"{_KEY_PREFIX}:{chat_id}:{persona_id}"
-
-
-def _base_key(persona_id: str) -> str:
-    return f"reply_style:__base__:{persona_id}"
 
 
 async def _get_persona_context(persona_id: str) -> tuple[str, str]:
@@ -43,19 +31,10 @@ async def _get_persona_context(persona_id: str) -> tuple[str, str]:
     return persona_id, ""
 
 
-_BASE_TTL_SECONDS = 43200  # 12 小时，覆盖到下一次定时生成
-
-
-async def get_base_reply_style(persona_id: str) -> str | None:
-    """读取指定 bot 的全局基线 reply_style"""
-    redis = AsyncRedisClient.get_instance()
-    return await redis.get(_base_key(persona_id))
-
-
 async def set_base_reply_style(style: str, persona_id: str) -> None:
     """写入指定 bot 的全局基线 reply_style"""
-    redis = AsyncRedisClient.get_instance()
-    await redis.set(_base_key(persona_id), style, ex=_BASE_TTL_SECONDS)
+    from app.orm.memory_crud import save_reply_style
+    await save_reply_style(persona_id, style, source="base")
     logger.info(f"[{persona_id}] Base reply_style updated: {style[:50]}...")
 
 
@@ -92,27 +71,11 @@ async def generate_base_reply_style(persona_id: str) -> str | None:
     return style
 
 
-async def get_identity_state(chat_id: str, persona_id: str) -> str | None:
-    """读取指定 bot 在指定群的漂移状态"""
-    redis = AsyncRedisClient.get_instance()
-    return await redis.hget(_state_key(chat_id, persona_id), "state")
-
-
-async def get_identity_updated_at(chat_id: str, persona_id: str) -> str | None:
-    """读取上次漂移更新时间（ISO 格式）"""
-    redis = AsyncRedisClient.get_instance()
-    return await redis.hget(_state_key(chat_id, persona_id), "updated_at")
-
-
-async def set_identity_state(chat_id: str, persona_id: str, state: str, ttl: int = 86400) -> None:
-    """写入指定 bot 在指定群的漂移状态"""
-    redis = AsyncRedisClient.get_instance()
-    now = datetime.now(CST).isoformat()
-    pipe = redis.pipeline()
-    pipe.hset(_state_key(chat_id, persona_id), mapping={"state": state, "updated_at": now})
-    pipe.expire(_state_key(chat_id, persona_id), ttl)
-    await pipe.execute()
-    logger.info(f"[{persona_id}] Identity state updated for {chat_id}: {state[:50]}...")
+async def set_identity_state(persona_id: str, state: str, observation: str | None = None) -> None:
+    """写入漂移后的 reply_style"""
+    from app.orm.memory_crud import save_reply_style
+    await save_reply_style(persona_id, state, source="drift", observation=observation)
+    logger.info(f"[{persona_id}] Identity state updated: {state[:50]}...")
 
 
 class IdentityDriftManager:
@@ -140,18 +103,12 @@ class IdentityDriftManager:
         return f"{chat_id}:{persona_id}"
 
     async def on_event(self, chat_id: str, persona_id: str) -> None:
-        """消息/回复事件 -> 进入两阶段锁流程
-
-        buffer 使用从上次漂移以来的真实消息数量，
-        而不是简单 +1，这样活跃群的非@消息也计入密度。
-        """
+        """消息/回复事件 -> 进入两阶段锁流程"""
         key = self._key(chat_id, persona_id)
-        msg_count = await _count_messages_since_last_drift(chat_id, persona_id)
-        self._buffers[key] = max(self._buffers.get(key, 0) + 1, msg_count)
+        self._buffers[key] = self._buffers.get(key, 0) + 1
         logger.info(
             f"Identity drift on_event: chat_id={chat_id}, persona={persona_id}, "
             f"buffer={self._buffers[key]}, "
-            f"msg_since_drift={msg_count}, "
             f"phase2_running={key in self._phase2_running}"
         )
 
@@ -219,7 +176,8 @@ async def _run_drift(chat_id: str, persona_id: str) -> None:
     """
     # 1. 收集上下文
     persona_name, persona_lite = await _get_persona_context(persona_id)
-    current_state = await get_identity_state(chat_id, persona_id)
+    from app.orm.memory_crud import get_latest_reply_style
+    current_state = await get_latest_reply_style(persona_id)
     recent_messages = await _get_recent_messages(chat_id, persona_name=persona_name)
     schedule_context = await _get_schedule_context(persona_id)
     recent_replies = await _get_recent_persona_replies(chat_id, persona_id)
@@ -271,7 +229,7 @@ async def _run_drift(chat_id: str, persona_id: str) -> None:
         return
 
     # 4. 保存
-    await set_identity_state(chat_id, persona_id, new_style)
+    await set_identity_state(persona_id, new_style, observation=observation_report)
 
 
 def _extract_text(content) -> str:
@@ -282,24 +240,6 @@ def _extract_text(content) -> str:
             for part in content
         ).strip()
     return (content or "").strip()
-
-
-async def _count_messages_since_last_drift(chat_id: str, persona_id: str) -> int:
-    """统计上次漂移以来的消息数量（含非@赤尾的消息）"""
-    updated_at_str = await get_identity_updated_at(chat_id, persona_id)
-    if updated_at_str:
-        try:
-            start_dt = datetime.fromisoformat(updated_at_str)
-        except ValueError:
-            start_dt = datetime.now(CST) - timedelta(hours=1)
-    else:
-        start_dt = datetime.now(CST) - timedelta(hours=1)
-
-    start_ts = int(start_dt.timestamp() * 1000)
-    end_ts = int(datetime.now(CST).timestamp() * 1000)
-
-    messages = await get_chat_messages_in_range(chat_id, start_ts, end_ts)
-    return len(messages) if messages else 0
 
 
 async def _get_recent_messages(chat_id: str, persona_name: str = "bot", max_messages: int = 50) -> str:

--- a/apps/agent-service/app/services/memory_context.py
+++ b/apps/agent-service/app/services/memory_context.py
@@ -1,15 +1,21 @@
 """赤尾聊天注入上下文 v4
 
-Life Engine 状态是唯一的运行时上下文来源。
-Schedule、碎片、daily dream 由 Life Engine 消化，不再直接注入。
+Life Engine 状态 + 最近碎片（精简）作为运行时上下文。
+Schedule、daily dream 由 Life Engine 消化，不再直接注入。
 """
 
 import logging
 from datetime import timedelta, timezone
 
+from app.orm.memory_crud import get_today_fragments
+
 logger = logging.getLogger(__name__)
 
 CST = timezone(timedelta(hours=8))
+
+# 最近碎片：只保留最近 2 条，总计不超过 800 字符
+_MAX_RECENT_FRAGMENTS = 2
+_MAX_FRAGMENT_CHARS = 800
 
 
 async def _build_life_state(persona_id: str) -> str:
@@ -60,10 +66,33 @@ async def build_inner_context(
         if trigger_username:
             sections.append(f"需要回复 {trigger_username} 的消息（消息中用 ⭐ 标记）。")
 
-    # === 此刻的状态（Life Engine — 唯一的运行时上下文来源）===
+    # === 此刻的状态（Life Engine）===
     life_state = await _build_life_state(persona_id)
     if life_state:
         sections.append(life_state)
+
+    # === 最近的经历（精简版：最近 2 条碎片，短期记忆）===
+    today_frags = await get_today_fragments(persona_id, grains=["conversation"])
+    if chat_type == "group":
+        today_frags = [f for f in today_frags if f.source_chat_id == chat_id]
+    if today_frags:
+        recent = today_frags[-_MAX_RECENT_FRAGMENTS:]
+        total = 0
+        lines = []
+        for f in recent:
+            text = f.content.strip()
+            if total + len(text) > _MAX_FRAGMENT_CHARS:
+                remaining = _MAX_FRAGMENT_CHARS - total
+                if remaining > 50:
+                    lines.append(text[:remaining] + "...")
+                break
+            lines.append(text)
+            total += len(text)
+        if lines:
+            sections.append(f"最近的经历：\n{''.join(lines)}")
+
+    # === 回忆引导 ===
+    sections.append("（如果隐约觉得知道点什么但想不起来，可以用 recall 想一想。）")
 
     return "\n\n".join(sections)
 

--- a/apps/agent-service/app/services/memory_context.py
+++ b/apps/agent-service/app/services/memory_context.py
@@ -1,36 +1,15 @@
-"""赤尾聊天注入上下文 v3
+"""赤尾聊天注入上下文 v4
 
-基于 experience_fragment 构建 system prompt 注入的所有上下文。
+Life Engine 状态是唯一的运行时上下文来源。
+Schedule、碎片、daily dream 由 Life Engine 消化，不再直接注入。
 """
 
 import logging
-from datetime import datetime, timedelta, timezone
-
-from app.orm.crud import get_plan_for_period
-from app.orm.memory_crud import get_recent_fragments_by_grain, get_today_fragments
-from app.services.identity_drift import get_base_reply_style, get_identity_state
+from datetime import timedelta, timezone
 
 logger = logging.getLogger(__name__)
 
 CST = timezone(timedelta(hours=8))
-
-MAX_FRAGMENT_SECTION_CHARS = 3000  # ~2000 tokens
-MAX_DISTANT_SECTION_CHARS = 800   # ~500 tokens
-
-_MEMORY_RECALL_HINT = (
-    "（你有写日记的习惯。如果隐约觉得知道点什么但想不起来，可以用 recall 想一想。"
-    "如果想确认某件事具体怎么说的，可以翻翻聊天记录。）"
-)
-
-
-async def _build_today_state(persona_id: str) -> str:
-    """今天 Schedule（Life Engine 接入前的替代方案）"""
-    now = datetime.now(CST)
-    today = now.strftime("%Y-%m-%d")
-    schedule = await get_plan_for_period("daily", today, today, persona_id)
-    if schedule and schedule.content:
-        return schedule.content
-    return ""
 
 
 async def _build_life_state(persona_id: str) -> str:
@@ -50,29 +29,6 @@ async def _build_life_state(persona_id: str) -> str:
     return ""
 
 
-def _filter_fragments_for_group(fragments: list, current_chat_id: str) -> list:
-    """群聊场景：只保留当前群的 conversation/glimpse 碎片"""
-    return [f for f in fragments if f.source_chat_id == current_chat_id]
-
-
-def _format_fragment_section(fragments: list, max_chars: int) -> str:
-    """格式化碎片列表为文本，超出截断"""
-    if not fragments:
-        return ""
-    lines = []
-    total = 0
-    for f in fragments:
-        text = f.content.strip()
-        if total + len(text) > max_chars:
-            remaining = max_chars - total
-            if remaining > 50:
-                lines.append(text[:remaining] + "...")
-            break
-        lines.append(text)
-        total += len(text)
-    return "\n\n".join(lines)
-
-
 async def build_inner_context(
     chat_id: str,
     chat_type: str,
@@ -87,7 +43,7 @@ async def build_inner_context(
 ) -> str:
     sections: list[str] = []
 
-    # === 场景提示 === (KEEP SAME)
+    # === 场景提示 ===
     if is_proactive:
         scene = f"你在群聊「{chat_name}」中。" if chat_name else ""
         scene += "\n你刚刷到了群里的对话。如果你想说点什么就说，不想说也可以不说。"
@@ -104,56 +60,21 @@ async def build_inner_context(
         if trigger_username:
             sections.append(f"需要回复 {trigger_username} 的消息（消息中用 ⭐ 标记）。")
 
-    # === 今日基调 ===
-    today_state = await _build_today_state(persona_id)
-    if today_state:
-        sections.append(f"你今天的基调：\n{today_state}")
-
-    # === 此刻的状态（Life Engine）===
+    # === 此刻的状态（Life Engine — 唯一的运行时上下文来源）===
     life_state = await _build_life_state(persona_id)
     if life_state:
         sections.append(life_state)
 
-    # === 脑子里的东西（今天的经历碎片）===
-    today_frags = await get_today_fragments(persona_id, grains=["conversation"])
-
-    if chat_type == "group":
-        visible_frags = _filter_fragments_for_group(today_frags, chat_id)
-    else:
-        visible_frags = today_frags
-
-    if visible_frags:
-        frag_text = _format_fragment_section(visible_frags, MAX_FRAGMENT_SECTION_CHARS)
-        if frag_text:
-            sections.append(f"脑子里的东西（今天的经历）：\n{frag_text}")
-
-    # === 更远的记忆 ===
-    distant_frags = await get_recent_fragments_by_grain(persona_id, "daily", limit=3)
-    if distant_frags:
-        distant_text = _format_fragment_section(distant_frags, MAX_DISTANT_SECTION_CHARS)
-        if distant_text:
-            sections.append(f"更远的记忆：\n{distant_text}")
-
-    # === 记忆回溯引导 ===
-    sections.append(_MEMORY_RECALL_HINT)
-
     return "\n\n".join(sections)
 
 
-async def get_reply_style(chat_id: str, persona_id: str, default_style: str = "") -> str:
-    """获取动态 reply-style：per-chat 漂移 → 全局基线 → DB 默认"""
-    try:
-        drift_state = await get_identity_state(chat_id, persona_id)
-        if drift_state:
-            return drift_state
-    except Exception:
-        pass
-    try:
-        base_state = await get_base_reply_style(persona_id)
-        if base_state:
-            return base_state
-    except Exception:
-        pass
+async def get_reply_style(persona_id: str, default_style: str = "") -> str:
+    """获取 reply_style：DB 最新记录 → DB 默认值"""
+    from app.orm.memory_crud import get_latest_reply_style
+
+    latest = await get_latest_reply_style(persona_id)
+    if latest:
+        return latest
     return default_style
 
 

--- a/apps/agent-service/tests/unit/test_identity_drift.py
+++ b/apps/agent-service/tests/unit/test_identity_drift.py
@@ -10,71 +10,34 @@ CST = timezone(timedelta(hours=8))
 
 
 @pytest.mark.asyncio
-async def test_get_identity_state_returns_none_when_empty():
-    """无状态时返回 None"""
-    mock_redis = AsyncMock()
-    mock_redis.hget = AsyncMock(return_value=None)
+async def test_set_base_reply_style_saves_to_db():
+    """写入基线 reply_style 到 DB"""
+    with patch("app.orm.memory_crud.save_reply_style", new_callable=AsyncMock) as mock_save:
+        from app.services.identity_drift import set_base_reply_style
 
-    with patch("app.services.identity_drift.AsyncRedisClient") as mock_cls:
-        mock_cls.get_instance.return_value = mock_redis
-        from app.services.identity_drift import get_identity_state
+        await set_base_reply_style("懒洋洋的，说话短", persona_id="akao")
 
-        result = await get_identity_state("chat_001", persona_id="akao")
-
-    assert result is None
-    mock_redis.hget.assert_called_once_with("reply_style:chat_001:akao", "state")
+    mock_save.assert_called_once_with("akao", "懒洋洋的，说话短", source="base")
 
 
 @pytest.mark.asyncio
-async def test_set_and_get_identity_state():
-    """写入后能读回"""
-    store = {}
+async def test_set_identity_state_saves_to_db():
+    """写入漂移 reply_style 到 DB"""
+    with patch("app.orm.memory_crud.save_reply_style", new_callable=AsyncMock) as mock_save:
+        from app.services.identity_drift import set_identity_state
 
-    async def fake_hset(key, mapping):
-        store[key] = mapping
+        await set_identity_state("akao", "有点困", observation="群里很安静")
 
-    async def fake_hget(key, field):
-        return store.get(key, {}).get(field)
-
-    async def fake_expire(key, ttl):
-        pass
-
-    mock_redis = AsyncMock()
-    mock_redis.hset = fake_hset
-    mock_redis.hget = fake_hget
-    mock_redis.expire = fake_expire
-    mock_pipe = MagicMock()
-    mock_pipe.hset = MagicMock()
-    mock_pipe.expire = MagicMock()
-    mock_pipe.execute = AsyncMock(side_effect=lambda: [
-        fake_hset("reply_style:chat_001:akao", {"state": "有点困", "updated_at": "2026-03-28T15:00:00"}),
-        None,
-    ])
-    mock_redis.pipeline = MagicMock(return_value=mock_pipe)
-
-    with patch("app.services.identity_drift.AsyncRedisClient") as mock_cls:
-        mock_cls.get_instance.return_value = mock_redis
-        from app.services.identity_drift import set_identity_state, get_identity_state
-
-        await set_identity_state("chat_001", "akao", "有点困")
-
-    mock_pipe.hset.assert_called_once()
-    mock_pipe.expire.assert_called_once()
+    mock_save.assert_called_once_with("akao", "有点困", source="drift", observation="群里很安静")
 
 
 @pytest.mark.asyncio
 async def test_on_event_single_triggers_drift_after_debounce():
     """单个事件 -> 等待 debounce -> 执行漂移"""
     with (
-        patch("app.services.identity_drift.AsyncRedisClient") as mock_redis_cls,
         patch("app.services.identity_drift.settings") as mock_settings,
         patch("app.services.identity_drift._run_drift", new_callable=AsyncMock) as mock_drift,
-        patch("app.services.identity_drift._count_messages_since_last_drift", new_callable=AsyncMock, return_value=1),
     ):
-        mock_redis = AsyncMock()
-        mock_redis.hget = AsyncMock(return_value=None)
-        mock_redis_cls.get_instance.return_value = mock_redis
-
         mock_settings.identity_drift_debounce_seconds = 0.1  # 100ms for test
         mock_settings.identity_drift_max_buffer = 20
 
@@ -93,15 +56,9 @@ async def test_on_event_single_triggers_drift_after_debounce():
 async def test_on_event_debounce_resets_timer():
     """多个事件在 debounce 内 -> 计时器重置 -> 只触发一次漂移"""
     with (
-        patch("app.services.identity_drift.AsyncRedisClient") as mock_redis_cls,
         patch("app.services.identity_drift.settings") as mock_settings,
         patch("app.services.identity_drift._run_drift", new_callable=AsyncMock) as mock_drift,
-        patch("app.services.identity_drift._count_messages_since_last_drift", new_callable=AsyncMock, return_value=1),
     ):
-        mock_redis = AsyncMock()
-        mock_redis.hget = AsyncMock(return_value=None)
-        mock_redis_cls.get_instance.return_value = mock_redis
-
         mock_settings.identity_drift_debounce_seconds = 0.2
         mock_settings.identity_drift_max_buffer = 20
 
@@ -127,15 +84,9 @@ async def test_on_event_debounce_resets_timer():
 async def test_on_event_forced_flush_at_threshold():
     """缓冲区超过 M 条 -> 强制进入二阶段"""
     with (
-        patch("app.services.identity_drift.AsyncRedisClient") as mock_redis_cls,
         patch("app.services.identity_drift.settings") as mock_settings,
         patch("app.services.identity_drift._run_drift", new_callable=AsyncMock) as mock_drift,
-        patch("app.services.identity_drift._count_messages_since_last_drift", new_callable=AsyncMock, return_value=1),
     ):
-        mock_redis = AsyncMock()
-        mock_redis.hget = AsyncMock(return_value=None)
-        mock_redis_cls.get_instance.return_value = mock_redis
-
         mock_settings.identity_drift_debounce_seconds = 10  # long debounce
         mock_settings.identity_drift_max_buffer = 3  # low threshold for test
 
@@ -163,15 +114,9 @@ async def test_phase2_buffers_new_events():
         await drift_release.wait()
 
     with (
-        patch("app.services.identity_drift.AsyncRedisClient") as mock_redis_cls,
         patch("app.services.identity_drift.settings") as mock_settings,
         patch("app.services.identity_drift._run_drift", side_effect=slow_drift) as mock_drift,
-        patch("app.services.identity_drift._count_messages_since_last_drift", new_callable=AsyncMock, return_value=1),
     ):
-        mock_redis = AsyncMock()
-        mock_redis.hget = AsyncMock(return_value=None)
-        mock_redis_cls.get_instance.return_value = mock_redis
-
         mock_settings.identity_drift_debounce_seconds = 0.05
         mock_settings.identity_drift_max_buffer = 20
 
@@ -199,7 +144,7 @@ async def test_phase2_buffers_new_events():
 
 @pytest.mark.asyncio
 async def test_run_drift_calls_observer_then_generator():
-    """_run_drift 先调 observer 再调 generator，保存 generator 的输出"""
+    """_run_drift 先调 observer 再调 generator，保存到 DB"""
     observer_response = MagicMock()
     observer_response.content = "## 情感状态\n精力低\n## 偏差诊断\n回复太长\n## 下一轮方向\n要短"
 
@@ -209,16 +154,11 @@ async def test_run_drift_calls_observer_then_generator():
     mock_model = AsyncMock()
     mock_model.ainvoke = AsyncMock(side_effect=[observer_response, generator_response])
 
-    mock_redis = AsyncMock()
-    mock_redis.hget = AsyncMock(return_value="上一轮的 reply_style")
-    mock_pipe = MagicMock()
-    mock_pipe.hset = MagicMock()
-    mock_pipe.expire = MagicMock()
-    mock_pipe.execute = AsyncMock()
-    mock_redis.pipeline = MagicMock(return_value=mock_pipe)
-
     with (
-        patch("app.services.identity_drift.AsyncRedisClient") as mock_redis_cls,
+        patch("app.orm.memory_crud.get_latest_reply_style",
+              new_callable=AsyncMock, return_value="上一轮的 reply_style"),
+        patch("app.orm.memory_crud.save_reply_style",
+              new_callable=AsyncMock) as mock_save,
         patch("app.services.identity_drift.ModelBuilder") as mock_mb,
         patch("app.services.identity_drift.get_prompt") as mock_get_prompt,
         patch("app.services.identity_drift._get_recent_messages",
@@ -230,7 +170,6 @@ async def test_run_drift_calls_observer_then_generator():
         patch("app.services.identity_drift._get_persona_context",
               new_callable=AsyncMock, return_value=("赤尾", "元气活泼傲娇少女")),
     ):
-        mock_redis_cls.get_instance.return_value = mock_redis
         mock_mb.build_chat_model = AsyncMock(return_value=mock_model)
 
         mock_observer_prompt = MagicMock()
@@ -249,12 +188,13 @@ async def test_run_drift_calls_observer_then_generator():
     # get_prompt 调了 observer 和 generator
     mock_get_prompt.assert_any_call("drift_observer")
     mock_get_prompt.assert_any_call("drift_generator")
-    # 保存的是 generator 的输出
-    mock_pipe.hset.assert_called_once()
-    call_args = mock_pipe.hset.call_args
-    mapping = call_args.kwargs.get("mapping") if call_args.kwargs else call_args[1] if len(call_args.args) > 1 else None
-    assert mapping is not None
-    assert "精力低" in mapping["state"] or "懒" in mapping["state"]
+    # 保存到 DB（source=drift，含 observation）
+    mock_save.assert_called_once()
+    call_args = mock_save.call_args
+    assert call_args[0][0] == "akao"  # persona_id
+    assert "精力低" in call_args[0][1] or "懒" in call_args[0][1]  # style_text
+    assert call_args[1]["source"] == "drift"
+    assert call_args[1]["observation"] is not None
 
 
 @pytest.mark.asyncio
@@ -291,55 +231,17 @@ async def test_get_recent_persona_replies_filters_assistant_only():
 
 
 @pytest.mark.asyncio
-async def test_get_base_reply_style_returns_none_when_empty():
-    """无基线时返回 None"""
-    mock_redis = AsyncMock()
-    mock_redis.get = AsyncMock(return_value=None)
-
-    with patch("app.services.identity_drift.AsyncRedisClient") as mock_cls:
-        mock_cls.get_instance.return_value = mock_redis
-        from app.services.identity_drift import get_base_reply_style
-
-        result = await get_base_reply_style(persona_id="akao")
-
-    assert result is None
-    mock_redis.get.assert_called_once_with("reply_style:__base__:akao")
-
-
-@pytest.mark.asyncio
-async def test_set_base_reply_style_stores_with_ttl():
-    """写入基线并设置 TTL"""
-    mock_redis = AsyncMock()
-    mock_redis.set = AsyncMock()
-
-    with patch("app.services.identity_drift.AsyncRedisClient") as mock_cls:
-        mock_cls.get_instance.return_value = mock_redis
-        from app.services.identity_drift import set_base_reply_style
-
-        await set_base_reply_style("懒洋洋的，说话短", persona_id="akao")
-
-    mock_redis.set.assert_called_once()
-    call_args = mock_redis.set.call_args
-    assert call_args[0][0] == "reply_style:__base__:akao"
-    assert call_args[0][1] == "懒洋洋的，说话短"
-    # TTL: 12 小时（覆盖到下一次生成）
-    assert call_args[1].get("ex") == 43200
-
-
-@pytest.mark.asyncio
 async def test_generate_base_reply_style_uses_schedule():
-    """基线生成：读 schedule + 调 LLM + 存 Redis"""
+    """基线生成：读 schedule + 调 LLM + 存 DB"""
     mock_response = MagicMock()
     mock_response.content = "[感冒中，懒懒的]\n\n--- 被问问题 ---\n赤尾: 不知道诶……头好晕"
 
     mock_model = AsyncMock()
     mock_model.ainvoke = AsyncMock(return_value=mock_response)
 
-    mock_redis = AsyncMock()
-    mock_redis.set = AsyncMock()
-
     with (
-        patch("app.services.identity_drift.AsyncRedisClient") as mock_redis_cls,
+        patch("app.orm.memory_crud.save_reply_style",
+              new_callable=AsyncMock) as mock_save,
         patch("app.services.identity_drift.ModelBuilder") as mock_mb,
         patch("app.services.identity_drift.get_prompt") as mock_get_prompt,
         patch("app.services.identity_drift._get_schedule_context",
@@ -347,7 +249,6 @@ async def test_generate_base_reply_style_uses_schedule():
         patch("app.services.identity_drift._get_persona_context",
               new_callable=AsyncMock, return_value=("赤尾", "元气活泼傲娇少女")),
     ):
-        mock_redis_cls.get_instance.return_value = mock_redis
         mock_mb.build_chat_model = AsyncMock(return_value=mock_model)
 
         mock_prompt = MagicMock()
@@ -361,7 +262,7 @@ async def test_generate_base_reply_style_uses_schedule():
     assert "感冒" in result
     mock_get_prompt.assert_called_with("drift_base_generator")
     mock_model.ainvoke.assert_called_once()
-    mock_redis.set.assert_called_once()
+    mock_save.assert_called_once_with("akao", result, source="base")
 
 
 @pytest.mark.asyncio

--- a/apps/agent-service/tests/unit/test_memory_context.py
+++ b/apps/agent-service/tests/unit/test_memory_context.py
@@ -1,164 +1,103 @@
-"""测试统一聊天注入上下文 v3（experience_fragment 版）"""
+"""测试统一聊天注入上下文 v4（Life Engine 版）"""
 
-import json
 import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
-
-
-def _make_fragment(content: str, grain: str = "conversation", source_chat_id: str = "chat_001"):
-    """创建模拟碎片"""
-    return MagicMock(content=content, grain=grain, source_chat_id=source_chat_id)
 
 
 # ── build_inner_context tests ──
 
 
 @pytest.mark.asyncio
-async def test_build_inner_context_group_with_fragments():
-    """群聊：场景 + schedule + 当前群碎片 + daily + 引导语"""
-    today_frags = [
-        _make_fragment("和A哥聊了动画", source_chat_id="chat_001"),
-        _make_fragment("有人分享了新番", grain="glimpse", source_chat_id="chat_001"),
-        _make_fragment("私聊里B说了秘密", source_chat_id="p2p_999"),  # 应被过滤
-    ]
-    daily_frags = [
-        _make_fragment("昨天去了咖啡店", grain="daily", source_chat_id=""),
-    ]
-
-    with (
-        patch("app.services.memory_context._build_today_state",
-              new_callable=AsyncMock, return_value="今天想出门逛逛"),
-        patch("app.services.memory_context._build_life_state",
-              new_callable=AsyncMock, return_value=""),
-        patch("app.services.memory_context.get_today_fragments",
-              new_callable=AsyncMock, return_value=today_frags),
-        patch("app.services.memory_context.get_recent_fragments_by_grain",
-              new_callable=AsyncMock, return_value=daily_frags),
+async def test_build_inner_context_group_basic():
+    """群聊：场景提示 + Life Engine 状态"""
+    with patch(
+        "app.services.memory_context._build_life_state",
+        new_callable=AsyncMock,
+        return_value="你此刻的状态：窝在被窝里\n你的心情：暖洋洋的",
     ):
         from app.services.memory_context import build_inner_context
+
         result = await build_inner_context(
-            chat_id="chat_001", chat_type="group", user_ids=["u1"],
-            trigger_user_id="u1", trigger_username="A哥", persona_id="akao",
+            chat_id="chat_001",
+            chat_type="group",
+            user_ids=["u1"],
+            trigger_user_id="u1",
+            trigger_username="A哥",
+            persona_id="akao",
             chat_name="KA技术群",
         )
 
     assert "群聊「KA技术群」" in result
     assert "回复 A哥" in result
-    assert "想出门逛逛" in result
-    assert "聊了动画" in result
-    assert "新番" in result
-    assert "秘密" not in result  # p2p 碎片被过滤
-    assert "咖啡店" in result  # daily 碎片
-    assert "recall" in result
+    assert "窝在被窝里" in result
+    assert "暖洋洋" in result
 
 
 @pytest.mark.asyncio
-async def test_build_inner_context_p2p_sees_all():
-    """私聊：可以看到所有碎片（包括其他群和 p2p）"""
-    today_frags = [
-        _make_fragment("群里的讨论", source_chat_id="chat_001"),
-        _make_fragment("另一个群的八卦", source_chat_id="chat_002"),
-        _make_fragment("私聊说的心事", source_chat_id="p2p_001"),
-    ]
-
-    with (
-        patch("app.services.memory_context._build_today_state",
-              new_callable=AsyncMock, return_value="心情不错"),
-        patch("app.services.memory_context._build_life_state",
-              new_callable=AsyncMock, return_value=""),
-        patch("app.services.memory_context.get_today_fragments",
-              new_callable=AsyncMock, return_value=today_frags),
-        patch("app.services.memory_context.get_recent_fragments_by_grain",
-              new_callable=AsyncMock, return_value=[]),
+async def test_build_inner_context_p2p():
+    """私聊：显示私聊场景"""
+    with patch(
+        "app.services.memory_context._build_life_state",
+        new_callable=AsyncMock,
+        return_value="",
     ):
         from app.services.memory_context import build_inner_context
+
         result = await build_inner_context(
-            chat_id="p2p_001", chat_type="p2p", user_ids=["u1"],
-            trigger_user_id="u1", trigger_username="A哥", persona_id="akao",
+            chat_id="p2p_001",
+            chat_type="p2p",
+            user_ids=["u1"],
+            trigger_user_id="u1",
+            trigger_username="A哥",
+            persona_id="akao",
         )
 
     assert "私聊" in result
-    assert "群里的讨论" in result
-    assert "八卦" in result
-    assert "心事" in result
 
 
 @pytest.mark.asyncio
-async def test_build_inner_context_group_filters_private():
-    """群聊：过滤掉 p2p 和其他群的碎片"""
-    today_frags = [
-        _make_fragment("当前群的话题", source_chat_id="chat_001"),
-        _make_fragment("私聊的秘密", source_chat_id="p2p_001"),
-        _make_fragment("其他群的讨论", source_chat_id="chat_999"),
-    ]
-
-    with (
-        patch("app.services.memory_context._build_today_state",
-              new_callable=AsyncMock, return_value=""),
-        patch("app.services.memory_context._build_life_state",
-              new_callable=AsyncMock, return_value=""),
-        patch("app.services.memory_context.get_today_fragments",
-              new_callable=AsyncMock, return_value=today_frags),
-        patch("app.services.memory_context.get_recent_fragments_by_grain",
-              new_callable=AsyncMock, return_value=[]),
+async def test_build_inner_context_no_life_state():
+    """无 Life Engine 状态时：只有场景提示，不崩溃"""
+    with patch(
+        "app.services.memory_context._build_life_state",
+        new_callable=AsyncMock,
+        return_value="",
     ):
         from app.services.memory_context import build_inner_context
+
         result = await build_inner_context(
-            chat_id="chat_001", chat_type="group", user_ids=["u1"],
-            trigger_user_id="u1", trigger_username="A哥", persona_id="akao",
-            chat_name="测试群",
-        )
-
-    assert "当前群的话题" in result
-    assert "秘密" not in result
-    assert "其他群" not in result
-
-
-@pytest.mark.asyncio
-async def test_build_inner_context_no_fragments():
-    """无碎片时：场景 + 引导语，不出现空段"""
-    with (
-        patch("app.services.memory_context._build_today_state",
-              new_callable=AsyncMock, return_value=""),
-        patch("app.services.memory_context._build_life_state",
-              new_callable=AsyncMock, return_value=""),
-        patch("app.services.memory_context.get_today_fragments",
-              new_callable=AsyncMock, return_value=[]),
-        patch("app.services.memory_context.get_recent_fragments_by_grain",
-              new_callable=AsyncMock, return_value=[]),
-    ):
-        from app.services.memory_context import build_inner_context
-        result = await build_inner_context(
-            chat_id="chat_001", chat_type="group", user_ids=[],
-            trigger_user_id="u1", trigger_username="A哥", persona_id="akao",
+            chat_id="chat_001",
+            chat_type="group",
+            user_ids=[],
+            trigger_user_id="u1",
+            trigger_username="A哥",
+            persona_id="akao",
             chat_name="测试群",
         )
 
     assert "群聊「测试群」" in result
-    assert "今天的基调" not in result
-    assert "脑子里的东西" not in result
-    assert "更远的记忆" not in result
-    assert "recall" in result
+    assert "此刻的状态" not in result
 
 
 @pytest.mark.asyncio
 async def test_build_inner_context_proactive():
     """主动发言：含 stimulus，无回复提示"""
-    with (
-        patch("app.services.memory_context._build_today_state",
-              new_callable=AsyncMock, return_value=""),
-        patch("app.services.memory_context._build_life_state",
-              new_callable=AsyncMock, return_value=""),
-        patch("app.services.memory_context.get_today_fragments",
-              new_callable=AsyncMock, return_value=[]),
-        patch("app.services.memory_context.get_recent_fragments_by_grain",
-              new_callable=AsyncMock, return_value=[]),
+    with patch(
+        "app.services.memory_context._build_life_state",
+        new_callable=AsyncMock,
+        return_value="",
     ):
         from app.services.memory_context import build_inner_context
+
         result = await build_inner_context(
-            chat_id="chat_001", chat_type="group", user_ids=["u1"],
-            trigger_user_id="u1", trigger_username="A哥", persona_id="akao",
-            chat_name="摸鱼群", is_proactive=True,
+            chat_id="chat_001",
+            chat_type="group",
+            user_ids=["u1"],
+            trigger_user_id="u1",
+            trigger_username="A哥",
+            persona_id="akao",
+            chat_name="摸鱼群",
+            is_proactive=True,
             proactive_stimulus="有人在讨论猫猫",
         )
 
@@ -168,66 +107,52 @@ async def test_build_inner_context_proactive():
     assert "回复" not in result
 
 
-# ── get_reply_style tests (unchanged) ──
+# ── get_reply_style tests ──
 
 
 @pytest.mark.asyncio
-async def test_get_reply_style_fallback_to_base():
-    """per-chat 无漂移 → fallback 到基线"""
-    with (
-        patch("app.services.memory_context.get_identity_state",
-              new_callable=AsyncMock, return_value=None),
-        patch("app.services.memory_context.get_base_reply_style",
-              new_callable=AsyncMock, return_value="[感冒中] 说话短短的"),
+async def test_get_reply_style_from_db():
+    """DB 有记录 → 返回 DB 值"""
+    with patch(
+        "app.orm.memory_crud.get_latest_reply_style",
+        new_callable=AsyncMock,
+        return_value="[感冒中] 说话短短的",
     ):
         from app.services.memory_context import get_reply_style
-        result = await get_reply_style("p2p_001", "akao")
+
+        result = await get_reply_style("akao")
 
     assert "感冒" in result
 
 
 @pytest.mark.asyncio
-async def test_get_reply_style_per_chat_takes_priority():
-    """per-chat 有漂移 → 用 per-chat，不读基线"""
-    with (
-        patch("app.services.memory_context.get_identity_state",
-              new_callable=AsyncMock, return_value="群里很嗨"),
-        patch("app.services.memory_context.get_base_reply_style",
-              new_callable=AsyncMock) as mock_base,
-    ):
-        from app.services.memory_context import get_reply_style
-        result = await get_reply_style("chat_001", "akao")
-
-    assert "很嗨" in result
-    mock_base.assert_not_called()
-
-
-@pytest.mark.asyncio
 async def test_get_reply_style_fallback_to_default():
-    """per-chat 无漂移 + 基线也无 → fallback 到调用方传入的 default_style"""
-    with (
-        patch("app.services.memory_context.get_identity_state",
-              new_callable=AsyncMock, return_value=None),
-        patch("app.services.memory_context.get_base_reply_style",
-              new_callable=AsyncMock, return_value=None),
+    """DB 无记录 → fallback 到 default_style"""
+    with patch(
+        "app.orm.memory_crud.get_latest_reply_style",
+        new_callable=AsyncMock,
+        return_value=None,
     ):
         from app.services.memory_context import get_reply_style
-        result = await get_reply_style("p2p_001", "akao", default_style="来自persona的默认风格")
+
+        result = await get_reply_style("akao", default_style="来自persona的默认风格")
 
     assert "来自persona的默认风格" in result
 
 
 @pytest.mark.asyncio
-async def test_get_reply_style_uses_persona_id():
-    """get_reply_style 应使用 persona_id 维度的 Redis key"""
-    with (
-        patch("app.services.memory_context.get_identity_state", return_value="drifted") as mock_drift,
-        patch("app.services.memory_context.get_base_reply_style", return_value=None),
+async def test_get_reply_style_empty_default():
+    """DB 无记录 + 无 default → 返回空字符串"""
+    with patch(
+        "app.orm.memory_crud.get_latest_reply_style",
+        new_callable=AsyncMock,
+        return_value=None,
     ):
         from app.services.memory_context import get_reply_style
-        result = await get_reply_style("chat_abc", "akao")
-        mock_drift.assert_called_once_with("chat_abc", "akao")
-        assert result == "drifted"
+
+        result = await get_reply_style("akao")
+
+    assert result == ""
 
 
 # ── Life Engine state injection tests ──
@@ -236,33 +161,13 @@ async def test_get_reply_style_uses_persona_id():
 @pytest.mark.asyncio
 async def test_inner_context_includes_life_engine_state():
     """build_inner_context 注入 Life Engine 状态"""
-    mock_row = MagicMock()
-    mock_row.current_state = "窝在被窝里刷手机"
-    mock_row.response_mood = "暖洋洋的，很放松"
-
-    with (
-        patch(
-            "app.services.memory_context._build_life_state",
-            new_callable=AsyncMock,
-            return_value="你此刻的状态：窝在被窝里刷手机\n你的心情：暖洋洋的，很放松",
-        ),
-        patch(
-            "app.services.memory_context.get_plan_for_period",
-            new_callable=AsyncMock,
-            return_value=None,
-        ),
-        patch(
-            "app.services.memory_context.get_today_fragments",
-            new_callable=AsyncMock,
-            return_value=[],
-        ),
-        patch(
-            "app.services.memory_context.get_recent_fragments_by_grain",
-            new_callable=AsyncMock,
-            return_value=[],
-        ),
+    with patch(
+        "app.services.memory_context._build_life_state",
+        new_callable=AsyncMock,
+        return_value="你此刻的状态：窝在被窝里刷手机\n你的心情：暖洋洋的，很放松",
     ):
         from app.services.memory_context import build_inner_context
+
         result = await build_inner_context(
             chat_id="oc_test",
             chat_type="group",
@@ -279,29 +184,13 @@ async def test_inner_context_includes_life_engine_state():
 @pytest.mark.asyncio
 async def test_inner_context_no_life_state_graceful():
     """DB 无 Life Engine 状态 → 不崩溃，不注入"""
-    with (
-        patch(
-            "app.services.memory_context._build_life_state",
-            new_callable=AsyncMock,
-            return_value="",
-        ),
-        patch(
-            "app.services.memory_context.get_plan_for_period",
-            new_callable=AsyncMock,
-            return_value=None,
-        ),
-        patch(
-            "app.services.memory_context.get_today_fragments",
-            new_callable=AsyncMock,
-            return_value=[],
-        ),
-        patch(
-            "app.services.memory_context.get_recent_fragments_by_grain",
-            new_callable=AsyncMock,
-            return_value=[],
-        ),
+    with patch(
+        "app.services.memory_context._build_life_state",
+        new_callable=AsyncMock,
+        return_value="",
     ):
         from app.services.memory_context import build_inner_context
+
         result = await build_inner_context(
             chat_id="oc_test",
             chat_type="p2p",

--- a/docs/superpowers/plans/2026-04-08-context-architecture-phase1.md
+++ b/docs/superpowers/plans/2026-04-08-context-architecture-phase1.md
@@ -1,0 +1,574 @@
+# Context Architecture Phase 1: 瘦身 + 落库
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 将 system prompt 从 8000+ 字符瘦身到 ~3000 字符，reply_style 落库审计，移除主 agent 搜索工具
+
+**Architecture:** 移除 inner-context 中的 schedule/碎片/daily dream 直接注入（Life Engine 已消化），reply_style 从 Redis 迁到 DB（append-only），主 agent 工具集从 11 个精简到 7 个
+
+**Tech Stack:** Python, SQLAlchemy, PostgreSQL, Langfuse, LangChain
+
+**Spec:** `docs/superpowers/specs/2026-04-08-context-architecture-redesign.md`
+
+---
+
+## File Structure
+
+| 文件 | 变更类型 | 职责 |
+|------|---------|------|
+| `apps/agent-service/app/orm/memory_models.py` | 修改 | 新增 ReplyStyleLog 模型 |
+| `apps/agent-service/app/orm/memory_crud.py` | 修改 | 新增 reply_style CRUD |
+| `apps/agent-service/app/services/identity_drift.py` | 修改 | Redis→DB 读写 |
+| `apps/agent-service/app/services/memory_context.py` | 修改 | 移除 schedule/碎片/dream 注入 |
+| `apps/agent-service/app/services/bot_context.py` | 修改 | reply_style 读取链路 |
+| `apps/agent-service/app/agents/domains/main/tools.py` | 修改 | 精简工具集 |
+| `apps/agent-service/app/agents/core/agent.py` | 修改 | 添加工具调用限制 |
+| `apps/agent-service/tests/unit/test_reply_style_log.py` | 新增 | reply_style 落库测试 |
+| `apps/agent-service/tests/unit/test_inner_context.py` | 新增 | inner-context 瘦身测试 |
+
+---
+
+### Task 1: reply_style_log 表模型
+
+**Files:**
+- Modify: `apps/agent-service/app/orm/memory_models.py`
+- Modify: `apps/agent-service/app/orm/memory_crud.py`
+- Test: `apps/agent-service/tests/unit/test_reply_style_log.py`
+
+- [ ] **Step 1: 写 ReplyStyleLog 模型**
+
+在 `memory_models.py` 末尾添加：
+
+```python
+class ReplyStyleLog(Base):
+    """Reply Style 审计日志 — 每次漂移 INSERT 一行，append-only"""
+
+    __tablename__ = "reply_style_log"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    persona_id: Mapped[str] = mapped_column(String(50), nullable=False, index=True)
+    style_text: Mapped[str] = mapped_column(Text, nullable=False)
+    observation: Mapped[str | None] = mapped_column(Text, nullable=True)
+    source: Mapped[str] = mapped_column(String(20), nullable=False)  # 'base' / 'drift' / 'manual'
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now()
+    )
+```
+
+- [ ] **Step 2: 写 CRUD 函数**
+
+在 `memory_crud.py` 末尾添加：
+
+```python
+async def save_reply_style(
+    persona_id: str,
+    style_text: str,
+    source: str,
+    observation: str | None = None,
+) -> None:
+    """写入 reply_style 审计日志（append-only）"""
+    from app.orm.memory_models import ReplyStyleLog
+
+    async with AsyncSessionLocal() as session:
+        session.add(ReplyStyleLog(
+            persona_id=persona_id,
+            style_text=style_text,
+            source=source,
+            observation=observation,
+        ))
+        await session.commit()
+
+
+async def get_latest_reply_style(persona_id: str) -> str | None:
+    """获取最新的 reply_style"""
+    from app.orm.memory_models import ReplyStyleLog
+
+    async with AsyncSessionLocal() as session:
+        result = await session.execute(
+            select(ReplyStyleLog.style_text)
+            .where(ReplyStyleLog.persona_id == persona_id)
+            .order_by(ReplyStyleLog.created_at.desc())
+            .limit(1)
+        )
+        row = result.scalar_one_or_none()
+        return row
+```
+
+- [ ] **Step 3: 写测试**
+
+```python
+# tests/unit/test_reply_style_log.py
+import pytest
+from app.orm.memory_crud import save_reply_style, get_latest_reply_style
+
+
+@pytest.mark.asyncio
+async def test_save_and_get_reply_style():
+    await save_reply_style("akao", "style v1", "base")
+    await save_reply_style("akao", "style v2", "drift", observation="太冷了")
+
+    latest = await get_latest_reply_style("akao")
+    assert latest == "style v2"
+
+
+@pytest.mark.asyncio
+async def test_get_latest_returns_none_when_empty():
+    result = await get_latest_reply_style("nonexistent")
+    assert result is None
+```
+
+- [ ] **Step 4: 提交 DDL 建表**
+
+通过 `/ops-db` skill 提交：
+
+```sql
+CREATE TABLE reply_style_log (
+    id SERIAL PRIMARY KEY,
+    persona_id VARCHAR(50) NOT NULL,
+    style_text TEXT NOT NULL,
+    observation TEXT,
+    source VARCHAR(20) NOT NULL,
+    created_at TIMESTAMPTZ DEFAULT now()
+);
+
+CREATE INDEX idx_reply_style_log_persona_created
+    ON reply_style_log (persona_id, created_at DESC);
+```
+
+- [ ] **Step 5: 运行测试确认通过**
+
+```bash
+cd apps/agent-service && uv run pytest tests/unit/test_reply_style_log.py -v
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/agent-service/app/orm/memory_models.py apps/agent-service/app/orm/memory_crud.py apps/agent-service/tests/unit/test_reply_style_log.py
+git commit -m "feat(memory): add reply_style_log table for audit trail"
+```
+
+---
+
+### Task 2: reply_style 读写迁移到 DB
+
+**Files:**
+- Modify: `apps/agent-service/app/services/identity_drift.py`
+- Modify: `apps/agent-service/app/services/memory_context.py`
+- Modify: `apps/agent-service/app/services/bot_context.py`
+
+- [ ] **Step 1: 修改 identity_drift.py — 基线写入改 DB**
+
+找到 `set_base_reply_style` 函数（约 L55-59），当前写 Redis：
+
+```python
+# 旧代码
+await redis_client.set(f"reply_style:__base__:{persona_id}", style, ex=43200)
+```
+
+替换为：
+
+```python
+from app.orm.memory_crud import save_reply_style
+
+await save_reply_style(persona_id, style, source="base")
+```
+
+- [ ] **Step 2: 修改 identity_drift.py — 漂移写入改 DB**
+
+找到 `_run_drift` 中写 Redis 的地方（约 L107-114），当前：
+
+```python
+await redis_client.hset(f"reply_style:{chat_id}:{persona_id}", mapping={
+    "state": style,
+    "updated_at": now.isoformat(),
+})
+await redis_client.expire(f"reply_style:{chat_id}:{persona_id}", ttl)
+```
+
+替换为（注意：去掉 chat_id 维度，改为 per-persona only）：
+
+```python
+from app.orm.memory_crud import save_reply_style
+
+await save_reply_style(
+    persona_id,
+    style,
+    source="drift",
+    observation=observation_report,
+)
+```
+
+- [ ] **Step 3: 修改 memory_context.py — 读取改 DB**
+
+找到 `get_reply_style` 函数（约 L143-157），当前三层 Redis fallback。替换为：
+
+```python
+async def get_reply_style(persona_id: str, default_style: str = "") -> str:
+    """获取 reply_style：DB 最新记录 → DB 默认值"""
+    from app.orm.memory_crud import get_latest_reply_style
+
+    latest = await get_latest_reply_style(persona_id)
+    if latest:
+        return latest
+    return default_style
+```
+
+- [ ] **Step 4: 修改 bot_context.py — 去掉 chat_id 参数**
+
+找到 `_load_persona` 中调用 `get_reply_style` 的地方（约 L116-118）：
+
+```python
+# 旧代码
+self._reply_style = await get_reply_style(
+    self.chat_id, self._persona_id, default_style
+)
+
+# 新代码
+self._reply_style = await get_reply_style(
+    self._persona_id, default_style
+)
+```
+
+- [ ] **Step 5: 删除 Redis 相关的旧函数**
+
+在 `memory_context.py` 中删除：
+- `get_identity_state()` — Redis 读取 per-chat 漂移
+- `set_base_reply_style()` — Redis 写入基线
+
+在 `identity_drift.py` 中删除：
+- 所有 `redis_client.set/hset/get/hget` 相关 reply_style 的调用
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/agent-service/app/services/identity_drift.py apps/agent-service/app/services/memory_context.py apps/agent-service/app/services/bot_context.py
+git commit -m "feat(drift): migrate reply_style from Redis to DB (append-only audit)"
+```
+
+---
+
+### Task 3: 瘦身 inner-context
+
+**Files:**
+- Modify: `apps/agent-service/app/services/memory_context.py`
+- Test: `apps/agent-service/tests/unit/test_inner_context.py`
+
+- [ ] **Step 1: 移除 schedule 直接注入**
+
+在 `build_inner_context` 中，删除整个 `_build_today_state` 调用块（约 L108-110）：
+
+```python
+# 删除以下代码
+today_state = await _build_today_state(persona_id)
+if today_state:
+    sections.append(f"你今天的基调：\n{today_state}")
+```
+
+同时删除 `_build_today_state` 函数定义（约 L26-33）。
+
+- [ ] **Step 2: 移除 conversation 碎片直接注入**
+
+在 `build_inner_context` 中，删除整个碎片注入块（约 L117-127）：
+
+```python
+# 删除以下代码
+today_frags = await get_today_fragments(persona_id, grains=["conversation"])
+if chat_type == "group":
+    visible_frags = _filter_fragments_for_group(today_frags, chat_id)
+else:
+    visible_frags = today_frags
+if visible_frags:
+    frag_text = _format_fragment_section(visible_frags, MAX_FRAGMENT_SECTION_CHARS)
+    if frag_text:
+        sections.append(f"脑子里的东西（今天的经历）：\n{frag_text}")
+```
+
+- [ ] **Step 3: 移除 daily dream 直接注入**
+
+删除 distant fragments 块（约 L129-133）：
+
+```python
+# 删除以下代码
+distant_frags = await get_recent_fragments_by_grain(persona_id, "daily", limit=3)
+if distant_frags:
+    distant_text = _format_fragment_section(distant_frags, MAX_DISTANT_SECTION_CHARS)
+    if distant_text:
+        sections.append(f"更远的记忆：\n{distant_text}")
+```
+
+- [ ] **Step 4: 清理不再使用的常量和函数**
+
+删除：
+- `MAX_FRAGMENT_SECTION_CHARS = 3000`
+- `MAX_DISTANT_SECTION_CHARS = 800`
+- `_format_fragment_section()` 函数
+- `_filter_fragments_for_group()` 函数
+- `_MEMORY_RECALL_HINT` 常量及其注入（recall 工具也被移除了）
+
+- [ ] **Step 5: 验证瘦身后的 build_inner_context**
+
+瘦身后函数应该只剩：
+
+```python
+async def build_inner_context(
+    chat_id: str,
+    chat_type: str,
+    user_ids: list[str],
+    trigger_user_id: str,
+    trigger_username: str,
+    persona_id: str,
+    chat_name: str = "",
+    *,
+    is_proactive: bool = False,
+    proactive_stimulus: str = "",
+) -> str:
+    sections: list[str] = []
+
+    # 场景提示
+    if is_proactive:
+        scene = f"你在群聊「{chat_name}」中。" if chat_name else ""
+        scene += "\n你刚刷到了群里的对话。如果你想说点什么就说，不想说也可以不说。"
+        scene += "\n不要刻意解释为什么突然说话，像朋友在群里自然接话就好。"
+        if proactive_stimulus:
+            scene += f"\n（你注意到的：{proactive_stimulus}）"
+        sections.append(scene)
+    elif chat_type == "p2p":
+        if trigger_username:
+            sections.append(f"你正在和 {trigger_username} 私聊。")
+    else:
+        if chat_name:
+            sections.append(f"你在群聊「{chat_name}」中。")
+        if trigger_username:
+            sections.append(f"需要回复 {trigger_username} 的消息（消息中用 ⭐ 标记）。")
+
+    # Life Engine 状态（唯一的状态来源）
+    life_state = await _build_life_state(persona_id)
+    if life_state:
+        sections.append(life_state)
+
+    return "\n\n".join(sections)
+```
+
+- [ ] **Step 6: 写测试确认瘦身效果**
+
+```python
+# tests/unit/test_inner_context.py
+import pytest
+from unittest.mock import AsyncMock, patch
+from app.services.memory_context import build_inner_context
+
+
+@pytest.mark.asyncio
+async def test_inner_context_only_contains_scene_and_life_state():
+    with patch("app.services.memory_context._build_life_state", new_callable=AsyncMock) as mock_life:
+        mock_life.return_value = "你此刻的状态：在桌前整理照片\n你的心情：平静"
+
+        result = await build_inner_context(
+            chat_id="oc_test",
+            chat_type="group",
+            user_ids=["user1"],
+            trigger_user_id="user1",
+            trigger_username="冯宇林",
+            persona_id="akao",
+            chat_name="测试群",
+        )
+
+        assert "测试群" in result
+        assert "冯宇林" in result
+        assert "在桌前整理照片" in result
+        # 不应包含 schedule、碎片、daily dream
+        assert "今天的基调" not in result
+        assert "脑子里的东西" not in result
+        assert "更远的记忆" not in result
+
+
+@pytest.mark.asyncio
+async def test_inner_context_total_length_under_1000():
+    with patch("app.services.memory_context._build_life_state", new_callable=AsyncMock) as mock_life:
+        mock_life.return_value = "你此刻的状态：测试状态\n你的心情：正常"
+
+        result = await build_inner_context(
+            chat_id="oc_test",
+            chat_type="group",
+            user_ids=[],
+            trigger_user_id="u1",
+            trigger_username="测试用户",
+            persona_id="akao",
+            chat_name="测试群",
+        )
+
+        assert len(result) < 1000
+```
+
+- [ ] **Step 7: 运行测试**
+
+```bash
+cd apps/agent-service && uv run pytest tests/unit/test_inner_context.py -v
+```
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add apps/agent-service/app/services/memory_context.py apps/agent-service/tests/unit/test_inner_context.py
+git commit -m "refactor(context): remove schedule/fragments/dream raw injection from inner-context"
+```
+
+---
+
+### Task 4: 精简主 agent 工具集
+
+**Files:**
+- Modify: `apps/agent-service/app/agents/domains/main/tools.py`
+- Modify: Langfuse `main` prompt（移除工具说明）
+
+- [ ] **Step 1: 修改 tools.py — 移除搜索工具**
+
+```python
+# 旧代码
+BASE_TOOLS = [
+    search_web,
+    search_images,
+    search_group_history,    # 移除
+    list_group_members,      # 移除
+    generate_image,
+    read_images,
+    recall,                  # 移除
+    check_chat_history,      # 移除
+]
+
+# 新代码
+BASE_TOOLS = [
+    search_web,
+    search_images,
+    generate_image,
+    read_images,
+]
+
+ALL_TOOLS = [
+    *BASE_TOOLS,
+    deep_research,
+    load_skill,
+    sandbox_bash,
+]
+```
+
+- [ ] **Step 2: 更新 Langfuse main prompt — 移除工具说明**
+
+创建 main prompt 新版本，`<tools>` 段中移除以下工具描述：
+- `search_group_history`
+- `list_group_members`
+- `recall`（不再有记忆回溯工具）
+- `check_chat_history`
+
+同时修改 `search_web` 描述，加入限制：
+
+```
+- **search_web**: 查询外部信息。仅在用户明确要求你查某个东西时使用。不要用它搜索群聊内容或个人记忆。
+```
+
+移除 `<inner-context>` 末尾的记忆回溯引导语（"如果隐约觉得知道点什么..."）。
+
+- [ ] **Step 3: 更新 deep_research 子 agent 的 BASE_TOOLS**
+
+deep_research 的子 agent 也继承 BASE_TOOLS，移除搜索工具后自动生效。但需要确认 research_agent prompt 中是否引用了被移除的工具——如果有则需要同步更新。
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/agent-service/app/agents/domains/main/tools.py
+git commit -m "refactor(tools): remove search/recall tools from main agent"
+```
+
+---
+
+### Task 5: 添加工具调用次数限制
+
+**Files:**
+- Modify: `apps/agent-service/app/agents/core/agent.py`
+
+- [ ] **Step 1: 确认 LangGraph agent 的迭代限制配置**
+
+查看 `create_agent()` 函数（`app/agents/core/agent.py`），找到 LangGraph agent 的创建位置。添加 `recursion_limit` 参数：
+
+```python
+# 在 create_agent 或 agent.run 调用中添加
+config = {"recursion_limit": 10}  # 最多 10 轮工具调用
+```
+
+具体实现取决于 LangGraph 版本。如果用的是 `create_react_agent`：
+
+```python
+agent = create_react_agent(model, tools, system_prompt=system_prompt)
+# 在 invoke/stream 时传 config
+result = await agent.ainvoke(messages, config={"recursion_limit": 10})
+```
+
+- [ ] **Step 2: 测试确认限制生效**
+
+手动触发一条需要多次工具调用的消息，确认不会超过 10 轮。
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/agent-service/app/agents/core/agent.py
+git commit -m "fix(agent): add recursion_limit=10 to prevent tool call loops"
+```
+
+---
+
+### Task 6: 集成验证
+
+- [ ] **Step 1: 本地运行完整测试套件**
+
+```bash
+cd apps/agent-service && uv run pytest tests/ -v --timeout=30
+```
+
+- [ ] **Step 2: 部署到测试泳道验证**
+
+```bash
+make deploy APP=agent-service LANE=ctx-v4 GIT_REF=chore/chiwei-feedback-analysis
+```
+
+- [ ] **Step 3: 绑定 dev bot 测试**
+
+```
+/ops bind TYPE=bot KEY=dev LANE=ctx-v4
+```
+
+在飞书 dev bot 中验证：
+1. @赤尾 正常回复（inner-context 瘦身生效）
+2. 回复长度在 20-100 字波动（之前的 prompt 改动生效）
+3. 赤尾不会尝试搜索群历史（工具已移除）
+4. 赤尾知道自己长什么样（appearance 注入生效）
+
+- [ ] **Step 4: 查 Langfuse trace 确认 system prompt 大小**
+
+```bash
+python3 ~/.claude/skills/langfuse/scripts/langfuse_api.py list-traces '{"limit":3,"orderBy":"timestamp.desc","name":"main"}'
+```
+
+获取最新 trace，确认 system prompt 总字符数 < 3500。
+
+- [ ] **Step 5: 确认 reply_style_log 有审计记录**
+
+```sql
+SELECT id, persona_id, source, length(style_text), created_at
+FROM reply_style_log
+ORDER BY created_at DESC
+LIMIT 5
+```
+
+- [ ] **Step 6: 验收后清理**
+
+```
+/ops unbind TYPE=bot KEY=dev
+make undeploy APP=agent-service LANE=ctx-v4
+```
+
+- [ ] **Step 7: Commit 并推送**
+
+```bash
+git push origin chore/chiwei-feedback-analysis
+```

--- a/docs/superpowers/specs/2026-04-08-context-architecture-redesign.md
+++ b/docs/superpowers/specs/2026-04-08-context-architecture-redesign.md
@@ -1,0 +1,84 @@
+# Context Architecture Redesign — 设计文档
+
+## 问题总结
+
+当前 system prompt 8000+ 字符，62% 是 inner-context 噪音。核心架构问题：
+
+1. **冗余注入**：schedule 和 conversation 碎片同时喂给 Life Engine（作为 tick 输入）和直接裸塞到 system prompt，信息重复且密度低
+2. **缺乏 per-user 上下文**：没有关系记忆系统，赤尾对所有人说话一个样
+3. **reply_style 纯 Redis**：核心行为状态无审计、不可追溯
+4. **主 agent 工具过重**：search_group_history / check_chat_history / recall 导致 12 轮工具调用死循环，找不到时编造答案
+5. **示例式行为锚点**：reply_style 的 few-shot 示例压制 per-user 差异
+
+## 目标架构
+
+```
+离线 (T+1d):
+  schedule ──→ Life Engine tick（唯一消费者，不再直接注入）
+  daily dream ──→ 关系记忆提取（按人拆分）
+
+准实时 (T+5min):
+  afterthought ──→ 关系记忆更新（事件驱动）
+
+system prompt (~3000 字):
+  identity + appearance           ~650   静态
+  rules + 回复习惯               ~800   静态，极简约束
+  Life Engine state（扩充版）     ~400   赤尾此刻
+  关系记忆(当前用户)             ~200   和这个人
+  tools                          ~400   精简后
+```
+
+## 设计决策
+
+### D1: Schedule 不直接注入
+
+Life Engine tick 已经读 schedule 作为决策输入，schedule 的信息已融入 current_state + response_mood。直接注入是冗余的，且 1500 字散文噪音远大于信号。
+
+### D2: Conversation 碎片不直接注入
+
+Life Engine tick 已经读最近 5 条碎片（每条截取 100 字）。3000 字裸塞的碎片大部分跟当前对话者无关。
+
+### D3: Daily dream 不直接注入
+
+日记是全天所有人的混合叙事，无法按人提取。应该在离线 pipeline 中拆分成 per-user 关系记忆。
+
+### D4: Life Engine state 需要扩充
+
+去掉 schedule + 碎片 + daily dream 后，Life Engine state 是唯一的状态来源。当前 ~200 字可能不够。扩充方向：
+- current_state 允许更长（当前 76-162 字，可以到 200-300 字）
+- 增加 `recent_context` 字段：最近一次有意义的互动摘要
+
+### D5: 搜索工具从主 agent 移除
+
+主 agent 不应该能搜索历史。相关上下文应该预注入。search_group_history / check_chat_history / recall 全部移除。deep_research 的 BASE_TOOLS 也要同步精简。
+
+### D6: reply_style 落库 + 维度修正
+
+- 从 Redis 迁到 DB（append-only 审计）
+- 维度从 per-chat × per-persona 改为 per-persona only
+- 去掉 chat_id 维度（赤尾的状态不因群而异）
+
+### D7: 关系记忆系统（新建）
+
+- per-user × per-persona 的自然语言记忆
+- 存 DB（append-only）
+- 更新频率：T+5min（复用 afterthought 触发）+ T+1d（daily dream 提取）
+- 注入时只取当前对话者的最新记忆
+
+## 分期
+
+### Phase 1: 瘦身 + 落库（低风险，立即可做）
+
+1. reply_style 从 Redis 迁到 DB
+2. 移除 schedule 直接注入
+3. 移除 conversation 碎片直接注入
+4. 移除 daily dream 直接注入
+5. 移除主 agent 搜索工具
+6. 添加工具调用次数限制
+
+### Phase 2: 扩充 + 新建（需要更多设计）
+
+7. Life Engine state 扩充
+8. 关系记忆系统
+9. reply_style 从示例式改为内心独白式
+10. afterthought 碎片格式改造（聚焦 per-user 提取）


### PR DESCRIPTION
## Summary
- reply_style 从 Redis 迁到 DB（append-only 审计）
- inner-context 从 8100 字符瘦身到 ~3300（移除 schedule/daily dream 直接注入，保留 Life Engine + 最近 2 条碎片）
- 移除 search_group_history/check_chat_history 工具，保留 recall
- 工具调用 recursion_limit=12 防止死循环
- Langfuse prompt 同步更新（appearance 注入、recall 工具说明、降傲娇、长度 20-100 波动）

## Test plan
- [x] ctx-v4 泳道部署验证，system prompt 从 8100→3300 chars
- [x] Langfuse trace 确认 schedule/fragments/dream 不再注入
- [x] recall 工具可用
- [ ] 合码后 prod 部署验证

🤖 Generated with [Claude Code](https://claude.com/claude-code)