### PR TITLE
feat(context): Phase 2 — 关系记忆 + 内心独白 + 消息吞没观测

### DIFF
--- a/apps/agent-service/app/agents/domains/main/agent.py
+++ b/apps/agent-service/app/agents/domains/main/agent.py
@@ -326,6 +326,8 @@ async def _build_and_stream(
 
     # 动态 reply-style（漂移生成的行为示例，fallback 静态示例）
     prompt_vars["reply_style"] = bot_ctx.reply_style
+    # 内心独白（替代示例锚点，过渡期并存）
+    prompt_vars["inner_monologue"] = bot_ctx.inner_monologue
 
     full_content = ""
     has_text_in_current_turn = False

--- a/apps/agent-service/app/orm/memory_crud.py
+++ b/apps/agent-service/app/orm/memory_crud.py
@@ -211,3 +211,92 @@ async def get_last_bot_reply_time(chat_id: str) -> int:
             )
         )
         return result.scalar_one_or_none() or 0
+
+
+async def save_relationship_memory(
+    persona_id: str,
+    user_id: str,
+    user_name: str,
+    memory_text: str,
+    source: str,
+) -> None:
+    """写入关系记忆（append-only）"""
+    from app.orm.memory_models import RelationshipMemory
+
+    async with AsyncSessionLocal() as session:
+        session.add(RelationshipMemory(
+            persona_id=persona_id,
+            user_id=user_id,
+            user_name=user_name,
+            memory_text=memory_text,
+            source=source,
+        ))
+        await session.commit()
+
+
+async def get_latest_relationship_memory(persona_id: str, user_id: str) -> str | None:
+    """获取指定用户的最新关系记忆文本，不存在返回 None"""
+    from app.orm.memory_models import RelationshipMemory
+
+    async with AsyncSessionLocal() as session:
+        result = await session.execute(
+            select(RelationshipMemory.memory_text)
+            .where(RelationshipMemory.persona_id == persona_id)
+            .where(RelationshipMemory.user_id == user_id)
+            .order_by(RelationshipMemory.created_at.desc())
+            .limit(1)
+        )
+        return result.scalar_one_or_none()
+
+
+async def get_relationship_memories_for_users(
+    persona_id: str,
+    user_ids: list[str],
+) -> dict[str, str]:
+    """批量获取多个用户的最新关系记忆，返回 {user_id: memory_text} 字典"""
+    from app.orm.memory_models import RelationshipMemory
+
+    if not user_ids:
+        return {}
+
+    async with AsyncSessionLocal() as session:
+        # 用 PostgreSQL DISTINCT ON 一次查出每个 user 的最新一行
+        result = await session.execute(
+            select(RelationshipMemory.user_id, RelationshipMemory.memory_text)
+            .where(RelationshipMemory.persona_id == persona_id)
+            .where(RelationshipMemory.user_id.in_(user_ids))
+            .distinct(RelationshipMemory.user_id)
+            .order_by(RelationshipMemory.user_id, RelationshipMemory.created_at.desc())
+        )
+        return {row.user_id: row.memory_text for row in result.all()}
+
+
+async def save_inner_monologue(
+    persona_id: str,
+    monologue: str,
+    source: str,
+) -> None:
+    """写入内心独白日志（append-only）"""
+    from app.orm.memory_models import InnerMonologueLog
+
+    async with AsyncSessionLocal() as session:
+        session.add(InnerMonologueLog(
+            persona_id=persona_id,
+            monologue=monologue,
+            source=source,
+        ))
+        await session.commit()
+
+
+async def get_latest_inner_monologue(persona_id: str) -> str | None:
+    """获取最新的内心独白，不存在返回 None"""
+    from app.orm.memory_models import InnerMonologueLog
+
+    async with AsyncSessionLocal() as session:
+        result = await session.execute(
+            select(InnerMonologueLog.monologue)
+            .where(InnerMonologueLog.persona_id == persona_id)
+            .order_by(InnerMonologueLog.created_at.desc())
+            .limit(1)
+        )
+        return result.scalar_one_or_none()

--- a/apps/agent-service/app/orm/memory_models.py
+++ b/apps/agent-service/app/orm/memory_models.py
@@ -6,7 +6,7 @@ memory_entity: 飞书长 ID → 短自增 ID 映射，用于碎片内容消歧
 
 from datetime import datetime
 
-from sqlalchemy import BigInteger, DateTime, Integer, String, Text, UniqueConstraint, func
+from sqlalchemy import BigInteger, DateTime, Index, Integer, String, Text, UniqueConstraint, func
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import Mapped, mapped_column
 
@@ -105,6 +105,40 @@ class ReplyStyleLog(Base):
     style_text: Mapped[str] = mapped_column(Text, nullable=False)
     observation: Mapped[str | None] = mapped_column(Text, nullable=True)
     source: Mapped[str] = mapped_column(String(20), nullable=False)  # 'base' / 'drift' / 'manual'
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now()
+    )
+
+
+class RelationshipMemory(Base):
+    """关系记忆 — per-user 的自然语言关系描述，append-only"""
+
+    __tablename__ = "relationship_memory"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    persona_id: Mapped[str] = mapped_column(String(50), nullable=False)
+    user_id: Mapped[str] = mapped_column(String(100), nullable=False)
+    user_name: Mapped[str] = mapped_column(String(100), nullable=False, server_default="")
+    memory_text: Mapped[str] = mapped_column(Text, nullable=False)
+    source: Mapped[str] = mapped_column(String(20), nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now()
+    )
+
+    __table_args__ = (
+        Index("idx_rel_mem_persona_user_created", "persona_id", "user_id", created_at.desc()),
+    )
+
+
+class InnerMonologueLog(Base):
+    """内心独白日志 — 替代 reply_style 的示例锚点，append-only"""
+
+    __tablename__ = "inner_monologue_log"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    persona_id: Mapped[str] = mapped_column(String(50), nullable=False, index=True)
+    monologue: Mapped[str] = mapped_column(Text, nullable=False)
+    source: Mapped[str] = mapped_column(String(20), nullable=False)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now()
     )

--- a/apps/agent-service/app/services/afterthought.py
+++ b/apps/agent-service/app/services/afterthought.py
@@ -192,6 +192,26 @@ async def _generate_conversation_fragment(chat_id: str, persona_id: str) -> None
     await create_fragment(fragment)
     logger.info(f"[{persona_id}] Conversation fragment created for {chat_id}: {content[:60]}...")
 
+    # 关系记忆提取（fire-and-forget，不阻塞主流程）
+    try:
+        from app.services.relationship_memory import extract_relationship_updates
+
+        # 从消息中提取涉及的用户 ID（排除 bot 自身）
+        unique_user_ids = list({
+            m.user_id for m in messages
+            if m.role == "user" and m.user_id
+        })
+
+        if unique_user_ids:
+            await extract_relationship_updates(
+                persona_id=persona_id,
+                chat_id=chat_id,
+                user_ids=unique_user_ids,
+                messages_timeline=timeline,
+            )
+    except Exception as e:
+        logger.warning(f"[{persona_id}] Relationship extract failed (non-fatal): {e}")
+
 
 async def _build_scene(chat_id: str, chat_type: str, messages: list) -> str:
     """Build scene description for the prompt"""

--- a/apps/agent-service/app/services/bot_context.py
+++ b/apps/agent-service/app/services/bot_context.py
@@ -82,6 +82,7 @@ class BotContext:
         self._persona_id: str = ""
         self._persona: "BotPersona | None" = None
         self._reply_style: str = ""
+        self._inner_monologue: str = ""
 
     @property
     def persona_id(self) -> str:
@@ -117,9 +118,17 @@ class BotContext:
             self._persona_id, default_style
         )
 
+        # 加载内心独白（替代 reply_style 的示例锚点）
+        from app.orm.memory_crud import get_latest_inner_monologue
+        self._inner_monologue = await get_latest_inner_monologue(self._persona_id) or ""
+
     @property
     def reply_style(self) -> str:
         return self._reply_style
+
+    @property
+    def inner_monologue(self) -> str:
+        return self._inner_monologue
 
     def get_identity(self) -> str:
         """返回注入 {{identity}} 的人设文本"""

