### PR TITLE
fix(life-engine): widen activity_type column to prevent state loss

### DIFF
--- a/apps/agent-service/app/data/models.py
+++ b/apps/agent-service/app/data/models.py
@@ -251,7 +251,7 @@ class LifeEngineState(Base):
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
     persona_id: Mapped[str] = mapped_column(String(50), nullable=False)
     current_state: Mapped[str] = mapped_column(Text, nullable=False)
-    activity_type: Mapped[str] = mapped_column(String(20), nullable=False)
+    activity_type: Mapped[str] = mapped_column(String(50), nullable=False)
     response_mood: Mapped[str] = mapped_column(Text, nullable=False)
     reasoning: Mapped[str | None] = mapped_column(Text, nullable=True)
     skip_until: Mapped[datetime | None] = mapped_column(


### PR DESCRIPTION
LLM 生成的 activity_type（如 getting_ready_to_sleep，22字符）超过
VARCHAR(20) 限制，导致 INSERT 失败、整条状态回滚丢失，下一次 tick
读到旧状态。扩大到 VARCHAR(50)，DDL 已同步执行。

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
