### PR TITLE
feat(relationship-memory): 两阶段提取管线重设计

### DIFF
--- a/apps/agent-service/app/agents/core/config.py
+++ b/apps/agent-service/app/agents/core/config.py
@@ -91,6 +91,15 @@ AgentRegistry.register(
 )
 
 AgentRegistry.register(
+    "relationship-filter",
+    AgentConfig(
+        prompt_id="relationship_filter",
+        model_id="relationship-model",
+        trace_name="relationship-filter",
+    ),
+)
+
+AgentRegistry.register(
     "relationship-extract",
     AgentConfig(
         prompt_id="relationship_extract",

--- a/apps/agent-service/app/api/router.py
+++ b/apps/agent-service/app/api/router.py
@@ -169,10 +169,7 @@ async def rebuild_relationship_memory(req: RebuildRelationshipMemoryRequest):
     async def _run():
         from datetime import datetime, timedelta
         from app.orm.crud import get_bot_persona, get_chat_messages_in_range
-        from app.services.relationship_memory import (
-            extract_relationship_updates,
-            format_timeline,
-        )
+        from app.services.relationship_memory import extract_relationship_updates
 
         start_dt = datetime.fromisoformat(req.start_time)
         end_dt = datetime.fromisoformat(req.end_time)
@@ -218,14 +215,11 @@ async def rebuild_relationship_memory(req: RebuildRelationshipMemoryRequest):
 
                 for persona_id, persona_name in personas.items():
                     try:
-                        timeline = await format_timeline(messages, persona_name)
-                        if not timeline:
-                            continue
                         await extract_relationship_updates(
                             persona_id=persona_id,
                             chat_id=chat_id,
                             user_ids=user_ids,
-                            messages_timeline=timeline,
+                            messages=messages,
                         )
                         logger.info(
                             f"[rebuild] {day_str} {persona_id}: "

--- a/apps/agent-service/app/orm/memory_crud.py
+++ b/apps/agent-service/app/orm/memory_crud.py
@@ -222,7 +222,7 @@ async def save_relationship_memory(
     impression: str,
     source: str,
 ) -> None:
-    """写入关系记忆（append-only，version 自增）"""
+    """写入关系记忆（append-only，version 自增）— 旧表，线上在用"""
     from app.orm.memory_models import RelationshipMemory
 
     async with AsyncSessionLocal() as session:
@@ -244,6 +244,63 @@ async def save_relationship_memory(
             source=source,
         ))
         await session.commit()
+
+
+async def save_relationship_memory_v2(
+    persona_id: str,
+    user_id: str,
+    core_facts: str,
+    impression: str,
+    source: str,
+) -> None:
+    """写入关系记忆 v2（append-only，version 自增）"""
+    from app.orm.memory_models import RelationshipMemoryV2
+
+    async with AsyncSessionLocal() as session:
+        result = await session.execute(
+            select(func.max(RelationshipMemoryV2.version))
+            .where(RelationshipMemoryV2.persona_id == persona_id)
+            .where(RelationshipMemoryV2.user_id == user_id)
+        )
+        max_version = result.scalar_one_or_none() or 0
+
+        session.add(RelationshipMemoryV2(
+            persona_id=persona_id,
+            user_id=user_id,
+            version=max_version + 1,
+            core_facts=core_facts,
+            impression=impression,
+            source=source,
+        ))
+        await session.commit()
+
+
+async def get_relationship_memories_for_users_v2(
+    persona_id: str,
+    user_ids: list[str],
+) -> dict[str, tuple[str, str]]:
+    """批量获取 v2 表多个用户的最新关系记忆"""
+    from app.orm.memory_models import RelationshipMemoryV2
+
+    if not user_ids:
+        return {}
+
+    async with AsyncSessionLocal() as session:
+        result = await session.execute(
+            select(
+                RelationshipMemoryV2.user_id,
+                RelationshipMemoryV2.core_facts,
+                RelationshipMemoryV2.impression,
+            )
+            .where(RelationshipMemoryV2.persona_id == persona_id)
+            .where(RelationshipMemoryV2.user_id.in_(user_ids))
+            .distinct(RelationshipMemoryV2.user_id)
+            .order_by(RelationshipMemoryV2.user_id, RelationshipMemoryV2.created_at.desc())
+        )
+        return {
+            row.user_id: (row.core_facts, row.impression)
+            for row in result.all()
+        }
 
 
 async def get_latest_relationship_memory(

--- a/apps/agent-service/app/orm/memory_crud.py
+++ b/apps/agent-service/app/orm/memory_crud.py
@@ -214,38 +214,6 @@ async def get_last_bot_reply_time(chat_id: str) -> int:
         return result.scalar_one_or_none() or 0
 
 
-async def save_relationship_memory(
-    persona_id: str,
-    user_id: str,
-    user_name: str,
-    core_facts: str,
-    impression: str,
-    source: str,
-) -> None:
-    """写入关系记忆（append-only，version 自增）— 旧表，线上在用"""
-    from app.orm.memory_models import RelationshipMemory
-
-    async with AsyncSessionLocal() as session:
-        result = await session.execute(
-            select(func.max(RelationshipMemory.version))
-            .where(RelationshipMemory.persona_id == persona_id)
-            .where(RelationshipMemory.user_id == user_id)
-        )
-        max_version = result.scalar_one_or_none() or 0
-
-        session.add(RelationshipMemory(
-            persona_id=persona_id,
-            user_id=user_id,
-            user_name=user_name,
-            memory_text="",
-            version=max_version + 1,
-            core_facts=core_facts,
-            impression=impression,
-            source=source,
-        ))
-        await session.commit()
-
-
 async def save_relationship_memory_v2(
     persona_id: str,
     user_id: str,
@@ -326,61 +294,4 @@ async def get_relationship_memories_for_users_v2(
         }
 
 
-async def get_latest_relationship_memory(
-    persona_id: str, user_id: str
-) -> tuple[str, str] | None:
-    """获取指定用户的最新关系记忆，返回 (core_facts, impression) 或 None"""
-    from app.orm.memory_models import RelationshipMemory
-
-    async with AsyncSessionLocal() as session:
-        result = await session.execute(
-            select(
-                RelationshipMemory.core_facts,
-                RelationshipMemory.impression,
-                RelationshipMemory.memory_text,
-            )
-            .where(RelationshipMemory.persona_id == persona_id)
-            .where(RelationshipMemory.user_id == user_id)
-            .order_by(RelationshipMemory.created_at.desc())
-            .limit(1)
-        )
-        row = result.one_or_none()
-        if row is None:
-            return None
-        if row.core_facts or row.impression:
-            return (row.core_facts, row.impression)
-        return (row.memory_text, "")
-
-
-async def get_relationship_memories_for_users(
-    persona_id: str,
-    user_ids: list[str],
-) -> dict[str, tuple[str, str]]:
-    """批量获取多个用户的最新关系记忆，返回 {user_id: (core_facts, impression)}"""
-    from app.orm.memory_models import RelationshipMemory
-
-    if not user_ids:
-        return {}
-
-    async with AsyncSessionLocal() as session:
-        # 用 PostgreSQL DISTINCT ON 一次查出每个 user 的最新一行
-        result = await session.execute(
-            select(
-                RelationshipMemory.user_id,
-                RelationshipMemory.core_facts,
-                RelationshipMemory.impression,
-                RelationshipMemory.memory_text,
-            )
-            .where(RelationshipMemory.persona_id == persona_id)
-            .where(RelationshipMemory.user_id.in_(user_ids))
-            .distinct(RelationshipMemory.user_id)
-            .order_by(RelationshipMemory.user_id, RelationshipMemory.created_at.desc())
-        )
-        out: dict[str, tuple[str, str]] = {}
-        for row in result.all():
-            if row.core_facts or row.impression:
-                out[row.user_id] = (row.core_facts, row.impression)
-            else:
-                out[row.user_id] = (row.memory_text, "")
-        return out
 

--- a/apps/agent-service/app/orm/memory_crud.py
+++ b/apps/agent-service/app/orm/memory_crud.py
@@ -275,6 +275,29 @@ async def save_relationship_memory_v2(
         await session.commit()
 
 
+async def get_latest_relationship_memory_v2(
+    persona_id: str, user_id: str
+) -> tuple[str, str] | None:
+    """获取 v2 表指定用户的最新关系记忆，返回 (core_facts, impression) 或 None"""
+    from app.orm.memory_models import RelationshipMemoryV2
+
+    async with AsyncSessionLocal() as session:
+        result = await session.execute(
+            select(
+                RelationshipMemoryV2.core_facts,
+                RelationshipMemoryV2.impression,
+            )
+            .where(RelationshipMemoryV2.persona_id == persona_id)
+            .where(RelationshipMemoryV2.user_id == user_id)
+            .order_by(RelationshipMemoryV2.created_at.desc())
+            .limit(1)
+        )
+        row = result.one_or_none()
+        if row is None:
+            return None
+        return (row.core_facts, row.impression)
+
+
 async def get_relationship_memories_for_users_v2(
     persona_id: str,
     user_ids: list[str],

--- a/apps/agent-service/app/orm/memory_models.py
+++ b/apps/agent-service/app/orm/memory_models.py
@@ -112,7 +112,7 @@ class ReplyStyleLog(Base):
 
 
 class RelationshipMemory(Base):
-    """关系记忆 — per-user 的自然语言关系描述，append-only"""
+    """关系记忆 — per-user 的自然语言关系描述，append-only（旧表，线上在用）"""
 
     __tablename__ = "relationship_memory"
 
@@ -131,6 +131,27 @@ class RelationshipMemory(Base):
 
     __table_args__ = (
         Index("idx_rel_mem_persona_user_created", "persona_id", "user_id", created_at.desc()),
+    )
+
+
+class RelationshipMemoryV2(Base):
+    """关系记忆 v2 — 两阶段管线产出，去掉冗余 user_name/memory_text"""
+
+    __tablename__ = "relationship_memory_v2"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    persona_id: Mapped[str] = mapped_column(String(50), nullable=False)
+    user_id: Mapped[str] = mapped_column(String(100), nullable=False)
+    core_facts: Mapped[str] = mapped_column(Text, nullable=False, server_default="")
+    impression: Mapped[str] = mapped_column(Text, nullable=False, server_default="")
+    source: Mapped[str] = mapped_column(String(20), nullable=False)
+    version: Mapped[int] = mapped_column(Integer, nullable=False, server_default="1")
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now()
+    )
+
+    __table_args__ = (
+        Index("idx_rel_mem_v2_persona_user_created", "persona_id", "user_id", created_at.desc()),
     )
 
 

--- a/apps/agent-service/app/orm/memory_models.py
+++ b/apps/agent-service/app/orm/memory_models.py
@@ -111,29 +111,6 @@ class ReplyStyleLog(Base):
     )
 
 
-class RelationshipMemory(Base):
-    """关系记忆 — per-user 的自然语言关系描述，append-only（旧表，线上在用）"""
-
-    __tablename__ = "relationship_memory"
-
-    id: Mapped[int] = mapped_column(primary_key=True)
-    persona_id: Mapped[str] = mapped_column(String(50), nullable=False)
-    user_id: Mapped[str] = mapped_column(String(100), nullable=False)
-    user_name: Mapped[str] = mapped_column(String(100), nullable=False, server_default="")
-    memory_text: Mapped[str] = mapped_column(Text, nullable=False, server_default="")
-    version: Mapped[int] = mapped_column(Integer, nullable=False, server_default="1")
-    core_facts: Mapped[str] = mapped_column(Text, nullable=False, server_default="")
-    impression: Mapped[str] = mapped_column(Text, nullable=False, server_default="")
-    source: Mapped[str] = mapped_column(String(20), nullable=False)
-    created_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), server_default=func.now()
-    )
-
-    __table_args__ = (
-        Index("idx_rel_mem_persona_user_created", "persona_id", "user_id", created_at.desc()),
-    )
-
-
 class RelationshipMemoryV2(Base):
     """关系记忆 v2 — 两阶段管线产出，去掉冗余 user_name/memory_text"""
 

--- a/apps/agent-service/app/orm/models.py
+++ b/apps/agent-service/app/orm/models.py
@@ -24,6 +24,7 @@ class Base(DeclarativeBase):
 class LarkUser(Base):
     __tablename__ = "lark_user"
 
+    id: Mapped[int] = mapped_column(BigInteger, autoincrement=True, unique=True)
     union_id: Mapped[str] = mapped_column(String, primary_key=True)
     name: Mapped[str] = mapped_column(String)
     avatar_origin: Mapped[str | None] = mapped_column(Text, nullable=True)
@@ -63,6 +64,7 @@ class ModelMapping(Base):
 class ConversationMessage(Base):
     __tablename__ = "conversation_messages"
 
+    id: Mapped[int] = mapped_column(BigInteger, autoincrement=True, unique=True)
     message_id: Mapped[str] = mapped_column(String(100), primary_key=True)
     user_id: Mapped[str] = mapped_column(String(100))
     content: Mapped[str] = mapped_column(Text)

--- a/apps/agent-service/app/services/afterthought.py
+++ b/apps/agent-service/app/services/afterthought.py
@@ -205,7 +205,7 @@ async def _generate_conversation_fragment(chat_id: str, persona_id: str) -> None
         # 从消息中提取涉及的用户 ID（排除 bot 自身）
         unique_user_ids = list({
             m.user_id for m in messages
-            if m.role == "user" and m.user_id
+            if m.role == "user" and m.user_id and m.user_id != "__proactive__"
         })
 
         if unique_user_ids:

--- a/apps/agent-service/app/services/afterthought.py
+++ b/apps/agent-service/app/services/afterthought.py
@@ -213,7 +213,7 @@ async def _generate_conversation_fragment(chat_id: str, persona_id: str) -> None
                 persona_id=persona_id,
                 chat_id=chat_id,
                 user_ids=unique_user_ids,
-                messages_timeline=timeline,
+                messages=messages,
             )
     except Exception as e:
         logger.warning(f"[{persona_id}] Relationship extract failed (non-fatal): {e}")

--- a/apps/agent-service/app/services/memory_context.py
+++ b/apps/agent-service/app/services/memory_context.py
@@ -73,10 +73,10 @@ async def build_inner_context(
 
     # === 关系记忆（对当前对话者的印象）===
     if trigger_user_id and trigger_user_id != "__proactive__":
-        from app.orm.memory_crud import get_latest_relationship_memory
+        from app.orm.memory_crud import get_latest_relationship_memory_v2
         from app.orm.crud import get_username
 
-        rel_memory = await get_latest_relationship_memory(persona_id, trigger_user_id)
+        rel_memory = await get_latest_relationship_memory_v2(persona_id, trigger_user_id)
         if rel_memory:
             core_facts, impression = rel_memory
             name = trigger_username or await get_username(trigger_user_id) or trigger_user_id[:6]

--- a/apps/agent-service/app/services/relationship_memory.py
+++ b/apps/agent-service/app/services/relationship_memory.py
@@ -14,8 +14,8 @@ from app.agents.core import ChatAgent
 from app.config.config import settings
 from app.orm.crud import get_bot_persona, get_username
 from app.orm.memory_crud import (
-    get_relationship_memories_for_users,
-    save_relationship_memory,
+    get_relationship_memories_for_users_v2,
+    save_relationship_memory_v2,
 )
 from app.utils.content_parser import parse_content
 
@@ -28,10 +28,12 @@ async def format_timeline(
     *,
     tz: timezone = timezone.utc,
     max_messages: int = 2000,
+    with_ids: bool = False,
 ) -> str:
     """格式化消息列表为时间线文本
 
     格式: [HH:MM] 名字: 消息内容
+    with_ids=True 时: #id [HH:MM] 名字: 消息内容（供 LLM 引用消息）
     afterthought 和 rebuild 共用此函数。
     """
     messages = messages[-max_messages:]
@@ -49,34 +51,128 @@ async def format_timeline(
 
         rendered = parse_content(msg.content).render()
         if rendered and rendered.strip():
-            lines.append(f"[{time_str}] {speaker}: {rendered[:200]}")
+            prefix = f"#{msg.id} " if with_ids and msg.id else ""
+            lines.append(f"{prefix}[{time_str}] {speaker}: {rendered[:200]}")
 
     return "\n".join(lines)
+
+
+def _parse_llm_json(content) -> list | None:
+    """从 LLM 响应中解析 JSON 数组"""
+    if isinstance(content, list):
+        content = "".join(
+            part.get("text", "") if isinstance(part, dict) else str(part)
+            for part in content
+        ).strip()
+    else:
+        content = (content or "").strip()
+
+    if not content or content == "[]":
+        return None
+
+    if content.startswith("```"):
+        content = content.split("\n", 1)[-1].rsplit("```", 1)[0].strip()
+    try:
+        return json.loads(content)
+    except json.JSONDecodeError:
+        return None
+
+
+async def _filter_relevant_messages(
+    messages: list,
+    persona_name: str,
+    persona_lite: str,
+) -> list:
+    """Stage 1: 话题切分 + 赤尾相关性筛选
+
+    把全部消息（带 #id）丢给 LLM，让它切分话题并标记赤尾参与的话题，
+    返回赤尾参与话题中的消息 id 列表。
+    """
+    timeline = await format_timeline(messages, persona_name, with_ids=True)
+    if not timeline:
+        return []
+
+    agent = ChatAgent(
+        prompt_id="relationship_filter",
+        tools=[],
+        model_id=settings.relationship_model,
+        trace_name="relationship-filter",
+    )
+    result = await agent.run(
+        messages=[HumanMessage(content="分析对话，找出我参与的话题")],
+        prompt_vars={
+            "persona_name": persona_name,
+            "persona_lite": persona_lite,
+            "messages": timeline,
+        },
+    )
+
+    topics = _parse_llm_json(result.content)
+    if not topics:
+        logger.info(f"[{persona_name}] Stage 1: no relevant topics found")
+        return []
+
+    # 收集所有相关消息 id
+    relevant_ids: set[int] = set()
+    for topic in topics:
+        if isinstance(topic, dict):
+            for mid in topic.get("message_ids", []):
+                if isinstance(mid, int):
+                    relevant_ids.add(mid)
+
+    logger.info(
+        f"[{persona_name}] Stage 1: {len(topics)} topics, "
+        f"{len(relevant_ids)} relevant messages out of {len(messages)}"
+    )
+    return list(relevant_ids)
 
 
 async def extract_relationship_updates(
     persona_id: str,
     chat_id: str,
     user_ids: list[str],
-    messages_timeline: str,
+    messages: list,
 ) -> None:
-    """从一段对话中提取关系记忆更新
+    """两阶段关系记忆提取
 
-    在 afterthought 生成 conversation 碎片后调用，rebuild 也复用此函数。
-    通过 ChatAgent 调用 LLM，自动 Langfuse trace。
+    Stage 1: 话题切分 + 筛选赤尾参与的对话片段
+    Stage 2: 基于筛选后的消息提取关系记忆更新
+
+    afterthought 和 rebuild 共用此函数。
     """
-    if not user_ids:
+    if not user_ids or not messages:
         return
 
     persona = await get_bot_persona(persona_id)
     persona_name = persona.display_name if persona else persona_id
     persona_lite = persona.persona_lite if persona else ""
 
-    current_memories = await get_relationship_memories_for_users(persona_id, user_ids)
+    # --- Stage 1: 筛选 ---
+    relevant_ids = await _filter_relevant_messages(
+        messages, persona_name, persona_lite,
+    )
+    if not relevant_ids:
+        logger.info(f"[{persona_id}] No relevant messages for chat {chat_id}, skip extract")
+        return
+
+    # 按 id 过滤消息，重新提取涉及的 user_ids
+    id_set = set(relevant_ids)
+    filtered_messages = [m for m in messages if m.id in id_set]
+    filtered_user_ids = list({
+        m.user_id for m in filtered_messages
+        if m.role == "user" and m.user_id
+    })
+    if not filtered_user_ids:
+        return
+
+    # --- Stage 2: 提取 ---
+    filtered_timeline = await format_timeline(filtered_messages, persona_name)
+
+    current_memories = await get_relationship_memories_for_users_v2(persona_id, filtered_user_ids)
 
     core_facts_lines = []
     impression_lines = []
-    for uid in user_ids:
+    for uid in filtered_user_ids:
         name = await get_username(uid) or uid[:6]
         mem = current_memories.get(uid)
         if mem:
@@ -98,30 +194,15 @@ async def extract_relationship_updates(
         prompt_vars={
             "persona_name": persona_name,
             "persona_lite": persona_lite,
-            "messages": messages_timeline,
+            "messages": filtered_timeline,
             "current_core_facts": "\n".join(core_facts_lines),
             "current_impression": "\n".join(impression_lines),
         },
     )
 
-    content = result.content or ""
-    if isinstance(content, list):
-        content = "".join(
-            part.get("text", "") if isinstance(part, dict) else str(part)
-            for part in content
-        ).strip()
-
-    if not content or content.strip() == "[]":
+    updates = _parse_llm_json(result.content)
+    if not updates:
         logger.info(f"[{persona_id}] No relationship updates for chat {chat_id}")
-        return
-
-    content = content.strip()
-    if content.startswith("```"):
-        content = content.split("\n", 1)[-1].rsplit("```", 1)[0].strip()
-    try:
-        updates = json.loads(content)
-    except json.JSONDecodeError:
-        logger.warning(f"[{persona_id}] Failed to parse relationship extract: {content[:200]}")
         return
 
     for item in updates:
@@ -132,10 +213,9 @@ async def extract_relationship_updates(
         core_facts = item.get("core_facts", "")
         impression = item.get("impression", "")
         if uid and (core_facts or impression):
-            await save_relationship_memory(
+            await save_relationship_memory_v2(
                 persona_id=persona_id,
                 user_id=uid,
-                user_name=name,
                 core_facts=core_facts,
                 impression=impression,
                 source="afterthought",

--- a/apps/agent-service/app/services/relationship_memory.py
+++ b/apps/agent-service/app/services/relationship_memory.py
@@ -160,7 +160,7 @@ async def extract_relationship_updates(
     filtered_messages = [m for m in messages if m.id in id_set]
     filtered_user_ids = list({
         m.user_id for m in filtered_messages
-        if m.role == "user" and m.user_id
+        if m.role == "user" and m.user_id and m.user_id != "__proactive__"
     })
     if not filtered_user_ids:
         return


### PR DESCRIPTION
## Summary
- 新增 Stage 1 话题切分+赤尾相关性筛选（relationship_filter prompt），过滤群聊噪声
- Stage 2 只对筛选后的消息调 relationship_extract 提取，解决"记住太多无关的人和事"
- 新建 relationship_memory_v2 表，删除旧表模型和 CRUD
- conversation_messages/lark_user ORM 加 id 字段，format_timeline 支持 #id 引用
- 过滤 __proactive__ user_id

## Test plan
- [x] rebuild 单天测试：441 条消息筛到 23 条（95% 噪声滤掉），4 人 vs 旧管线 15 人
- [x] v2 表数据验证：core_facts/impression 全是赤尾真实交互
- [x] memory_context 注入验证：Langfuse trace 确认读取 v2 数据
- [x] 全量 rebuild 3/26-4/10 三 persona 两群完成