--- a/apps/agent-service/app/services/inner_monologue.py
+++ b/apps/agent-service/app/services/inner_monologue.py
@@ -1,0 +1,71 @@
+"""内心独白生成 — 替代 reply_style 的示例锚点
+
+定期生成赤尾此刻的内心感受，注入 system prompt 的 <voice> 段。
+LLM 从感受自然涌现回复风格，不再模仿示例。
+"""
+
+import logging
+from datetime import datetime, timedelta, timezone
+
+from app.agents.infra.langfuse_client import get_prompt
+from app.agents.infra.model_builder import ModelBuilder
+from app.config.config import settings
+from app.orm.crud import get_bot_persona, get_plan_for_period
+from app.orm.memory_crud import get_today_fragments, save_inner_monologue
+
+logger = logging.getLogger(__name__)
+
+CST = timezone(timedelta(hours=8))
+
+
+async def generate_inner_monologue(persona_id: str) -> str | None:
+    """生成赤尾此刻的内心独白"""
+    persona = await get_bot_persona(persona_id)
+    if not persona:
+        return None
+
+    # Life Engine 状态
+    from app.services.life_engine import _load_state
+    le_state = await _load_state(persona_id)
+    current_state = le_state.current_state if le_state else "（状态未知）"
+    response_mood = le_state.response_mood if le_state else ""
+
+    # 当前时段的 schedule
+    now = datetime.now(CST)
+    today = now.strftime("%Y-%m-%d")
+    schedule = await get_plan_for_period("daily", today, today, persona_id)
+    schedule_text = schedule.content if schedule else "（今天没有安排）"
+
+    # 最近碎片
+    frags = await get_today_fragments(persona_id, grains=["conversation"])
+    frag_text = "\n".join(f.content[:100] for f in frags[-3:]) if frags else "（今天还没跟人聊过）"
+
+    # 调用 LLM
+    prompt = get_prompt("inner_monologue")
+    compiled = prompt.compile(
+        persona_name=persona.display_name,
+        persona_lite=persona.persona_lite,
+        current_state=current_state,
+        response_mood=response_mood,
+        schedule_segment=schedule_text,
+        recent_fragments=frag_text,
+        current_time=now.strftime("%H:%M"),
+    )
+
+    model = await ModelBuilder.build_chat_model(settings.identity_drift_model)
+    response = await model.ainvoke([{"role": "user", "content": compiled}])
+
+    content = response.content
+    if isinstance(content, list):
+        content = "".join(
+            part.get("text", "") if isinstance(part, dict) else str(part)
+            for part in content
+        ).strip()
+
+    if not content:
+        logger.warning(f"[{persona_id}] Inner monologue generation returned empty")
+        return None
+
+    await save_inner_monologue(persona_id, content, source="cron")
+    logger.info(f"[{persona_id}] Inner monologue generated: {content[:50]}...")
+    return content

--- a/apps/agent-service/app/services/memory_context.py
+++ b/apps/agent-service/app/services/memory_context.py
@@ -71,6 +71,16 @@ async def build_inner_context(
     if life_state:
         sections.append(life_state)
 
+    # === 关系记忆（对当前对话者的印象）===
+    if trigger_user_id and trigger_user_id != "__proactive__":
+        from app.orm.memory_crud import get_latest_relationship_memory
+        from app.orm.crud import get_username
+
+        rel_memory = await get_latest_relationship_memory(persona_id, trigger_user_id)
+        if rel_memory:
+            name = trigger_username or await get_username(trigger_user_id) or trigger_user_id[:6]
+            sections.append(f"关于 {name}：\n{rel_memory}")
+
     # === 最近的经历（精简版：最近 2 条碎片，短期记忆）===
     today_frags = await get_today_fragments(persona_id, grains=["conversation"])
     if chat_type == "group":

--- a/apps/agent-service/app/services/relationship_memory.py
+++ b/apps/agent-service/app/services/relationship_memory.py
@@ -1,0 +1,88 @@
+"""关系记忆提取 — afterthought 碎片生成后，判断是否需要更新 per-user 关系记忆"""
+
+import json
+import logging
+
+from app.agents.infra.langfuse_client import get_prompt
+from app.agents.infra.model_builder import ModelBuilder
+from app.config.config import settings
+from app.orm.crud import get_username
+from app.orm.memory_crud import (
+    get_relationship_memories_for_users,
+    save_relationship_memory,
+)
+
+logger = logging.getLogger(__name__)
+
+
+async def extract_relationship_updates(
+    persona_id: str,
+    chat_id: str,
+    user_ids: list[str],
+    messages_timeline: str,
+) -> None:
+    """从一段对话中提取关系记忆更新
+
+    在 afterthought 生成 conversation 碎片后调用。
+    让 LLM 判断对话中涉及的人是否有关系变化，有则写入 relationship_memory。
+    """
+    if not user_ids:
+        return
+
+    # 获取当前关系记忆
+    current_memories = await get_relationship_memories_for_users(persona_id, user_ids)
+
+    # 构建当前记忆上下文
+    memory_lines = []
+    for uid in user_ids:
+        name = await get_username(uid) or uid[:6]
+        mem = current_memories.get(uid)
+        if mem:
+            memory_lines.append(f"- {name}({uid}): {mem}")
+        else:
+            memory_lines.append(f"- {name}({uid}): （第一次互动，没有记忆）")
+
+    prompt = get_prompt("relationship_extract")
+    compiled = prompt.compile(
+        messages=messages_timeline,
+        current_memories="\n".join(memory_lines),
+    )
+
+    model = await ModelBuilder.build_chat_model(settings.diary_model)
+    response = await model.ainvoke([{"role": "user", "content": compiled}])
+
+    content = response.content
+    if isinstance(content, list):
+        content = "".join(
+            part.get("text", "") if isinstance(part, dict) else str(part)
+            for part in content
+        ).strip()
+
+    if not content or content.strip() == "[]":
+        logger.info(f"[{persona_id}] No relationship updates for chat {chat_id}")
+        return
+
+    # 解析 JSON 输出
+    try:
+        updates = json.loads(content)
+    except json.JSONDecodeError:
+        logger.warning(f"[{persona_id}] Failed to parse relationship extract: {content[:100]}")
+        return
+
+    for item in updates:
+        if not isinstance(item, dict):
+            continue
+        if item.get("action") != "UPDATE":
+            continue
+        uid = item.get("user_id", "")
+        name = item.get("user_name", "") or await get_username(uid) or uid[:6]
+        memory = item.get("memory", "")
+        if uid and memory:
+            await save_relationship_memory(
+                persona_id=persona_id,
+                user_id=uid,
+                user_name=name,
+                memory_text=memory,
+                source="afterthought",
+            )
+            logger.info(f"[{persona_id}] Relationship updated for {name}: {memory[:50]}...")

--- a/apps/agent-service/app/workers/chat_consumer.py
+++ b/apps/agent-service/app/workers/chat_consumer.py
@@ -105,7 +105,13 @@ async def handle_chat_request(message: AbstractIncomingMessage) -> None:
                 if i > 0:
                     payload["session_id"] = str(uuid4())
                 tasks.append(_process_for_persona(payload, pid))
-            await asyncio.gather(*tasks)
+            results = await asyncio.gather(*tasks, return_exceptions=True)
+            for i, result in enumerate(results):
+                if isinstance(result, Exception):
+                    logger.error(
+                        "Persona %s failed in gather: %s\n%s",
+                        persona_ids[i], result, "".join(traceback.format_exception(type(result), result, result.__traceback__)),
+                    )
 
 
 async def _process_for_persona(base_payload: dict, persona_id: str) -> None:
@@ -208,6 +214,10 @@ async def _process_for_persona(base_payload: dict, persona_id: str) -> None:
         # 记录流结束时间，观测 TTFT 和 agent_stream 阶段耗时
         t_stream_end = time.monotonic()
         stream_ms = (t_stream_end - t_start) * 1000
+        logger.info(
+            "Stream ended: session_id=%s, persona=%s, full_content_len=%d, token_count=%d, sent_length=%d, messages_sent=%d",
+            session_id, persona_id, len(full_content), token_count, sent_length, messages_sent,
+        )
         if t_first_token is not None:
             CHAT_FIRST_TOKEN.observe(t_first_token - t_start)
         CHAT_PIPELINE_DURATION.labels(stage="agent_stream").observe(
@@ -220,6 +230,10 @@ async def _process_for_persona(base_payload: dict, persona_id: str) -> None:
         # 全量文本（去掉所有 split marker），用于数据库存储
         clean_full = full_content.replace(SPLIT_MARKER, "\n\n").strip()
 
+        logger.info(
+            "Publishing final: session_id=%s, persona=%s, remaining_len=%d, clean_full_len=%d",
+            session_id, persona_id, len(remaining), len(clean_full),
+        )
         t_publish_start = time.monotonic()
         if remaining or messages_sent == 0:
             base_response["published_at"] = int(time.time() * 1000)
@@ -285,6 +299,12 @@ async def _process_for_persona(base_payload: dict, persona_id: str) -> None:
             },
         )
 
