### PR TITLE
fix(agent-service): rebuild 复用 extract + 禁止裸调模型 + Langfuse trace

### DIFF
--- a/apps/agent-service/app/agents/core/config.py
+++ b/apps/agent-service/app/agents/core/config.py
@@ -89,3 +89,66 @@ AgentRegistry.register(
         trace_name="schedule-critic",
     ),
 )
+
+AgentRegistry.register(
+    "relationship-extract",
+    AgentConfig(
+        prompt_id="relationship_extract",
+        model_id="relationship-model",
+        trace_name="relationship-extract",
+    ),
+)
+
+AgentRegistry.register(
+    "afterthought",
+    AgentConfig(
+        prompt_id="afterthought_conversation",
+        model_id="diary-model",
+        trace_name="afterthought",
+    ),
+)
+
+AgentRegistry.register(
+    "voice-generator",
+    AgentConfig(
+        prompt_id="voice_generator",
+        model_id="offline-model",
+        trace_name="voice-generator",
+    ),
+)
+
+AgentRegistry.register(
+    "dream-daily",
+    AgentConfig(
+        prompt_id="dream_daily",
+        model_id="diary-model",
+        trace_name="dream-daily",
+    ),
+)
+
+AgentRegistry.register(
+    "dream-weekly",
+    AgentConfig(
+        prompt_id="dream_weekly",
+        model_id="diary-model",
+        trace_name="dream-weekly",
+    ),
+)
+
+AgentRegistry.register(
+    "schedule-monthly",
+    AgentConfig(
+        prompt_id="schedule_monthly",
+        model_id="offline-model",
+        trace_name="schedule-monthly",
+    ),
+)
+
+AgentRegistry.register(
+    "schedule-weekly",
+    AgentConfig(
+        prompt_id="schedule_weekly",
+        model_id="offline-model",
+        trace_name="schedule-weekly",
+    ),
+)

--- a/apps/agent-service/app/api/router.py
+++ b/apps/agent-service/app/api/router.py
@@ -152,7 +152,6 @@ class RebuildRelationshipMemoryRequest(BaseModel):
     chat_ids: list[str]
     start_time: str  # ISO 8601
     end_time: str  # ISO 8601
-    batch_size: int = 50
 
 
 @api_router.post("/admin/rebuild-relationship-memory", tags=["Admin"])
@@ -210,36 +209,30 @@ async def rebuild_relationship_memory(req: RebuildRelationshipMemoryRequest):
 
                 messages.sort(key=lambda m: m.create_time)
 
-                for persona_id, persona_name in personas.items():
-                    # 按 batch_size 分批，每批完整时间线 + 所有用户
-                    for i in range(0, len(messages), req.batch_size):
-                        batch = messages[i : i + req.batch_size]
-                        batch_user_ids = list({
-                            m.user_id for m in batch
-                            if m.role == "user" and m.user_id and m.user_id != "__proactive__"
-                        })
-                        if not batch_user_ids:
-                            continue
+                user_ids = list({
+                    m.user_id for m in messages
+                    if m.role == "user" and m.user_id and m.user_id != "__proactive__"
+                })
+                if not user_ids:
+                    continue
 
-                        try:
-                            timeline = await format_timeline(batch, persona_name)
-                            if not timeline:
-                                continue
-                            await extract_relationship_updates(
-                                persona_id=persona_id,
-                                chat_id=chat_id,
-                                user_ids=batch_user_ids,
-                                messages_timeline=timeline,
-                            )
-                            logger.info(
-                                f"[rebuild] {day_str} {persona_id} batch {i // req.batch_size + 1}: "
-                                f"{len(batch_user_ids)} users"
-                            )
-                        except Exception as e:
-                            logger.error(
-                                f"[rebuild] {day_str} {persona_id} batch {i // req.batch_size + 1} "
-                                f"failed: {e}"
-                            )
+                for persona_id, persona_name in personas.items():
+                    try:
+                        timeline = await format_timeline(messages, persona_name)
+                        if not timeline:
+                            continue
+                        await extract_relationship_updates(
+                            persona_id=persona_id,
+                            chat_id=chat_id,
+                            user_ids=user_ids,
+                            messages_timeline=timeline,
+                        )
+                        logger.info(
+                            f"[rebuild] {day_str} {persona_id}: "
+                            f"{len(user_ids)} users, {len(messages)} msgs"
+                        )
+                    except Exception as e:
+                        logger.error(f"[rebuild] {day_str} {persona_id} failed: {e}")
 
             logger.info(f"[rebuild] Day {day_count}/{total_days} ({day_str}) done.")
             day = next_day

--- a/apps/agent-service/app/api/router.py
+++ b/apps/agent-service/app/api/router.py
@@ -169,18 +169,20 @@ async def rebuild_relationship_memory(req: RebuildRelationshipMemoryRequest):
 
     async def _run():
         from datetime import datetime, timedelta
