### PR TITLE
fix(lark-server): daily photo card 缺少 toV1() 导致换一批失败

### DIFF
--- a/apps/lark-proxy/src/bot-manager.ts
+++ b/apps/lark-proxy/src/bot-manager.ts
@@ -27,6 +27,7 @@ const REGISTERED_EVENT_TYPES = [
     'im.message.reaction.deleted_v1',
     'im.chat.access_event.bot_p2p_chat_entered_v1',
     'im.chat.updated_v1',
+    'card.action.trigger',
 ];
 
 export class BotManager {

--- a/apps/lark-server/src/core/services/callback/update-card.ts
+++ b/apps/lark-server/src/core/services/callback/update-card.ts
@@ -1,6 +1,6 @@
 import type { LarkCallbackInfo } from 'types/lark';
 import { BaseChatInfoRepository } from 'infrastructure/dal/repositories/repositories';
-import { patchMessage } from '@lark-client';
+import { sendReq } from '@lark-client';
 import { searchAndBuildPhotoCard, searchAndBuildDailyPhotoCard } from '@core/services/media/photo/photo-card';
 
 type CardBuilder = (params: any, allow_send_limit_photo?: boolean) => Promise<any>;
@@ -20,7 +20,19 @@ async function handleUpdateCard(
             basicChatInfo?.permission_config?.allow_send_limit_photo,
         );
 
-        await patchMessage(data.context.open_message_id, updatedCard);
+        const delayCard = {
+            open_ids: [data.operator.open_id],
+            elements: updatedCard.getElements(),
+        };
+
+        await sendReq(
+            '/open-apis/interactive/v1/card/update',
+            {
+                token: data.token,
+                card: delayCard,
+            },
+            'POST',
+        );
     } catch (e) {
         console.error('update card error:', {
             message: e instanceof Error ? e.message : 'Unknown error',

--- a/apps/lark-server/src/core/services/callback/update-card.ts
+++ b/apps/lark-server/src/core/services/callback/update-card.ts
@@ -1,6 +1,6 @@
 import type { LarkCallbackInfo } from 'types/lark';
 import { BaseChatInfoRepository } from 'infrastructure/dal/repositories/repositories';
-import { sendReq } from '@lark-client';
+import { patchMessage } from '@lark-client';
 import { searchAndBuildPhotoCard, searchAndBuildDailyPhotoCard } from '@core/services/media/photo/photo-card';
 
 type CardBuilder = (params: any, allow_send_limit_photo?: boolean) => Promise<any>;
@@ -10,7 +10,6 @@ async function handleUpdateCard(
     cardBuilder: CardBuilder,
     builderParams: any,
 ) {
-    console.info('[handleUpdateCard] received data keys:', Object.keys(data), 'token:', data.token?.substring(0, 10), 'operator:', data.operator?.open_id, 'context:', data.context);
     try {
         const basicChatInfo = await BaseChatInfoRepository.findOne({
             where: { chat_id: data.context.open_chat_id },
@@ -21,19 +20,7 @@ async function handleUpdateCard(
             basicChatInfo?.permission_config?.allow_send_limit_photo,
         );
 
-        const delayCard = {
-            open_ids: [data.operator.open_id], // 非共享卡片需要更新卡片的open_ids
-            elements: updatedCard.getElements(),
-        };
-
-        await sendReq(
-            '/open-apis/interactive/v1/card/update',
-            {
-                token: data.token,
-                card: delayCard,
-            },
-            'POST',
-        );
+        await patchMessage(data.context.open_message_id, updatedCard);
     } catch (e) {
         console.error('update card error:', {
             message: e instanceof Error ? e.message : 'Unknown error',

--- a/apps/lark-server/src/core/services/callback/update-card.ts
+++ b/apps/lark-server/src/core/services/callback/update-card.ts
@@ -10,6 +10,7 @@ async function handleUpdateCard(
     cardBuilder: CardBuilder,
     builderParams: any,
 ) {
+    console.info('[handleUpdateCard] received data keys:', Object.keys(data), 'token:', data.token?.substring(0, 10), 'operator:', data.operator?.open_id, 'context:', data.context);
     try {
         const basicChatInfo = await BaseChatInfoRepository.findOne({
             where: { chat_id: data.context.open_chat_id },

--- a/apps/lark-server/src/core/services/media/photo/photo-card.ts
+++ b/apps/lark-server/src/core/services/media/photo/photo-card.ts
@@ -27,7 +27,7 @@ export async function searchAndBuildPhotoCard(tags: string[], allow_send_limit_p
 
     const { chunks, weights } = calcBestChunks(images);
 
-    const card = new LarkCard().withConfig({ update_multi: true }).addElement(
+    const card = new LarkCard().addElement(
         new ColumnSet()
             .setHorizontalSpacing('small')
             .addColumns(
@@ -127,7 +127,7 @@ export async function searchAndBuildDailyPhotoCard(
 
     const { chunks, weights } = calcBestChunks(images);
 
-    const card = new LarkCard().withConfig({ update_multi: true }).withHeader(new CardHeader('今日新图').color('green')).addElement(
+    const card = new LarkCard().withHeader(new CardHeader('今日新图').color('green')).addElement(
         new ColumnSet()
             .setHorizontalSpacing('small')
             .addColumns(
@@ -162,5 +162,6 @@ export async function searchAndBuildDailyPhotoCard(
         ),
     );
 
-    return card;
+    // 需要支持延迟更新卡片，返回 V1 版本
+    return card.toV1();
 }

--- a/apps/lark-server/src/core/services/media/photo/photo-card.ts
+++ b/apps/lark-server/src/core/services/media/photo/photo-card.ts
@@ -27,7 +27,7 @@ export async function searchAndBuildPhotoCard(tags: string[], allow_send_limit_p
 
     const { chunks, weights } = calcBestChunks(images);
 
-    const card = new LarkCard().addElement(
+    const card = new LarkCard().withConfig({ update_multi: true }).addElement(
         new ColumnSet()
             .setHorizontalSpacing('small')
             .addColumns(
@@ -127,7 +127,7 @@ export async function searchAndBuildDailyPhotoCard(
 
     const { chunks, weights } = calcBestChunks(images);
 
-    const card = new LarkCard().withHeader(new CardHeader('今日新图').color('green')).addElement(
+    const card = new LarkCard().withConfig({ update_multi: true }).withHeader(new CardHeader('今日新图').color('green')).addElement(
         new ColumnSet()
             .setHorizontalSpacing('small')
             .addColumns(

--- a/apps/lark-server/src/infrastructure/integrations/lark-client.ts
+++ b/apps/lark-server/src/infrastructure/integrations/lark-client.ts
@@ -200,6 +200,19 @@ export async function sendReq<T>(url: string, data: any, method: string) {
     );
 }
 
+export async function patchMessage(messageId: string, content: any) {
+    const client = larkClientManager.getCurrentClient();
+    return handleResponse(
+        client.im.message.patch({
+            path: { message_id: messageId },
+            data: {
+                content: JSON.stringify(content),
+            },
+        }),
+        'patch_message',
+    );
+}
+
 export async function getChatList(page_token?: string) {
     const client = larkClientManager.getCurrentClient();
     return handleResponse(

--- a/apps/lark-server/src/infrastructure/integrations/lark-client.ts
+++ b/apps/lark-server/src/infrastructure/integrations/lark-client.ts
@@ -200,19 +200,6 @@ export async function sendReq<T>(url: string, data: any, method: string) {
     );
 }
 
-export async function patchMessage(messageId: string, content: any) {
-    const client = larkClientManager.getCurrentClient();
-    return handleResponse(
-        client.im.message.patch({
-            path: { message_id: messageId },
-            data: {
-                content: JSON.stringify(content),
-            },
-        }),
-        'patch_message',
-    );
-}
-
 export async function getChatList(page_token?: string) {
     const client = larkClientManager.getCurrentClient();
     return handleResponse(


### PR DESCRIPTION
## Summary
- `searchAndBuildDailyPhotoCard` 漏掉了 `.toV1()` 调用，发出 V2 卡片后用 V1 card update API 更新导致失败
- `searchAndBuildPhotoCard` 已有 `.toV1()`（含注释说明原因），本 PR 补齐一致性

## Test plan
- [ ] 部署后在飞书群内发"发图"命令，点击"换一批"确认卡片正常刷新
- [ ] 等 19:30 每日新图推送后，点击"换一批"确认正常

🤖 Generated with [Claude Code](https://claude.com/claude-code)