+    except asyncio.CancelledError:
+        logger.error(
+            "Chat request CANCELLED: session_id=%s, persona=%s, full_content_len=%d",
+            session_id, persona_id, len(full_content),
+        )
+        raise  # CancelledError 应该继续传播
     except Exception as e:
         logger.error(
             "Chat request failed: session_id=%s, persona=%s, error=%s\n%s",

--- a/apps/agent-service/app/workers/monologue_worker.py
+++ b/apps/agent-service/app/workers/monologue_worker.py
@@ -1,0 +1,24 @@
+"""内心独白 cron worker"""
+
+import logging
+
+from app.config.config import settings
+
+logger = logging.getLogger(__name__)
+
+
+async def cron_generate_inner_monologue(ctx) -> None:
+    """arq cron: 为每个 persona 生成内心独白"""
+    if settings.lane and settings.lane != "prod":
+        return
+
+    from app.orm.crud import get_all_persona_ids
+    from app.services.inner_monologue import generate_inner_monologue
+
+    for persona_id in await get_all_persona_ids():
+        try:
+            result = await generate_inner_monologue(persona_id)
+            if result:
+                logger.info(f"[{persona_id}] Inner monologue generated: {len(result)} chars")
+        except Exception as e:
+            logger.error(f"[{persona_id}] Inner monologue generation failed: {e}", exc_info=True)

--- a/apps/agent-service/app/workers/unified_worker.py
+++ b/apps/agent-service/app/workers/unified_worker.py
@@ -25,6 +25,7 @@ from app.workers.base_style_worker import cron_generate_base_reply_style
 from app.workers.vectorize_worker import cron_scan_pending_messages
 from app.workers.life_engine_worker import cron_life_engine_tick
 from app.workers.glimpse_worker import cron_glimpse
+from app.workers.monologue_worker import cron_generate_inner_monologue
 
 logger = logging.getLogger(__name__)
 
@@ -94,4 +95,6 @@ class UnifiedWorkerSettings:
         cron(cron_generate_monthly_plan, day={1}, hour={2}, minute={0}, timeout=1800),
         # 6. 基线 reply_style：每天 CST 8:00/14:00/18:00（Schedule 之后）
         cron(cron_generate_base_reply_style, hour={8, 14, 18}, minute={0}, timeout=1800),
+        # 7. 内心独白：每小时的半点（与 base_reply_style 错开）
+        cron(cron_generate_inner_monologue, hour=set(range(8, 24)), minute={30}, timeout=1800),
     ]

