### PR TITLE
feat: 动态配置系统（按泳道隔离）

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,7 +79,7 @@ SDK (agent-service/lark-server) → paas-engine (读取 API, /internal/dynamic-c
 
 - 基础设施连接（DB/Redis）走 ConfigBundle（部署时环境变量）
 - 业务行为参数（模型/阈值/flag）走 Dynamic Config（运行时 SDK 读取，10s 缓存）
-- SDK 用法：`dynamic_config.get("key", default="value")`，lane 从 context 自动获取
+- 接入指南和 API 详见 `docs/dynamic-config.md`
 
 ## 通用规范
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,6 +69,18 @@ PaaS Engine API
 
 SDK 在 `packages/ts-shared/`（TS）和 `packages/py-shared/`（Python）。
 
+### 动态配置
+
+```
+Dashboard → monitor-dashboard → paas-engine (管理 API, /api/paas/dynamic-config/)
+                                            ↕ dynamic_configs 表
+SDK (agent-service/lark-server) → paas-engine (读取 API, /internal/dynamic-config/resolved)
+```
+
+- 基础设施连接（DB/Redis）走 ConfigBundle（部署时环境变量）
+- 业务行为参数（模型/阈值/flag）走 Dynamic Config（运行时 SDK 读取，10s 缓存）
+- SDK 用法：`dynamic_config.get("key", default="value")`，lane 从 context 自动获取
+
 ## 通用规范
 
 - 镜像 tag: 语义化版本号（如 `1.0.0.2`），由 PaaS Engine 服务端分配

--- a/apps/agent-service/app/api/routes.py
+++ b/apps/agent-service/app/api/routes.py
@@ -55,7 +55,10 @@ async def debug_dynamic_config():
     from app.api.middleware import get_lane
     from inner_shared.dynamic_config import DynamicConfig
 
-    config = DynamicConfig(lane_provider=get_lane)
+    config = DynamicConfig(
+        paas_engine_url="http://paas-engine-feat-dynamic-config-by-lane:8080",
+        lane_provider=get_lane,
+    )
     return {
         "lane": get_lane() or "prod",
         "default_model": config.get("default_model", default="NOT_SET"),

--- a/apps/agent-service/app/api/routes.py
+++ b/apps/agent-service/app/api/routes.py
@@ -49,6 +49,20 @@ async def health_check():
     }
 
 
+# TODO: 临时诊断端点，验证 DynamicConfig SDK，验完删除
+@router.get("/debug/dynamic-config", tags=["Debug"])
+async def debug_dynamic_config():
+    from app.api.middleware import get_lane
+    from inner_shared.dynamic_config import DynamicConfig
+
+    config = DynamicConfig(lane_provider=get_lane)
+    return {
+        "lane": get_lane() or "prod",
+        "default_model": config.get("default_model", default="NOT_SET"),
+        "proactive_threshold": config.get_float("proactive_threshold", default=-1),
+    }
+
+
 # ---------------------------------------------------------------------------
 # Admin triggers
 # ---------------------------------------------------------------------------

--- a/apps/agent-service/app/api/routes.py
+++ b/apps/agent-service/app/api/routes.py
@@ -49,23 +49,6 @@ async def health_check():
     }
 
 
-# TODO: 临时诊断端点，验证 DynamicConfig SDK，验完删除
-@router.get("/debug/dynamic-config", tags=["Debug"])
-async def debug_dynamic_config():
-    from app.api.middleware import get_lane
-    from inner_shared.dynamic_config import DynamicConfig
-
-    config = DynamicConfig(
-        paas_engine_url="http://paas-engine-feat-dynamic-config-by-lane:8080",
-        lane_provider=get_lane,
-    )
-    return {
-        "lane": get_lane() or "prod",
-        "default_model": config.get("default_model", default="NOT_SET"),
-        "proactive_threshold": config.get_float("proactive_threshold", default=-1),
-    }
-
-
 # ---------------------------------------------------------------------------
 # Admin triggers
 # ---------------------------------------------------------------------------

--- a/apps/monitor-dashboard-web/src/App.tsx
+++ b/apps/monitor-dashboard-web/src/App.tsx
@@ -17,6 +17,7 @@ import {
   ThunderboltOutlined,
   AuditOutlined,
   EditOutlined,
+  SettingOutlined,
 } from '@ant-design/icons';
 import { Navigate, Route, Routes, useLocation, useNavigate } from 'react-router-dom';
 import { useEffect, useState, lazy, Suspense } from 'react';
@@ -35,6 +36,7 @@ const ModelMappings = lazy(() => import('./pages/ModelMappings'));
 const MongoExplorer = lazy(() => import('./pages/MongoExplorer'));
 const AuditLogs = lazy(() => import('./pages/AuditLogs'));
 const DbMutations = lazy(() => import('./pages/DbMutations'));
+const DynamicConfig = lazy(() => import('./pages/DynamicConfig'));
 import { themeConfig } from './theme';
 import { clearToken, getLane } from './api/client';
 
