### PR TITLE
fix: revert mention detection to union_id — bot_info.app_id absent from Lark API

### DIFF
--- a/apps/lark-server/src/core/rules/rule.ts
+++ b/apps/lark-server/src/core/rules/rule.ts
@@ -1,6 +1,6 @@
 import { LarkBaseChatInfo } from 'infrastructure/dal/entities';
 import { Message } from 'core/models/message';
-import { getBotAppId } from '@core/services/bot/bot-var';
+import { getBotAppId, getBotUnionId } from '@core/services/bot/bot-var';
 import { UserBlacklistRepository } from '@infrastructure/dal/repositories/repositories';
 
 // 定义规则函数类型
@@ -82,7 +82,7 @@ export interface RuleConfig {
 
 // 工具函数：通用规则
 export const NeedRobotMention: Rule = (message) =>
-    message.hasBotMention(getBotAppId()) || message.isP2P();
+    message.hasMention(getBotUnionId()) || message.isP2P();
 
 export const NeedNotRobotMention: Rule = (message) => !NeedRobotMention(message);
 

--- a/apps/lark-server/src/core/services/bot/bot-var.ts
+++ b/apps/lark-server/src/core/services/bot/bot-var.ts
@@ -17,3 +17,7 @@ function getBotConfigInternal() {
 export function getBotAppId(): string {
     return getBotConfigInternal().app_id;
 }
+
+export function getBotUnionId(): string {
+    return getBotConfigInternal().robot_union_id;
+}

--- a/apps/lark-server/src/core/services/bot/multi-bot-manager.ts
+++ b/apps/lark-server/src/core/services/bot/multi-bot-manager.ts
@@ -53,6 +53,16 @@ export class MultiBotManager {
         return null;
     }
 
+    // 根据union_id获取机器人配置
+    getBotConfigByUnionId(unionId: string): BotConfig | null {
+        for (const bot of this.botConfigs.values()) {
+            if (bot.robot_union_id === unionId) {
+                return bot;
+            }
+        }
+        return null;
+    }
+
     // 获取所有机器人配置
     getAllBotConfigs(): BotConfig[] {
         return Array.from(this.botConfigs.values());

--- a/apps/lark-server/src/infrastructure/dal/entities/bot-config.ts
+++ b/apps/lark-server/src/infrastructure/dal/entities/bot-config.ts
@@ -17,6 +17,9 @@ export class BotConfig {
     @Column({ type: 'varchar', length: 100 })
     verification_token!: string; // 验证令牌
 
+    @Column({ type: 'varchar', length: 100 })
+    robot_union_id!: string; // 机器人Union ID
+
     @Column({ type: 'varchar', length: 20, default: 'http' })
     init_type!: 'http' | 'websocket'; // 初始化类型：http或websocket
 

--- a/apps/lark-server/src/infrastructure/integrations/lark/utils/mention-utils.ts
+++ b/apps/lark-server/src/infrastructure/integrations/lark/utils/mention-utils.ts
@@ -1,4 +1,5 @@
 import { LarkMention } from 'types/lark';
+import { multiBotManager } from '@core/services/bot/multi-bot-manager';
 
 export class MentionUtils {
     static addMentions(mentions: LarkMention[] | undefined): string[] {
@@ -7,13 +8,14 @@ export class MentionUtils {
 
     /**
      * 提取被 @mention 的 bot 的 app_id 列表（用于 agent-service 路由）
-     * 只包含 mentioned_type === 'bot' 的 mention
+     * 飞书 mention 不提供 bot_info.app_id，通过 union_id 反查 bot config 获取
      */
     static extractBotAppIds(mentions: LarkMention[] | undefined): string[] {
         if (!mentions) return [];
         return mentions
-            .filter((m) => m.mentioned_type === 'bot' && m.bot_info?.app_id)
-            .map((m) => m.bot_info!.app_id!);
+            .filter((m) => m.mentioned_type === 'bot')
+            .map((m) => multiBotManager.getBotConfigByUnionId(m.id.union_id!)?.app_id)
+            .filter((appId): appId is string => !!appId);
     }
 
     static addMentionMap(mentions: LarkMention[] | undefined): Record<
@@ -27,10 +29,13 @@ export class MentionUtils {
         return mentions
             ? mentions.reduce(
                   (acc, m) => {
+                      const botConfig = m.mentioned_type === 'bot'
+                          ? multiBotManager.getBotConfigByUnionId(m.id.union_id!)
+                          : null;
                       acc[m.id.union_id!] = {
                           name: m.name,
                           openId: m.id.open_id!,
-                          appId: m.mentioned_type === 'bot' ? m.bot_info?.app_id : undefined,
+                          appId: botConfig?.app_id,
                       };
                       return acc;
                   },


### PR DESCRIPTION
飞书 mention 入参不提供 bot_info 字段，导致 extractBotAppIds 永远返回空数组，
NeedRobotMention 在群聊中始终 false。

- 恢复 robot_union_id 到 BotConfig entity
- NeedRobotMention 改回 hasMention(getBotUnionId())
- extractBotAppIds / addMentionMap 通过 union_id 反查 multiBotManager 获取 app_id

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