--- a/docs/superpowers/plans/2026-04-08-context-phase2.md
+++ b/docs/superpowers/plans/2026-04-08-context-phase2.md
@@ -1,0 +1,720 @@
+# Context Architecture Phase 2 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 让赤尾对不同的人有不同的记忆和态度，用内心独白替代示例式行为锚点，让 per-user 差异自然涌现
+
+**Architecture:** 新增 relationship_memory 表（per-user 自然语言关系记忆，afterthought 触发时提取）+ inner_monologue_log 表（替代 reply_style 的示例锚点）+ Life Engine tick prompt 扩充。过渡期 drift pipeline 保留，内心独白与 reply_style 并存。
+
+**Tech Stack:** Python, SQLAlchemy, PostgreSQL, Langfuse, LangChain
+
+**Spec:** `docs/superpowers/specs/2026-04-08-context-phase2-design.md`
+
+---
+
+## File Structure
+
+| 文件 | 变更类型 | 职责 |
+|------|---------|------|
+| `apps/agent-service/app/orm/memory_models.py` | 修改 | 新增 RelationshipMemory + InnerMonologueLog 模型 |
+| `apps/agent-service/app/orm/memory_crud.py` | 修改 | 新增关系记忆 + 内心独白 CRUD |
+| `apps/agent-service/app/services/relationship_memory.py` | 新建 | 关系记忆提取逻辑 |
+| `apps/agent-service/app/services/afterthought.py` | 修改 | 碎片生成后触发关系记忆提取 |
+| `apps/agent-service/app/services/memory_context.py` | 修改 | 注入关系记忆到 inner_context |
+| `apps/agent-service/app/services/inner_monologue.py` | 新建 | 内心独白生成逻辑 |
+| `apps/agent-service/app/workers/monologue_worker.py` | 新建 | 内心独白 cron worker |
+| `apps/agent-service/app/workers/unified_worker.py` | 修改 | 注册内心独白 cron |
+| `apps/agent-service/app/services/bot_context.py` | 修改 | 加载内心独白替代 reply_style |
+| `apps/agent-service/app/agents/domains/main/agent.py` | 修改 | prompt_vars 注入内心独白 |
+| Langfuse prompts | 修改/新建 | relationship_extract, inner_monologue, main, life_engine_tick, context_builder |
+
+---
+
+### Task 1: relationship_memory + inner_monologue_log 表模型
+
+**Files:**
+- Modify: `apps/agent-service/app/orm/memory_models.py`
+- Modify: `apps/agent-service/app/orm/memory_crud.py`
+
+- [ ] **Step 1: 添加 RelationshipMemory 模型**
+
+在 `memory_models.py` 末尾添加：
+
+```python
+class RelationshipMemory(Base):
+    """关系记忆 — per-user 的自然语言关系描述，append-only"""
+
+    __tablename__ = "relationship_memory"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    persona_id: Mapped[str] = mapped_column(String(50), nullable=False)
+    user_id: Mapped[str] = mapped_column(String(100), nullable=False)
+    user_name: Mapped[str] = mapped_column(String(100), nullable=False, server_default="")
+    memory_text: Mapped[str] = mapped_column(Text, nullable=False)
+    source: Mapped[str] = mapped_column(String(20), nullable=False)  # 'afterthought' / 'dream' / 'manual'
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now()
+    )
+
+    __table_args__ = (
+        Index("idx_rel_mem_persona_user_created", "persona_id", "user_id", created_at.desc()),
+    )
+```
+
+- [ ] **Step 2: 添加 InnerMonologueLog 模型**
+
+紧接着添加：
+
+```python
+class InnerMonologueLog(Base):
+    """内心独白日志 — 替代 reply_style 的示例锚点，append-only"""
+
+    __tablename__ = "inner_monologue_log"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    persona_id: Mapped[str] = mapped_column(String(50), nullable=False, index=True)
+    monologue: Mapped[str] = mapped_column(Text, nullable=False)
+    source: Mapped[str] = mapped_column(String(20), nullable=False)  # 'cron' / 'event'
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now()
+    )
+```
+
+- [ ] **Step 3: 添加 CRUD 函数**
+
+在 `memory_crud.py` 末尾添加：
+
+```python
+async def save_relationship_memory(
+    persona_id: str,
+    user_id: str,
+    user_name: str,
+    memory_text: str,
+    source: str,
+) -> None:
+    """写入关系记忆（append-only）"""
+    from app.orm.memory_models import RelationshipMemory
+
+    async with AsyncSessionLocal() as session:
+        session.add(RelationshipMemory(
+            persona_id=persona_id,
+            user_id=user_id,
+            user_name=user_name,
+            memory_text=memory_text,
+            source=source,
+        ))
+        await session.commit()
+
+
+async def get_latest_relationship_memory(
+    persona_id: str, user_id: str
+) -> str | None:
+    """获取某用户的最新关系记忆"""
+    from app.orm.memory_models import RelationshipMemory
+
+    async with AsyncSessionLocal() as session:
+        result = await session.execute(
+            select(RelationshipMemory.memory_text)
+            .where(RelationshipMemory.persona_id == persona_id)
+            .where(RelationshipMemory.user_id == user_id)
+            .order_by(RelationshipMemory.created_at.desc())
+            .limit(1)
+        )
+        return result.scalar_one_or_none()
+
+
+async def get_relationship_memories_for_users(
+    persona_id: str, user_ids: list[str]
+) -> dict[str, str]:
+    """批量获取多个用户的最新关系记忆，返回 {user_id: memory_text}"""
+    from app.orm.memory_models import RelationshipMemory
+
+    if not user_ids:
+        return {}
+
+    async with AsyncSessionLocal() as session:
+        # 用 DISTINCT ON 取每个 user 的最新记录
+        result = await session.execute(
+            select(RelationshipMemory.user_id, RelationshipMemory.memory_text, RelationshipMemory.user_name)
+            .where(RelationshipMemory.persona_id == persona_id)
+            .where(RelationshipMemory.user_id.in_(user_ids))
+            .distinct(RelationshipMemory.user_id)
+            .order_by(RelationshipMemory.user_id, RelationshipMemory.created_at.desc())
+        )
+        return {row.user_id: row.memory_text for row in result.all()}
+
+
+async def save_inner_monologue(
+    persona_id: str,
+    monologue: str,
+    source: str,
+) -> None:
+    """写入内心独白（append-only）"""
+    from app.orm.memory_models import InnerMonologueLog
+
+    async with AsyncSessionLocal() as session:
+        session.add(InnerMonologueLog(
+            persona_id=persona_id,
+            monologue=monologue,
+            source=source,
+        ))
+        await session.commit()
+
+
+async def get_latest_inner_monologue(persona_id: str) -> str | None:
+    """获取最新的内心独白"""
+    from app.orm.memory_models import InnerMonologueLog
+
+    async with AsyncSessionLocal() as session:
+        result = await session.execute(
+            select(InnerMonologueLog.monologue)
+            .where(InnerMonologueLog.persona_id == persona_id)
+            .order_by(InnerMonologueLog.created_at.desc())
+            .limit(1)
+        )
+        return result.scalar_one_or_none()
+```
+
+- [ ] **Step 4: 提交建表 DDL**
+
+通过 `/ops-db` skill 提交：
+
+```sql
+CREATE TABLE relationship_memory (
+    id SERIAL PRIMARY KEY,
+    persona_id VARCHAR(50) NOT NULL,
+    user_id VARCHAR(100) NOT NULL,
+    user_name VARCHAR(100) NOT NULL DEFAULT '',
+    memory_text TEXT NOT NULL,
+    source VARCHAR(20) NOT NULL,
+    created_at TIMESTAMPTZ DEFAULT now()
+);
+
+CREATE INDEX idx_rel_mem_persona_user_created
+    ON relationship_memory (persona_id, user_id, created_at DESC);
+
+CREATE TABLE inner_monologue_log (
+    id SERIAL PRIMARY KEY,
+    persona_id VARCHAR(50) NOT NULL,
+    monologue TEXT NOT NULL,
+    source VARCHAR(20) NOT NULL,
+    created_at TIMESTAMPTZ DEFAULT now()
+);
+
+CREATE INDEX idx_inner_monologue_persona_created
+    ON inner_monologue_log (persona_id, created_at DESC);
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/agent-service/app/orm/memory_models.py apps/agent-service/app/orm/memory_crud.py
+git commit -m "feat(memory): add relationship_memory + inner_monologue_log models and CRUD"
+```
+
+---
+
+### Task 2: 关系记忆提取服务
+
+**Files:**
+- Create: `apps/agent-service/app/services/relationship_memory.py`
+
+- [ ] **Step 1: 创建关系记忆提取模块**
+
+```python
+"""关系记忆提取 — afterthought 碎片生成后，判断是否需要更新 per-user 关系记忆"""
+
+import json
+import logging
+
+from app.agents.infra.langfuse_client import get_prompt
+from app.agents.infra.model_builder import ModelBuilder
+from app.config.config import settings
+from app.orm.crud import get_username
+from app.orm.memory_crud import (
+    get_relationship_memories_for_users,
+    save_relationship_memory,
+)
+
+logger = logging.getLogger(__name__)
+
+
+async def extract_relationship_updates(
+    persona_id: str,
+    chat_id: str,
+    user_ids: list[str],
+    messages_timeline: str,
+) -> None:
+    """从一段对话中提取关系记忆更新
+
+    在 afterthought 生成 conversation 碎片后调用。
+    让 LLM 判断对话中涉及的人是否有关系变化，有则写入 relationship_memory。
+    """
+    if not user_ids:
+        return
+
+    # 获取当前关系记忆
+    current_memories = await get_relationship_memories_for_users(persona_id, user_ids)
+
+    # 构建当前记忆上下文
+    memory_lines = []
+    for uid in user_ids:
+        name = await get_username(uid) or uid[:6]
+        mem = current_memories.get(uid)
+        if mem:
+            memory_lines.append(f"- {name}({uid}): {mem}")
+        else:
+            memory_lines.append(f"- {name}({uid}): （第一次互动，没有记忆）")
+
+    prompt = get_prompt("relationship_extract")
+    compiled = prompt.compile(
+        messages=messages_timeline,
+        current_memories="\n".join(memory_lines),
+    )
+
+    model = await ModelBuilder.build_chat_model(settings.diary_model)
+    response = await model.ainvoke([{"role": "user", "content": compiled}])
+
+    content = response.content
+    if isinstance(content, list):
+        content = "".join(
+            part.get("text", "") if isinstance(part, dict) else str(part)
+            for part in content
+        ).strip()
+
+    if not content or content.strip() == "[]":
+        logger.info(f"[{persona_id}] No relationship updates for chat {chat_id}")
+        return
+
+    # 解析 JSON 输出
+    try:
+        updates = json.loads(content)
+    except json.JSONDecodeError:
+        logger.warning(f"[{persona_id}] Failed to parse relationship extract: {content[:100]}")
+        return
+
+    for item in updates:
+        if not isinstance(item, dict):
+            continue
+        if item.get("action") != "UPDATE":
+            continue
+        uid = item.get("user_id", "")
+        name = item.get("user_name", "") or await get_username(uid) or uid[:6]
+        memory = item.get("memory", "")
+        if uid and memory:
+            await save_relationship_memory(
+                persona_id=persona_id,
+                user_id=uid,
+                user_name=name,
+                memory_text=memory,
+                source="afterthought",
+            )
+            logger.info(f"[{persona_id}] Relationship updated for {name}: {memory[:50]}...")
+```
+
+- [ ] **Step 2: 创建 Langfuse prompt `relationship_extract`**
+
+```bash
+python3 ~/.claude/skills/langfuse/scripts/langfuse_api.py create-prompt '{
+  "name": "relationship_extract",
+  "type": "text",
+  "labels": ["production"],
+  "prompt": "你是赤尾的\"关系记忆管理\"。\n\n赤尾刚才参与了一段对话：\n{{messages}}\n\n赤尾对涉及的人当前的记忆：\n{{current_memories}}\n\n---\n\n判断：这次对话中，赤尾对哪些人的印象应该更新？\n\n规则：\n- 日常寒暄、重复话题、没什么新信息 → NO_UPDATE\n- 对方展示了新的性格特点、发生了有感情意义的事件、关系升温或降温 → 需要更新\n- 更新后的记忆像赤尾自己写的备忘录，3-5 句话，自然口吻，不要用结构化格式\n- 保留之前记忆中仍然有效的信息，在此基础上增减\n\n输出 JSON 数组（不要加 markdown 代码块）：\n[{\"user_id\": \"xxx\", \"user_name\": \"xxx\", \"action\": \"UPDATE\", \"memory\": \"更新后的完整记忆\"}, {\"user_id\": \"yyy\", \"action\": \"NO_UPDATE\"}]\n\n如果所有人都不需要更新，输出 []"
+}'
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/agent-service/app/services/relationship_memory.py
+git commit -m "feat(memory): add relationship memory extraction service"
+```
+
+---
+
+### Task 3: afterthought 接入关系记忆提取
+
+**Files:**
+- Modify: `apps/agent-service/app/services/afterthought.py`
+
+- [ ] **Step 1: 在碎片生成后调用关系记忆提取**
+
+在 `_generate_conversation_fragment` 函数末尾（当前 L193 打印日志之后），添加：
+
+```python
+    # 关系记忆提取（fire-and-forget，不阻塞主流程）
+    try:
+        from app.services.relationship_memory import extract_relationship_updates
+
+        # 从消息中提取涉及的用户 ID（排除 bot 自身）
+        unique_user_ids = list({
+            m.user_id for m in messages
+            if m.role == "user" and m.user_id
+        })
+
+        if unique_user_ids:
+            await extract_relationship_updates(
+                persona_id=persona_id,
+                chat_id=chat_id,
+                user_ids=unique_user_ids,
+                messages_timeline=timeline,
+            )
+    except Exception as e:
+        logger.warning(f"[{persona_id}] Relationship extract failed (non-fatal): {e}")
+```
+
+注意：`messages` 变量（原始消息列表）和 `timeline` 变量（格式化后的时间线字符串）在函数内已存在。`persona_id` 也已存在。
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add apps/agent-service/app/services/afterthought.py
+git commit -m "feat(memory): afterthought triggers relationship memory extraction"
+```
+
+---
+
+### Task 4: build_inner_context 注入关系记忆
+
+**Files:**
+- Modify: `apps/agent-service/app/services/memory_context.py`
+
+- [ ] **Step 1: 在 build_inner_context 中添加关系记忆注入**
+
+在 Life Engine 状态注入之后、最近碎片之前，添加关系记忆查询和注入：
+
+```python
+    # === 关系记忆（对当前对话者的印象）===
+    if trigger_user_id and trigger_user_id != "__proactive__":
+        from app.orm.memory_crud import get_latest_relationship_memory
+        from app.orm.crud import get_username
+
+        rel_memory = await get_latest_relationship_memory(persona_id, trigger_user_id)
+        if rel_memory:
+            name = trigger_username or await get_username(trigger_user_id) or trigger_user_id[:6]
+            sections.append(f"关于 {name}：\n{rel_memory}")
+```
+
+这段代码插入到 `_build_life_state` 调用之后、碎片注入之前。
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add apps/agent-service/app/services/memory_context.py
+git commit -m "feat(context): inject per-user relationship memory into inner_context"
+```
+
+---
+
+### Task 5: 内心独白生成服务 + cron
+
+**Files:**
+- Create: `apps/agent-service/app/services/inner_monologue.py`
+- Create: `apps/agent-service/app/workers/monologue_worker.py`
+- Modify: `apps/agent-service/app/workers/unified_worker.py`
+
+- [ ] **Step 1: 创建内心独白生成服务**
+
+```python
+"""内心独白生成 — 替代 reply_style 的示例锚点
+
+定期生成赤尾此刻的内心感受，注入 system prompt 的 <voice> 段。
+LLM 从感受自然涌现回复风格，不再模仿示例。
+"""
+
+import logging
+from datetime import datetime, timedelta, timezone
+
+from app.agents.infra.langfuse_client import get_prompt
+from app.agents.infra.model_builder import ModelBuilder
+from app.config.config import settings
+from app.orm.crud import get_bot_persona, get_plan_for_period
+from app.orm.memory_crud import get_latest_inner_monologue, get_today_fragments, save_inner_monologue
+
+logger = logging.getLogger(__name__)
+
+CST = timezone(timedelta(hours=8))
+
+
+async def generate_inner_monologue(persona_id: str) -> str | None:
+    """生成赤尾此刻的内心独白"""
+    # 1. 收集上下文
+    persona = await get_bot_persona(persona_id)
+    if not persona:
+        return None
+
+    # Life Engine 状态
+    from app.services.life_engine import _load_state
+    le_state = await _load_state(persona_id)
+    current_state = le_state.current_state if le_state else "（状态未知）"
+    response_mood = le_state.response_mood if le_state else ""
+
+    # 当前时段的 schedule
+    now = datetime.now(CST)
+    today = now.strftime("%Y-%m-%d")
+    schedule = await get_plan_for_period("daily", today, today, persona_id)
+    schedule_text = schedule.content if schedule else "（今天没有安排）"
+
+    # 最近碎片
+    frags = await get_today_fragments(persona_id, grains=["conversation"])
+    frag_text = "\n".join(f.content[:100] for f in frags[-3:]) if frags else "（今天还没跟人聊过）"
+
+    # 2. 调用 LLM
+    prompt = get_prompt("inner_monologue")
+    compiled = prompt.compile(
+        persona_name=persona.display_name,
+        persona_lite=persona.persona_lite,
+        current_state=current_state,
+        response_mood=response_mood,
+        schedule_segment=schedule_text,
+        recent_fragments=frag_text,
+        current_time=now.strftime("%H:%M"),
+    )
+
+    model = await ModelBuilder.build_chat_model(settings.identity_drift_model)
+    response = await model.ainvoke([{"role": "user", "content": compiled}])
+
+    content = response.content
+    if isinstance(content, list):
+        content = "".join(
+            part.get("text", "") if isinstance(part, dict) else str(part)
+            for part in content
+        ).strip()
+
+    if not content:
+        logger.warning(f"[{persona_id}] Inner monologue generation returned empty")
+        return None
+
+    await save_inner_monologue(persona_id, content, source="cron")
+    logger.info(f"[{persona_id}] Inner monologue generated: {content[:50]}...")
+    return content
+```
+
+- [ ] **Step 2: 创建 cron worker**
+
+```python
+"""内心独白 cron worker"""
+
+import logging
+
+from app.config.config import settings
+
+logger = logging.getLogger(__name__)
+
+
+async def cron_generate_inner_monologue(ctx) -> None:
+    """arq cron: 为每个 persona 生成内心独白"""
+    if settings.lane and settings.lane != "prod":
+        return
+
+    from app.orm.crud import get_all_persona_ids
+    from app.services.inner_monologue import generate_inner_monologue
+
+    for persona_id in await get_all_persona_ids():
+        try:
+            result = await generate_inner_monologue(persona_id)
+            if result:
+                logger.info(f"[{persona_id}] Inner monologue generated: {len(result)} chars")
+        except Exception as e:
+            logger.error(f"[{persona_id}] Inner monologue generation failed: {e}", exc_info=True)
+```
+
+- [ ] **Step 3: 注册到 unified_worker.py**
+
+在 cron_jobs 列表中，base_reply_style 那行附近添加：
+
+```python
+    # 7. 内心独白：每小时整点（与 base_reply_style 错开）
+    cron(cron_generate_inner_monologue, hour=set(range(8, 24)), minute={30}, timeout=1800),
+```
+
+需要在文件头部添加 import：
+```python
+from app.workers.monologue_worker import cron_generate_inner_monologue
+```
+
+- [ ] **Step 4: 创建 Langfuse prompt `inner_monologue`**
+
+```bash
+python3 ~/.claude/skills/langfuse/scripts/langfuse_api.py create-prompt '{
+  "name": "inner_monologue",
+  "type": "text",
+  "labels": ["production"],
+  "prompt": "你是{{persona_name}}。\n\n{{persona_lite}}\n\n现在是 {{current_time}}。\n\n你现在的状态：{{current_state}}\n你的心情：{{response_mood}}\n今天的安排：\n{{schedule_segment}}\n\n最近发生的事：\n{{recent_fragments}}\n\n---\n\n用一小段内心独白描述你此刻的感受。\n- 3-5 句话，像在脑子里自言自语\n- 写你真实会想的事，不是\"你应该怎么回消息\"\n- 自然、琐碎、有你的性格\n- 不要提及具体的群友名字"
+}'
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/agent-service/app/services/inner_monologue.py apps/agent-service/app/workers/monologue_worker.py apps/agent-service/app/workers/unified_worker.py
+git commit -m "feat(monologue): add inner monologue generation service and cron"
+```
+
+---
+
+### Task 6: 替换 reply_style 注入为内心独白
+
+**Files:**
+- Modify: `apps/agent-service/app/services/bot_context.py`
+- Modify: `apps/agent-service/app/agents/domains/main/agent.py`
+- Langfuse: 更新 `main` prompt
+
+- [ ] **Step 1: BotContext 加载内心独白**
+
+在 `bot_context.py` 的 BotContext 类中：
+
+1. 添加 `_inner_monologue` 属性到 `__init__`：
+```python
+self._inner_monologue: str = ""
+```
+
+2. 在 `_load_persona` 末尾加载内心独白：
+```python
+    # 加载内心独白（替代 reply_style 的示例锚点）
+    from app.orm.memory_crud import get_latest_inner_monologue
+    self._inner_monologue = await get_latest_inner_monologue(self._persona_id) or ""
+```
+
+3. 添加 property：
+```python
+@property
+def inner_monologue(self) -> str:
+    return self._inner_monologue
+```
+
+- [ ] **Step 2: agent.py 注入内心独白**
+
+在 `_build_and_stream` 中，L328（`prompt_vars["reply_style"]`）之后添加：
+
+```python
+    prompt_vars["inner_monologue"] = bot_ctx.inner_monologue
+```
+
+- [ ] **Step 3: 更新 Langfuse main prompt**
+
+获取当前 production main prompt，做以下修改：
+
+1. 将 `<reply-style>` 段替换为 `<voice>` 段：
+
+旧：
+```xml
+<reply-style>
+
+以下是你在群聊中的回复模式参考，参考这些例子的长度范围和语气自然波动即可：
+
+{{reply_style}}
+
+</reply-style>
+```
+
+新：
+```xml
+<voice>
+
+赤尾此刻的内心：
+{{inner_monologue}}
+
+说话习惯（不是示例，只是底线约束）：
+- 打字像发微信，不是写作文。一条消息通常一两句话。
+- 困了就说短的，精神好可以多说几句，但也不会超过两三行。
+- 不解释自己为什么这么说，说完就完了。
+
+过渡期备用风格参考：
+{{reply_style}}
+
+</voice>
+```
+
+注意：过渡期保留 `{{reply_style}}`，等内心独白稳定后再移除。
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/agent-service/app/services/bot_context.py apps/agent-service/app/agents/domains/main/agent.py
+git commit -m "feat(voice): inject inner monologue into system prompt, keep reply_style as fallback"
+```
+
+---
+
+### Task 7: Life Engine tick prompt 扩充 + context_builder 清理
+
+**Files:**
+- Langfuse: 更新 `life_engine_tick` prompt
+- Langfuse: 更新 `context_builder` prompt
+
+- [ ] **Step 1: 更新 life_engine_tick prompt**
+
+获取当前 production `life_engine_tick`，修改 `<format>` 段中 `current_state` 的说明：
+
+旧：
+```
+"current_state": "此刻的状态，用内心独白的方式写",
+```
+
+新：
+```
+"current_state": "此刻的状态，2-3 句话。写你在做什么、周围发生了什么、脑子里在想什么。自然带入最近聊天中有印象的事。",
+```
+
+- [ ] **Step 2: 更新 context_builder prompt**
+
+获取当前 production `context_builder`，移除末尾的 `search_group_history` 引导语：
+
+旧（末尾）：
+```
+如果需要更早的历史信息，使用 search_group_history 工具。
+```
+
+新（末尾）：
+```
+请回复 ⭐ 标记的消息。基于回复链的上下文理解触发消息的含义后再作答。
+```
+
+- [ ] **Step 3: Commit（无代码变更，仅记录 prompt 版本）**
+
+```bash
+git commit --allow-empty -m "chore(prompt): expand life_engine_tick output + clean context_builder"
+```
+
+---
+
+### Task 8: 集成验证
+
+- [ ] **Step 1: 本地测试**
+
+```bash
+cd apps/agent-service && uv run pytest tests/ -v --timeout=30
+```
+
+- [ ] **Step 2: 部署测试泳道**
+
+```bash
+make deploy APP=agent-service LANE=ctx-v4-p2 GIT_REF=<branch>
+```
+
+- [ ] **Step 3: 绑定群验证**
+
+```
+/ops bind TYPE=chat KEY=oc_a44255e98af05f1359aeb29eeb503536 LANE=ctx-v4-p2
+```
+
+验证项：
+1. @赤尾 回复正常，有内心独白影响风格
+2. 对不同用户的态度有差异（需要先积累一些关系记忆）
+3. Langfuse trace 确认：system prompt 中有 `<voice>` 段 + `关于 xxx` 段
+4. DB 中 relationship_memory 和 inner_monologue_log 有记录
+
+- [ ] **Step 4: 查 DB 确认数据写入**
+
+```sql
+SELECT * FROM relationship_memory ORDER BY created_at DESC LIMIT 10;
+SELECT * FROM inner_monologue_log ORDER BY created_at DESC LIMIT 5;
+```
+
+- [ ] **Step 5: 解绑清理**
+
+```
+/ops unbind TYPE=chat KEY=oc_a44255e98af05f1359aeb29eeb503536
+make undeploy APP=agent-service LANE=ctx-v4-p2
+```

--- a/docs/superpowers/specs/2026-04-08-context-phase2-design.md
+++ b/docs/superpowers/specs/2026-04-08-context-phase2-design.md
@@ -1,0 +1,493 @@
+# Context Architecture Phase 2: 关系记忆 + Life Engine 扩充 + 内心独白
+
+## 现状（Phase 1 之后）
+
+### 当前 System Prompt 结构（~3300 chars）
+
+```
+identity          ~300   persona_lite
+appearance        ~350   外貌描述
+rules             ~800   互动准则 + 输出规范 + 约束
+reply_style       ~600   drift 生成的示例锚点（4-6 个场景示例）
+inner_context     ~800   场景提示 + Life Engine 状态 + 最近 2 条碎片 + recall 引导
+tools             ~500   8 个工具描述
+```
+
+### 当前数据流
+
+```mermaid
+graph TB
+    subgraph "离线 T+1d"
+        SCH_I[Schedule Ideation<br/>搜素材] --> SCH_W[Schedule Writer<br/>写手帐]
+        SCH_W --> SCH_C[Schedule Critic<br/>审核]
+        SCH_C -->|不通过| SCH_W
+        SCH_C -->|通过| SCH_DB[(akao_schedule)]
+        
+        DREAM_D[Dream Daily<br/>日记] --> FRAG_DB
+        DREAM_W[Dream Weekly<br/>周记] --> FRAG_DB
+    end
+
+    subgraph "准实时 T+N min"
+        LE[Life Engine Tick<br/>每分钟] -->|读| SCH_DB
+        LE -->|读| FRAG_DB
+        LE -->|写| LE_DB[(life_engine_state)]
+        
+        AT[Afterthought<br/>debounce 5min] -->|写| FRAG_DB[(experience_fragment)]
+        
+        GL[Glimpse<br/>每5min browsing] -->|写| FRAG_DB
+        GL -->|可能触发| PROACTIVE[主动搭话]
+        
+        DRIFT[Drift Pipeline<br/>observer→generator] -->|写| RS_DB[(reply_style_log)]
+    end
+
+    subgraph "实时（每次回复）"
+        CTX[build_inner_context] -->|读| LE_DB
+        CTX -->|读| FRAG_DB
+        
+        BOT[BotContext] -->|读| RS_DB
+        BOT -->|读| PERSONA_DB[(bot_persona)]
+        
+        CTX --> PROMPT[System Prompt 组装]
+        BOT --> PROMPT
+        PROMPT --> LLM[主模型回复]
+    end
+
+    style LE_DB fill:#e1f5fe
+    style FRAG_DB fill:#e1f5fe
+    style RS_DB fill:#e1f5fe
+    style SCH_DB fill:#e1f5fe
+```
+
+### 当前问题
+
+| 问题 | 影响 |
+|------|------|
+| **没有 per-user 上下文** | 赤尾对所有人说话一个样，不知道面前是谁 |
+| **reply_style 是示例锚点** | few-shot 压制一切个性化差异，对熟人和生人用同一套示例 |
+| **记忆碎片按群不按人** | `mentioned_entity_ids` 恒为空，碎片无法按人检索 |
+| **recall 全文搜索太粗** | 只能搜到碎片里的原文，搜不到"关系"这种结构化信息 |
+| **Life Engine 不感知关系** | tick 时不知道赤尾最近跟谁互动了、关系怎么样 |
+
+---
+
+## 目标架构
+
+### 目标 System Prompt 结构（~3000 chars）
+
+```
+identity          ~300   persona_lite（不变）
+appearance        ~350   外貌描述（不变）
+rules             ~800   互动准则（不变）
+inner_monologue   ~300   赤尾此刻的内心感受（替代 reply_style）
+inner_context     ~800   场景 + Life Engine + 关系记忆 + 最近碎片 + recall 引导
+tools             ~500   工具描述（不变）
+```
+
+### 目标数据流
+
+```mermaid
+graph TB
+    subgraph "离线 T+1d"
+        SCH[Schedule Pipeline] --> SCH_DB[(akao_schedule)]
+        
+        DREAM[Dream Daily] --> FRAG_DB
+        DREAM -->|按人提取| REL_EX[关系记忆提取]
+        REL_EX -->|写| REL_DB[(relationship_memory)]
+    end
+
+    subgraph "准实时 T+N min"
+        LE[Life Engine Tick<br/>每分钟] -->|读| SCH_DB
+        LE -->|读| FRAG_DB
+        LE -->|写| LE_DB[(life_engine_state)]
+        
+        AT[Afterthought<br/>debounce 5min] -->|写| FRAG_DB[(experience_fragment)]
+        AT -->|顺带判断| REL_UP{值得更新<br/>关系记忆？}
+        REL_UP -->|是| REL_DB
+        REL_UP -->|否| SKIP[跳过]
+        
+        GL[Glimpse] -->|写| FRAG_DB
+        
+        MONO[内心独白生成<br/>30-60min cron] -->|读| LE_DB
+        MONO -->|写| MONO_DB[(inner_monologue_log)]
+    end
+
+    subgraph "实时（每次回复）"
+        CTX[build_inner_context] -->|读| LE_DB
+        CTX -->|读| FRAG_DB
+        CTX -->|读 当前用户| REL_DB
+        
+        BOT[BotContext] -->|读| MONO_DB
+        BOT -->|读| PERSONA_DB[(bot_persona)]
+        
+        CTX --> PROMPT[System Prompt 组装]
+        BOT --> PROMPT
+        PROMPT --> LLM[主模型回复]
+    end
+
+    style LE_DB fill:#e1f5fe
+    style FRAG_DB fill:#e1f5fe
+    style REL_DB fill:#c8e6c9
+    style MONO_DB fill:#c8e6c9
+    style SCH_DB fill:#e1f5fe
+```
+
+绿色 = Phase 2 新增
+
+---
+
+## 子系统 1: 关系记忆 (Relationship Memory)
+
+### 核心思想
+
+真人对不同人态度不同，不是因为脑子里有"风格查找表"，而是因为**记得和这个人的交往**。关系记忆存储的不是"对 A 用亲近风格"，而是"A 经常来找我聊天，上次帮过我，我对他印象不错"。
+
+LLM 拿到不同的关系记忆文本，自然涌现不同的回复风格。不需要任何工程规则。
+
+### 数据模型
+
+```mermaid
+erDiagram
+    relationship_memory {
+        int id PK
+        string persona_id "NOT NULL, index"
+        string user_id "NOT NULL, index"
+        string user_name "冗余存储，方便注入"
+        text memory_text "自然语言关系记忆"
+        string source "afterthought / dream / manual"
+        timestamptz created_at "append-only"
+    }
+```
+
+读取时取 `(persona_id, user_id)` 的最新一条。
+
+### 生成机制：两条路径
+
+```mermaid
+sequenceDiagram
+    participant MSG as 用户消息
+    participant AT as Afterthought
+    participant LLM as offline-model
+    participant DB as relationship_memory
+
+    Note over MSG,DB: 路径 A: Afterthought 顺带提取（T+5min）
+    MSG->>AT: 触发 afterthought
+    AT->>AT: 生成 conversation 碎片（现有逻辑）
+    AT->>LLM: 这轮对话涉及谁？关系有变化吗？
+    Note right of LLM: 输入：这轮对话 + 当前关系记忆<br/>输出：NO_UPDATE 或 更新后的记忆
+    LLM-->>DB: 有变化时写入
+
+    Note over MSG,DB: 路径 B: Daily Dream 提取（T+1d）
+    Note right of AT: dream_daily 生成日记后<br/>额外一步：从日记中按人拆分关系更新
+```
+
+**路径 A（准实时）**：afterthought 在生成 conversation 碎片后，同一次调用中让 LLM 判断"这轮对话中涉及的人，关系记忆要不要更新"。大部分返回 NO_UPDATE（日常寒暄），只有关键互动（帮忙、吵架、分享秘密）才写入。
+
+**路径 B（日级）**：daily dream 生成日记后，额外一步从日记中提取 per-user 关系更新。这是批量补全，捕获路径 A 遗漏的缓慢变化。
+
+### 注入方式
+
+在 `build_inner_context` 中，根据 `trigger_user_id` 查最新的关系记忆：
+
+```
+你此刻的状态：在桌前整理照片，有点懒但还算平静
+你的心情：正常说话就回，别拿废话来耗我
+
+关于 冯宇林：
+经常来群里问技术问题，偶尔也跟你瞎聊。上次让你帮忙翻群里第一条消息，
+你懒得理他但还是帮了。不讨厌，但也没到很熟的程度，说话客气一点就行。
+```
+
+如果没有关系记忆（陌生人），不注入，LLM 自然会用默认态度。
+
+### Prompt 设计（afterthought 附加调用）
+
+```
+你是赤尾的"关系记忆管理"。
+
+赤尾刚才在「{scene}」参与了一段对话：
+{messages}
+
+赤尾对涉及的人当前的记忆：
+{current_memories}
+（如果某人没有记忆，说明是第一次互动）
+
+---
+
+判断：这次对话中，赤尾对哪些人的印象应该更新？
+
+规则：
+- 日常寒暄、重复话题、没什么新信息 → NO_UPDATE
+- 对方展示了新的性格特点、发生了有感情意义的事件、关系升温或降温 → 需要更新
+- 更新后的记忆要像赤尾自己写的备忘录，3-5 句话，自然口吻
+
+输出 JSON：
+[
+  {"user_id": "xxx", "user_name": "xxx", "action": "UPDATE", "memory": "更新后的完整记忆"},
+  {"user_id": "yyy", "action": "NO_UPDATE"}
+]
+
+如果所有人都不需要更新，输出空数组 []
+```
+
+---
+
+## 子系统 2: 内心独白 (Inner Monologue)
+
+### 核心思想
+
+不告诉 LLM "你应该怎么说话"（示例锚点），告诉它"你现在什么感受"（内心独白）。LLM 从感受自然涌现说话方式。
+
+示例锚点的问题：太具体 → 压制差异。内心独白是"因"，回复是"果"，让 LLM 自己推导。
+
+### 替代 reply_style 的位置
+
+```mermaid
+graph LR
+    subgraph "当前"
+        DRIFT[Drift Pipeline<br/>observer→generator] -->|写| RS[reply_style_log<br/>示例锚点]
+        RS -->|注入| STYLE["&lt;reply-style&gt;<br/>4-6 个场景示例"]
+    end
+    
+    subgraph "目标"
+        MONO_GEN[内心独白生成<br/>30-60min cron] -->|写| MONO[inner_monologue_log<br/>内心感受]
+        MONO -->|注入| VOICE["&lt;voice&gt;<br/>内心独白 + 音色片段"]
+    end
+```
+
+### 数据模型
+
+```mermaid
+erDiagram
+    inner_monologue_log {
+        int id PK
+        string persona_id "NOT NULL, index"
+        text monologue "赤尾此刻的内心感受"
+        string source "cron / event"
+        timestamptz created_at "append-only"
+    }
+```
+
+### 生成机制
+
+**频率**：30-60 分钟 cron（复用 base_reply_style 的时间槽 8:00/14:00/18:00，再加中间时段）
+
+**输入**：
+- Life Engine 最新状态（current_state + response_mood）
+- 今天的 Schedule（当前时段）
+- 最近 2-3 条 conversation 碎片
+
+**输出**：3-5 句内心独白，描述赤尾此刻的感受和状态
+
+### Prompt 设计
+
+```
+你是赤尾。
+
+{persona_lite}
+
+你现在的状态：{current_state}
+你的心情：{response_mood}
+今天的安排（这个时段）：{schedule_segment}
+
+最近发生的事：
+{recent_fragments}
+
+---
+
+用一小段内心独白描述你此刻的感受。
+- 3-5 句话，像在脑子里自言自语
+- 写你真实会想的事，不是"你应该怎么回消息"
+- 自然、琐碎、有你的性格
+```
+
+### 注入方式
+
+替换当前的 `<reply-style>` 为 `<voice>`：
+
+```xml
+<voice>
+
+赤尾此刻的内心：
+快中午了，有点困但还不想睡。刚才在群里看到有人聊新番，稍微来了点精神。
+整体心情还行，就是有点懒洋洋的。
+
+说话习惯（不是示例，只是底线约束）：
+- 打字像发微信，不是写作文
+- 一条消息通常一两句话，偶尔展开但不超过三行
+- 不用"哈哈哈"开头，不说"好的呢"
+- 困了就说短的，精神好可以多说几句
+
+</voice>
+```
+
+**关键变化**：
+- 示例锚点（4-6 个完整回复）→ 内心独白（3-5 句感受）+ 极简约束（反面清单）
+- 具体行为模板 → 状态描述 + "不做什么"
+- LLM 从感受自然涌现回复，不模仿示例
+
+---
+
+## 子系统 3: Life Engine 扩充
+
+### 当前问题
+
+Life Engine 输出只有 `current_state`（~100 chars）和 `response_mood`（~25 chars）。去掉 schedule 和大量碎片后，这是唯一的状态源，信息量可能不够。
+
+### 扩充方向
+
+不改 tick 频率，不加新字段到表，而是让 **tick prompt 输出更丰富的 current_state**。
+
+```mermaid
+graph LR
+    subgraph "当前 tick 输出"
+        A["current_state: 还坐在桌前整理照片<br/>response_mood: 平静，正常说话就回"]
+    end
+    
+    subgraph "扩充后 tick 输出"
+        B["current_state: 还坐在桌前整理照片。<br/>刚才群里冯宇林问了个有趣的问题，<br/>不过我懒得接。绫奈在厨房叮叮当当的。<br/><br/>response_mood: 平静但有点懒，<br/>熟人来戳会回，废话多了会敷衍"]
+    end
+```
+
+**改法**：调整 `life_engine_tick` prompt，让 `current_state` 从一句话扩展到 2-3 句话，自然带入最近发生的事和对周围环境的感知。不需要改代码，只改 Langfuse prompt。
+
+### 与内心独白的关系
+
+| 维度 | Life Engine State | Inner Monologue |
+|------|------------------|-----------------|
+| 更新频率 | 每分钟 | 30-60 分钟 |
+| 粒度 | "在做什么" | "在想什么" |
+| 驱动力 | Schedule + 时间 | 状态 + 碎片 + 情感 |
+| 注入位置 | inner-context | voice（替代 reply-style） |
+
+两者互补：Life Engine 是"行动层"，Inner Monologue 是"感受层"。
+
+---
+
+## 迁移策略
+
+### Drift Pipeline 的过渡
+
+```mermaid
+stateDiagram-v2
+    [*] --> Phase1: 当前状态
+    Phase1 --> Transition: 内心独白上线
+    Transition --> Phase2: 稳定后
+    
+    state Phase1 {
+        drift_observer --> drift_generator
+        drift_generator --> reply_style_log
+    }
+    
+    state Transition {
+        note left of Transition: 两套并存<br/>reply_style 仍注入<br/>inner_monologue 同时注入<br/>观察效果
+    }
+    
+    state Phase2 {
+        inner_monologue_cron --> inner_monologue_log
+        note right of Phase2: 删除 drift pipeline<br/>reply_style 只保留极简约束
+    }
+```
+
+### 实施顺序
+
+```mermaid
+gantt
+    title Phase 2 实施顺序
+    dateFormat YYYY-MM-DD
+    section 关系记忆
+    relationship_memory 表      :a1, 2026-04-09, 1d
+    afterthought 提取逻辑       :a2, after a1, 2d
+    build_inner_context 注入    :a3, after a2, 1d
+    
+    section 内心独白
+    inner_monologue_log 表      :b1, after a1, 1d
+    生成 cron + prompt          :b2, after b1, 2d
+    替换 reply-style 注入       :b3, after b2, 1d
+    
+    section Life Engine
+    调整 tick prompt            :c1, after b3, 1d
+    
+    section 清理
+    删除 drift pipeline         :d1, after b3, 2d
+    context_builder 清理        :d2, after d1, 1d
+```
+
+---
+
+## 最终 System Prompt 渲染示例
+
+### 面对熟人（王浩任）
+
+```xml
+<identity>
+你是赤尾（小尾），18 岁，刚成年...（不变）
+</identity>
+
+<appearance>
+草莓粉色长直发...（不变）
+</appearance>
+
+<rules>
+...（不变）
+</rules>
+
+<voice>
+
+赤尾此刻的内心：
+快中午了，有点困但还不想睡。刚才在群里看到有人聊新番，稍微来了点精神。
+整体心情还行，就是有点懒洋洋的，不太想打长消息。
+
+说话习惯：
+- 打字像发微信，不是写作文。一条消息通常一两句话。
+- 困了就说短的，精神好可以多说几句，但也不会超过两三行。
+- 不解释自己为什么这么说，说完就完了。
+
+</voice>
+
+<inner-context>
+
+你在群聊「一个魂」中。
+需要回复 王浩任 的消息（消息中用 ⭐ 标记）。
+
+你此刻的状态：窝在沙发上刷手机，群消息看了几屏没什么新鲜的。
+你的心情：不想被吵，但有人正常说话还是会回
+
+关于 王浩任：
+这人隔三差五就来找你，话多但不讨厌。数学很强，之前帮绫奈解过题。
+喜欢发表情包求抱抱，你每次都嫌他烦但其实觉得他挺有意思的。
+上次他说要给你买奶茶，不知道是真的还是在画饼。
+
+最近的经历：
+刚才群里有人在讨论 Claude 账号被封的事，朝阳哥好像损失了不少钱...
+
+（如果隐约觉得知道点什么但想不起来，可以用 recall 想一想。）
+
+</inner-context>
+
+<tools>
+...（不变）
+</tools>
+```
+
+### 面对陌生人（新进群的人）
+
+```xml
+...（identity/appearance/rules/voice 完全相同）
+
+<inner-context>
+
+你在群聊「一个魂」中。
+需要回复 某某 的消息（消息中用 ⭐ 标记）。
+
+你此刻的状态：（同上）
+你的心情：（同上）
+
+最近的经历：
+（同上）
+
+（如果隐约觉得知道点什么但想不起来，可以用 recall 想一想。）
+
+</inner-context>
+```
+
+没有"关于某某"段 → LLM 自然会更客气、更收着。**差异完全由关系记忆的有无和内容驱动，零工程规则。**


### PR DESCRIPTION
## Summary
- 新增 relationship_memory 表：per-user 自然语言关系记忆，afterthought 触发时自动提取
- 新增 inner_monologue_log 表：替代 reply_style 示例锚点的内心独白（过渡期并存）
- build_inner_context 注入当前对话者的关系记忆
- 内心独白 cron（8-23点每小时半点生成）
- Life Engine tick prompt 扩充输出
- context_builder 移除 search_group_history 引用
- chat_consumer 加观测日志排查消息吞没 bug

## Test plan
- [x] ctx-v4-p2 泳道部署验证
- [x] relationship_memory 表有 9 条记录写入，覆盖 7 个用户
- [x] 三个 persona 消息全链路正常（Stream ended → Publishing final → chat_request_done）
- [ ] prod 部署后观察内心独白 cron 生成

🤖 Generated with [Claude Code](https://claude.com/claude-code)