@@ -59,6 +61,7 @@ const menuItems: MenuItem[] = [
   { type: 'divider' },
   { key: '/providers', icon: <CloudServerOutlined />, label: '服务商' },
   { key: '/model-mappings', icon: <ApiOutlined />, label: '模型映射' },
+  { key: '/dynamic-config', icon: <SettingOutlined />, label: '动态配置' },
   { type: 'divider' },
   { key: '/kibana', icon: <FileSearchOutlined />, label: 'Grafana' },
   { key: '/langfuse', icon: <MonitorOutlined />, label: 'Langfuse 链路' },
@@ -282,6 +285,7 @@ export default function App() {
                   <Route path="/messages" element={<Messages />} />
                   <Route path="/providers" element={<Providers />} />
                   <Route path="/model-mappings" element={<ModelMappings />} />
+                  <Route path="/dynamic-config" element={<DynamicConfig />} />
                   <Route path="/mongo" element={<MongoExplorer />} />
                   <Route path="*" element={<Navigate to="/" replace />} />
                 </Routes>

--- a/apps/monitor-dashboard-web/src/pages/DynamicConfig.tsx
+++ b/apps/monitor-dashboard-web/src/pages/DynamicConfig.tsx
@@ -51,10 +51,17 @@ export default function DynamicConfig() {
 
   const fetchLanes = useCallback(async () => {
     try {
-      const { data } = await api.get('/dynamic-config');
-      const raw: RawConfig[] = Array.isArray(data) ? data : (data?.data || []);
+      const [configRes, statusRes] = await Promise.all([
+        api.get('/dynamic-config').catch(() => ({ data: [] })),
+        api.get('/service-status').catch(() => ({ data: { releases: [] } })),
+      ]);
       const laneSet = new Set<string>(['prod']);
+      // 从已有配置中提取 lane
+      const raw: RawConfig[] = Array.isArray(configRes.data) ? configRes.data : (configRes.data?.data || []);
       raw.forEach((c: RawConfig) => laneSet.add(c.lane));
+      // 从已部署 release 中提取 lane
+      const releases: { lane?: string }[] = statusRes.data?.releases || [];
+      releases.forEach((r) => { if (r.lane) laneSet.add(r.lane); });
       setLanes(Array.from(laneSet).sort());
     } catch {
       // ignore

--- a/apps/monitor-dashboard-web/src/pages/DynamicConfig.tsx
+++ b/apps/monitor-dashboard-web/src/pages/DynamicConfig.tsx
@@ -1,0 +1,234 @@
+import { useEffect, useState, useCallback } from 'react';
+import {
+  Button,
+  Form,
+  Input,
+  Modal,
+  Popconfirm,
+  Select,
+  Space,
+  Table,
+  Tag,
+  Typography,
+  message,
+} from 'antd';
+import type { ColumnsType } from 'antd/es/table';
+import { PlusOutlined, EditOutlined, DeleteOutlined, UndoOutlined } from '@ant-design/icons';
+import { api } from '../api/client';
+
+const { Text } = Typography;
+
+interface ConfigEntry {
+  value: string;
+  lane: string;
+}
+
+interface RawConfig {
+  key: string;
+  lane: string;
+  value: string;
+  updated_at: string;
+}
+
+export default function DynamicConfig() {
+  const [lanes, setLanes] = useState<string[]>(['prod']);
+  const [selectedLane, setSelectedLane] = useState('prod');
+  const [resolved, setResolved] = useState<Record<string, ConfigEntry>>({});
+  const [loading, setLoading] = useState(false);
+  const [modalOpen, setModalOpen] = useState(false);
+  const [editingKey, setEditingKey] = useState<string | null>(null);
+  const [form] = Form.useForm();
+
+  const fetchResolved = useCallback(async (lane: string) => {
+    setLoading(true);
+    try {
+      const { data } = await api.get('/dynamic-config/resolved', { params: { lane } });
+      setResolved(data?.configs || data?.data?.configs || {});
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  const fetchLanes = useCallback(async () => {
+    try {
+      const { data } = await api.get('/dynamic-config');
+      const raw: RawConfig[] = Array.isArray(data) ? data : (data?.data || []);
+      const laneSet = new Set<string>(['prod']);
+      raw.forEach((c: RawConfig) => laneSet.add(c.lane));
+      setLanes(Array.from(laneSet).sort());
+    } catch {
+      // ignore
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchLanes();
+  }, [fetchLanes]);
+
+  useEffect(() => {
+    fetchResolved(selectedLane);
+  }, [selectedLane, fetchResolved]);
+
+  const handleSave = async () => {
+    try {
+      const values = await form.validateFields();
+      await api.put(`/dynamic-config/${encodeURIComponent(values.key)}`, {
+        lane: selectedLane,
+        value: values.value,
+      });
+      message.success('已保存');
+      setModalOpen(false);
+      form.resetFields();
+      setEditingKey(null);
+      fetchResolved(selectedLane);
+      fetchLanes();
+    } catch {
+      // form validation error
+    }
+  };
+
+  const handleDelete = async (key: string) => {
+    if (selectedLane === 'prod') {
+      await api.delete(`/dynamic-config/${encodeURIComponent(key)}`);
+      message.success('已删除');
+    } else {
+      await api.delete(`/dynamic-config/${encodeURIComponent(key)}`, {
+        params: { lane: selectedLane },
+      });
+      message.success('已恢复到 prod');
+    }
+    fetchResolved(selectedLane);
+    fetchLanes();
+  };
+
+  const openEdit = (key: string, value: string) => {
+    setEditingKey(key);
+    form.setFieldsValue({ key, value });
+    setModalOpen(true);
+  };
+
+  const openCreate = () => {
+    setEditingKey(null);
+    form.resetFields();
+    setModalOpen(true);
+  };
+
+  const dataSource = Object.entries(resolved)
+    .map(([key, entry]) => ({ key, ...entry }))
+    .sort((a, b) => a.key.localeCompare(b.key));
+
+  const columns: ColumnsType<{ key: string; value: string; lane: string }> = [
+    {
+      title: 'Key',
+      dataIndex: 'key',
+      width: 280,
+      render: (text: string) => <Text code>{text}</Text>,
+    },
+    {
+      title: 'Value',
+      dataIndex: 'value',
+      ellipsis: true,
+    },
+    {
+      title: '来源',
+      dataIndex: 'lane',
+      width: 120,
+      render: (lane: string) => (
+        <Tag color={lane === selectedLane && lane !== 'prod' ? 'blue' : 'default'}>
+          {lane === selectedLane && lane !== 'prod' ? '本泳道' : 'prod'}
+        </Tag>
+      ),
+    },
+    {
+      title: '操作',
+      width: 160,
+      render: (_: unknown, record: { key: string; value: string; lane: string }) => (
+        <Space>
+          <Button
+            type="link"
+            size="small"
+            icon={<EditOutlined />}
+            onClick={() => openEdit(record.key, record.value)}
+          >
+            编辑
+          </Button>
+          {selectedLane !== 'prod' && record.lane === selectedLane ? (
+            <Popconfirm title="恢复到 prod 值？" onConfirm={() => handleDelete(record.key)}>
+              <Button type="link" size="small" icon={<UndoOutlined />} danger>
+                恢复
+              </Button>
+            </Popconfirm>
+          ) : selectedLane === 'prod' ? (
+            <Popconfirm title="删除此配置？" onConfirm={() => handleDelete(record.key)}>
+              <Button type="link" size="small" icon={<DeleteOutlined />} danger>
+                删除
+              </Button>
+            </Popconfirm>
+          ) : null}
+        </Space>
+      ),
+    },
+  ];
+
+  return (
+    <div>
+      <div style={{ marginBottom: 16, display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+        <Space>
+          <Text strong>泳道：</Text>
+          <Select
+            value={selectedLane}
+            onChange={setSelectedLane}
+            style={{ width: 160 }}
+            options={lanes.map((l) => ({ label: l, value: l }))}
+          />
+        </Space>
+        <Button type="primary" icon={<PlusOutlined />} onClick={openCreate}>
+          新增配置
+        </Button>
+      </div>
+
+      <Table
+        dataSource={dataSource}
+        columns={columns}
+        loading={loading}
+        pagination={false}
+        size="middle"
+        rowKey="key"
+      />
+
+      <Modal
+        title={editingKey ? `编辑 ${editingKey}` : '新增配置'}
+        open={modalOpen}
+        onOk={handleSave}
+        onCancel={() => { setModalOpen(false); form.resetFields(); setEditingKey(null); }}
+        okText="保存"
+        cancelText="取消"
+      >
+        <Form form={form} layout="vertical">
+          <Form.Item
+            name="key"
+            label="Key"
+            rules={[{ required: true, message: '请输入 key' }]}
+          >
+            <Input disabled={!!editingKey} placeholder="如 default_model" />
+          </Form.Item>
+          <Form.Item
+            name="value"
+            label="Value"
+            rules={[{ required: true, message: '请输入 value' }]}
+          >
+            <Input.TextArea rows={3} placeholder="配置值" />
+          </Form.Item>
+          <Form.Item label="泳道">
+            <Tag>{selectedLane}</Tag>
+            {selectedLane !== 'prod' && (
+              <Text type="secondary" style={{ marginLeft: 8 }}>
+                此值仅在 {selectedLane} 泳道生效
+              </Text>
+            )}
+          </Form.Item>
+        </Form>
+      </Modal>
+    </div>
+  );
+}

--- a/apps/monitor-dashboard/src/index.ts
+++ b/apps/monitor-dashboard/src/index.ts
@@ -19,6 +19,7 @@ import serviceStatusRoutes from './routes/service-status';
 import operationsRoutes from './routes/operations';
 import auditLogsRoutes from './routes/audit-logs';
 import activityRoutes from './routes/activity';
+import dynamicConfigRoutes from './routes/dynamic-config';
 
 const PORT = Number(process.env.DASHBOARD_PORT || 3002);
 
@@ -67,6 +68,7 @@ const bootstrap = async () => {
   dashboard.route('/', operationsRoutes);
   dashboard.route('/', auditLogsRoutes);
   dashboard.route('/', activityRoutes);
+  dashboard.route('/', dynamicConfigRoutes);
 
   app.route('/dashboard', dashboard);
 

--- a/apps/monitor-dashboard/src/paas-client.ts
+++ b/apps/monitor-dashboard/src/paas-client.ts
@@ -73,6 +73,17 @@ function createClient(configFn: () => { baseURL: string; headers: Record<string,
       const res = await axios.delete(`${url}${path}`, config);
       return unwrap(res.data);
     },
+
+    async put(path: string, body?: unknown, extraHeaders?: Record<string, string>) {
+      const { baseURL, headers } = configFn();
+      const url = laneAwareUrl(baseURL, extraHeaders?.['x-lane']);
+      const config: AxiosRequestConfig = {
+        headers: { ...headers, 'Content-Type': 'application/json', ...extraHeaders },
+        timeout: TIMEOUT,
+      };
+      const res = await axios.put(`${url}${path}`, body, config);
+      return unwrap(res.data);
+    },
   };
 }
 

--- a/apps/monitor-dashboard/src/routes/dynamic-config.ts
+++ b/apps/monitor-dashboard/src/routes/dynamic-config.ts
@@ -1,0 +1,40 @@
+import { Hono } from 'hono';
+import { paasClient } from '../paas-client';
+
+const app = new Hono();
+
+/** GET /api/dynamic-config — 列出所有配置 */
+app.get('/api/dynamic-config', async (c) => {
+  const lane = c.req.query('lane');
+  const params: Record<string, string> = {};
+  if (lane) params.lane = lane;
+  const data = await paasClient.get('/api/paas/dynamic-config/', params);
+  return c.json(data);
+});
+
+/** GET /api/dynamic-config/resolved — 解析后的配置快照 */
+app.get('/api/dynamic-config/resolved', async (c) => {
+  const lane = c.req.query('lane') || 'prod';
+  const data = await paasClient.get('/api/paas/dynamic-config/resolved', { lane });
+  return c.json(data);
+});
+
+/** PUT /api/dynamic-config/:key — 设置配置 */
+app.put('/api/dynamic-config/:key', async (c) => {
+  const key = c.req.param('key');
+  const body = await c.req.json();
+  const data = await paasClient.put(`/api/paas/dynamic-config/${encodeURIComponent(key)}`, body);
+  return c.json(data);
+});
+
+/** DELETE /api/dynamic-config/:key — 删除配置 */
+app.delete('/api/dynamic-config/:key', async (c) => {
+  const key = c.req.param('key');
+  const lane = c.req.query('lane');
+  const params: Record<string, string> = {};
+  if (lane) params.lane = lane;
+  const data = await paasClient.del(`/api/paas/dynamic-config/${encodeURIComponent(key)}`, params);
+  return c.json(data);
+});
+
+export default app;

--- a/apps/monitor-dashboard/src/routes/dynamic-config.ts
+++ b/apps/monitor-dashboard/src/routes/dynamic-config.ts
@@ -3,19 +3,25 @@ import { paasClient } from '../paas-client';
 
 const app = new Hono();
 
+/** 从请求中提取 x-lane header，透传给 paasClient 以路由到对应泳道的 paas-engine */
+function getLaneHeaders(c: { req: { header: (name: string) => string | undefined } }): Record<string, string> | undefined {
+  const lane = c.req.header('x-lane');
+  return lane ? { 'x-lane': lane } : undefined;
+}
+
 /** GET /api/dynamic-config — 列出所有配置 */
 app.get('/api/dynamic-config', async (c) => {
   const lane = c.req.query('lane');
   const params: Record<string, string> = {};
   if (lane) params.lane = lane;
-  const data = await paasClient.get('/api/paas/dynamic-config/', params);
+  const data = await paasClient.get('/api/paas/dynamic-config/', params, getLaneHeaders(c));
   return c.json(data);
 });
 
 /** GET /api/dynamic-config/resolved — 解析后的配置快照 */
 app.get('/api/dynamic-config/resolved', async (c) => {
   const lane = c.req.query('lane') || 'prod';
-  const data = await paasClient.get('/api/paas/dynamic-config/resolved', { lane });
+  const data = await paasClient.get('/api/paas/dynamic-config/resolved', { lane }, getLaneHeaders(c));
   return c.json(data);
 });
 
@@ -23,7 +29,7 @@ app.get('/api/dynamic-config/resolved', async (c) => {
 app.put('/api/dynamic-config/:key', async (c) => {
   const key = c.req.param('key');
   const body = await c.req.json();
-  const data = await paasClient.put(`/api/paas/dynamic-config/${encodeURIComponent(key)}`, body);
+  const data = await paasClient.put(`/api/paas/dynamic-config/${encodeURIComponent(key)}`, body, getLaneHeaders(c));
   return c.json(data);
 });
 
@@ -33,7 +39,7 @@ app.delete('/api/dynamic-config/:key', async (c) => {
   const lane = c.req.query('lane');
   const params: Record<string, string> = {};
   if (lane) params.lane = lane;
-  const data = await paasClient.del(`/api/paas/dynamic-config/${encodeURIComponent(key)}`, params);
+  const data = await paasClient.del(`/api/paas/dynamic-config/${encodeURIComponent(key)}`, params, getLaneHeaders(c));
   return c.json(data);
 });
 

--- a/apps/paas-engine/cmd/paas-engine/main.go
+++ b/apps/paas-engine/cmd/paas-engine/main.go
@@ -37,6 +37,7 @@ func main() {
 	ciConfigRepo := repository.NewCIConfigRepo(db)
 	pipelineRunRepo := repository.NewPipelineRunRepo(db)
 	configBundleRepo := repository.NewConfigBundleRepo(db)
+	dynamicConfigRepo := repository.NewDynamicConfigRepo(db)
 
 	// K8s 客户端（可选，无集群时降级运行）
 	cs, _, k8sErr := kubernetes.NewClientset(cfg.KubeconfigPath)
@@ -76,6 +77,7 @@ func main() {
 	imageRepoSvc := service.NewImageRepoService(imageRepoRepo, appRepo)
 	buildSvc := service.NewBuildService(imageRepoRepo, buildRepo, buildExecutor, lokiClient)
 	configBundleSvc := service.NewConfigBundleService(configBundleRepo, appRepo, releaseRepo)
+	dynamicConfigSvc := service.NewDynamicConfigService(dynamicConfigRepo)
 	releaseSvc := service.NewReleaseService(appRepo, imageRepoRepo, buildRepo, releaseRepo, deployer, configBundleSvc)
 	logSvc := service.NewLogService(appRepo, lokiClient, cfg.DeployNamespace)
 	pipelineSvc := service.NewPipelineService(ciConfigRepo, pipelineRunRepo, testExecutor, buildSvc, releaseSvc, appRepo, imageRepoRepo, lokiClient, cfg.CINamespace)
@@ -142,6 +144,7 @@ func main() {
 		httpadapter.NewOpsHandler(opsDbs, writeDbs, mutationRepo),
 		httpadapter.NewPipelineHandler(pipelineSvc),
 		httpadapter.NewConfigBundleHandler(configBundleSvc),
+		httpadapter.NewDynamicConfigHandler(dynamicConfigSvc),
 		cfg.APIToken,
 	)
 

--- a/apps/paas-engine/internal/adapter/http/dynamic_config_handler.go
+++ b/apps/paas-engine/internal/adapter/http/dynamic_config_handler.go
@@ -1,0 +1,61 @@
+package http
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/chiwei-platform/paas-engine/internal/service"
+	"github.com/go-chi/chi/v5"
+)
+
+type DynamicConfigHandler struct {
+	svc *service.DynamicConfigService
+}
+
+func NewDynamicConfigHandler(svc *service.DynamicConfigService) *DynamicConfigHandler {
+	return &DynamicConfigHandler{svc: svc}
+}
+
+func (h *DynamicConfigHandler) Resolve(w http.ResponseWriter, r *http.Request) {
+	lane := r.URL.Query().Get("lane")
+	result, err := h.svc.Resolve(r.Context(), lane)
+	if err != nil {
+		writeError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, result)
+}
+
+func (h *DynamicConfigHandler) List(w http.ResponseWriter, r *http.Request) {
+	lane := r.URL.Query().Get("lane")
+	configs, err := h.svc.List(r.Context(), lane)
+	if err != nil {
+		writeError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, configs)
+}
+
+func (h *DynamicConfigHandler) Set(w http.ResponseWriter, r *http.Request) {
+	key := chi.URLParam(r, "key")
+	var req service.SetDynamicConfigRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, err)
+		return
+	}
+	if err := h.svc.Set(r.Context(), key, req); err != nil {
+		writeError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]string{"key": key, "lane": req.Lane, "status": "ok"})
+}
+
+func (h *DynamicConfigHandler) Delete(w http.ResponseWriter, r *http.Request) {
+	key := chi.URLParam(r, "key")
+	lane := r.URL.Query().Get("lane")
+	if err := h.svc.Delete(r.Context(), key, lane); err != nil {
+		writeError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]string{"deleted": key})
+}

--- a/apps/paas-engine/internal/adapter/http/router.go
+++ b/apps/paas-engine/internal/adapter/http/router.go
@@ -16,6 +16,7 @@ func NewRouter(
 	opsH *OpsHandler,
 	pipelineH *PipelineHandler,
 	configBundleH *ConfigBundleHandler,
+	dynamicConfigH *DynamicConfigHandler,
 	apiToken string,
 ) http.Handler {
 	r := chi.NewRouter()
@@ -28,6 +29,9 @@ func NewRouter(
 		writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
 	})
 	r.Handle("/metrics", promhttp.Handler())
+
+	// Dynamic Config — internal read endpoint (no auth, for SDK)
+	r.Get("/internal/dynamic-config/resolved", dynamicConfigH.Resolve)
 
 	r.Route("/api/paas", func(r chi.Router) {
 		r.Use(authMiddleware(apiToken))
@@ -131,6 +135,14 @@ func NewRouter(
 					r.Delete("/{key}", configBundleH.DeleteLaneOverrideKey)
 				})
 			})
+		})
+
+		// Dynamic Config (management)
+		r.Route("/dynamic-config", func(r chi.Router) {
+			r.Get("/", dynamicConfigH.List)
+			r.Get("/resolved", dynamicConfigH.Resolve)
+			r.Put("/{key}", dynamicConfigH.Set)
+			r.Delete("/{key}", dynamicConfigH.Delete)
 		})
 	})
 

--- a/apps/paas-engine/internal/adapter/repository/db.go
+++ b/apps/paas-engine/internal/adapter/repository/db.go
@@ -25,6 +25,7 @@ func OpenDB(dsn string) (*gorm.DB, error) {
 		&JobRunModel{},
 		&ConfigBundleModel{},
 		&DbMutationModel{},
+		&DynamicConfigModel{},
 	); err != nil {
 		return nil, err
 	}

--- a/apps/paas-engine/internal/adapter/repository/dynamic_config_repo.go
+++ b/apps/paas-engine/internal/adapter/repository/dynamic_config_repo.go
@@ -1,0 +1,95 @@
+package repository
+
+import (
+	"context"
+	"errors"
+
+	"github.com/chiwei-platform/paas-engine/internal/domain"
+	"github.com/chiwei-platform/paas-engine/internal/port"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+var _ port.DynamicConfigRepository = (*DynamicConfigRepo)(nil)
+
+type DynamicConfigRepo struct {
+	db *gorm.DB
+}
+
+func NewDynamicConfigRepo(db *gorm.DB) *DynamicConfigRepo {
+	return &DynamicConfigRepo{db: db}
+}
+
+func (r *DynamicConfigRepo) Upsert(ctx context.Context, config *domain.DynamicConfig) error {
+	m := DynamicConfigModel{
+		Key:       config.Key,
+		Lane:      config.Lane,
+		Value:     config.Value,
+		UpdatedAt: config.UpdatedAt,
+	}
+	return r.db.WithContext(ctx).Clauses(clause.OnConflict{
+		Columns:   []clause.Column{{Name: "key"}, {Name: "lane"}},
+		DoUpdates: clause.AssignmentColumns([]string{"value", "updated_at"}),
+	}).Create(&m).Error
+}
+
+func (r *DynamicConfigRepo) FindByKeyAndLane(ctx context.Context, key, lane string) (*domain.DynamicConfig, error) {
+	var m DynamicConfigModel
+	result := r.db.WithContext(ctx).First(&m, "key = ? AND lane = ?", key, lane)
+	if result.Error != nil {
+		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
+			return nil, domain.ErrDynamicConfigNotFound
+		}
+		return nil, result.Error
+	}
+	return modelToDynamicConfig(&m), nil
+}
+
+func (r *DynamicConfigRepo) FindByLane(ctx context.Context, lane string) ([]*domain.DynamicConfig, error) {
+	var models []DynamicConfigModel
+	if err := r.db.WithContext(ctx).Where("lane = ?", lane).Find(&models).Error; err != nil {
+		return nil, err
+	}
+	return modelsToDynamicConfigs(models), nil
+}
+
+func (r *DynamicConfigRepo) FindAll(ctx context.Context) ([]*domain.DynamicConfig, error) {
+	var models []DynamicConfigModel
+	if err := r.db.WithContext(ctx).Order("key, lane").Find(&models).Error; err != nil {
+		return nil, err
+	}
+	return modelsToDynamicConfigs(models), nil
+}
+
+func (r *DynamicConfigRepo) DeleteByKeyAndLane(ctx context.Context, key, lane string) error {
+	result := r.db.WithContext(ctx).Delete(&DynamicConfigModel{}, "key = ? AND lane = ?", key, lane)
+	if result.RowsAffected == 0 {
+		return domain.ErrDynamicConfigNotFound
+	}
+	return result.Error
+}
+
+func (r *DynamicConfigRepo) DeleteByKey(ctx context.Context, key string) error {
+	result := r.db.WithContext(ctx).Delete(&DynamicConfigModel{}, "key = ?", key)
+	if result.RowsAffected == 0 {
+		return domain.ErrDynamicConfigNotFound
+	}
+	return result.Error
+}
+
+func modelToDynamicConfig(m *DynamicConfigModel) *domain.DynamicConfig {
+	return &domain.DynamicConfig{
+		Key:       m.Key,
+		Lane:      m.Lane,
+		Value:     m.Value,
+		UpdatedAt: m.UpdatedAt,
+	}
+}
+
+func modelsToDynamicConfigs(models []DynamicConfigModel) []*domain.DynamicConfig {
+	configs := make([]*domain.DynamicConfig, 0, len(models))
+	for i := range models {
+		configs = append(configs, modelToDynamicConfig(&models[i]))
+	}
+	return configs
+}

--- a/apps/paas-engine/internal/adapter/repository/model.go
+++ b/apps/paas-engine/internal/adapter/repository/model.go
@@ -157,3 +157,13 @@ type DbMutationModel struct {
 }
 
 func (DbMutationModel) TableName() string { return "db_mutations" }
+
+// DynamicConfigModel 是 DynamicConfig 的数据库持久化模型。
+type DynamicConfigModel struct {
+	Key       string    `gorm:"primaryKey"`
+	Lane      string    `gorm:"primaryKey;default:prod"`
+	Value     string    `gorm:"not null"`
+	UpdatedAt time.Time
+}
+
+func (DynamicConfigModel) TableName() string { return "dynamic_configs" }

--- a/apps/paas-engine/internal/domain/dynamic_config.go
+++ b/apps/paas-engine/internal/domain/dynamic_config.go
@@ -1,0 +1,12 @@
+package domain
+
+import "time"
+
+// DynamicConfig 表示一条动态配置项。
+// PK 为 (Key, Lane)，lane="prod" 是基线值，其他 lane 是覆盖。
+type DynamicConfig struct {
+	Key       string    `json:"key"`
+	Lane      string    `json:"lane"`
+	Value     string    `json:"value"`
+	UpdatedAt time.Time `json:"updated_at"`
+}

--- a/apps/paas-engine/internal/domain/errors.go
+++ b/apps/paas-engine/internal/domain/errors.go
@@ -20,6 +20,7 @@ var (
 
 	ErrNonMainProdDeploy = fmt.Errorf("%w: prod lane only accepts images built from main branch", ErrInvalidInput)
 
-	ErrCIConfigNotFound   = fmt.Errorf("ci config %w", ErrNotFound)
-	ErrPipelineRunNotFound = fmt.Errorf("pipeline run %w", ErrNotFound)
+	ErrCIConfigNotFound      = fmt.Errorf("ci config %w", ErrNotFound)
+	ErrPipelineRunNotFound   = fmt.Errorf("pipeline run %w", ErrNotFound)
+	ErrDynamicConfigNotFound = fmt.Errorf("dynamic config %w", ErrNotFound)
 )

--- a/apps/paas-engine/internal/port/repository.go
+++ b/apps/paas-engine/internal/port/repository.go
@@ -49,3 +49,12 @@ type ConfigBundleRepository interface {
 	Update(ctx context.Context, bundle *domain.ConfigBundle) error
 	Delete(ctx context.Context, name string) error
 }
+
+type DynamicConfigRepository interface {
+	Upsert(ctx context.Context, config *domain.DynamicConfig) error
+	FindByKeyAndLane(ctx context.Context, key, lane string) (*domain.DynamicConfig, error)
+	FindByLane(ctx context.Context, lane string) ([]*domain.DynamicConfig, error)
+	FindAll(ctx context.Context) ([]*domain.DynamicConfig, error)
+	DeleteByKeyAndLane(ctx context.Context, key, lane string) error
+	DeleteByKey(ctx context.Context, key string) error
+}

--- a/apps/paas-engine/internal/service/dynamic_config_service.go
+++ b/apps/paas-engine/internal/service/dynamic_config_service.go
@@ -1,0 +1,102 @@
+package service
+
+import (
+	"context"
+	"time"
+
+	"github.com/chiwei-platform/paas-engine/internal/domain"
+	"github.com/chiwei-platform/paas-engine/internal/port"
+)
+
+type DynamicConfigService struct {
+	repo port.DynamicConfigRepository
+}
+
+func NewDynamicConfigService(repo port.DynamicConfigRepository) *DynamicConfigService {
+	return &DynamicConfigService{repo: repo}
+}
+
+// ResolvedEntry 是解析后的单条配置，带来源 lane 标注。
+type ResolvedEntry struct {
+	Value string `json:"value"`
+	Lane  string `json:"lane"`
+}
+
+// ResolvedConfig 是解析后的全量配置快照。
+type ResolvedConfig struct {
+	Configs    map[string]ResolvedEntry `json:"configs"`
+	ResolvedAt time.Time               `json:"resolved_at"`
+}
+
+// Resolve 返回指定泳道的合并配置（lane 覆盖 + prod 补缺）。
+func (s *DynamicConfigService) Resolve(ctx context.Context, lane string) (*ResolvedConfig, error) {
+	if lane == "" {
+		lane = "prod"
+	}
+
+	// 先取 prod 基线
+	prodConfigs, err := s.repo.FindByLane(ctx, "prod")
+	if err != nil {
+		return nil, err
+	}
+
+	result := make(map[string]ResolvedEntry, len(prodConfigs))
+	for _, c := range prodConfigs {
+		result[c.Key] = ResolvedEntry{Value: c.Value, Lane: "prod"}
+	}
+
+	// 非 prod 泳道：用该泳道的值覆盖
+	if lane != "prod" {
+		laneConfigs, err := s.repo.FindByLane(ctx, lane)
+		if err != nil {
+			return nil, err
+		}
+		for _, c := range laneConfigs {
+			result[c.Key] = ResolvedEntry{Value: c.Value, Lane: lane}
+		}
+	}
+
+	return &ResolvedConfig{
+		Configs:    result,
+		ResolvedAt: time.Now(),
+	}, nil
+}
+
+// List 返回所有配置（可选按 lane 筛选）。
+func (s *DynamicConfigService) List(ctx context.Context, lane string) ([]*domain.DynamicConfig, error) {
+	if lane != "" {
+		return s.repo.FindByLane(ctx, lane)
+	}
+	return s.repo.FindAll(ctx)
+}
+
+// SetDynamicConfigRequest 是设置配置的请求体。
+type SetDynamicConfigRequest struct {
+	Lane  string `json:"lane"`
+	Value string `json:"value"`
+}
+
+// Set 设置一条配置（upsert 语义）。
+func (s *DynamicConfigService) Set(ctx context.Context, key string, req SetDynamicConfigRequest) error {
+	if key == "" {
+		return domain.ErrInvalidInput
+	}
+	lane := req.Lane
+	if lane == "" {
+		lane = "prod"
+	}
+	return s.repo.Upsert(ctx, &domain.DynamicConfig{
+		Key:       key,
+		Lane:      lane,
+		Value:     req.Value,
+		UpdatedAt: time.Now(),
+	})
+}
+
+// Delete 删除配置。lane 为空则删除所有 lane 的该 key。
+func (s *DynamicConfigService) Delete(ctx context.Context, key, lane string) error {
+	if lane != "" {
+		return s.repo.DeleteByKeyAndLane(ctx, key, lane)
+	}
+	return s.repo.DeleteByKey(ctx, key)
+}

--- a/apps/paas-engine/internal/service/dynamic_config_service_test.go
+++ b/apps/paas-engine/internal/service/dynamic_config_service_test.go
@@ -1,0 +1,174 @@
+package service
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/chiwei-platform/paas-engine/internal/domain"
+)
+
+// --- stub for DynamicConfigRepository ---
+
+type stubDynamicConfigRepo struct {
+	configs map[string]*domain.DynamicConfig // key = "key|lane"
+}
+
+func newStubDynamicConfigRepo() *stubDynamicConfigRepo {
+	return &stubDynamicConfigRepo{configs: make(map[string]*domain.DynamicConfig)}
+}
+
+func compositeKey(key, lane string) string { return key + "|" + lane }
+
+func (r *stubDynamicConfigRepo) Upsert(_ context.Context, config *domain.DynamicConfig) error {
+	r.configs[compositeKey(config.Key, config.Lane)] = config
+	return nil
+}
+
+func (r *stubDynamicConfigRepo) FindByKeyAndLane(_ context.Context, key, lane string) (*domain.DynamicConfig, error) {
+	c, ok := r.configs[compositeKey(key, lane)]
+	if !ok {
+		return nil, domain.ErrDynamicConfigNotFound
+	}
+	return c, nil
+}
+
+func (r *stubDynamicConfigRepo) FindByLane(_ context.Context, lane string) ([]*domain.DynamicConfig, error) {
+	var result []*domain.DynamicConfig
+	for _, c := range r.configs {
+		if c.Lane == lane {
+			result = append(result, c)
+		}
+	}
+	return result, nil
+}
+
+func (r *stubDynamicConfigRepo) FindAll(_ context.Context) ([]*domain.DynamicConfig, error) {
+	var result []*domain.DynamicConfig
+	for _, c := range r.configs {
+		result = append(result, c)
+	}
+	return result, nil
+}
+
+func (r *stubDynamicConfigRepo) DeleteByKeyAndLane(_ context.Context, key, lane string) error {
+	ck := compositeKey(key, lane)
+	if _, ok := r.configs[ck]; !ok {
+		return domain.ErrDynamicConfigNotFound
+	}
+	delete(r.configs, ck)
+	return nil
+}
+
+func (r *stubDynamicConfigRepo) DeleteByKey(_ context.Context, key string) error {
+	found := false
+	for ck, c := range r.configs {
+		if c.Key == key {
+			delete(r.configs, ck)
+			found = true
+		}
+	}
+	if !found {
+		return domain.ErrDynamicConfigNotFound
+	}
+	return nil
+}
+
+// --- tests ---
+
+func TestResolve_ProdBaseline(t *testing.T) {
+	repo := newStubDynamicConfigRepo()
+	repo.configs[compositeKey("model", "prod")] = &domain.DynamicConfig{
+		Key: "model", Lane: "prod", Value: "gemini", UpdatedAt: time.Now(),
+	}
+	svc := NewDynamicConfigService(repo)
+
+	result, err := svc.Resolve(context.Background(), "prod")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Configs["model"].Value != "gemini" {
+		t.Errorf("expected gemini, got %s", result.Configs["model"].Value)
+	}
+	if result.Configs["model"].Lane != "prod" {
+		t.Errorf("expected lane=prod, got %s", result.Configs["model"].Lane)
+	}
+}
+
+func TestResolve_LaneOverride(t *testing.T) {
+	repo := newStubDynamicConfigRepo()
+	repo.configs[compositeKey("model", "prod")] = &domain.DynamicConfig{
+		Key: "model", Lane: "prod", Value: "gemini", UpdatedAt: time.Now(),
+	}
+	repo.configs[compositeKey("model", "dev")] = &domain.DynamicConfig{
+		Key: "model", Lane: "dev", Value: "gpt-4o", UpdatedAt: time.Now(),
+	}
+	repo.configs[compositeKey("threshold", "prod")] = &domain.DynamicConfig{
+		Key: "threshold", Lane: "prod", Value: "0.7", UpdatedAt: time.Now(),
+	}
+	svc := NewDynamicConfigService(repo)
+
+	result, err := svc.Resolve(context.Background(), "dev")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Configs["model"].Value != "gpt-4o" {
+		t.Errorf("expected gpt-4o, got %s", result.Configs["model"].Value)
+	}
+	if result.Configs["model"].Lane != "dev" {
+		t.Errorf("expected lane=dev, got %s", result.Configs["model"].Lane)
+	}
+	if result.Configs["threshold"].Value != "0.7" {
+		t.Errorf("expected 0.7, got %s", result.Configs["threshold"].Value)
+	}
+	if result.Configs["threshold"].Lane != "prod" {
+		t.Errorf("expected lane=prod, got %s", result.Configs["threshold"].Lane)
+	}
+}
+
+func TestResolve_EmptyLaneFallbackProd(t *testing.T) {
+	repo := newStubDynamicConfigRepo()
+	repo.configs[compositeKey("model", "prod")] = &domain.DynamicConfig{
+		Key: "model", Lane: "prod", Value: "gemini", UpdatedAt: time.Now(),
+	}
+	svc := NewDynamicConfigService(repo)
+
+	result, err := svc.Resolve(context.Background(), "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Configs["model"].Value != "gemini" {
+		t.Errorf("expected gemini, got %s", result.Configs["model"].Value)
+	}
+}
+
+func TestSetAndDelete(t *testing.T) {
+	repo := newStubDynamicConfigRepo()
+	svc := NewDynamicConfigService(repo)
+
+	err := svc.Set(context.Background(), "model", SetDynamicConfigRequest{Lane: "prod", Value: "gemini"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := svc.Resolve(context.Background(), "prod")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Configs["model"].Value != "gemini" {
+		t.Errorf("expected gemini, got %s", result.Configs["model"].Value)
+	}
+
+	err = svc.Delete(context.Background(), "model", "prod")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result, err = svc.Resolve(context.Background(), "prod")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, exists := result.Configs["model"]; exists {
+		t.Error("expected model to be deleted")
+	}
+}

--- a/docs/dynamic-config.md
+++ b/docs/dynamic-config.md
@@ -1,0 +1,82 @@
+# 动态配置系统
+
+业务行为参数（模型选择、阈值、feature flag 等）的运行时配置。修改后无需重新部署，10 秒内生效。
+
+基础设施连接（DB/Redis 连接串）仍走 ConfigBundle（部署时环境变量）。
+
+## 概念
+
+- **全局配置空间**，唯一隔离维度是泳道
+- `prod` 是基线值，其他泳道是覆盖值
+- 读取时自动合并：泳道覆盖 > prod 基线，无覆盖则 fallback 到 prod
+- SDK 从 request context 自动获取当前泳道，业务代码无需感知
+
+## 管理
+
+Dashboard「动态配置」页面，支持：
+
+- 切换泳道查看合并后的生效配置
+- 新增 / 编辑配置值
+- 非 prod 泳道可「恢复到 prod」（删除覆盖）
+
+## 服务接入
+
+### Python（agent-service 等）
+
+```python
+# app/infra/dynamic_config.py — 创建一次，全局使用
+from inner_shared.dynamic_config import DynamicConfig
+from app.api.middleware import get_lane
+
+dynamic_config = DynamicConfig(lane_provider=get_lane)
+```
+
+```python
+# 业务代码中
+from app.infra.dynamic_config import dynamic_config
+
+model = dynamic_config.get("default_model", default="gemini")
+threshold = dynamic_config.get_float("proactive_threshold", default=0.7)
+enabled = dynamic_config.get_bool("feature_x_enabled", default=False)
+count = dynamic_config.get_int("max_retry", default=3)
+```
+
+### TypeScript（lark-server 等）
+
+```typescript
+// src/infrastructure/dynamic-config.ts — 创建一次，全局使用
+import { DynamicConfig } from 'ts-shared';
+
+export const dynamicConfig = new DynamicConfig();
+```
+
+```typescript
+// 业务代码中（注意 async）
+import { dynamicConfig } from '../infrastructure/dynamic-config';
+
+const model = await dynamicConfig.get("default_model", "gemini");
+const threshold = await dynamicConfig.getFloat("proactive_threshold", 0.7);
+const enabled = await dynamicConfig.getBool("feature_x_enabled", false);
+```
+
+## API
+
+| 用途 | 端点 | 认证 |
+|------|------|------|
+| SDK 读取 | `GET /internal/dynamic-config/resolved?lane=xxx` | 无（集群内部） |
+| 管理查询 | `GET /api/paas/dynamic-config/` | API Token |
+| 管理设置 | `PUT /api/paas/dynamic-config/{key}` body: `{"lane":"prod","value":"..."}` | API Token |
+| 管理删除 | `DELETE /api/paas/dynamic-config/{key}?lane=xxx` | API Token |
+
+## 数据存储
+
+```sql
+-- paas-engine PostgreSQL
+CREATE TABLE dynamic_configs (
+    key        TEXT      NOT NULL,
+    lane       TEXT      NOT NULL DEFAULT 'prod',
+    value      TEXT      NOT NULL,
+    updated_at TIMESTAMP NOT NULL DEFAULT now(),
+    PRIMARY KEY (key, lane)
+);
+```

--- a/docs/superpowers/plans/2026-04-14-dynamic-config-by-lane.md
+++ b/docs/superpowers/plans/2026-04-14-dynamic-config-by-lane.md
@@ -1,0 +1,1394 @@
+# Dynamic Config by Lane — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 实现按泳道隔离的运行时动态配置系统，支持 SDK 透明读取（10s 缓存）和 Dashboard 管理。
+
+**Architecture:** 扩展 paas-engine 新增一张 `dynamic_configs` 表（PK: key+lane），提供管理 API（auth 保护）和内部读取端点（无 auth，供集群内 SDK 使用）。Python/TS SDK 各实现一个 `dynamic_config` 模块，通过 lane_provider 自动获取当前泳道，lazy 拉取全量快照并缓存 10s。Dashboard 通过 monitor-dashboard 后端代理调用管理 API。
+
+**Tech Stack:** Go (paas-engine, GORM, chi), Python (httpx), TypeScript (Bun/Hono), React + Ant Design (dashboard)
+
+**Spec:** `docs/superpowers/specs/2026-04-14-dynamic-config-by-lane-design.md`
+
+---
+
+### Task 1: paas-engine 数据层 — Domain + Port + Model + Repo
+
+**Files:**
+- Create: `apps/paas-engine/internal/domain/dynamic_config.go`
+- Modify: `apps/paas-engine/internal/domain/errors.go` (追加 ErrDynamicConfigNotFound)
+- Modify: `apps/paas-engine/internal/port/repository.go` (追加 DynamicConfigRepository 接口)
+- Modify: `apps/paas-engine/internal/adapter/repository/model.go` (追加 DynamicConfigModel)
+- Modify: `apps/paas-engine/internal/adapter/repository/db.go` (AutoMigrate 追加)
+- Create: `apps/paas-engine/internal/adapter/repository/dynamic_config_repo.go`
+
+- [ ] **Step 1: 创建 domain 模型**
+
+`apps/paas-engine/internal/domain/dynamic_config.go`:
+```go
+package domain
+
+import "time"
+
+// DynamicConfig 表示一条动态配置项。
+// PK 为 (Key, Lane)，lane="prod" 是基线值，其他 lane 是覆盖。
+type DynamicConfig struct {
+	Key       string    `json:"key"`
+	Lane      string    `json:"lane"`
+	Value     string    `json:"value"`
+	UpdatedAt time.Time `json:"updated_at"`
+}
+```
+
+- [ ] **Step 2: 追加 domain 错误**
+
+在 `apps/paas-engine/internal/domain/errors.go` 的 var 块中追加：
+```go
+ErrDynamicConfigNotFound = fmt.Errorf("dynamic config %w", ErrNotFound)
+```
+
+- [ ] **Step 3: 追加 Port 接口**
+
+在 `apps/paas-engine/internal/port/repository.go` 末尾追加：
+```go
+type DynamicConfigRepository interface {
+	Upsert(ctx context.Context, config *domain.DynamicConfig) error
+	FindByKeyAndLane(ctx context.Context, key, lane string) (*domain.DynamicConfig, error)
+	FindByLane(ctx context.Context, lane string) ([]*domain.DynamicConfig, error)
+	FindAll(ctx context.Context) ([]*domain.DynamicConfig, error)
+	DeleteByKeyAndLane(ctx context.Context, key, lane string) error
+	DeleteByKey(ctx context.Context, key string) error
+}
+```
+
+- [ ] **Step 4: 追加 DB Model**
+
+在 `apps/paas-engine/internal/adapter/repository/model.go` 末尾追加：
+```go
+// DynamicConfigModel 是 DynamicConfig 的数据库持久化模型。
+type DynamicConfigModel struct {
+	Key       string    `gorm:"primaryKey"`
+	Lane      string    `gorm:"primaryKey;default:prod"`
+	Value     string    `gorm:"not null"`
+	UpdatedAt time.Time
+}
+
+func (DynamicConfigModel) TableName() string { return "dynamic_configs" }
+```
+
+- [ ] **Step 5: 追加 AutoMigrate**
+
+在 `apps/paas-engine/internal/adapter/repository/db.go` 的 `db.AutoMigrate()` 调用中，追加 `&DynamicConfigModel{}`（在 `&DbMutationModel{}` 之后）。
+
+- [ ] **Step 6: 实现 Repo**
+
+`apps/paas-engine/internal/adapter/repository/dynamic_config_repo.go`:
+```go
+package repository
+
+import (
+	"context"
+	"errors"
+
+	"github.com/chiwei-platform/paas-engine/internal/domain"
+	"github.com/chiwei-platform/paas-engine/internal/port"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+var _ port.DynamicConfigRepository = (*DynamicConfigRepo)(nil)
+
+type DynamicConfigRepo struct {
+	db *gorm.DB
+}
+
+func NewDynamicConfigRepo(db *gorm.DB) *DynamicConfigRepo {
+	return &DynamicConfigRepo{db: db}
+}
+
+func (r *DynamicConfigRepo) Upsert(ctx context.Context, config *domain.DynamicConfig) error {
+	m := DynamicConfigModel{
+		Key:       config.Key,
+		Lane:      config.Lane,
+		Value:     config.Value,
+		UpdatedAt: config.UpdatedAt,
+	}
+	return r.db.WithContext(ctx).Clauses(clause.OnConflict{
+		Columns:   []clause.Column{{Name: "key"}, {Name: "lane"}},
+		DoUpdates: clause.AssignmentColumns([]string{"value", "updated_at"}),
+	}).Create(&m).Error
+}
+
+func (r *DynamicConfigRepo) FindByKeyAndLane(ctx context.Context, key, lane string) (*domain.DynamicConfig, error) {
+	var m DynamicConfigModel
+	result := r.db.WithContext(ctx).First(&m, "key = ? AND lane = ?", key, lane)
+	if result.Error != nil {
+		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
+			return nil, domain.ErrDynamicConfigNotFound
+		}
+		return nil, result.Error
+	}
+	return modelToDynamicConfig(&m), nil
+}
+
+func (r *DynamicConfigRepo) FindByLane(ctx context.Context, lane string) ([]*domain.DynamicConfig, error) {
+	var models []DynamicConfigModel
+	if err := r.db.WithContext(ctx).Where("lane = ?", lane).Find(&models).Error; err != nil {
+		return nil, err
+	}
+	return modelsToDynamicConfigs(models), nil
+}
+
+func (r *DynamicConfigRepo) FindAll(ctx context.Context) ([]*domain.DynamicConfig, error) {
+	var models []DynamicConfigModel
+	if err := r.db.WithContext(ctx).Order("key, lane").Find(&models).Error; err != nil {
+		return nil, err
+	}
+	return modelsToDynamicConfigs(models), nil
+}
+
+func (r *DynamicConfigRepo) DeleteByKeyAndLane(ctx context.Context, key, lane string) error {
+	result := r.db.WithContext(ctx).Delete(&DynamicConfigModel{}, "key = ? AND lane = ?", key, lane)
+	if result.RowsAffected == 0 {
+		return domain.ErrDynamicConfigNotFound
+	}
+	return result.Error
+}
+
+func (r *DynamicConfigRepo) DeleteByKey(ctx context.Context, key string) error {
+	result := r.db.WithContext(ctx).Delete(&DynamicConfigModel{}, "key = ?", key)
+	if result.RowsAffected == 0 {
+		return domain.ErrDynamicConfigNotFound
+	}
+	return result.Error
+}
+
+func modelToDynamicConfig(m *DynamicConfigModel) *domain.DynamicConfig {
+	return &domain.DynamicConfig{
+		Key:       m.Key,
+		Lane:      m.Lane,
+		Value:     m.Value,
+		UpdatedAt: m.UpdatedAt,
+	}
+}
+
+func modelsToDynamicConfigs(models []DynamicConfigModel) []*domain.DynamicConfig {
+	configs := make([]*domain.DynamicConfig, 0, len(models))
+	for i := range models {
+		configs = append(configs, modelToDynamicConfig(&models[i]))
+	}
+	return configs
+}
+```
+
+- [ ] **Step 7: 编译验证**
+
+Run: `cd apps/paas-engine && go build ./...`
+Expected: 编译通过
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add apps/paas-engine/internal/domain/dynamic_config.go \
+       apps/paas-engine/internal/domain/errors.go \
+       apps/paas-engine/internal/port/repository.go \
+       apps/paas-engine/internal/adapter/repository/model.go \
+       apps/paas-engine/internal/adapter/repository/db.go \
+       apps/paas-engine/internal/adapter/repository/dynamic_config_repo.go
+git commit -m "feat(paas-engine): add dynamic config data layer"
+```
+
+---
+
+### Task 2: paas-engine Service 层 + 测试
+
+**Files:**
+- Create: `apps/paas-engine/internal/service/dynamic_config_service.go`
+- Create: `apps/paas-engine/internal/service/dynamic_config_service_test.go`
+
+- [ ] **Step 1: 写测试 — stub repo + Resolve 测试**
+
+`apps/paas-engine/internal/service/dynamic_config_service_test.go`:
+```go
+package service
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/chiwei-platform/paas-engine/internal/domain"
+)
+
+// --- stub for DynamicConfigRepository ---
+
+type stubDynamicConfigRepo struct {
+	configs map[string]*domain.DynamicConfig // key = "key|lane"
+}
+
+func newStubDynamicConfigRepo() *stubDynamicConfigRepo {
+	return &stubDynamicConfigRepo{configs: make(map[string]*domain.DynamicConfig)}
+}
+
+func compositeKey(key, lane string) string { return key + "|" + lane }
+
+func (r *stubDynamicConfigRepo) Upsert(_ context.Context, config *domain.DynamicConfig) error {
+	r.configs[compositeKey(config.Key, config.Lane)] = config
+	return nil
+}
+
+func (r *stubDynamicConfigRepo) FindByKeyAndLane(_ context.Context, key, lane string) (*domain.DynamicConfig, error) {
+	c, ok := r.configs[compositeKey(key, lane)]
+	if !ok {
+		return nil, domain.ErrDynamicConfigNotFound
+	}
+	return c, nil
+}
+
+func (r *stubDynamicConfigRepo) FindByLane(_ context.Context, lane string) ([]*domain.DynamicConfig, error) {
+	var result []*domain.DynamicConfig
+	for _, c := range r.configs {
+		if c.Lane == lane {
+			result = append(result, c)
+		}
+	}
+	return result, nil
+}
+
+func (r *stubDynamicConfigRepo) FindAll(_ context.Context) ([]*domain.DynamicConfig, error) {
+	var result []*domain.DynamicConfig
+	for _, c := range r.configs {
+		result = append(result, c)
+	}
+	return result, nil
+}
+
+func (r *stubDynamicConfigRepo) DeleteByKeyAndLane(_ context.Context, key, lane string) error {
+	ck := compositeKey(key, lane)
+	if _, ok := r.configs[ck]; !ok {
+		return domain.ErrDynamicConfigNotFound
+	}
+	delete(r.configs, ck)
+	return nil
+}
+
+func (r *stubDynamicConfigRepo) DeleteByKey(_ context.Context, key string) error {
+	found := false
+	for ck, c := range r.configs {
+		if c.Key == key {
+			delete(r.configs, ck)
+			found = true
+		}
+	}
+	if !found {
+		return domain.ErrDynamicConfigNotFound
+	}
+	return nil
+}
+
+// --- tests ---
+
+func TestResolve_ProdBaseline(t *testing.T) {
+	repo := newStubDynamicConfigRepo()
+	repo.configs[compositeKey("model", "prod")] = &domain.DynamicConfig{
+		Key: "model", Lane: "prod", Value: "gemini", UpdatedAt: time.Now(),
+	}
+	svc := NewDynamicConfigService(repo)
+
+	result, err := svc.Resolve(context.Background(), "prod")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Configs["model"].Value != "gemini" {
+		t.Errorf("expected gemini, got %s", result.Configs["model"].Value)
+	}
+	if result.Configs["model"].Lane != "prod" {
+		t.Errorf("expected lane=prod, got %s", result.Configs["model"].Lane)
+	}
+}
+
+func TestResolve_LaneOverride(t *testing.T) {
+	repo := newStubDynamicConfigRepo()
+	repo.configs[compositeKey("model", "prod")] = &domain.DynamicConfig{
+		Key: "model", Lane: "prod", Value: "gemini", UpdatedAt: time.Now(),
+	}
+	repo.configs[compositeKey("model", "dev")] = &domain.DynamicConfig{
+		Key: "model", Lane: "dev", Value: "gpt-4o", UpdatedAt: time.Now(),
+	}
+	repo.configs[compositeKey("threshold", "prod")] = &domain.DynamicConfig{
+		Key: "threshold", Lane: "prod", Value: "0.7", UpdatedAt: time.Now(),
+	}
+	svc := NewDynamicConfigService(repo)
+
+	result, err := svc.Resolve(context.Background(), "dev")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// model should be overridden by dev
+	if result.Configs["model"].Value != "gpt-4o" {
+		t.Errorf("expected gpt-4o, got %s", result.Configs["model"].Value)
+	}
+	if result.Configs["model"].Lane != "dev" {
+		t.Errorf("expected lane=dev, got %s", result.Configs["model"].Lane)
+	}
+	// threshold should fallback to prod
+	if result.Configs["threshold"].Value != "0.7" {
+		t.Errorf("expected 0.7, got %s", result.Configs["threshold"].Value)
+	}
+	if result.Configs["threshold"].Lane != "prod" {
+		t.Errorf("expected lane=prod, got %s", result.Configs["threshold"].Lane)
+	}
+}
+
+func TestResolve_EmptyLaneFallbackProd(t *testing.T) {
+	repo := newStubDynamicConfigRepo()
+	repo.configs[compositeKey("model", "prod")] = &domain.DynamicConfig{
+		Key: "model", Lane: "prod", Value: "gemini", UpdatedAt: time.Now(),
+	}
+	svc := NewDynamicConfigService(repo)
+
+	result, err := svc.Resolve(context.Background(), "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Configs["model"].Value != "gemini" {
+		t.Errorf("expected gemini, got %s", result.Configs["model"].Value)
+	}
+}
+
+func TestSetAndDelete(t *testing.T) {
+	repo := newStubDynamicConfigRepo()
+	svc := NewDynamicConfigService(repo)
+
+	// Set
+	err := svc.Set(context.Background(), "model", SetDynamicConfigRequest{Lane: "prod", Value: "gemini"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := svc.Resolve(context.Background(), "prod")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Configs["model"].Value != "gemini" {
+		t.Errorf("expected gemini, got %s", result.Configs["model"].Value)
+	}
+
+	// Delete
+	err = svc.Delete(context.Background(), "model", "prod")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result, err = svc.Resolve(context.Background(), "prod")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, exists := result.Configs["model"]; exists {
+		t.Error("expected model to be deleted")
+	}
+}
+```
+
+- [ ] **Step 2: 运行测试确认失败**
+
+Run: `cd apps/paas-engine && go test ./internal/service/ -run TestResolve -v`
+Expected: 编译失败 — `NewDynamicConfigService` 未定义
+
+- [ ] **Step 3: 实现 Service**
+
+`apps/paas-engine/internal/service/dynamic_config_service.go`:
+```go
+package service
+
+import (
+	"context"
+	"time"
+
+	"github.com/chiwei-platform/paas-engine/internal/domain"
+	"github.com/chiwei-platform/paas-engine/internal/port"
+)
+
+type DynamicConfigService struct {
+	repo port.DynamicConfigRepository
+}
+
+func NewDynamicConfigService(repo port.DynamicConfigRepository) *DynamicConfigService {
+	return &DynamicConfigService{repo: repo}
+}
+
+// ResolvedEntry 是解析后的单条配置，带来源 lane 标注。
+type ResolvedEntry struct {
+	Value string `json:"value"`
+	Lane  string `json:"lane"`
+}
+
+// ResolvedConfig 是解析后的全量配置快照。
+type ResolvedConfig struct {
+	Configs    map[string]ResolvedEntry `json:"configs"`
+	ResolvedAt time.Time               `json:"resolved_at"`
+}
+
+// Resolve 返回指定泳道的合并配置（lane 覆盖 + prod 补缺）。
+func (s *DynamicConfigService) Resolve(ctx context.Context, lane string) (*ResolvedConfig, error) {
+	if lane == "" {
+		lane = "prod"
+	}
+
+	// 先取 prod 基线
+	prodConfigs, err := s.repo.FindByLane(ctx, "prod")
+	if err != nil {
+		return nil, err
+	}
+
+	result := make(map[string]ResolvedEntry, len(prodConfigs))
+	for _, c := range prodConfigs {
+		result[c.Key] = ResolvedEntry{Value: c.Value, Lane: "prod"}
+	}
+
+	// 非 prod 泳道：用该泳道的值覆盖
+	if lane != "prod" {
+		laneConfigs, err := s.repo.FindByLane(ctx, lane)
+		if err != nil {
+			return nil, err
+		}
+		for _, c := range laneConfigs {
+			result[c.Key] = ResolvedEntry{Value: c.Value, Lane: lane}
+		}
+	}
+
+	return &ResolvedConfig{
+		Configs:    result,
+		ResolvedAt: time.Now(),
+	}, nil
+}
+
+// List 返回所有配置（可选按 lane 筛选）。
+func (s *DynamicConfigService) List(ctx context.Context, lane string) ([]*domain.DynamicConfig, error) {
+	if lane != "" {
+		return s.repo.FindByLane(ctx, lane)
+	}
+	return s.repo.FindAll(ctx)
+}
+
+// SetDynamicConfigRequest 是设置配置的请求体。
+type SetDynamicConfigRequest struct {
+	Lane  string `json:"lane"`
+	Value string `json:"value"`
+}
+
+// Set 设置一条配置（upsert 语义）。
+func (s *DynamicConfigService) Set(ctx context.Context, key string, req SetDynamicConfigRequest) error {
+	if key == "" {
+		return domain.ErrInvalidInput
+	}
+	lane := req.Lane
+	if lane == "" {
+		lane = "prod"
+	}
+	return s.repo.Upsert(ctx, &domain.DynamicConfig{
+		Key:       key,
+		Lane:      lane,
+		Value:     req.Value,
+		UpdatedAt: time.Now(),
+	})
+}
+
+// Delete 删除配置。lane 为空则删除所有 lane 的该 key。
+func (s *DynamicConfigService) Delete(ctx context.Context, key, lane string) error {
+	if lane != "" {
+		return s.repo.DeleteByKeyAndLane(ctx, key, lane)
+	}
+	return s.repo.DeleteByKey(ctx, key)
+}
+```
+
+- [ ] **Step 4: 运行测试确认通过**
+
+Run: `cd apps/paas-engine && go test ./internal/service/ -run "TestResolve|TestSetAndDelete" -v`
+Expected: 全部 PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/paas-engine/internal/service/dynamic_config_service.go \
+       apps/paas-engine/internal/service/dynamic_config_service_test.go
+git commit -m "feat(paas-engine): add dynamic config service with tests"
+```
+
+---
+
+### Task 3: paas-engine HTTP 层 + 路由 + 接线
+
+**Files:**
+- Create: `apps/paas-engine/internal/adapter/http/dynamic_config_handler.go`
+- Modify: `apps/paas-engine/internal/adapter/http/router.go` (追加路由)
+- Modify: `apps/paas-engine/cmd/paas-engine/main.go` (接线)
+
+- [ ] **Step 1: 实现 Handler**
+
+`apps/paas-engine/internal/adapter/http/dynamic_config_handler.go`:
+```go
+package http
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/chiwei-platform/paas-engine/internal/service"
+	"github.com/go-chi/chi/v5"
+)
+
+type DynamicConfigHandler struct {
+	svc *service.DynamicConfigService
+}
+
+func NewDynamicConfigHandler(svc *service.DynamicConfigService) *DynamicConfigHandler {
+	return &DynamicConfigHandler{svc: svc}
+}
+
+// Resolve 返回合并后的全量配置快照（供 SDK 调用，无 auth）。
+func (h *DynamicConfigHandler) Resolve(w http.ResponseWriter, r *http.Request) {
+	lane := r.URL.Query().Get("lane")
+	result, err := h.svc.Resolve(r.Context(), lane)
+	if err != nil {
+		writeError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, result)
+}
+
+// List 列出所有配置（支持 ?lane= 筛选）。
+func (h *DynamicConfigHandler) List(w http.ResponseWriter, r *http.Request) {
+	lane := r.URL.Query().Get("lane")
+	configs, err := h.svc.List(r.Context(), lane)
+	if err != nil {
+		writeError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, configs)
+}
+
+// Set 设置配置（upsert 语义）。
+func (h *DynamicConfigHandler) Set(w http.ResponseWriter, r *http.Request) {
+	key := chi.URLParam(r, "key")
+	var req service.SetDynamicConfigRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, err)
+		return
+	}
+	if err := h.svc.Set(r.Context(), key, req); err != nil {
+		writeError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]string{"key": key, "lane": req.Lane, "status": "ok"})
+}
+
+// Delete 删除配置。?lane= 指定 lane 则只删该 lane 的覆盖，不传则删所有。
+func (h *DynamicConfigHandler) Delete(w http.ResponseWriter, r *http.Request) {
+	key := chi.URLParam(r, "key")
+	lane := r.URL.Query().Get("lane")
+	if err := h.svc.Delete(r.Context(), key, lane); err != nil {
+		writeError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]string{"deleted": key})
+}
+```
+
+- [ ] **Step 2: 注册路由**
+
+在 `apps/paas-engine/internal/adapter/http/router.go` 中：
+
+1. `NewRouter` 函数签名追加参数 `dynamicConfigH *DynamicConfigHandler`（加在 `configBundleH` 之后，`apiToken` 之前）
+
+2. 在 `r.Route("/api/paas", ...)` 块**之前**追加内部读取端点（无 auth）：
+```go
+// Dynamic Config — internal read endpoint (no auth, for SDK)
+r.Get("/internal/dynamic-config/resolved", dynamicConfigH.Resolve)
+```
+
+3. 在 `r.Route("/api/paas", ...)` 块**内部**、`// Config Bundles` 之后追加管理端点：
+```go
+// Dynamic Config (management)
+r.Route("/dynamic-config", func(r chi.Router) {
+	r.Get("/", dynamicConfigH.List)
+	r.Get("/resolved", dynamicConfigH.Resolve)
+	r.Put("/{key}", dynamicConfigH.Set)
+	r.Delete("/{key}", dynamicConfigH.Delete)
+})
+```
+
+注意：`Resolve` 注册了两次 —— `/internal/` 路径供 SDK 无 auth 调用，`/api/paas/` 路径供 Dashboard 带 auth 调用。同一个 handler 方法。
+
+- [ ] **Step 3: main.go 接线**
+
+在 `apps/paas-engine/cmd/paas-engine/main.go` 中：
+
+1. 在 `configBundleRepo := ...` 之后追加：
+```go
+dynamicConfigRepo := repository.NewDynamicConfigRepo(db)
+```
+
+2. 在 `configBundleSvc := ...` 之后追加：
+```go
+dynamicConfigSvc := service.NewDynamicConfigService(dynamicConfigRepo)
+```
+
+3. 修改 `httpadapter.NewRouter(...)` 调用，在 `httpadapter.NewConfigBundleHandler(configBundleSvc)` 之后追加：
+```go
+httpadapter.NewDynamicConfigHandler(dynamicConfigSvc),
+```
+
+- [ ] **Step 4: 编译验证**
+
+Run: `cd apps/paas-engine && go build ./...`
+Expected: 编译通过
+
+- [ ] **Step 5: 全量测试**
+
+Run: `cd apps/paas-engine && go test ./... -v`
+Expected: 全部 PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/paas-engine/internal/adapter/http/dynamic_config_handler.go \
+       apps/paas-engine/internal/adapter/http/router.go \
+       apps/paas-engine/cmd/paas-engine/main.go
+git commit -m "feat(paas-engine): add dynamic config HTTP endpoints and wiring"
+```
+
+---
+
+### Task 4: Python SDK
+
+**Files:**
+- Create: `packages/py-shared/inner_shared/dynamic_config.py`
+- Modify: `packages/py-shared/inner_shared/__init__.py` (追加导出)
+
+- [ ] **Step 1: 实现 SDK**
+
+`packages/py-shared/inner_shared/dynamic_config.py`:
+```python
+"""
+DynamicConfig — 运行时动态配置 SDK (Python)
+
+用法::
+
+    from inner_shared.dynamic_config import dynamic_config
+
+    model = dynamic_config.get("default_model", default="gemini")
+    threshold = dynamic_config.get_float("proactive_threshold", default=0.7)
+    enabled = dynamic_config.get_bool("feature_x_enabled", default=False)
+    count = dynamic_config.get_int("max_retry", default=3)
+"""
+
+import logging
+import threading
+import time
+from collections.abc import Callable
+from typing import Any
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+_CACHE_TTL = 10  # seconds
+
+
+class DynamicConfig:
+    """
+    运行时动态配置读取器。
+
+    从 paas-engine 拉取全量配置快照，按泳道缓存 10s。
+    lane 通过 lane_provider 自动获取（从 context），取不到则为 "prod"。
+    """
+
+    def __init__(
+        self,
+        paas_engine_url: str = "http://paas-engine:8080",
+        lane_provider: Callable[[], str | None] | None = None,
+    ):
+        self._paas_engine_url = paas_engine_url.rstrip("/")
+        self._lane_provider = lane_provider
+        self._cache: dict[str, tuple[dict[str, dict[str, str]], float]] = {}
+        self._lock = threading.Lock()
+
+    def _get_lane(self) -> str:
+        if self._lane_provider:
+            lane = self._lane_provider()
+            if lane:
+                return lane
+        return "prod"
+
+    def _fetch_snapshot(self, lane: str) -> dict[str, dict[str, str]]:
+        """从 paas-engine 拉取合并后的配置快照。"""
+        url = f"{self._paas_engine_url}/internal/dynamic-config/resolved"
+        try:
+            with httpx.Client(timeout=5.0) as client:
+                resp = client.get(url, params={"lane": lane})
+                if resp.status_code == 200:
+                    body = resp.json()
+                    data = body.get("data", body)
+                    return data.get("configs", {})
+                logger.warning(
+                    "[DynamicConfig] paas-engine responded %d", resp.status_code
+                )
+        except Exception as e:
+            logger.warning("[DynamicConfig] failed to fetch config: %s", e)
+        return {}
+
+    def _get_snapshot(self, lane: str) -> dict[str, dict[str, str]]:
+        """获取缓存的快照，过期则刷新。"""
+        now = time.monotonic()
+        with self._lock:
+            if lane in self._cache:
+                snapshot, expire_at = self._cache[lane]
+                if now < expire_at:
+                    return snapshot
+
+        # 缓存过期或不存在，拉取新数据（lock 外执行网络请求）
+        snapshot = self._fetch_snapshot(lane)
+        with self._lock:
+            self._cache[lane] = (snapshot, now + _CACHE_TTL)
+        return snapshot
+
+    def get(self, key: str, *, default: str = "") -> str:
+        """获取配置值（字符串），不存在则返回 default。"""
+        lane = self._get_lane()
+        snapshot = self._get_snapshot(lane)
+        entry = snapshot.get(key)
+        if entry is None:
+            return default
+        return entry.get("value", default)
+
+    def get_int(self, key: str, *, default: int = 0) -> int:
+        """获取配置值（整数），转换失败返回 default。"""
+        raw = self.get(key, default="")
+        if raw == "":
+            return default
+        try:
+            return int(raw)
+        except (ValueError, TypeError):
+            return default
+
+    def get_float(self, key: str, *, default: float = 0.0) -> float:
+        """获取配置值（浮点），转换失败返回 default。"""
+        raw = self.get(key, default="")
+        if raw == "":
+            return default
+        try:
+            return float(raw)
+        except (ValueError, TypeError):
+            return default
+
+    def get_bool(self, key: str, *, default: bool = False) -> bool:
+        """获取配置值（布尔），true/1/yes 为 True，其他为 False。"""
+        raw = self.get(key, default="")
+        if raw == "":
+            return default
+        return raw.lower() in ("true", "1", "yes")
+```
+
+- [ ] **Step 2: 追加导出**
+
+在 `packages/py-shared/inner_shared/__init__.py` 中：
+
+1. 在 `from .lane_router import LaneRouter` 之后追加：
+```python
+# DynamicConfig
+from .dynamic_config import DynamicConfig
+```
+
+2. 在 `__all__` 列表中追加：
+```python
+    # DynamicConfig
+    "DynamicConfig",
+```
+
+- [ ] **Step 3: 语法验证**
+
+Run: `cd packages/py-shared && python -c "from inner_shared.dynamic_config import DynamicConfig; print('OK')"`
+Expected: `OK`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/py-shared/inner_shared/dynamic_config.py \
+       packages/py-shared/inner_shared/__init__.py
+git commit -m "feat(py-shared): add DynamicConfig SDK"
+```
+
+---
+
+### Task 5: TypeScript SDK
+
+**Files:**
+- Create: `packages/ts-shared/src/dynamic-config/index.ts`
+- Modify: `packages/ts-shared/src/index.ts` (追加导出)
+
+- [ ] **Step 1: 实现 SDK**
+
+`packages/ts-shared/src/dynamic-config/index.ts`:
+```typescript
+/**
+ * DynamicConfig — 运行时动态配置 SDK (TypeScript)
+ *
+ * 用法:
+ *   import { DynamicConfig } from 'ts-shared/dynamic-config'
+ *
+ *   const config = new DynamicConfig({ laneProvider: () => context.get('lane') })
+ *   const model = config.get("default_model", "gemini")
+ *   const threshold = config.getFloat("proactive_threshold", 0.7)
+ */
+
+import { context } from '../middleware/context';
+
+const CACHE_TTL = 10_000; // 10 seconds in ms
+
+interface ConfigEntry {
+    value: string;
+    lane: string;
+}
+
+interface ResolvedResponse {
+    data?: {
+        configs: Record<string, ConfigEntry>;
+        resolved_at: string;
+    };
+    configs?: Record<string, ConfigEntry>;
+}
+
+interface CacheEntry {
+    snapshot: Record<string, ConfigEntry>;
+    expireAt: number;
+}
+
+export interface DynamicConfigOptions {
+    paasEngineUrl?: string;
+    laneProvider?: () => string | undefined;
+}
+
+export class DynamicConfig {
+    private paasEngineUrl: string;
+    private laneProvider: () => string | undefined;
+    private cache: Map<string, CacheEntry> = new Map();
+
+    constructor(options: DynamicConfigOptions = {}) {
+        this.paasEngineUrl = (options.paasEngineUrl || 'http://paas-engine:8080').replace(/\/+$/, '');
+        this.laneProvider = options.laneProvider || (() => context.get<string>('lane'));
+    }
+
+    private getLane(): string {
+        const lane = this.laneProvider();
+        return lane || 'prod';
+    }
+
+    private async fetchSnapshot(lane: string): Promise<Record<string, ConfigEntry>> {
+        try {
+            const url = `${this.paasEngineUrl}/internal/dynamic-config/resolved?lane=${encodeURIComponent(lane)}`;
+            const resp = await fetch(url, { signal: AbortSignal.timeout(5000) });
+            if (resp.ok) {
+                const body: ResolvedResponse = await resp.json();
+                const data = body.data ?? body;
+                return data.configs ?? {};
+            }
+            console.warn(`[DynamicConfig] paas-engine responded ${resp.status}`);
+        } catch (err) {
+            console.warn('[DynamicConfig] failed to fetch config:', err);
+        }
+        return {};
+    }
+
+    private async getSnapshot(lane: string): Promise<Record<string, ConfigEntry>> {
+        const now = Date.now();
+        const cached = this.cache.get(lane);
+        if (cached && now < cached.expireAt) {
+            return cached.snapshot;
+        }
+        const snapshot = await this.fetchSnapshot(lane);
+        this.cache.set(lane, { snapshot, expireAt: now + CACHE_TTL });
+        return snapshot;
+    }
+
+    async get(key: string, defaultValue: string = ''): Promise<string> {
+        const lane = this.getLane();
+        const snapshot = await this.getSnapshot(lane);
+        return snapshot[key]?.value ?? defaultValue;
+    }
+
+    async getInt(key: string, defaultValue: number = 0): Promise<number> {
+        const raw = await this.get(key);
+        if (raw === '') return defaultValue;
+        const n = parseInt(raw, 10);
+        return isNaN(n) ? defaultValue : n;
+    }
+
+    async getFloat(key: string, defaultValue: number = 0): Promise<number> {
+        const raw = await this.get(key);
+        if (raw === '') return defaultValue;
+        const n = parseFloat(raw);
+        return isNaN(n) ? defaultValue : n;
+    }
+
+    async getBool(key: string, defaultValue: boolean = false): Promise<boolean> {
+        const raw = await this.get(key);
+        if (raw === '') return defaultValue;
+        return ['true', '1', 'yes'].includes(raw.toLowerCase());
+    }
+}
+```
+
+- [ ] **Step 2: 追加导出**
+
+在 `packages/ts-shared/src/index.ts` 末尾追加：
+```typescript
+
+// DynamicConfig exports
+export type { DynamicConfigOptions } from './dynamic-config';
+export { DynamicConfig } from './dynamic-config';
+```
+
+- [ ] **Step 3: 类型检查**
+
+Run: `cd packages/ts-shared && npx tsc --noEmit 2>&1 | head -20`
+Expected: 无错误（或项目原有的错误，不应有新增）
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/ts-shared/src/dynamic-config/index.ts \
+       packages/ts-shared/src/index.ts
+git commit -m "feat(ts-shared): add DynamicConfig SDK"
+```
+
+---
+
+### Task 6: Dashboard — 后端代理 + 前端页面
+
+**Files:**
+- Modify: `apps/monitor-dashboard/src/paas-client.ts` (追加 put 方法)
+- Create: `apps/monitor-dashboard/src/routes/dynamic-config.ts`
+- Modify: `apps/monitor-dashboard/src/index.ts` (注册路由)
+- Create: `apps/monitor-dashboard-web/src/pages/DynamicConfig.tsx`
+- Modify: `apps/monitor-dashboard-web/src/App.tsx` (追加菜单和路由)
+
+- [ ] **Step 1: paasClient 追加 put 方法**
+
+在 `apps/monitor-dashboard/src/paas-client.ts` 的 `createClient` 函数中，在 `del` 方法之后追加：
+```typescript
+    async put(path: string, body?: unknown, extraHeaders?: Record<string, string>) {
+      const { baseURL, headers } = configFn();
+      const url = laneAwareUrl(baseURL, extraHeaders?.['x-lane']);
+      const config: AxiosRequestConfig = {
+        headers: { ...headers, 'Content-Type': 'application/json', ...extraHeaders },
+        timeout: TIMEOUT,
+      };
+      const res = await axios.put(`${url}${path}`, body, config);
+      return unwrap(res.data);
+    },
+```
+
+- [ ] **Step 2: 创建后端代理路由**
+
+`apps/monitor-dashboard/src/routes/dynamic-config.ts`:
+```typescript
+import { Hono } from 'hono';
+import { paasClient } from '../paas-client';
+
+const app = new Hono();
+
+/** GET /api/dynamic-config — 列出所有配置 */
+app.get('/api/dynamic-config', async (c) => {
+  const lane = c.req.query('lane');
+  const params: Record<string, string> = {};
+  if (lane) params.lane = lane;
+  const data = await paasClient.get('/api/paas/dynamic-config/', params);
+  return c.json(data);
+});
+
+/** GET /api/dynamic-config/resolved — 解析后的配置快照 */
+app.get('/api/dynamic-config/resolved', async (c) => {
+  const lane = c.req.query('lane') || 'prod';
+  const data = await paasClient.get('/api/paas/dynamic-config/resolved', { lane });
+  return c.json(data);
+});
+
+/** PUT /api/dynamic-config/:key — 设置配置 */
+app.put('/api/dynamic-config/:key', async (c) => {
+  const key = c.req.param('key');
+  const body = await c.req.json();
+  const data = await paasClient.put(`/api/paas/dynamic-config/${encodeURIComponent(key)}`, body);
+  return c.json(data);
+});
+
+/** DELETE /api/dynamic-config/:key — 删除配置 */
+app.delete('/api/dynamic-config/:key', async (c) => {
+  const key = c.req.param('key');
+  const lane = c.req.query('lane');
+  const params: Record<string, string> = {};
+  if (lane) params.lane = lane;
+  const data = await paasClient.del(`/api/paas/dynamic-config/${encodeURIComponent(key)}`, params);
+  return c.json(data);
+});
+
+export default app;
+```
+
+- [ ] **Step 3: 注册路由**
+
+在 `apps/monitor-dashboard/src/index.ts` 中：
+
+1. 追加 import：
+```typescript
+import dynamicConfigRoutes from './routes/dynamic-config';
+```
+
+2. 在 `dashboard.route('/', activityRoutes);` 之后追加：
+```typescript
+dashboard.route('/', dynamicConfigRoutes);
+```
+
+- [ ] **Step 4: 创建前端页面**
+
+`apps/monitor-dashboard-web/src/pages/DynamicConfig.tsx`:
+```tsx
+import { useEffect, useState, useCallback } from 'react';
+import {
+  Button,
+  Form,
+  Input,
+  Modal,
+  Popconfirm,
+  Select,
+  Space,
+  Table,
+  Tag,
+  Typography,
+  message,
+} from 'antd';
+import type { ColumnsType } from 'antd/es/table';
+import { PlusOutlined, EditOutlined, DeleteOutlined, UndoOutlined } from '@ant-design/icons';
+import { api } from '../api/client';
+
+const { Text } = Typography;
+
+interface ConfigEntry {
+  value: string;
+  lane: string;
+}
+
+interface ResolvedData {
+  configs: Record<string, ConfigEntry>;
+  resolved_at: string;
+}
+
+interface RawConfig {
+  key: string;
+  lane: string;
+  value: string;
+  updated_at: string;
+}
+
+export default function DynamicConfig() {
+  const [lanes, setLanes] = useState<string[]>(['prod']);
+  const [selectedLane, setSelectedLane] = useState('prod');
+  const [resolved, setResolved] = useState<Record<string, ConfigEntry>>({});
+  const [loading, setLoading] = useState(false);
+  const [modalOpen, setModalOpen] = useState(false);
+  const [editingKey, setEditingKey] = useState<string | null>(null);
+  const [form] = Form.useForm();
+
+  const fetchResolved = useCallback(async (lane: string) => {
+    setLoading(true);
+    try {
+      const { data } = await api.get('/dynamic-config/resolved', { params: { lane } });
+      setResolved(data?.configs || data?.data?.configs || {});
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  const fetchLanes = useCallback(async () => {
+    try {
+      const { data } = await api.get('/dynamic-config');
+      const raw: RawConfig[] = Array.isArray(data) ? data : (data?.data || []);
+      const laneSet = new Set<string>(['prod']);
+      raw.forEach((c: RawConfig) => laneSet.add(c.lane));
+      setLanes(Array.from(laneSet).sort());
+    } catch {
+      // ignore
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchLanes();
+  }, [fetchLanes]);
+
+  useEffect(() => {
+    fetchResolved(selectedLane);
+  }, [selectedLane, fetchResolved]);
+
+  const handleSave = async () => {
+    try {
+      const values = await form.validateFields();
+      await api.put(`/dynamic-config/${encodeURIComponent(values.key)}`, {
+        lane: selectedLane,
+        value: values.value,
+      });
+      message.success('已保存');
+      setModalOpen(false);
+      form.resetFields();
+      setEditingKey(null);
+      fetchResolved(selectedLane);
+      fetchLanes();
+    } catch {
+      // form validation error
+    }
+  };
+
+  const handleDelete = async (key: string) => {
+    if (selectedLane === 'prod') {
+      await api.delete(`/dynamic-config/${encodeURIComponent(key)}`);
+      message.success('已删除');
+    } else {
+      await api.delete(`/dynamic-config/${encodeURIComponent(key)}`, {
+        params: { lane: selectedLane },
+      });
+      message.success('已恢复到 prod');
+    }
+    fetchResolved(selectedLane);
+    fetchLanes();
+  };
+
+  const openEdit = (key: string, value: string) => {
+    setEditingKey(key);
+    form.setFieldsValue({ key, value });
+    setModalOpen(true);
+  };
+
+  const openCreate = () => {
+    setEditingKey(null);
+    form.resetFields();
+    setModalOpen(true);
+  };
+
+  const dataSource = Object.entries(resolved)
+    .map(([key, entry]) => ({ key, ...entry }))
+    .sort((a, b) => a.key.localeCompare(b.key));
+
+  const columns: ColumnsType<{ key: string; value: string; lane: string }> = [
+    {
+      title: 'Key',
+      dataIndex: 'key',
+      width: 280,
+      render: (text: string) => <Text code>{text}</Text>,
+    },
+    {
+      title: 'Value',
+      dataIndex: 'value',
+      ellipsis: true,
+    },
+    {
+      title: '来源',
+      dataIndex: 'lane',
+      width: 120,
+      render: (lane: string) => (
+        <Tag color={lane === selectedLane && lane !== 'prod' ? 'blue' : 'default'}>
+          {lane === selectedLane && lane !== 'prod' ? '本泳道' : 'prod'}
+        </Tag>
+      ),
+    },
+    {
+      title: '操作',
+      width: 160,
+      render: (_: unknown, record: { key: string; value: string; lane: string }) => (
+        <Space>
+          <Button
+            type="link"
+            size="small"
+            icon={<EditOutlined />}
+            onClick={() => openEdit(record.key, record.value)}
+          >
+            编辑
+          </Button>
+          {selectedLane !== 'prod' && record.lane === selectedLane ? (
+            <Popconfirm title="恢复到 prod 值？" onConfirm={() => handleDelete(record.key)}>
+              <Button type="link" size="small" icon={<UndoOutlined />} danger>
+                恢复
+              </Button>
+            </Popconfirm>
+          ) : selectedLane === 'prod' ? (
+            <Popconfirm title="删除此配置？" onConfirm={() => handleDelete(record.key)}>
+              <Button type="link" size="small" icon={<DeleteOutlined />} danger>
+                删除
+              </Button>
+            </Popconfirm>
+          ) : null}
+        </Space>
+      ),
+    },
+  ];
+
+  return (
+    <div>
+      <div style={{ marginBottom: 16, display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+        <Space>
+          <Text strong>泳道：</Text>
+          <Select
+            value={selectedLane}
+            onChange={setSelectedLane}
+            style={{ width: 160 }}
+            options={lanes.map((l) => ({ label: l, value: l }))}
+          />
+        </Space>
+        <Button type="primary" icon={<PlusOutlined />} onClick={openCreate}>
+          新增配置
+        </Button>
+      </div>
+
+      <Table
+        dataSource={dataSource}
+        columns={columns}
+        loading={loading}
+        pagination={false}
+        size="middle"
+        rowKey="key"
+      />
+
+      <Modal
+        title={editingKey ? `编辑 ${editingKey}` : '新增配置'}
+        open={modalOpen}
+        onOk={handleSave}
+        onCancel={() => { setModalOpen(false); form.resetFields(); setEditingKey(null); }}
+        okText="保存"
+        cancelText="取消"
+      >
+        <Form form={form} layout="vertical">
+          <Form.Item
+            name="key"
+            label="Key"
+            rules={[{ required: true, message: '请输入 key' }]}
+          >
+            <Input disabled={!!editingKey} placeholder="如 default_model" />
+          </Form.Item>
+          <Form.Item
+            name="value"
+            label="Value"
+            rules={[{ required: true, message: '请输入 value' }]}
+          >
+            <Input.TextArea rows={3} placeholder="配置值" />
+          </Form.Item>
+          <Form.Item label="泳道">
+            <Tag>{selectedLane}</Tag>
+            {selectedLane !== 'prod' && (
+              <Text type="secondary" style={{ marginLeft: 8 }}>
+                此值仅在 {selectedLane} 泳道生效
+              </Text>
+            )}
+          </Form.Item>
+        </Form>
+      </Modal>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 5: 注册前端路由和菜单**
+
+在 `apps/monitor-dashboard-web/src/App.tsx` 中：
+
+1. 追加 import icon（在现有 icon import 行追加）：
+```typescript
+import { SettingOutlined } from '@ant-design/icons';
+```
+
+2. 追加 lazy import（在现有 lazy import 行之后）：
+```typescript
+const DynamicConfig = lazy(() => import('./pages/DynamicConfig'));
+```
+
+3. 在 `menuItems` 数组中追加（在 `{ key: '/model-mappings', ... }` 之后）：
+```typescript
+{ key: '/dynamic-config', icon: <SettingOutlined />, label: '动态配置' },
+```
+
+4. 在 `<Routes>` 中追加（在 `<Route path="/model-mappings" ...>` 之后）：
+```tsx
+<Route path="/dynamic-config" element={<DynamicConfig />} />
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/monitor-dashboard/src/paas-client.ts \
+       apps/monitor-dashboard/src/routes/dynamic-config.ts \
+       apps/monitor-dashboard/src/index.ts \
+       apps/monitor-dashboard-web/src/pages/DynamicConfig.tsx \
+       apps/monitor-dashboard-web/src/App.tsx
+git commit -m "feat(dashboard): add dynamic config management page"
+```
+
+---
+
+### Task 7: 部署验证 + 文档更新
+
+**Files:**
+- Modify: `CLAUDE.md` (追加 Dynamic Config 说明)
+
+- [ ] **Step 1: paas-engine 全量测试**
+
+Run: `cd apps/paas-engine && go test ./... -v`
+Expected: 全部 PASS
+
+- [ ] **Step 2: 部署 paas-engine 到泳道**
+
+部署 paas-engine（新增了 DB 表和 API 端点）：
+```bash
+make deploy APP=paas-engine LANE=feat-dynamic-config-by-lane GIT_REF=feat/dynamic-config-by-lane
+```
+
+- [ ] **Step 3: 验证 API**
+
+用 `/api-test` skill 测试：
+1. `PUT /api/paas/dynamic-config/default_model` body `{"lane":"prod","value":"gemini"}` — 设置基线
+2. `PUT /api/paas/dynamic-config/default_model` body `{"lane":"dev","value":"gpt-4o"}` — 设置 dev 覆盖
+3. `GET /internal/dynamic-config/resolved?lane=prod` — 应返回 gemini
+4. `GET /internal/dynamic-config/resolved?lane=dev` — 应返回 gpt-4o
+5. `GET /internal/dynamic-config/resolved?lane=staging` — 应 fallback 到 gemini
+6. `DELETE /api/paas/dynamic-config/default_model?lane=dev` — 删除 dev 覆盖
+7. `GET /internal/dynamic-config/resolved?lane=dev` — 应 fallback 到 gemini
+
+- [ ] **Step 4: 部署 dashboard 到泳道并验证页面**
+
+```bash
+make deploy APP=monitor-dashboard LANE=feat-dynamic-config-by-lane GIT_REF=feat/dynamic-config-by-lane
+make deploy APP=monitor-dashboard-web LANE=feat-dynamic-config-by-lane GIT_REF=feat/dynamic-config-by-lane
+```
+
+在 Dashboard 页面验证动态配置管理页面。
+
+- [ ] **Step 5: 更新 CLAUDE.md**
+
+在 `CLAUDE.md` 的 `## 核心数据流` 段落之后追加：
+```markdown
+### 动态配置
+
+```
+Dashboard → monitor-dashboard → paas-engine (管理 API, /api/paas/dynamic-config/)
+                                            ↕ dynamic_configs 表
+SDK (agent-service/lark-server) → paas-engine (读取 API, /internal/dynamic-config/resolved)
+```
+
+- 基础设施连接（DB/Redis）走 ConfigBundle（部署时环境变量）
+- 业务行为参数（模型/阈值/flag）走 Dynamic Config（运行时 SDK 读取，10s 缓存）
+- SDK 用法：`dynamic_config.get("key", default="value")`，lane 从 context 自动获取
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add CLAUDE.md
+git commit -m "docs: add dynamic config system documentation"
+```

--- a/docs/superpowers/specs/2026-04-14-dynamic-config-by-lane-design.md
+++ b/docs/superpowers/specs/2026-04-14-dynamic-config-by-lane-design.md
@@ -1,0 +1,124 @@
+# 动态配置系统（按泳道隔离）
+
+## 问题
+
+当前 ConfigBundle 是部署时静态下发环境变量，不支持运行时热更新。业务行为参数（模型选择、阈值、feature flag 等）修改后需要重新部署才能生效。同时，当 prod Pod 通过 fallback 处理其他泳道的请求时，无法读到该泳道的配置。
+
+系统普遍不了解 ConfigBundle，且 ConfigBundle 解决的是基础设施连接问题，不适合承载业务行为参数。
+
+## 设计目标
+
+- 业务行为参数的运行时动态配置，修改后无需重新部署
+- 按泳道隔离，fallback 到 prod
+- SDK 透明接入，业务代码只调 `get("key", default=...)`，lane 从 context 自动获取
+- Dashboard 页面按泳道管理配置
+
+## 数据模型
+
+```sql
+CREATE TABLE dynamic_configs (
+    key        TEXT      NOT NULL,
+    lane       TEXT      NOT NULL DEFAULT 'prod',
+    value      TEXT      NOT NULL,
+    updated_at TIMESTAMP NOT NULL DEFAULT now(),
+    PRIMARY KEY (key, lane)
+);
+```
+
+- `lane='prod'` 是基线值，其他 lane 是覆盖值
+- 删除某 lane 的覆盖 = 该 lane fallback 到 prod
+- value 统一 TEXT，类型转换由 SDK 负责
+- 无"注册"概念，直接写 key-value 即存在
+
+## API 设计
+
+扩展 paas-engine，新增路由组 `/api/paas/dynamic-config/`。
+
+### 读取（SDK 用）
+
+| 方法 | 路径 | 说明 |
+|------|------|------|
+| GET | `/resolved?lane=dev` | 返回合并后的全量快照（lane 覆盖 + prod 补缺） |
+
+响应：
+
+```json
+{
+  "configs": {
+    "default_model": {"value": "gemini", "lane": "prod"},
+    "proactive_threshold": {"value": "0.5", "lane": "dev"}
+  },
+  "resolved_at": "2026-04-14T10:00:00Z"
+}
+```
+
+每个值带 `lane` 字段标注来源，方便调试。
+
+### 管理（Dashboard 用）
+
+| 方法 | 路径 | 说明 |
+|------|------|------|
+| GET | `/` | 列出所有配置（支持 `?lane=xxx` 筛选） |
+| PUT | `/{key}` | 设置值，body: `{"lane": "prod", "value": "gemini"}`，upsert 语义 |
+| DELETE | `/{key}?lane=dev` | 删除某 lane 的覆盖（fallback 到 prod） |
+| DELETE | `/{key}` | 删除所有 lane 的该 key（不传 lane） |
+
+## SDK 设计
+
+Python（`packages/py-shared`）和 TypeScript（`packages/ts-shared`）各一个，行为一致。
+
+### 使用方式
+
+```python
+from inner_shared.dynamic_config import dynamic_config
+
+model = dynamic_config.get("default_model", default="gemini")
+threshold = dynamic_config.get_float("proactive_threshold", default=0.7)
+enabled = dynamic_config.get_bool("feature_x_enabled", default=False)
+count = dynamic_config.get_int("max_retry", default=3)
+```
+
+```typescript
+import { dynamicConfig } from 'ts-shared/dynamic-config'
+
+const model = dynamicConfig.get("default_model", "gemini")
+const threshold = dynamicConfig.getFloat("proactive_threshold", 0.7)
+```
+
+### 内部机制
+
+1. **缓存结构**：`dict[lane, (snapshot, expire_time)]`，每个 lane 一份快照
+2. **读取流程**：
+   - 从 context 取 lane（取不到则为 `"prod"`）
+   - 查缓存，未过期则直接读
+   - 过期则调 `GET /api/paas/dynamic-config/resolved?lane={lane}`，刷新缓存
+   - key 不在 snapshot 中则返回 default
+3. **缓存 TTL**：10 秒，过期后下次读触发刷新（同步，lazy）
+4. **初始化**：无需显式初始化，首次调用时自动连接 paas-engine（地址通过 LaneRouter 解析）
+5. **类型方法**：`get` 返回 str，`get_int` / `get_float` / `get_bool` 做转换，转换失败返回 default
+
+## Dashboard 页面
+
+在现有 paas-engine Dashboard 中新增「动态配置」页面。
+
+### 布局
+
+- 顶部：泳道选择器（下拉，默认 prod）
+- 主体：表格，列为 Key | Value | 来源(prod/当前 lane) | 操作
+- 操作列：编辑、删除覆盖（非 prod lane 时显示"恢复到 prod"）
+- 表格上方：「新增配置」按钮
+
+### 交互
+
+- 选 prod：直接编辑基线值
+- 选其他泳道：显示合并结果，来源列标注继承自 prod 还是本 lane 覆盖；编辑时创建该 lane 的覆盖；"恢复到 prod" 删除覆盖
+- 新增：输入 key + value，写入当前选中的 lane
+
+## 与现有系统的关系
+
+| 系统 | 职责 | 生效时机 |
+|------|------|---------|
+| ConfigBundle | 基础设施连接（DB/Redis/MQ 连接串） | 部署时，环境变量 |
+| Dynamic Config | 业务行为参数（模型/阈值/flag） | 运行时，SDK 读取，10s 缓存 |
+
+两者正交，互不干扰。

--- a/packages/py-shared/inner_shared/__init__.py
+++ b/packages/py-shared/inner_shared/__init__.py
@@ -38,6 +38,9 @@ from .utils import (
 # LaneRouter
 from .lane_router import LaneRouter
 
+# DynamicConfig
+from .dynamic_config import DynamicConfig
+
 __all__ = [
     # Decorators
     "log_io",
@@ -66,6 +69,8 @@ __all__ = [
     "split_time",
     # LaneRouter
     "LaneRouter",
+    # DynamicConfig
+    "DynamicConfig",
     # Misc
     "hello",
 ]

--- a/packages/py-shared/inner_shared/dynamic_config.py
+++ b/packages/py-shared/inner_shared/dynamic_config.py
@@ -1,0 +1,118 @@
+"""
+DynamicConfig — 运行时动态配置 SDK (Python)
+
+用法::
+
+    from inner_shared.dynamic_config import dynamic_config
+
+    model = dynamic_config.get("default_model", default="gemini")
+    threshold = dynamic_config.get_float("proactive_threshold", default=0.7)
+    enabled = dynamic_config.get_bool("feature_x_enabled", default=False)
+    count = dynamic_config.get_int("max_retry", default=3)
+"""
+
+import logging
+import threading
+import time
+from collections.abc import Callable
+from typing import Any
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+_CACHE_TTL = 10  # seconds
+
+
+class DynamicConfig:
+    """
+    运行时动态配置读取器。
+
+    从 paas-engine 拉取全量配置快照，按泳道缓存 10s。
+    lane 通过 lane_provider 自动获取（从 context），取不到则为 "prod"。
+    """
+
+    def __init__(
+        self,
+        paas_engine_url: str = "http://paas-engine:8080",
+        lane_provider: Callable[[], str | None] | None = None,
+    ):
+        self._paas_engine_url = paas_engine_url.rstrip("/")
+        self._lane_provider = lane_provider
+        self._cache: dict[str, tuple[dict[str, dict[str, str]], float]] = {}
+        self._lock = threading.Lock()
+
+    def _get_lane(self) -> str:
+        if self._lane_provider:
+            lane = self._lane_provider()
+            if lane:
+                return lane
+        return "prod"
+
+    def _fetch_snapshot(self, lane: str) -> dict[str, dict[str, str]]:
+        """从 paas-engine 拉取合并后的配置快照。"""
+        url = f"{self._paas_engine_url}/internal/dynamic-config/resolved"
+        try:
+            with httpx.Client(timeout=5.0) as client:
+                resp = client.get(url, params={"lane": lane})
+                if resp.status_code == 200:
+                    body = resp.json()
+                    data = body.get("data", body)
+                    return data.get("configs", {})
+                logger.warning(
+                    "[DynamicConfig] paas-engine responded %d", resp.status_code
+                )
+        except Exception as e:
+            logger.warning("[DynamicConfig] failed to fetch config: %s", e)
+        return {}
+
+    def _get_snapshot(self, lane: str) -> dict[str, dict[str, str]]:
+        """获取缓存的快照，过期则刷新。"""
+        now = time.monotonic()
+        with self._lock:
+            if lane in self._cache:
+                snapshot, expire_at = self._cache[lane]
+                if now < expire_at:
+                    return snapshot
+
+        # 缓存过期或不存在，拉取新数据（lock 外执行网络请求）
+        snapshot = self._fetch_snapshot(lane)
+        with self._lock:
+            self._cache[lane] = (snapshot, now + _CACHE_TTL)
+        return snapshot
+
+    def get(self, key: str, *, default: str = "") -> str:
+        """获取配置值（字符串），不存在则返回 default。"""
+        lane = self._get_lane()
+        snapshot = self._get_snapshot(lane)
+        entry = snapshot.get(key)
+        if entry is None:
+            return default
+        return entry.get("value", default)
+
+    def get_int(self, key: str, *, default: int = 0) -> int:
+        """获取配置值（整数），转换失败返回 default。"""
+        raw = self.get(key, default="")
+        if raw == "":
+            return default
+        try:
+            return int(raw)
+        except (ValueError, TypeError):
+            return default
+
+    def get_float(self, key: str, *, default: float = 0.0) -> float:
+        """获取配置值（浮点），转换失败返回 default。"""
+        raw = self.get(key, default="")
+        if raw == "":
+            return default
+        try:
+            return float(raw)
+        except (ValueError, TypeError):
+            return default
+
+    def get_bool(self, key: str, *, default: bool = False) -> bool:
+        """获取配置值（布尔），true/1/yes 为 True，其他为 False。"""
+        raw = self.get(key, default="")
+        if raw == "":
+            return default
+        return raw.lower() in ("true", "1", "yes")

--- a/packages/ts-shared/src/dynamic-config/index.ts
+++ b/packages/ts-shared/src/dynamic-config/index.ts
@@ -1,0 +1,106 @@
+/**
+ * DynamicConfig — 运行时动态配置 SDK (TypeScript)
+ *
+ * 用法:
+ *   import { DynamicConfig } from 'ts-shared/dynamic-config'
+ *
+ *   const config = new DynamicConfig({ laneProvider: () => context.get('lane') })
+ *   const model = await config.get("default_model", "gemini")
+ *   const threshold = await config.getFloat("proactive_threshold", 0.7)
+ */
+
+import { context } from '../middleware/context';
+
+const CACHE_TTL = 10_000; // 10 seconds in ms
+
+interface ConfigEntry {
+    value: string;
+    lane: string;
+}
+
+interface ResolvedResponse {
+    data?: {
+        configs: Record<string, ConfigEntry>;
+        resolved_at: string;
+    };
+    configs?: Record<string, ConfigEntry>;
+}
+
+interface CacheEntry {
+    snapshot: Record<string, ConfigEntry>;
+    expireAt: number;
+}
+
+export interface DynamicConfigOptions {
+    paasEngineUrl?: string;
+    laneProvider?: () => string | undefined;
+}
+
+export class DynamicConfig {
+    private paasEngineUrl: string;
+    private laneProvider: () => string | undefined;
+    private cache: Map<string, CacheEntry> = new Map();
+
+    constructor(options: DynamicConfigOptions = {}) {
+        this.paasEngineUrl = (options.paasEngineUrl || 'http://paas-engine:8080').replace(/\/+$/, '');
+        this.laneProvider = options.laneProvider || (() => context.get<string>('lane'));
+    }
+
+    private getLane(): string {
+        const lane = this.laneProvider();
+        return lane || 'prod';
+    }
+
+    private async fetchSnapshot(lane: string): Promise<Record<string, ConfigEntry>> {
+        try {
+            const url = `${this.paasEngineUrl}/internal/dynamic-config/resolved?lane=${encodeURIComponent(lane)}`;
+            const resp = await fetch(url, { signal: AbortSignal.timeout(5000) });
+            if (resp.ok) {
+                const body: ResolvedResponse = await resp.json();
+                const data = body.data ?? body;
+                return data.configs ?? {};
+            }
+            console.warn(`[DynamicConfig] paas-engine responded ${resp.status}`);
+        } catch (err) {
+            console.warn('[DynamicConfig] failed to fetch config:', err);
+        }
+        return {};
+    }
+
+    private async getSnapshot(lane: string): Promise<Record<string, ConfigEntry>> {
+        const now = Date.now();
+        const cached = this.cache.get(lane);
+        if (cached && now < cached.expireAt) {
+            return cached.snapshot;
+        }
+        const snapshot = await this.fetchSnapshot(lane);
+        this.cache.set(lane, { snapshot, expireAt: now + CACHE_TTL });
+        return snapshot;
+    }
+
+    async get(key: string, defaultValue: string = ''): Promise<string> {
+        const lane = this.getLane();
+        const snapshot = await this.getSnapshot(lane);
+        return snapshot[key]?.value ?? defaultValue;
+    }
+
+    async getInt(key: string, defaultValue: number = 0): Promise<number> {
+        const raw = await this.get(key);
+        if (raw === '') return defaultValue;
+        const n = parseInt(raw, 10);
+        return isNaN(n) ? defaultValue : n;
+    }
+
+    async getFloat(key: string, defaultValue: number = 0): Promise<number> {
+        const raw = await this.get(key);
+        if (raw === '') return defaultValue;
+        const n = parseFloat(raw);
+        return isNaN(n) ? defaultValue : n;
+    }
+
+    async getBool(key: string, defaultValue: boolean = false): Promise<boolean> {
+        const raw = await this.get(key);
+        if (raw === '') return defaultValue;
+        return ['true', '1', 'yes'].includes(raw.toLowerCase());
+    }
+}

--- a/packages/ts-shared/src/index.ts
+++ b/packages/ts-shared/src/index.ts
@@ -68,3 +68,7 @@ export { MongoService, getMongoService, resetMongoService, createMongoService, M
 // LaneRouter exports
 export type { ServiceInfo, LaneRouterOptions } from './lane-router';
 export { LaneRouter } from './lane-router';
+
+// DynamicConfig exports
+export type { DynamicConfigOptions } from './dynamic-config';
+export { DynamicConfig } from './dynamic-config';


### PR DESCRIPTION
## Summary

- paas-engine 新增 `dynamic_configs` 表和 CRUD + resolved API
- Python/TypeScript SDK（`DynamicConfig` 类），10s 缓存，lane 从 context 自动获取
- Dashboard「动态配置」管理页面，支持按泳道查看/编辑/恢复

## 验证

- paas-engine 全量测试通过（67 个）
- 泳道部署 API 全链路验证（set/resolve/delete/fallback）
- 集群内 SDK 端到端验证（agent-service 通过 SDK 成功读取配置）
- Dashboard 前端页面验收通过

## 部署

paas-engine → monitor-dashboard → monitor-dashboard-web（顺序部署）

🤖 Generated with [Claude Code](https://claude.com/claude-code)