-        from app.orm.crud import get_bot_persona, get_chat_messages_in_range, get_username
-        from app.services.relationship_memory import rebuild_relationship_memory_for_user
+        from app.orm.crud import get_bot_persona, get_chat_messages_in_range
+        from app.services.relationship_memory import (
+            extract_relationship_updates,
+            format_timeline,
+        )
 
         start_dt = datetime.fromisoformat(req.start_time)
         end_dt = datetime.fromisoformat(req.end_time)
 
-        # 预加载 persona 信息
         personas = {}
         for persona_id in req.persona_ids:
             persona = await get_bot_persona(persona_id)
             if persona:
-                personas[persona_id] = (persona.display_name, persona.persona_lite or "")
+                personas[persona_id] = persona.display_name or persona_id
 
         total_days = (end_dt.date() - start_dt.date()).days
         logger.info(
@@ -188,7 +190,6 @@ async def rebuild_relationship_memory(req: RebuildRelationshipMemoryRequest):
             f"{total_days} days ({start_dt.date()} ~ {end_dt.date()})"
         )
 
-        # 按天拆分
         day = start_dt
         day_count = 0
         while day < end_dt:
@@ -207,36 +208,38 @@ async def rebuild_relationship_memory(req: RebuildRelationshipMemoryRequest):
                 if not messages:
                     continue
 
-                user_ids = list({
-                    m.user_id for m in messages
-                    if m.role == "user" and m.user_id and m.user_id != "__proactive__"
-                })
+                messages.sort(key=lambda m: m.create_time)
 
-                for persona_id, (persona_name, persona_lite) in personas.items():
-                    for user_id in user_ids:
-                        user_messages = [
-                            m for m in messages
-                            if m.user_id == user_id or m.role == "assistant"
-                        ]
-                        user_messages.sort(key=lambda m: m.create_time)
+                for persona_id, persona_name in personas.items():
+                    # 按 batch_size 分批，每批完整时间线 + 所有用户
+                    for i in range(0, len(messages), req.batch_size):
+                        batch = messages[i : i + req.batch_size]
+                        batch_user_ids = list({
+                            m.user_id for m in batch
+                            if m.role == "user" and m.user_id and m.user_id != "__proactive__"
+                        })
+                        if not batch_user_ids:
+                            continue
 
                         try:
