### PR TITLE
feat(relationship-memory): 切 relationship-model(gpt-5.4) 降成本

### DIFF
--- a/apps/agent-service/app/config/config.py
+++ b/apps/agent-service/app/config/config.py
@@ -60,6 +60,9 @@ class Settings(BaseSettings):
     # Life Engine
     life_engine_model: str = "offline-model"
 
+    # 关系记忆提取
+    relationship_model: str = "relationship-model"
+
     # Identity 漂移
     identity_drift_model: str = "offline-model"
     identity_drift_debounce_seconds: int = 120  # 一阶段等待: 2 分钟

--- a/apps/agent-service/app/services/relationship_memory.py
+++ b/apps/agent-service/app/services/relationship_memory.py
@@ -60,7 +60,7 @@ async def extract_relationship_updates(
         current_impression="\n".join(impression_lines),
     )
 
-    model = await ModelBuilder.build_chat_model(settings.diary_model)
+    model = await ModelBuilder.build_chat_model(settings.relationship_model)
     response = await model.ainvoke([{"role": "user", "content": compiled}])
 
     content = response.content
@@ -188,7 +188,7 @@ async def rebuild_relationship_memory_for_user(
             current_impression=im_line,
         )
 
-        model = await ModelBuilder.build_chat_model(settings.diary_model)
+        model = await ModelBuilder.build_chat_model(settings.relationship_model)
         response = await model.ainvoke([{"role": "user", "content": compiled}])
 
         content_text = response.content


### PR DESCRIPTION
## Summary
- 新增 `relationship-model` 独立模型映射，初始指向 gpt-5.4
- relationship_extract 从 diary-model(gemini,自费) 切到 relationship-model(gpt-5.4,公司)
- 后续可直接改 DB model_mappings 切模型对比，不用改代码

🤖 Generated with [Claude Code](https://claude.com/claude-code)