### PR TITLE
fix(lark-proxy): 注册 card.action.trigger 到 EventDispatcher

### DIFF
--- a/apps/lark-proxy/src/bot-manager.ts
+++ b/apps/lark-proxy/src/bot-manager.ts
@@ -27,6 +27,7 @@ const REGISTERED_EVENT_TYPES = [
     'im.message.reaction.deleted_v1',
     'im.chat.access_event.bot_p2p_chat_entered_v1',
     'im.chat.updated_v1',
+    'card.action.trigger',
 ];
 
 export class BotManager {


### PR DESCRIPTION
## Summary
- 飞书将卡片交互回调作为 v2 事件发送到事件订阅 URL (`/webhook/{bot}/event`)，但 `REGISTERED_EVENT_TYPES` 缺少 `card.action.trigger`，导致 SDK 丢弃事件
- 所有卡片回调（换一批、查看详情）均失效，lark-proxy 日志可见 `no card.action.trigger handle` 警告

## Test plan
- [ ] 部署后在飞书点击"每日新图"卡片的"换一批"按钮，确认卡片正常刷新
- [ ] 点击"查看详情"按钮，确认正常返回图片详情

🤖 Generated with [Claude Code](https://claude.com/claude-code)