### PR TITLE
fix(image): 在 generate_image 工具返回中追加图片展示提醒

### DIFF
--- a/apps/agent-service/app/agent/tools/image.py
+++ b/apps/agent-service/app/agent/tools/image.py
@@ -137,4 +137,11 @@ async def generate_image(
     if not content_blocks:
         return "图片生成失败，请稍后重试"
 
+    # Remind model to include image markdown — this is the last text
+    # before the model generates its response, so it gets full attention.
+    refs = " ".join(f"![描述]({f})" for f in filenames)
+    content_blocks.append(
+        {"type": "text", "text": f"⚠️ 用户看不到上面的图片。你的回复里必须包含 {refs} 才能展示给用户。"}
+    )
+
     return content_blocks


### PR DESCRIPTION
之前的 prompt 调整（skill/system prompt）都在图片生成前几轮，
到模型写回复时已不在注意力焦点。把提醒放在 tool result 末尾，
是模型生成回复前最后看到的文本，注意力最强。

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
