### PR TITLE
feat: PR 合并后飞书 webhook 通知

### DIFF
--- a/.github/workflows/notify-feishu-on-merge.yml
+++ b/.github/workflows/notify-feishu-on-merge.yml
@@ -1,0 +1,80 @@
+name: Notify Feishu on PR Merge
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+jobs:
+  notify:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Extract summary from PR body
+        id: summary
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          # Extract text between ## Summary and next ## (or EOF)
+          SUMMARY=$(echo "$PR_BODY" | sed -n '/^## Summary/,/^## /{/^## Summary/d;/^## /d;p}')
+
+          # Fallback: if no Summary section, take first 5 lines
+          if [ -z "$(echo "$SUMMARY" | tr -d '[:space:]')" ]; then
+            SUMMARY=$(echo "$PR_BODY" | head -5)
+          fi
+
+          # Fallback: if body is empty
+          if [ -z "$(echo "$SUMMARY" | tr -d '[:space:]')" ]; then
+            SUMMARY="（无描述）"
+          fi
+
+          # Trim leading/trailing blank lines
+          SUMMARY=$(echo "$SUMMARY" | sed '/./,$!d' | sed -e :a -e '/^\n*$/{$d;N;ba}')
+
+          # Write to output (handle multiline)
+          {
+            echo "content<<SUMMARY_EOF"
+            echo "$SUMMARY"
+            echo "SUMMARY_EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Send Feishu notification
+        env:
+          WEBHOOK_URL: ${{ secrets.FEISHU_MERGE_WEBHOOK_URL }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          SUMMARY: ${{ steps.summary.outputs.content }}
+        run: |
+          # Build JSON payload safely with jq
+          PAYLOAD=$(jq -n \
+            --arg title "[PR #${PR_NUMBER}] ${PR_TITLE}" \
+            --arg summary "$SUMMARY" \
+            --arg url "$PR_URL" \
+            '{
+              msg_type: "interactive",
+              card: {
+                header: {
+                  title: { tag: "plain_text", content: $title },
+                  template: "green"
+                },
+                elements: [
+                  { tag: "markdown", content: $summary },
+                  {
+                    tag: "action",
+                    actions: [
+                      {
+                        tag: "button",
+                        text: { tag: "plain_text", content: "查看 PR" },
+                        url: $url,
+                        type: "primary"
+                      }
+                    ]
+                  }
+                ]
+              }
+            }')
+
+          curl -s -X POST "$WEBHOOK_URL" \
+            -H "Content-Type: application/json" \
+            -d "$PAYLOAD"

--- a/.github/workflows/notify-feishu-on-merge.yml
+++ b/.github/workflows/notify-feishu-on-merge.yml
@@ -46,34 +46,31 @@ jobs:
           PR_URL: ${{ github.event.pull_request.html_url }}
           SUMMARY: ${{ steps.summary.outputs.content }}
         run: |
-          # Build JSON payload safely with jq
-          PAYLOAD=$(jq -n \
-            --arg title "[PR #${PR_NUMBER}] ${PR_TITLE}" \
-            --arg summary "$SUMMARY" \
-            --arg url "$PR_URL" \
-            '{
-              msg_type: "interactive",
-              card: {
-                header: {
-                  title: { tag: "plain_text", content: $title },
-                  template: "green"
-                },
-                elements: [
-                  { tag: "markdown", content: $summary },
-                  {
-                    tag: "action",
-                    actions: [
+          # Build JSON payload safely with python3 (guaranteed on ubuntu runner)
+          PAYLOAD=$(python3 -c "
+          import json, os
+          print(json.dumps({
+              'msg_type': 'interactive',
+              'card': {
+                  'header': {
+                      'title': {'tag': 'plain_text', 'content': f'[PR #{os.environ[\"PR_NUMBER\"]}] {os.environ[\"PR_TITLE\"]}'},
+                      'template': 'green'
+                  },
+                  'elements': [
+                      {'tag': 'markdown', 'content': os.environ['SUMMARY']},
                       {
-                        tag: "button",
-                        text: { tag: "plain_text", content: "查看 PR" },
-                        url: $url,
-                        type: "primary"
+                          'tag': 'action',
+                          'actions': [{
+                              'tag': 'button',
+                              'text': {'tag': 'plain_text', 'content': '查看 PR'},
+                              'url': os.environ['PR_URL'],
+                              'type': 'primary'
+                          }]
                       }
-                    ]
-                  }
-                ]
+                  ]
               }
-            }')
+          }))
+          ")
 
           curl -s -X POST "$WEBHOOK_URL" \
             -H "Content-Type: application/json" \

--- a/docs/superpowers/specs/2026-04-09-notify-feishu-on-merge-design.md
+++ b/docs/superpowers/specs/2026-04-09-notify-feishu-on-merge-design.md
@@ -1,0 +1,74 @@
+# PR 合并飞书通知
+
+## 背景
+
+PR 合并到 main 后缺乏即时通知，需要手动检查 GitHub 才能知道合码状态。希望合并后自动往飞书群发一条通知。
+
+## 方案
+
+GitHub Actions workflow，监听 PR 合并事件，通过飞书 webhook 发送卡片消息。
+
+## 触发条件
+
+- 事件：`pull_request` → `closed`
+- 条件：`github.event.pull_request.merged == true`
+- 目标分支：`main`
+
+## 消息内容
+
+| 字段 | 来源 |
+|------|------|
+| PR 标题 | `github.event.pull_request.title` |
+| PR 编号 | `github.event.pull_request.number` |
+| PR 链接 | `github.event.pull_request.html_url` |
+| 改动核心内容 | PR body 中 `## Summary` 段落；fallback 到 body 前 5 行 |
+
+## 消息格式
+
+飞书 webhook interactive card：
+
+```json
+{
+  "msg_type": "interactive",
+  "card": {
+    "header": {
+      "title": { "tag": "plain_text", "content": "[PR #编号] 标题" },
+      "template": "green"
+    },
+    "elements": [
+      {
+        "tag": "markdown",
+        "content": "Summary 内容"
+      },
+      {
+        "tag": "action",
+        "actions": [
+          {
+            "tag": "button",
+            "text": { "tag": "plain_text", "content": "查看 PR" },
+            "url": "PR 链接",
+            "type": "primary"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+## 安全
+
+- Webhook URL 作为 GitHub repo secret：`FEISHU_MERGE_WEBHOOK_URL`
+- Workflow 通过 `${{ secrets.FEISHU_MERGE_WEBHOOK_URL }}` 引用
+- 不在代码中硬编码任何 URL
+
+## 文件变更
+
+- 新增：`.github/workflows/notify-feishu-on-merge.yml`
+
+## Summary 提取逻辑
+
+1. 用 shell 从 PR body 中匹配 `## Summary` 到下一个 `##`（或 EOF）之间的文本
+2. 去除首尾空行
+3. 如果提取为空，fallback 到 body 前 5 行
+4. 如果 body 本身为空，显示"（无描述）"


### PR DESCRIPTION
## Summary
- 新增 GitHub Actions workflow，PR 合并到 main 时自动发飞书卡片通知
- 从 PR body 提取 `## Summary` 段落作为改动核心内容（fallback 到前 5 行）
- Webhook URL 通过 GitHub Secret `FEISHU_MERGE_WEBHOOK_URL` 注入，不硬编码

## Test plan
- [ ] 在 repo settings 添加 `FEISHU_MERGE_WEBHOOK_URL` secret
- [ ] 合并本 PR 后验证飞书群收到通知卡片

🤖 Generated with [Claude Code](https://claude.com/claude-code)