-                            result = await rebuild_relationship_memory_for_user(
+                            timeline = await format_timeline(batch, persona_name)
+                            if not timeline:
+                                continue
+                            await extract_relationship_updates(
                                 persona_id=persona_id,
-                                user_id=user_id,
-                                messages=user_messages,
-                                persona_name=persona_name,
-                                persona_lite=persona_lite,
-                                batch_size=req.batch_size,
+                                chat_id=chat_id,
+                                user_ids=batch_user_ids,
+                                messages_timeline=timeline,
                             )
-                            if result["final_version"] > 0:
-                                user_name = await get_username(user_id) or user_id[:6]
-                                logger.info(
-                                    f"[rebuild] {day_str} {persona_id}/{user_name}: "
-                                    f"v={result['final_version']}"
-                                )
+                            logger.info(
+                                f"[rebuild] {day_str} {persona_id} batch {i // req.batch_size + 1}: "
+                                f"{len(batch_user_ids)} users"
+                            )
                         except Exception as e:
-                            logger.error(f"[rebuild] {day_str} {persona_id}/{user_id} failed: {e}")
+                            logger.error(
+                                f"[rebuild] {day_str} {persona_id} batch {i // req.batch_size + 1} "
+                                f"failed: {e}"
+                            )
 
             logger.info(f"[rebuild] Day {day_count}/{total_days} ({day_str}) done.")
             day = next_day

--- a/apps/agent-service/app/services/afterthought.py
+++ b/apps/agent-service/app/services/afterthought.py
@@ -11,13 +11,14 @@ import asyncio
 import logging
 from datetime import datetime, timedelta, timezone
 
-from app.agents.infra.langfuse_client import get_prompt
-from app.agents.infra.model_builder import ModelBuilder
+from langchain.messages import HumanMessage
+
+from app.agents.core import ChatAgent
 from app.config.config import settings
-from app.orm.crud import get_bot_persona, get_chat_messages_in_range, get_username
+from app.orm.crud import get_bot_persona, get_chat_messages_in_range
 from app.orm.memory_crud import create_fragment
 from app.orm.memory_models import ExperienceFragment
-from app.utils.content_parser import parse_content
+from app.services.relationship_memory import format_timeline
 
 logger = logging.getLogger(__name__)
 
@@ -156,23 +157,28 @@ async def _generate_conversation_fragment(chat_id: str, persona_id: str) -> None
     scene = await _build_scene(chat_id, chat_type, messages)
 
     # Format timeline with plain names
-    timeline = await _format_timeline(messages, persona_name)
+    timeline = await format_timeline(messages, persona_name, tz=CST)
     if not timeline:
         logger.info(f"[{persona_id}] Empty timeline for {chat_id}, skip")
         return
 
-    # Call LLM
-    prompt = get_prompt("afterthought_conversation")
-    compiled = prompt.compile(
-        persona_name=persona_name,
-        persona_lite=persona_lite,
-        scene=scene,
-        messages=timeline,
+    # Call LLM via ChatAgent
+    agent = ChatAgent(
+        prompt_id="afterthought_conversation",
+        tools=[],
+        model_id=settings.diary_model,
+        trace_name="afterthought",
     )
-
-    model = await ModelBuilder.build_chat_model(settings.diary_model)
-    response = await model.ainvoke([{"role": "user", "content": compiled}])
-    content = _extract_text(response.content)
+    result = await agent.run(
+        messages=[HumanMessage(content="生成经历碎片")],
+        prompt_vars={
+            "persona_name": persona_name,
+            "persona_lite": persona_lite,
+            "scene": scene,
+            "messages": timeline,
+        },
+    )
+    content = _extract_text(result.content)
 
     if not content:
         logger.warning(f"[{persona_id}] Afterthought LLM returned empty for {chat_id}")
@@ -244,30 +250,3 @@ async def _build_scene(chat_id: str, chat_type: str, messages: list) -> str:
         return "在群里"
 
 
-async def _format_timeline(
-    messages: list,
-    persona_name: str,
-    max_messages: int = 50,
-) -> str:
-    """格式化消息列表为时间线文本，使用纯名字标注说话人
-
-    格式: [HH:MM] 名字: 消息内容
-    """
-    messages = messages[-max_messages:]
-
-    lines: list[str] = []
-    for msg in messages:
-        msg_time = datetime.fromtimestamp(msg.create_time / 1000, tz=CST)
-        time_str = msg_time.strftime("%H:%M")
-
-        if msg.role == "assistant":
-            speaker = persona_name
-        else:
-            name = await get_username(msg.user_id)
-            speaker = name or msg.user_id[:6]
-
-        rendered = parse_content(msg.content).render()
-        if rendered and rendered.strip():
-            lines.append(f"[{time_str}] {speaker}: {rendered[:200]}")
-
-    return "\n".join(lines)

--- a/apps/agent-service/app/services/relationship_memory.py
+++ b/apps/agent-service/app/services/relationship_memory.py
@@ -1,18 +1,57 @@
-"""关系记忆提取 — afterthought 碎片生成后，判断是否需要更新 per-user 关系记忆"""
+"""关系记忆提取 — afterthought 碎片生成后，判断是否需要更新 per-user 关系记忆
+
+所有 LLM 调用走 ChatAgent，自动 Langfuse trace + 重试。
+rebuild 复用 extract_relationship_updates，不维护两套提取逻辑。
+"""
 
 import json
 import logging
+from datetime import datetime, timezone
 
-from app.agents.infra.langfuse_client import get_prompt
-from app.agents.infra.model_builder import ModelBuilder
+from langchain.messages import HumanMessage
+
+from app.agents.core import ChatAgent
 from app.config.config import settings
 from app.orm.crud import get_bot_persona, get_username
 from app.orm.memory_crud import (
     get_relationship_memories_for_users,
     save_relationship_memory,
 )
+from app.utils.content_parser import parse_content
 
 logger = logging.getLogger(__name__)
+
+
+async def format_timeline(
+    messages: list,
+    persona_name: str,
+    *,
+    tz: timezone = timezone.utc,
+    max_messages: int = 50,
+) -> str:
+    """格式化消息列表为时间线文本
+
+    格式: [HH:MM] 名字: 消息内容
+    afterthought 和 rebuild 共用此函数。
+    """
+    messages = messages[-max_messages:]
+
+    lines: list[str] = []
+    for msg in messages:
+        msg_time = datetime.fromtimestamp(msg.create_time / 1000, tz=tz)
+        time_str = msg_time.strftime("%H:%M")
+
+        if msg.role == "assistant":
+            speaker = persona_name
+        else:
+            name = await get_username(msg.user_id)
+            speaker = name or msg.user_id[:6]
+
+        rendered = parse_content(msg.content).render()
+        if rendered and rendered.strip():
+            lines.append(f"[{time_str}] {speaker}: {rendered[:200]}")
+
+    return "\n".join(lines)
 
 
 async def extract_relationship_updates(
@@ -23,21 +62,18 @@ async def extract_relationship_updates(
 ) -> None:
     """从一段对话中提取关系记忆更新
 
-    在 afterthought 生成 conversation 碎片后调用。
-    让 LLM 以角色视角判断对话中涉及的人是否有关系变化，有则写入 relationship_memory。
+    在 afterthought 生成 conversation 碎片后调用，rebuild 也复用此函数。
+    通过 ChatAgent 调用 LLM，自动 Langfuse trace。
     """
     if not user_ids:
         return
 
-    # 获取 persona 信息（注入角色视角）
     persona = await get_bot_persona(persona_id)
     persona_name = persona.display_name if persona else persona_id
     persona_lite = persona.persona_lite if persona else ""
 
-    # 获取当前关系记忆
     current_memories = await get_relationship_memories_for_users(persona_id, user_ids)
 
-    # 构建当前记忆上下文（分 core_facts / impression）
     core_facts_lines = []
     impression_lines = []
     for uid in user_ids:
@@ -51,19 +87,24 @@ async def extract_relationship_updates(
             core_facts_lines.append(f"- {name}({uid}): （第一次互动）")
             impression_lines.append(f"- {name}({uid}): （第一次互动）")
 
-    prompt = get_prompt("relationship_extract")
-    compiled = prompt.compile(
-        persona_name=persona_name,
-        persona_lite=persona_lite,
-        messages=messages_timeline,
-        current_core_facts="\n".join(core_facts_lines),
-        current_impression="\n".join(impression_lines),
+    agent = ChatAgent(
+        prompt_id="relationship_extract",
+        tools=[],
+        model_id=settings.relationship_model,
+        trace_name="relationship-extract",
+    )
+    result = await agent.run(
+        messages=[HumanMessage(content="根据对话更新关系记忆")],
+        prompt_vars={
+            "persona_name": persona_name,
+            "persona_lite": persona_lite,
+            "messages": messages_timeline,
+            "current_core_facts": "\n".join(core_facts_lines),
+            "current_impression": "\n".join(impression_lines),
+        },
     )
 
-    model = await ModelBuilder.build_chat_model(settings.relationship_model)
-    response = await model.ainvoke([{"role": "user", "content": compiled}])
-
-    content = response.content
+    content = result.content or ""
     if isinstance(content, list):
         content = "".join(
             part.get("text", "") if isinstance(part, dict) else str(part)
@@ -74,7 +115,6 @@ async def extract_relationship_updates(
         logger.info(f"[{persona_id}] No relationship updates for chat {chat_id}")
         return
 
-    # 解析 JSON 输出（strip markdown code fence）
     content = content.strip()
     if content.startswith("```"):
         content = content.split("\n", 1)[-1].rsplit("```", 1)[0].strip()
@@ -104,139 +144,3 @@ async def extract_relationship_updates(
                 f"[{persona_id}] Relationship updated for {name}: "
                 f"facts={core_facts[:30]}... impression={impression[:30]}..."
             )
-
-
-async def rebuild_relationship_memory_for_user(
-    persona_id: str,
-    user_id: str,
-    messages: list,
-    persona_name: str,
-    persona_lite: str,
-    batch_size: int = 50,
-) -> dict:
-    """为单个 (persona_id, user_id) 渐进式重建关系记忆
-
-    Args:
-        messages: 该用户参与的 ConversationMessage 列表（按时间正序）
-        persona_name: 角色显示名
-        persona_lite: 角色简介
-        batch_size: 每批消息数量
-
-    Returns:
-        {"batches": int, "final_version": int, "core_facts": str, "impression": str}
-    """
-    from datetime import datetime, timezone
-    from app.orm.memory_crud import get_latest_relationship_memory
-
-    user_name = await get_username(user_id) or user_id[:6]
-
-    # 从 DB 加载已有记忆作为起点，而不是从零开始
-    existing = await get_latest_relationship_memory(persona_id, user_id)
-    if existing:
-        current_core_facts, current_impression = existing
-        logger.info(
-            f"[rebuild] {persona_id}/{user_name}: loaded existing memory "
-            f"(facts={current_core_facts[:50]}...)"
-        )
-    else:
-        current_core_facts = ""
-        current_impression = ""
-        logger.info(f"[rebuild] {persona_id}/{user_name}: no existing memory, starting fresh")
-    prev_core_facts = current_core_facts
-    prev_impression = current_impression
-    batch_count = 0
-    final_version = 0
-
-    # 预加载所有出现的 user_id → name 映射，避免 N+1 查询
-    unique_uids = {m.user_id for m in messages if m.role == "user" and m.user_id}
-    name_cache: dict[str, str] = {}
-    for uid in unique_uids:
-        name_cache[uid] = await get_username(uid) or uid[:6]
-
-    for i in range(0, len(messages), batch_size):
-        batch = messages[i : i + batch_size]
-        batch_count += 1
-
-        # 格式化时间线
-        lines = []
-        for msg in batch:
-            msg_time = datetime.fromtimestamp(msg.create_time / 1000, tz=timezone.utc)
-            time_str = msg_time.strftime("%H:%M")
-            if msg.role == "assistant":
-                speaker = persona_name
-            else:
-                speaker = name_cache.get(msg.user_id, msg.user_id[:6])
-            content = msg.content or ""
-            if content.strip():
-                lines.append(f"[{time_str}] {speaker}: {content[:200]}")
-
-        if not lines:
-            continue
-
-        timeline = "\n".join(lines)
-
-        # 构建 prompt 上下文
-        cf_line = f"- {user_name}({user_id}): {current_core_facts or '（第一次互动）'}"
-        im_line = f"- {user_name}({user_id}): {current_impression or '（第一次互动）'}"
-
-        prompt = get_prompt("relationship_extract")
-        compiled = prompt.compile(
-            persona_name=persona_name,
-            persona_lite=persona_lite,
-            messages=timeline,
-            current_core_facts=cf_line,
-            current_impression=im_line,
-        )
-
-        model = await ModelBuilder.build_chat_model(settings.relationship_model)
-        response = await model.ainvoke([{"role": "user", "content": compiled}])
-
-        content_text = response.content
-        if isinstance(content_text, list):
-            content_text = "".join(
-                part.get("text", "") if isinstance(part, dict) else str(part)
-                for part in content_text
-            ).strip()
-
-        if not content_text or content_text.strip() == "[]":
-            continue
-
-        # strip markdown code fence
-        content_text = content_text.strip()
-        if content_text.startswith("```"):
-            content_text = content_text.split("\n", 1)[-1].rsplit("```", 1)[0].strip()
-
-        try:
-            updates = json.loads(content_text)
-        except json.JSONDecodeError:
-            logger.warning(f"[rebuild] Failed to parse batch {batch_count}: {content_text[:100]}")
-            continue
-
-        for item in updates:
-            if not isinstance(item, dict):
-                continue
-            if item.get("user_id") == user_id:
-                current_core_facts = item.get("core_facts", current_core_facts)
-                current_impression = item.get("impression", current_impression)
-                break
-
-        # 仅在内容变化时写入，避免重复 version
-        if (current_core_facts or current_impression) and \
-           (current_core_facts, current_impression) != (prev_core_facts, prev_impression):
-            await save_relationship_memory(
-                persona_id=persona_id,
-                user_id=user_id,
-                user_name=user_name,
-                core_facts=current_core_facts,
-                impression=current_impression,
-                source="rebuild",
-            )
-            prev_core_facts, prev_impression = current_core_facts, current_impression
-            final_version += 1
-
-    return {
-        "batches": batch_count,
-        "final_version": final_version,
-        "core_facts": current_core_facts,
-        "impression": current_impression,
-    }

--- a/apps/agent-service/app/services/relationship_memory.py
+++ b/apps/agent-service/app/services/relationship_memory.py
@@ -27,7 +27,7 @@ async def format_timeline(
     persona_name: str,
     *,
     tz: timezone = timezone.utc,
-    max_messages: int = 50,
+    max_messages: int = 2000,
 ) -> str:
     """格式化消息列表为时间线文本
 

--- a/apps/agent-service/app/services/voice_generator.py
+++ b/apps/agent-service/app/services/voice_generator.py
@@ -7,8 +7,9 @@
 import logging
 from datetime import datetime, timedelta, timezone
 
-from app.agents.infra.langfuse_client import get_prompt
-from app.agents.infra.model_builder import ModelBuilder
+from langchain.messages import HumanMessage
+
+from app.agents.core import ChatAgent
 from app.config.config import settings
 from app.orm.crud import get_bot_persona, get_plan_for_period
 from app.orm.memory_crud import get_today_fragments, save_reply_style
@@ -23,30 +24,21 @@ async def generate_voice(
     recent_context: str = "",
     source: str = "cron",
 ) -> str | None:
-    """生成完整 voice 内容（内心独白 + 风格示例）
-
-    Args:
-        persona_id: bot persona ID
-        recent_context: 可选，近期消息+回复（event-driven 路径传入）
-        source: "cron" 或 "drift"，写入 reply_style_log.source
-    """
+    """生成完整 voice 内容（内心独白 + 风格示例）"""
     persona = await get_bot_persona(persona_id)
     if not persona:
         return None
 
-    # Life Engine 状态
     from app.services.life_engine import _load_state
     le_state = await _load_state(persona_id)
     current_state = le_state.current_state if le_state else "（状态未知）"
     response_mood = le_state.response_mood if le_state else ""
 
-    # 当前时段的 schedule
     now = datetime.now(CST)
     today = now.strftime("%Y-%m-%d")
     schedule = await get_plan_for_period("daily", today, today, persona_id)
     schedule_text = schedule.content if schedule else "（今天没有安排）"
 
-    # 最近碎片
     frags = await get_today_fragments(persona_id, grains=["conversation"])
     frag_text = (
         "\n".join(f.content[:100] for f in frags[-3:])
@@ -54,30 +46,31 @@ async def generate_voice(
         else "（今天还没跟人聊过）"
     )
 
-    # 组装 recent_context（event-driven 路径会传入具体内容）
     recent_ctx_block = ""
     if recent_context:
-        recent_ctx_block = (
-            f"最近的对话和你的回复：\n{recent_context}"
-        )
+        recent_ctx_block = f"最近的对话和你的回复：\n{recent_context}"
 
-    # 调用 LLM
-    prompt = get_prompt("voice_generator")
-    compiled = prompt.compile(
-        persona_name=persona.display_name,
-        persona_lite=persona.persona_lite,
-        current_state=current_state,
-        response_mood=response_mood,
-        schedule_segment=schedule_text,
-        recent_fragments=frag_text,
-        recent_context=recent_ctx_block,
-        current_time=now.strftime("%H:%M"),
+    agent = ChatAgent(
+        prompt_id="voice_generator",
+        tools=[],
+        model_id=settings.identity_drift_model,
+        trace_name="voice-generator",
+    )
+    result = await agent.run(
+        messages=[HumanMessage(content="生成当前状态的内心独白和语气示例")],
+        prompt_vars={
+            "persona_name": persona.display_name,
+            "persona_lite": persona.persona_lite,
+            "current_state": current_state,
+            "response_mood": response_mood,
+            "schedule_segment": schedule_text,
+            "recent_fragments": frag_text,
+            "recent_context": recent_ctx_block,
+            "current_time": now.strftime("%H:%M"),
+        },
     )
 
-    model = await ModelBuilder.build_chat_model(settings.identity_drift_model)
-    response = await model.ainvoke([{"role": "user", "content": compiled}])
-
-    content = response.content
+    content = result.content or ""
     if isinstance(content, list):
         content = "".join(
             part.get("text", "") if isinstance(part, dict) else str(part)
@@ -88,7 +81,6 @@ async def generate_voice(
         logger.warning(f"[{persona_id}] Voice generation returned empty")
         return None
 
-    # 保存到 reply_style_log（复用现有表，voice 内容包含 monologue + examples）
     await save_reply_style(persona_id, content, source=source)
     logger.info(f"[{persona_id}] Voice generated ({source}): {content[:60]}...")
     return content

--- a/apps/agent-service/app/workers/dream_worker.py
+++ b/apps/agent-service/app/workers/dream_worker.py
@@ -10,8 +10,9 @@ weekly dream: 最近 7 个 daily 碎片 → 一周回顾
 import logging
 from datetime import date, datetime, timedelta, timezone
 
-from app.agents.infra.langfuse_client import get_prompt
-from app.agents.infra.model_builder import ModelBuilder
+from langchain.messages import HumanMessage
+
+from app.agents.core import ChatAgent
 from app.config.config import settings
 from app.orm.crud import get_all_persona_ids, get_bot_persona
 from app.orm.memory_crud import create_fragment, get_fragments_in_date_range, get_recent_fragments_by_grain
@@ -44,36 +45,23 @@ async def cron_generate_weekly_dreams(ctx) -> None:
 
 
 async def generate_daily_dream(persona_id: str, target_date: date | None = None) -> ExperienceFragment | None:
-    """生成 daily 碎片
-
-    Args:
-        persona_id: persona 标识
-        target_date: 目标日期，默认为昨天
-
-    Returns:
-        写入的 ExperienceFragment，无碎片时返回 None
-    """
+    """生成 daily 碎片"""
     if target_date is None:
         target_date = date.today() - timedelta(days=1)
 
     day_start = datetime(target_date.year, target_date.month, target_date.day, tzinfo=CST)
     day_end = day_start + timedelta(days=1)
 
-    # 1. 取当天 conversation + glimpse 碎片
     today_frags = await get_fragments_in_date_range(
         persona_id, target_date, target_date, grains=["conversation", "glimpse"]
     )
-
     if not today_frags:
         logger.info(f"[{persona_id}] No fragments for {target_date}, skip daily dream")
         return None
 
     persona_obj = await get_bot_persona(persona_id)
-
-    # 2. 最近 daily 碎片（连续性上下文）
     recent_dailies = await get_recent_fragments_by_grain(persona_id, "daily", limit=3)
 
-    # 3. 格式化
     persona_name = persona_obj.display_name if persona_obj else persona_id
     persona_lite = persona_obj.persona_lite if persona_obj else ""
     today_text = "\n\n---\n\n".join(f.content for f in today_frags)
@@ -83,24 +71,28 @@ async def generate_daily_dream(persona_id: str, target_date: date | None = None)
         else "（前几天没有做梦）"
     )
 
-    # 4. LLM 生成
-    prompt_template = get_prompt("dream_daily")
-    compiled = prompt_template.compile(
-        persona_name=persona_name,
-        persona_lite=persona_lite,
-        date=target_date.isoformat(),
-        today_fragments=today_text,
-        recent_dreams=recent_text,
+    agent = ChatAgent(
+        prompt_id="dream_daily",
+        tools=[],
+        model_id=settings.diary_model,
+        trace_name="dream-daily",
     )
-    model = await ModelBuilder.build_chat_model(settings.diary_model)
-    response = await model.ainvoke([{"role": "user", "content": compiled}])
-    content = _extract_text(response.content)
+    result = await agent.run(
+        messages=[HumanMessage(content="回忆今天发生的事")],
+        prompt_vars={
+            "persona_name": persona_name,
+            "persona_lite": persona_lite,
+            "date": target_date.isoformat(),
+            "today_fragments": today_text,
+            "recent_dreams": recent_text,
+        },
+    )
+    content = _extract_text(result.content)
 
     if not content:
         logger.warning(f"[{persona_id}] Daily dream LLM returned empty for {target_date}")
         return None
 
-    # 5. 写入碎片
     fragment = ExperienceFragment(
         persona_id=persona_id,
         grain="daily",
@@ -115,15 +107,7 @@ async def generate_daily_dream(persona_id: str, target_date: date | None = None)
 
 
 async def generate_weekly_dream(persona_id: str, target_date: date | None = None) -> ExperienceFragment | None:
-    """生成 weekly 碎片 from 最近 7 个 daily 碎片
-
-    Args:
-        persona_id: persona 标识
-        target_date: 基准日期（本周一），默认为今天
-
-    Returns:
-        写入的 ExperienceFragment，无 daily 碎片时返回 None
-    """
+    """生成 weekly 碎片 from 最近 7 个 daily 碎片"""
     if target_date is None:
         target_date = date.today()
 
@@ -137,15 +121,21 @@ async def generate_weekly_dream(persona_id: str, target_date: date | None = None
     persona_lite = persona_obj.persona_lite if persona_obj else ""
     dailies_text = "\n\n---\n\n".join(f.content for f in reversed(dailies))
 
-    prompt_template = get_prompt("dream_weekly")
-    compiled = prompt_template.compile(
-        persona_name=persona_name,
-        persona_lite=persona_lite,
-        dailies=dailies_text,
+    agent = ChatAgent(
+        prompt_id="dream_weekly",
+        tools=[],
+        model_id=settings.diary_model,
+        trace_name="dream-weekly",
     )
-    model = await ModelBuilder.build_chat_model(settings.diary_model)
-    response = await model.ainvoke([{"role": "user", "content": compiled}])
-    content = _extract_text(response.content)
+    result = await agent.run(
+        messages=[HumanMessage(content="回顾这一周")],
+        prompt_vars={
+            "persona_name": persona_name,
+            "persona_lite": persona_lite,
+            "dailies": dailies_text,
+        },
+    )
+    content = _extract_text(result.content)
 
     if not content:
         logger.warning(f"[{persona_id}] Weekly dream LLM returned empty")

--- a/apps/agent-service/app/workers/schedule_worker.py
+++ b/apps/agent-service/app/workers/schedule_worker.py
@@ -13,6 +13,9 @@
 import logging
 from datetime import date, datetime, timedelta, timezone
 
+from langchain.messages import HumanMessage
+
+from app.agents.core import ChatAgent
 from app.agents.infra.langfuse_client import get_prompt
 from app.agents.infra.model_builder import ModelBuilder
 from app.config.config import settings
@@ -125,26 +128,30 @@ async def _run_writer(
     from app.agents.core.config import AgentRegistry
 
     config = AgentRegistry.get("schedule-writer")
-    prompt_template = get_prompt(config.prompt_id)
-
     weekday = _WEEKDAY_CN[target_date.weekday()]
     is_weekend = "周末！" if target_date.weekday() >= 5 else ""
 
-    compiled = prompt_template.compile(
-        persona_core=persona_core,
-        date=target_date.isoformat(),
-        weekday=weekday,
-        is_weekend=is_weekend,
-        weekly_plan=weekly_plan,
-        yesterday_journal=yesterday_journal,
-        ideation_output=ideation_output,
-        previous_output=previous_output,
-        critic_feedback=critic_feedback,
+    agent = ChatAgent(
+        prompt_id=config.prompt_id,
+        tools=[],
+        model_id=config.model_id,
+        trace_name=config.trace_name,
     )
-
-    model = await ModelBuilder.build_chat_model(config.model_id)
-    response = await model.ainvoke([{"role": "user", "content": compiled}])
-    return _extract_text(response.content)
+    result = await agent.run(
+        messages=[HumanMessage(content="写今天的手帐")],
+        prompt_vars={
+            "persona_core": persona_core,
+            "date": target_date.isoformat(),
+            "weekday": weekday,
+            "is_weekend": is_weekend,
+            "weekly_plan": weekly_plan,
+            "yesterday_journal": yesterday_journal,
+            "ideation_output": ideation_output,
+            "previous_output": previous_output,
+            "critic_feedback": critic_feedback,
+        },
+    )
+    return _extract_text(result.content)
 
 
 async def _run_critic(
@@ -156,17 +163,22 @@ async def _run_critic(
     from app.agents.core.config import AgentRegistry
 
     config = AgentRegistry.get("schedule-critic")
-    prompt_template = get_prompt(config.prompt_id)
 
-    compiled = prompt_template.compile(
-        persona_name=persona_name,
-        today_schedule=schedule_text,
-        recent_schedules=recent_schedules_text,
+    agent = ChatAgent(
+        prompt_id=config.prompt_id,
+        tools=[],
+        model_id=config.model_id,
+        trace_name=config.trace_name,
     )
-
-    model = await ModelBuilder.build_chat_model(config.model_id)
-    response = await model.ainvoke([{"role": "user", "content": compiled}])
-    return _extract_text(response.content)
+    result = await agent.run(
+        messages=[HumanMessage(content="审查今天的手帐质量")],
+        prompt_vars={
+            "persona_name": persona_name,
+            "today_schedule": schedule_text,
+            "recent_schedules": recent_schedules_text,
+        },
+    )
+    return _extract_text(result.content)
 
 
 # ==================== ArQ cron 入口 ====================
@@ -250,22 +262,26 @@ async def generate_monthly_plan(
     season = _get_season(month_start.month)
     month_cn = f"{month_start.year}年{month_start.month}月"
 
-    # 获取人设和 Langfuse prompt 并编译
     from app.orm.crud import get_bot_persona as _get_persona
     _persona = await _get_persona(persona_id)
-    prompt_template = get_prompt("schedule_monthly")
-    compiled = prompt_template.compile(
-        persona_name=_persona.display_name if _persona else persona_id,
-        persona_core=_persona.persona_core if _persona else "",
-        month=month_cn,
-        season=season,
-        previous_monthly_plan=prev_plan_text,
-    )
 
-    # 调用 LLM
-    model = await ModelBuilder.build_chat_model(_schedule_model())
-    response = await model.ainvoke([{"role": "user", "content": compiled}])
-    content = _extract_text(response.content)
+    agent = ChatAgent(
+        prompt_id="schedule_monthly",
+        tools=[],
+        model_id=_schedule_model(),
+        trace_name="schedule-monthly",
+    )
+    result = await agent.run(
+        messages=[HumanMessage(content="制定本月计划")],
+        prompt_vars={
+            "persona_name": _persona.display_name if _persona else persona_id,
+            "persona_core": _persona.persona_core if _persona else "",
+            "month": month_cn,
+            "season": season,
+            "previous_monthly_plan": prev_plan_text,
+        },
+    )
+    content = _extract_text(result.content)
 
     if not content:
         logger.warning(f"LLM returned empty monthly plan for {month_cn}")
@@ -334,22 +350,26 @@ async def generate_weekly_plan(
 
     week_desc = f"{period_start}（{_WEEKDAY_CN[week_start.weekday()]}）~ {period_end}（{_WEEKDAY_CN[week_end.weekday()]}）"
 
-    # 获取人设和 Langfuse prompt 并编译
     from app.orm.crud import get_bot_persona as _get_persona
     _persona = await _get_persona(persona_id)
-    prompt_template = get_prompt("schedule_weekly")
-    compiled = prompt_template.compile(
-        persona_name=_persona.display_name if _persona else persona_id,
-        persona_core=_persona.persona_core if _persona else "",
-        week=week_desc,
-        monthly_plan=monthly_text,
-        previous_weekly_plan=prev_plan_text,
-    )
 
-    # 调用 LLM
-    model = await ModelBuilder.build_chat_model(_schedule_model())
-    response = await model.ainvoke([{"role": "user", "content": compiled}])
-    content = _extract_text(response.content)
+    agent = ChatAgent(
+        prompt_id="schedule_weekly",
+        tools=[],
+        model_id=_schedule_model(),
+        trace_name="schedule-weekly",
+    )
+    result = await agent.run(
+        messages=[HumanMessage(content="制定本周计划")],
+        prompt_vars={
+            "persona_name": _persona.display_name if _persona else persona_id,
+            "persona_core": _persona.persona_core if _persona else "",
+            "week": week_desc,
+            "monthly_plan": monthly_text,
+            "previous_weekly_plan": prev_plan_text,
+        },
+    )
+    content = _extract_text(result.content)
 
     if not content:
         logger.warning(f"LLM returned empty weekly plan for {week_desc}")


### PR DESCRIPTION
## Summary
- **根因修复**: rebuild 端点之前逐用户处理+砍掉对话上下文，导致 core_facts 张冠李戴（王浩任的属性贴到高佳乐身上等）。改为复用 extract_relationship_updates，按天整体处理，完整时间线
- **禁止裸调模型**: 9+ 处 model.ainvoke() 裸调改为走 ChatAgent，自动 Langfuse trace + 重试
- **删除 rebuild_relationship_memory_for_user**: 不再维护两套提取逻辑
- **注册 7 个新 AgentConfig**: relationship-extract, afterthought, voice-generator, dream-daily/weekly, schedule-monthly/weekly
- **Langfuse prompt v9**: 去掉工程规则补丁，用自然语言引导

## Test plan
- [x] 泳道部署验证 rebuild 输出无张冠李戴
- [x] Langfuse trace 可见完整输入输出
- [x] 消息渲染为纯文本（非 raw JSON）

🤖 Generated with [Claude Code](https://claude.com/claude-code)