### PR TITLE
feat: sidecar transparent proxy for lane routing

### DIFF
--- a/apps/agent-service/app/main.py
+++ b/apps/agent-service/app/main.py
@@ -70,5 +70,9 @@ app.add_middleware(PrometheusMiddleware)
 # Header context middleware (trace_id, app_name, lane)
 app.add_middleware(HeaderContextMiddleware)
 
+# x-ctx-* context propagation (for sidecar lane routing)
+from inner_shared.middlewares.context_propagation import create_context_propagation_middleware
+app.add_middleware(create_context_propagation_middleware())
+
 # Register routes
 app.include_router(api_router)

--- a/apps/lane-sidecar/.gitignore
+++ b/apps/lane-sidecar/.gitignore
@@ -1,0 +1,1 @@
+lane-sidecar

--- a/apps/lane-sidecar/Dockerfile
+++ b/apps/lane-sidecar/Dockerfile
@@ -1,0 +1,13 @@
+# apps/lane-sidecar/Dockerfile
+FROM harbor.local:30002/library/golang:1.25-alpine AS builder
+WORKDIR /app
+ENV GOPROXY=https://goproxy.cn,direct
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+RUN CGO_ENABLED=0 go build -ldflags="-s -w" -o /bin/lane-sidecar ./cmd/lane-sidecar
+
+FROM harbor.local:30002/library/alpine:3.21
+RUN apk add --no-cache ca-certificates iptables
+COPY --from=builder /bin/lane-sidecar /usr/local/bin/lane-sidecar
+ENTRYPOINT ["lane-sidecar"]

--- a/apps/lane-sidecar/Dockerfile
+++ b/apps/lane-sidecar/Dockerfile
@@ -2,8 +2,7 @@
 FROM harbor.local:30002/library/golang:1.25-alpine AS builder
 WORKDIR /app
 ENV GOPROXY=https://goproxy.cn,direct
-COPY go.mod go.sum ./
-RUN go mod download
+COPY go.mod ./
 COPY . .
 RUN CGO_ENABLED=0 go build -ldflags="-s -w" -o /bin/lane-sidecar ./cmd/lane-sidecar
 

--- a/apps/lane-sidecar/Makefile
+++ b/apps/lane-sidecar/Makefile
@@ -1,0 +1,10 @@
+.PHONY: build test lint
+
+build:
+	go build -o output/lane-sidecar ./cmd/lane-sidecar
+
+test:
+	go test ./... -v -count=1
+
+lint:
+	go vet ./...

--- a/apps/lane-sidecar/cmd/lane-sidecar/main.go
+++ b/apps/lane-sidecar/cmd/lane-sidecar/main.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/chiwei-platform/lane-sidecar/internal/iptables"
+	"github.com/chiwei-platform/lane-sidecar/internal/proxy"
+	"github.com/chiwei-platform/lane-sidecar/internal/registry"
+)
+
+func main() {
+	initMode := flag.Bool("init", false, "run iptables setup and exit (init container mode)")
+	proxyPort := flag.Int("port", 15001, "proxy listen port")
+	healthPort := flag.Int("health-port", 15021, "health check port")
+	registryURL := flag.String("registry-url", envOrDefault("REGISTRY_URL", "http://lite-registry:8080"), "lite-registry URL")
+	pollInterval := flag.Duration("poll-interval", 30*time.Second, "registry poll interval")
+	flag.Parse()
+
+	if *initMode {
+		log.Println("[init] setting up iptables rules")
+		if err := iptables.Setup(*proxyPort, iptables.ProxyUID); err != nil {
+			log.Fatalf("[init] iptables setup failed: %v", err)
+		}
+		log.Println("[init] iptables rules applied successfully")
+		return
+	}
+
+	reg := registry.NewClient(*registryURL, *pollInterval)
+	defer reg.Stop()
+
+	srv := proxy.NewServer(fmt.Sprintf(":%d", *proxyPort), reg)
+
+	healthSrv := &http.Server{
+		Addr: fmt.Sprintf(":%d", *healthPort),
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte("ok"))
+		}),
+	}
+	go healthSrv.ListenAndServe()
+
+	go func() {
+		sigCh := make(chan os.Signal, 1)
+		signal.Notify(sigCh, syscall.SIGTERM, syscall.SIGINT)
+		<-sigCh
+		log.Println("[proxy] shutting down...")
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		srv.Shutdown(ctx)
+		healthSrv.Shutdown(ctx)
+	}()
+
+	log.Printf("[proxy] starting on :%d, health on :%d", *proxyPort, *healthPort)
+	if err := srv.ListenAndServe(); err != http.ErrServerClosed {
+		log.Fatalf("[proxy] server error: %v", err)
+	}
+}
+
+func envOrDefault(key, fallback string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return fallback
+}

--- a/apps/lane-sidecar/go.mod
+++ b/apps/lane-sidecar/go.mod
@@ -1,0 +1,3 @@
+module github.com/chiwei-platform/lane-sidecar
+
+go 1.25.0

--- a/apps/lane-sidecar/go.mod
+++ b/apps/lane-sidecar/go.mod
@@ -1,3 +1,9 @@
 module github.com/chiwei-platform/lane-sidecar
 
 go 1.25.0
+
+require (
+	github.com/soheilhy/cmux v0.1.5 // indirect
+	golang.org/x/net v0.0.0-20201202161906-c7110b5ffcbb // indirect
+	golang.org/x/text v0.3.3 // indirect
+)

--- a/apps/lane-sidecar/go.sum
+++ b/apps/lane-sidecar/go.sum
@@ -1,0 +1,14 @@
+github.com/soheilhy/cmux v0.1.5 h1:jjzc5WVemNEDTLwv9tlmemhC73tI08BNOIGwBOo10Js=
+github.com/soheilhy/cmux v0.1.5/go.mod h1:T7TcVDs9LWfQgPlPsdngu6I6QIoyIFZDDC6sNE1GqG0=
+golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
+golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
+golang.org/x/net v0.0.0-20201202161906-c7110b5ffcbb h1:eBmm0M9fYhWpKZLjQUUKka/LtIxf46G4fxeEz5KJr9U=
+golang.org/x/net v0.0.0-20201202161906-c7110b5ffcbb/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
+golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+golang.org/x/text v0.3.3 h1:cokOdA+Jmi5PJGXLlLllQSgYigAEfHXJAERHVMaCc2k=
+golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
+golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=

--- a/apps/lane-sidecar/internal/iptables/setup.go
+++ b/apps/lane-sidecar/internal/iptables/setup.go
@@ -11,17 +11,49 @@ const (
 	ProxyPort = 15001
 )
 
+// SkipPorts 是不应被 sidecar 拦截的端口（非 HTTP 协议）。
+var SkipPorts = []int{
+	5432,  // PostgreSQL
+	6379,  // Redis
+	27017, // MongoDB
+	5672,  // RabbitMQ (AMQP)
+	15672, // RabbitMQ Management
+	443,   // HTTPS (TLS, sidecar 无法解析)
+}
+
 func Rules(proxyPort, proxyUID int) [][]string {
-	return [][]string{
+	rules := [][]string{
 		{"iptables", "-t", "nat", "-N", "LANE_SIDECAR_OUTPUT"},
+
+		// sidecar 自身流量不拦截
 		{"iptables", "-t", "nat", "-A", "LANE_SIDECAR_OUTPUT",
 			"-m", "owner", "--uid-owner", fmt.Sprint(proxyUID), "-j", "RETURN"},
+
+		// localhost 不拦截
 		{"iptables", "-t", "nat", "-A", "LANE_SIDECAR_OUTPUT",
 			"-d", "127.0.0.1/32", "-j", "RETURN"},
-		{"iptables", "-t", "nat", "-A", "LANE_SIDECAR_OUTPUT",
-			"-p", "tcp", "-j", "REDIRECT", "--to-port", fmt.Sprint(proxyPort)},
-		{"iptables", "-t", "nat", "-A", "OUTPUT", "-j", "LANE_SIDECAR_OUTPUT"},
 	}
+
+	// 跳过非 HTTP 端口（数据库、缓存、MQ、TLS）
+	for _, port := range SkipPorts {
+		rules = append(rules, []string{
+			"iptables", "-t", "nat", "-A", "LANE_SIDECAR_OUTPUT",
+			"-p", "tcp", "--dport", fmt.Sprint(port), "-j", "RETURN",
+		})
+	}
+
+	// 其余出站 TCP 重定向到 sidecar
+	rules = append(rules, []string{
+		"iptables", "-t", "nat", "-A", "LANE_SIDECAR_OUTPUT",
+		"-p", "tcp", "-j", "REDIRECT", "--to-port", fmt.Sprint(proxyPort),
+	})
+
+	// 挂到 OUTPUT 链
+	rules = append(rules, []string{
+		"iptables", "-t", "nat", "-A", "OUTPUT", "-j", "LANE_SIDECAR_OUTPUT",
+	})
+
+	return rules
 }
 
 func Setup(proxyPort, proxyUID int) error {

--- a/apps/lane-sidecar/internal/iptables/setup.go
+++ b/apps/lane-sidecar/internal/iptables/setup.go
@@ -1,0 +1,37 @@
+package iptables
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+const (
+	ProxyUID  = 1337
+	ProxyPort = 15001
+)
+
+func Rules(proxyPort, proxyUID int) [][]string {
+	return [][]string{
+		{"iptables", "-t", "nat", "-N", "LANE_SIDECAR_OUTPUT"},
+		{"iptables", "-t", "nat", "-A", "LANE_SIDECAR_OUTPUT",
+			"-m", "owner", "--uid-owner", fmt.Sprint(proxyUID), "-j", "RETURN"},
+		{"iptables", "-t", "nat", "-A", "LANE_SIDECAR_OUTPUT",
+			"-d", "127.0.0.1/32", "-j", "RETURN"},
+		{"iptables", "-t", "nat", "-A", "LANE_SIDECAR_OUTPUT",
+			"-p", "tcp", "-j", "REDIRECT", "--to-port", fmt.Sprint(proxyPort)},
+		{"iptables", "-t", "nat", "-A", "OUTPUT", "-j", "LANE_SIDECAR_OUTPUT"},
+	}
+}
+
+func Setup(proxyPort, proxyUID int) error {
+	for _, args := range Rules(proxyPort, proxyUID) {
+		cmd := exec.Command(args[0], args[1:]...)
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			return fmt.Errorf("failed to run %s: %w\noutput: %s",
+				strings.Join(args, " "), err, string(out))
+		}
+	}
+	return nil
+}

--- a/apps/lane-sidecar/internal/iptables/setup.go
+++ b/apps/lane-sidecar/internal/iptables/setup.go
@@ -11,51 +11,32 @@ const (
 	ProxyPort = 15001
 )
 
-// SkipPorts 是不应被 sidecar 拦截的端口（非 HTTP 协议）。
-var SkipPorts = []int{
-	5432,  // PostgreSQL
-	6379,  // Redis
-	27017, // MongoDB
-	5672,  // RabbitMQ (AMQP)
-	15672, // RabbitMQ Management
-	443,   // HTTPS (TLS, sidecar 无法解析)
-}
-
+// Rules generates iptables NAT rules that redirect all outbound TCP traffic
+// to the sidecar proxy. The sidecar itself detects the protocol: HTTP traffic
+// gets lane-aware routing, non-HTTP traffic is passed through via TCP tunnel.
 func Rules(proxyPort, proxyUID int) [][]string {
-	rules := [][]string{
+	return [][]string{
+		// 新建自定义链
 		{"iptables", "-t", "nat", "-N", "LANE_SIDECAR_OUTPUT"},
 
-		// sidecar 自身流量不拦截
+		// sidecar 自身流量不拦截（避免死循环）
 		{"iptables", "-t", "nat", "-A", "LANE_SIDECAR_OUTPUT",
 			"-m", "owner", "--uid-owner", fmt.Sprint(proxyUID), "-j", "RETURN"},
 
 		// localhost 不拦截
 		{"iptables", "-t", "nat", "-A", "LANE_SIDECAR_OUTPUT",
 			"-d", "127.0.0.1/32", "-j", "RETURN"},
+
+		// 所有出站 TCP 重定向到 sidecar（sidecar 做协议检测分流）
+		{"iptables", "-t", "nat", "-A", "LANE_SIDECAR_OUTPUT",
+			"-p", "tcp", "-j", "REDIRECT", "--to-port", fmt.Sprint(proxyPort)},
+
+		// 挂到 OUTPUT 链
+		{"iptables", "-t", "nat", "-A", "OUTPUT", "-j", "LANE_SIDECAR_OUTPUT"},
 	}
-
-	// 跳过非 HTTP 端口（数据库、缓存、MQ、TLS）
-	for _, port := range SkipPorts {
-		rules = append(rules, []string{
-			"iptables", "-t", "nat", "-A", "LANE_SIDECAR_OUTPUT",
-			"-p", "tcp", "--dport", fmt.Sprint(port), "-j", "RETURN",
-		})
-	}
-
-	// 其余出站 TCP 重定向到 sidecar
-	rules = append(rules, []string{
-		"iptables", "-t", "nat", "-A", "LANE_SIDECAR_OUTPUT",
-		"-p", "tcp", "-j", "REDIRECT", "--to-port", fmt.Sprint(proxyPort),
-	})
-
-	// 挂到 OUTPUT 链
-	rules = append(rules, []string{
-		"iptables", "-t", "nat", "-A", "OUTPUT", "-j", "LANE_SIDECAR_OUTPUT",
-	})
-
-	return rules
 }
 
+// Setup executes the iptables rules.
 func Setup(proxyPort, proxyUID int) error {
 	for _, args := range Rules(proxyPort, proxyUID) {
 		cmd := exec.Command(args[0], args[1:]...)

--- a/apps/lane-sidecar/internal/proxy/originaldst_linux.go
+++ b/apps/lane-sidecar/internal/proxy/originaldst_linux.go
@@ -1,0 +1,57 @@
+//go:build linux
+
+package proxy
+
+import (
+	"fmt"
+	"net"
+	"syscall"
+	"unsafe"
+)
+
+// SO_ORIGINAL_DST is the sockopt for retrieving the original destination
+// address from an iptables REDIRECT target. Value 80 = SO_ORIGINAL_DST.
+const soOriginalDst = 80
+
+// GetOriginalDst retrieves the original destination address of a connection
+// that was redirected by iptables REDIRECT. This is used when the Host
+// header is unavailable (e.g. non-HTTP traffic).
+func GetOriginalDst(conn *net.TCPConn) (net.Addr, error) {
+	rawConn, err := conn.SyscallConn()
+	if err != nil {
+		return nil, fmt.Errorf("get raw conn: %w", err)
+	}
+
+	var (
+		addr    syscall.RawSockaddrInet4
+		addrErr error
+	)
+
+	err = rawConn.Control(func(fd uintptr) {
+		addrLen := uint32(unsafe.Sizeof(addr))
+		_, _, errno := syscall.Syscall6(
+			syscall.SYS_GETSOCKOPT,
+			fd,
+			syscall.SOL_IP,
+			soOriginalDst,
+			uintptr(unsafe.Pointer(&addr)),
+			uintptr(unsafe.Pointer(&addrLen)),
+			0,
+		)
+		if errno != 0 {
+			addrErr = fmt.Errorf("getsockopt SO_ORIGINAL_DST: %w", errno)
+		}
+	})
+	if err != nil {
+		return nil, fmt.Errorf("raw conn control: %w", err)
+	}
+	if addrErr != nil {
+		return nil, addrErr
+	}
+
+	// RawSockaddrInet4.Port is big-endian.
+	port := int(addr.Port>>8) | int(addr.Port&0xff)<<8
+	ip := net.IPv4(addr.Addr[0], addr.Addr[1], addr.Addr[2], addr.Addr[3])
+
+	return &net.TCPAddr{IP: ip, Port: port}, nil
+}

--- a/apps/lane-sidecar/internal/proxy/originaldst_other.go
+++ b/apps/lane-sidecar/internal/proxy/originaldst_other.go
@@ -1,0 +1,14 @@
+//go:build !linux
+
+package proxy
+
+import (
+	"errors"
+	"net"
+)
+
+// GetOriginalDst is a stub for non-Linux platforms.
+// SO_ORIGINAL_DST is a Linux-only iptables feature.
+func GetOriginalDst(conn *net.TCPConn) (net.Addr, error) {
+	return nil, errors.New("GetOriginalDst: not supported on this platform")
+}

--- a/apps/lane-sidecar/internal/proxy/server.go
+++ b/apps/lane-sidecar/internal/proxy/server.go
@@ -1,15 +1,19 @@
-// Package proxy provides a transparent HTTP reverse proxy that intercepts
-// outbound traffic (via iptables REDIRECT) and routes requests to lane-specific
-// service instances based on the x-ctx-lane header.
+// Package proxy provides a transparent reverse proxy that intercepts outbound
+// traffic (via iptables REDIRECT) and routes HTTP requests to lane-specific
+// service instances based on the x-ctx-lane header. Non-HTTP traffic is
+// passed through to the original destination via TCP tunneling.
 package proxy
 
 import (
+	"bufio"
 	"context"
+	"io"
 	"log"
 	"net"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
+	"sync"
 	"time"
 
 	"github.com/chiwei-platform/lane-sidecar/internal/registry"
@@ -20,8 +24,7 @@ import (
 // tests it redirects to httptest servers.
 type HostMapper func(host string) string
 
-// DefaultHostMapper returns the host unchanged — used in production where
-// DNS resolution handles the mapping.
+// DefaultHostMapper returns the host unchanged.
 func DefaultHostMapper(host string) string { return host }
 
 // Handler is an http.Handler that reverse-proxies every incoming request
@@ -55,8 +58,6 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		Director: func(req *http.Request) {
 			req.URL.Scheme = target.Scheme
 			req.URL.Host = target.Host
-			// Preserve the original Host header so upstream services
-			// see the logical service name, not the resolved address.
 			req.Host = r.Host
 		},
 		ErrorHandler: func(w http.ResponseWriter, r *http.Request, err error) {
@@ -67,20 +68,33 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	proxy.ServeHTTP(w, r)
 }
 
-// Server wraps a Handler in an http.Server with production-ready timeouts.
+// Server accepts TCP connections, detects the protocol, and routes:
+//   - HTTP traffic → lane-aware reverse proxy
+//   - Non-HTTP traffic → TCP passthrough to original destination
 type Server struct {
 	handler    *Handler
 	listenAddr string
+	listener   net.Listener
 	httpServer *http.Server
+	httpLn     *chanListener
+
+	ctx    context.Context
+	cancel context.CancelFunc
+	wg     sync.WaitGroup
 }
 
-// NewServer creates a Server that listens on listenAddr (e.g. ":15001")
-// and routes traffic through the given resolver.
+// NewServer creates a Server that listens on listenAddr (e.g. ":15001").
 func NewServer(listenAddr string, resolver registry.Resolver) *Server {
 	handler := NewHandler(resolver, nil)
+	ctx, cancel := context.WithCancel(context.Background())
+	httpLn := &chanListener{ch: make(chan net.Conn), done: make(chan struct{})}
+
 	s := &Server{
 		handler:    handler,
 		listenAddr: listenAddr,
+		httpLn:     httpLn,
+		ctx:        ctx,
+		cancel:     cancel,
 	}
 	s.httpServer = &http.Server{
 		Handler:      handler,
@@ -90,18 +104,160 @@ func NewServer(listenAddr string, resolver registry.Resolver) *Server {
 	return s
 }
 
-// ListenAndServe starts the proxy server. It blocks until the server is
-// shut down or encounters a fatal error.
+// ListenAndServe starts the proxy server.
 func (s *Server) ListenAndServe() error {
 	ln, err := net.Listen("tcp", s.listenAddr)
 	if err != nil {
 		return err
 	}
+	s.listener = ln
 	log.Printf("[proxy] listening on %s", s.listenAddr)
-	return s.httpServer.Serve(ln)
+
+	// Start HTTP server on the channel-based listener
+	go s.httpServer.Serve(s.httpLn)
+
+	for {
+		conn, err := ln.Accept()
+		if err != nil {
+			select {
+			case <-s.ctx.Done():
+				return http.ErrServerClosed
+			default:
+				log.Printf("[proxy] accept error: %v", err)
+				continue
+			}
+		}
+		s.wg.Add(1)
+		go func() {
+			defer s.wg.Done()
+			s.handleConn(conn)
+		}()
+	}
 }
 
-// Shutdown gracefully shuts down the proxy server.
+// Shutdown gracefully shuts down the server.
 func (s *Server) Shutdown(ctx context.Context) error {
-	return s.httpServer.Shutdown(ctx)
+	s.cancel()
+	if s.listener != nil {
+		s.listener.Close()
+	}
+	close(s.httpLn.done)
+	s.httpServer.Shutdown(ctx)
+	s.wg.Wait()
+	return nil
+}
+
+func (s *Server) handleConn(conn net.Conn) {
+	defer conn.Close()
+
+	// Peek at first byte to detect protocol
+	br := bufio.NewReader(conn)
+	first, err := br.Peek(1)
+	if err != nil {
+		return
+	}
+
+	peekConn := &bufferedConn{Conn: conn, reader: br, done: make(chan struct{})}
+
+	if isHTTPByte(first[0]) {
+		// HTTP → hand off to http.Server via channel listener
+		s.httpLn.ch <- peekConn
+		// Wait for http.Server to finish with this connection
+		<-peekConn.done
+	} else {
+		// Non-HTTP → TCP passthrough to original destination
+		s.tcpPassthrough(peekConn)
+	}
+}
+
+// tcpPassthrough tunnels the connection to the original destination.
+func (s *Server) tcpPassthrough(conn net.Conn) {
+	tcpConn, ok := conn.(*bufferedConn)
+	if !ok {
+		log.Printf("[proxy] non-TCP connection, closing")
+		return
+	}
+
+	origConn, ok := tcpConn.Conn.(*net.TCPConn)
+	if !ok {
+		log.Printf("[proxy] cannot get original dst: not a TCPConn")
+		return
+	}
+
+	origDst, err := GetOriginalDst(origConn)
+	if err != nil {
+		log.Printf("[proxy] get original dst: %v", err)
+		return
+	}
+
+	upstream, err := net.DialTimeout("tcp", origDst.String(), 5*time.Second)
+	if err != nil {
+		log.Printf("[proxy] dial original dst %s: %v", origDst, err)
+		return
+	}
+	defer upstream.Close()
+
+	// Bidirectional copy
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		io.Copy(upstream, conn)
+	}()
+	go func() {
+		defer wg.Done()
+		io.Copy(conn, upstream)
+	}()
+	wg.Wait()
+}
+
+// isHTTPByte checks if the byte looks like the start of an HTTP method.
+// HTTP/1.x methods start with: G(ET), P(OST/UT/ATCH), D(ELETE), H(EAD), O(PTIONS), C(ONNECT), T(RACE)
+func isHTTPByte(b byte) bool {
+	switch b {
+	case 'G', 'P', 'D', 'H', 'O', 'C', 'T':
+		return true
+	default:
+		return false
+	}
+}
+
+// bufferedConn wraps a net.Conn with a bufio.Reader for peeked data.
+type bufferedConn struct {
+	net.Conn
+	reader   *bufio.Reader
+	done     chan struct{}
+	closeOnce sync.Once
+}
+
+func (c *bufferedConn) Read(b []byte) (int, error) {
+	return c.reader.Read(b)
+}
+
+func (c *bufferedConn) Close() error {
+	c.closeOnce.Do(func() { close(c.done) })
+	return c.Conn.Close()
+}
+
+// chanListener feeds connections from a channel to http.Server.
+type chanListener struct {
+	ch   chan net.Conn
+	done chan struct{}
+}
+
+func (l *chanListener) Accept() (net.Conn, error) {
+	select {
+	case conn := <-l.ch:
+		return conn, nil
+	case <-l.done:
+		return nil, net.ErrClosed
+	}
+}
+
+func (l *chanListener) Close() error {
+	return nil
+}
+
+func (l *chanListener) Addr() net.Addr {
+	return &net.TCPAddr{IP: net.IPv4zero, Port: 15001}
 }

--- a/apps/lane-sidecar/internal/proxy/server.go
+++ b/apps/lane-sidecar/internal/proxy/server.go
@@ -5,7 +5,6 @@
 package proxy
 
 import (
-	"bufio"
 	"context"
 	"io"
 	"log"
@@ -17,6 +16,7 @@ import (
 	"time"
 
 	"github.com/chiwei-platform/lane-sidecar/internal/registry"
+	"github.com/soheilhy/cmux"
 )
 
 // HostMapper translates a logical host (e.g. "agent-service-dev:8000") to an
@@ -68,33 +68,23 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	proxy.ServeHTTP(w, r)
 }
 
-// Server accepts TCP connections, detects the protocol, and routes:
-//   - HTTP traffic → lane-aware reverse proxy
-//   - Non-HTTP traffic → TCP passthrough to original destination
+// Server uses cmux to multiplex a single TCP listener into HTTP and non-HTTP
+// streams. HTTP traffic gets lane-aware routing; everything else gets TCP
+// passthrough to the original destination (via SO_ORIGINAL_DST).
 type Server struct {
 	handler    *Handler
 	listenAddr string
-	listener   net.Listener
 	httpServer *http.Server
-	httpLn     *chanListener
-
-	ctx    context.Context
-	cancel context.CancelFunc
-	wg     sync.WaitGroup
+	mux        cmux.CMux
+	listener   net.Listener
 }
 
 // NewServer creates a Server that listens on listenAddr (e.g. ":15001").
 func NewServer(listenAddr string, resolver registry.Resolver) *Server {
 	handler := NewHandler(resolver, nil)
-	ctx, cancel := context.WithCancel(context.Background())
-	httpLn := &chanListener{ch: make(chan net.Conn), done: make(chan struct{})}
-
 	s := &Server{
 		handler:    handler,
 		listenAddr: listenAddr,
-		httpLn:     httpLn,
-		ctx:        ctx,
-		cancel:     cancel,
 	}
 	s.httpServer = &http.Server{
 		Handler:      handler,
@@ -104,7 +94,7 @@ func NewServer(listenAddr string, resolver registry.Resolver) *Server {
 	return s
 }
 
-// ListenAndServe starts the proxy server.
+// ListenAndServe starts the proxy server with protocol multiplexing.
 func (s *Server) ListenAndServe() error {
 	ln, err := net.Listen("tcp", s.listenAddr)
 	if err != nil {
@@ -113,82 +103,50 @@ func (s *Server) ListenAndServe() error {
 	s.listener = ln
 	log.Printf("[proxy] listening on %s", s.listenAddr)
 
-	// Start HTTP server on the channel-based listener
-	go s.httpServer.Serve(s.httpLn)
+	s.mux = cmux.New(ln)
 
-	for {
-		conn, err := ln.Accept()
-		if err != nil {
-			select {
-			case <-s.ctx.Done():
-				return http.ErrServerClosed
-			default:
-				log.Printf("[proxy] accept error: %v", err)
-				continue
-			}
-		}
-		s.wg.Add(1)
-		go func() {
-			defer s.wg.Done()
-			s.handleConn(conn)
-		}()
-	}
+	// HTTP matcher: match requests starting with an HTTP method
+	httpLn := s.mux.Match(httpMethodMatcher())
+	// Everything else: TCP passthrough
+	tcpLn := s.mux.Match(cmux.Any())
+
+	go s.httpServer.Serve(httpLn)
+	go s.serveTCPPassthrough(tcpLn)
+
+	return s.mux.Serve()
 }
 
 // Shutdown gracefully shuts down the server.
 func (s *Server) Shutdown(ctx context.Context) error {
-	s.cancel()
-	if s.listener != nil {
-		s.listener.Close()
+	if s.mux != nil {
+		s.mux.Close()
 	}
-	close(s.httpLn.done)
-	s.httpServer.Shutdown(ctx)
-	s.wg.Wait()
-	return nil
+	return s.httpServer.Shutdown(ctx)
 }
 
-func (s *Server) handleConn(conn net.Conn) {
-	defer conn.Close()
-
-	// Peek at first bytes to detect protocol (need enough for "OPTIONS ")
-	br := bufio.NewReader(conn)
-	peeked, err := br.Peek(8)
-	if err != nil {
-		// Short read — try with what we have (minimum 4 bytes for "GET ")
-		peeked, err = br.Peek(4)
+// serveTCPPassthrough accepts non-HTTP connections and tunnels them to
+// their original destination using SO_ORIGINAL_DST.
+func (s *Server) serveTCPPassthrough(ln net.Listener) {
+	for {
+		conn, err := ln.Accept()
 		if err != nil {
 			return
 		}
-	}
-
-	peekConn := &bufferedConn{Conn: conn, reader: br, done: make(chan struct{})}
-
-	if isHTTPRequest(peeked) {
-		// HTTP → hand off to http.Server via channel listener
-		s.httpLn.ch <- peekConn
-		// Wait for http.Server to finish with this connection
-		<-peekConn.done
-	} else {
-		// Non-HTTP → TCP passthrough to original destination
-		s.tcpPassthrough(peekConn)
+		go s.handleTCPConn(conn)
 	}
 }
 
-// tcpPassthrough tunnels the connection to the original destination.
-func (s *Server) tcpPassthrough(conn net.Conn) {
-	tcpConn, ok := conn.(*bufferedConn)
-	if !ok {
-		log.Printf("[proxy] non-TCP connection, closing")
+func (s *Server) handleTCPConn(conn net.Conn) {
+	defer conn.Close()
+
+	// Unwrap to get the raw TCP connection for SO_ORIGINAL_DST
+	rawConn := unwrapTCPConn(conn)
+	if rawConn == nil {
+		log.Printf("[proxy] tcp passthrough: cannot unwrap to TCPConn")
 		return
 	}
 
-	origConn, ok := tcpConn.Conn.(*net.TCPConn)
-	if !ok {
-		log.Printf("[proxy] cannot get original dst: not a TCPConn")
-		return
-	}
-
-	origDst, err := GetOriginalDst(origConn)
+	origDst, err := GetOriginalDst(rawConn)
 	if err != nil {
 		log.Printf("[proxy] get original dst: %v", err)
 		return
@@ -201,7 +159,6 @@ func (s *Server) tcpPassthrough(conn net.Conn) {
 	}
 	defer upstream.Close()
 
-	// Bidirectional copy
 	var wg sync.WaitGroup
 	wg.Add(2)
 	go func() {
@@ -215,69 +172,51 @@ func (s *Server) tcpPassthrough(conn net.Conn) {
 	wg.Wait()
 }
 
-// httpMethods lists all HTTP/1.x methods followed by a space.
-// We check the full method + space to avoid false positives from binary
-// protocols whose first bytes happen to match a single HTTP letter.
-var httpMethods = []string{
-	"GET ", "PUT ", "POST ", "HEAD ",
-	"DELETE ", "PATCH ", "OPTIONS ", "CONNECT ", "TRACE ",
-}
-
-// isHTTPRequest checks if peeked bytes look like the start of an HTTP request.
-func isHTTPRequest(peeked []byte) bool {
-	for _, method := range httpMethods {
-		if len(peeked) >= len(method) {
-			match := true
-			for i := 0; i < len(method); i++ {
-				if peeked[i] != method[i] {
-					match = false
-					break
-				}
-			}
-			if match {
-				return true
-			}
-		}
+// unwrapTCPConn tries to get the underlying *net.TCPConn from a possibly
+// wrapped connection (cmux wraps connections with its own type).
+func unwrapTCPConn(conn net.Conn) *net.TCPConn {
+	// Try direct cast
+	if tc, ok := conn.(*net.TCPConn); ok {
+		return tc
 	}
-	return false
-}
-
-// bufferedConn wraps a net.Conn with a bufio.Reader for peeked data.
-type bufferedConn struct {
-	net.Conn
-	reader   *bufio.Reader
-	done     chan struct{}
-	closeOnce sync.Once
-}
-
-func (c *bufferedConn) Read(b []byte) (int, error) {
-	return c.reader.Read(b)
-}
-
-func (c *bufferedConn) Close() error {
-	c.closeOnce.Do(func() { close(c.done) })
-	return c.Conn.Close()
-}
-
-// chanListener feeds connections from a channel to http.Server.
-type chanListener struct {
-	ch   chan net.Conn
-	done chan struct{}
-}
-
-func (l *chanListener) Accept() (net.Conn, error) {
-	select {
-	case conn := <-l.ch:
-		return conn, nil
-	case <-l.done:
-		return nil, net.ErrClosed
+	// cmux wraps connections — try to access the underlying conn
+	type unwrapper interface {
+		Conn() net.Conn
 	}
-}
-
-func (l *chanListener) Close() error {
+	if uw, ok := conn.(unwrapper); ok {
+		return unwrapTCPConn(uw.Conn())
+	}
 	return nil
 }
 
-func (l *chanListener) Addr() net.Addr {
-	return &net.TCPAddr{IP: net.IPv4zero, Port: 15001}
+// httpMethodMatcher returns a cmux matcher that matches HTTP/1.x requests
+// by checking for a full HTTP method followed by a space.
+func httpMethodMatcher() cmux.Matcher {
+	methods := []string{
+		"GET ", "PUT ", "POST ", "HEAD ",
+		"DELETE ", "PATCH ", "OPTIONS ", "CONNECT ", "TRACE ",
+	}
+	return func(r io.Reader) bool {
+		buf := make([]byte, 8)
+		n, err := io.ReadAtLeast(r, buf, 4)
+		if err != nil {
+			return false
+		}
+		data := buf[:n]
+		for _, method := range methods {
+			if len(data) >= len(method) {
+				match := true
+				for i := 0; i < len(method); i++ {
+					if data[i] != method[i] {
+						match = false
+						break
+					}
+				}
+				if match {
+					return true
+				}
+			}
+		}
+		return false
+	}
 }

--- a/apps/lane-sidecar/internal/proxy/server.go
+++ b/apps/lane-sidecar/internal/proxy/server.go
@@ -172,19 +172,16 @@ func (s *Server) handleTCPConn(conn net.Conn) {
 	wg.Wait()
 }
 
-// unwrapTCPConn tries to get the underlying *net.TCPConn from a possibly
-// wrapped connection (cmux wraps connections with its own type).
+// unwrapTCPConn extracts the underlying *net.TCPConn from a possibly
+// wrapped connection. cmux.MuxConn embeds net.Conn, so we access it
+// via the embedded field.
 func unwrapTCPConn(conn net.Conn) *net.TCPConn {
-	// Try direct cast
 	if tc, ok := conn.(*net.TCPConn); ok {
 		return tc
 	}
-	// cmux wraps connections — try to access the underlying conn
-	type unwrapper interface {
-		Conn() net.Conn
-	}
-	if uw, ok := conn.(unwrapper); ok {
-		return unwrapTCPConn(uw.Conn())
+	// cmux.MuxConn embeds net.Conn
+	if mc, ok := conn.(*cmux.MuxConn); ok {
+		return unwrapTCPConn(mc.Conn)
 	}
 	return nil
 }

--- a/apps/lane-sidecar/internal/proxy/server.go
+++ b/apps/lane-sidecar/internal/proxy/server.go
@@ -150,16 +150,20 @@ func (s *Server) Shutdown(ctx context.Context) error {
 func (s *Server) handleConn(conn net.Conn) {
 	defer conn.Close()
 
-	// Peek at first byte to detect protocol
+	// Peek at first bytes to detect protocol (need enough for "OPTIONS ")
 	br := bufio.NewReader(conn)
-	first, err := br.Peek(1)
+	peeked, err := br.Peek(8)
 	if err != nil {
-		return
+		// Short read — try with what we have (minimum 4 bytes for "GET ")
+		peeked, err = br.Peek(4)
+		if err != nil {
+			return
+		}
 	}
 
 	peekConn := &bufferedConn{Conn: conn, reader: br, done: make(chan struct{})}
 
-	if isHTTPByte(first[0]) {
+	if isHTTPRequest(peeked) {
 		// HTTP → hand off to http.Server via channel listener
 		s.httpLn.ch <- peekConn
 		// Wait for http.Server to finish with this connection
@@ -211,15 +215,31 @@ func (s *Server) tcpPassthrough(conn net.Conn) {
 	wg.Wait()
 }
 
-// isHTTPByte checks if the byte looks like the start of an HTTP method.
-// HTTP/1.x methods start with: G(ET), P(OST/UT/ATCH), D(ELETE), H(EAD), O(PTIONS), C(ONNECT), T(RACE)
-func isHTTPByte(b byte) bool {
-	switch b {
-	case 'G', 'P', 'D', 'H', 'O', 'C', 'T':
-		return true
-	default:
-		return false
+// httpMethods lists all HTTP/1.x methods followed by a space.
+// We check the full method + space to avoid false positives from binary
+// protocols whose first bytes happen to match a single HTTP letter.
+var httpMethods = []string{
+	"GET ", "PUT ", "POST ", "HEAD ",
+	"DELETE ", "PATCH ", "OPTIONS ", "CONNECT ", "TRACE ",
+}
+
+// isHTTPRequest checks if peeked bytes look like the start of an HTTP request.
+func isHTTPRequest(peeked []byte) bool {
+	for _, method := range httpMethods {
+		if len(peeked) >= len(method) {
+			match := true
+			for i := 0; i < len(method); i++ {
+				if peeked[i] != method[i] {
+					match = false
+					break
+				}
+			}
+			if match {
+				return true
+			}
+		}
 	}
+	return false
 }
 
 // bufferedConn wraps a net.Conn with a bufio.Reader for peeked data.

--- a/apps/lane-sidecar/internal/proxy/server.go
+++ b/apps/lane-sidecar/internal/proxy/server.go
@@ -1,0 +1,107 @@
+// Package proxy provides a transparent HTTP reverse proxy that intercepts
+// outbound traffic (via iptables REDIRECT) and routes requests to lane-specific
+// service instances based on the x-ctx-lane header.
+package proxy
+
+import (
+	"context"
+	"log"
+	"net"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"time"
+
+	"github.com/chiwei-platform/lane-sidecar/internal/registry"
+)
+
+// HostMapper translates a logical host (e.g. "agent-service-dev:8000") to an
+// actual network address. In production this is the identity function; in
+// tests it redirects to httptest servers.
+type HostMapper func(host string) string
+
+// DefaultHostMapper returns the host unchanged — used in production where
+// DNS resolution handles the mapping.
+func DefaultHostMapper(host string) string { return host }
+
+// Handler is an http.Handler that reverse-proxies every incoming request
+// after resolving the target through the lane registry.
+type Handler struct {
+	resolver   registry.Resolver
+	hostMapper HostMapper
+}
+
+// NewHandler creates a Handler. If hostMapper is nil, DefaultHostMapper is used.
+func NewHandler(resolver registry.Resolver, hostMapper HostMapper) *Handler {
+	if hostMapper == nil {
+		hostMapper = DefaultHostMapper
+	}
+	return &Handler{resolver: resolver, hostMapper: hostMapper}
+}
+
+// ServeHTTP resolves the request's target host via the lane registry,
+// applies the host mapper, and reverse-proxies the request.
+func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	lane := r.Header.Get("x-ctx-lane")
+	targetHost := h.resolver.ResolveHost(r.Host, lane)
+	actualHost := h.hostMapper(targetHost)
+
+	target := &url.URL{
+		Scheme: "http",
+		Host:   actualHost,
+	}
+
+	proxy := &httputil.ReverseProxy{
+		Director: func(req *http.Request) {
+			req.URL.Scheme = target.Scheme
+			req.URL.Host = target.Host
+			// Preserve the original Host header so upstream services
+			// see the logical service name, not the resolved address.
+			req.Host = r.Host
+		},
+		ErrorHandler: func(w http.ResponseWriter, r *http.Request, err error) {
+			log.Printf("[proxy] error forwarding to %s: %v", actualHost, err)
+			http.Error(w, "sidecar proxy error", http.StatusBadGateway)
+		},
+	}
+	proxy.ServeHTTP(w, r)
+}
+
+// Server wraps a Handler in an http.Server with production-ready timeouts.
+type Server struct {
+	handler    *Handler
+	listenAddr string
+	httpServer *http.Server
+}
+
+// NewServer creates a Server that listens on listenAddr (e.g. ":15001")
+// and routes traffic through the given resolver.
+func NewServer(listenAddr string, resolver registry.Resolver) *Server {
+	handler := NewHandler(resolver, nil)
+	s := &Server{
+		handler:    handler,
+		listenAddr: listenAddr,
+	}
+	s.httpServer = &http.Server{
+		Handler:      handler,
+		ReadTimeout:  30 * time.Second,
+		WriteTimeout: 60 * time.Second,
+	}
+	return s
+}
+
+// ListenAndServe starts the proxy server. It blocks until the server is
+// shut down or encounters a fatal error.
+func (s *Server) ListenAndServe() error {
+	ln, err := net.Listen("tcp", s.listenAddr)
+	if err != nil {
+		return err
+	}
+	log.Printf("[proxy] listening on %s", s.listenAddr)
+	return s.httpServer.Serve(ln)
+}
+
+// Shutdown gracefully shuts down the proxy server.
+func (s *Server) Shutdown(ctx context.Context) error {
+	return s.httpServer.Shutdown(ctx)
+}

--- a/apps/lane-sidecar/internal/proxy/server_test.go
+++ b/apps/lane-sidecar/internal/proxy/server_test.go
@@ -95,6 +95,21 @@ func TestHandler_FallbackWhenNoLane(t *testing.T) {
 	}
 }
 
+func TestIsHTTPByte(t *testing.T) {
+	httpBytes := []byte{'G', 'P', 'D', 'H', 'O', 'C', 'T'}
+	for _, b := range httpBytes {
+		if !isHTTPByte(b) {
+			t.Errorf("expected %c to be HTTP", b)
+		}
+	}
+	nonHTTPBytes := []byte{0x16, 0x00, 'A', 'X', '\n'}
+	for _, b := range nonHTTPBytes {
+		if isHTTPByte(b) {
+			t.Errorf("did not expect %c (0x%02x) to be HTTP", b, b)
+		}
+	}
+}
+
 func TestHandler_ExternalTrafficPassthrough(t *testing.T) {
 	externalBackend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Write([]byte("external-response"))

--- a/apps/lane-sidecar/internal/proxy/server_test.go
+++ b/apps/lane-sidecar/internal/proxy/server_test.go
@@ -4,6 +4,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/chiwei-platform/lane-sidecar/internal/registry"
@@ -95,29 +96,39 @@ func TestHandler_FallbackWhenNoLane(t *testing.T) {
 	}
 }
 
-func TestIsHTTPRequest(t *testing.T) {
+func TestHttpMethodMatcher(t *testing.T) {
+	matcher := httpMethodMatcher()
+
 	httpStarts := []string{
-		"GET /api", "POST /da", "PUT /foo", "DELETE /",
-		"HEAD /he", "PATCH /p", "OPTIONS ", "CONNECT ", "TRACE /t",
+		"GET /api/test HTTP/1.1",
+		"POST /data HTTP/1.1",
+		"PUT /foo HTTP/1.1",
+		"DELETE /bar HTTP/1.1",
+		"HEAD /health HTTP/1.1",
+		"PATCH /patch HTTP/1.1",
+		"OPTIONS /opt HTTP/1.1",
+		"CONNECT host:443 HTTP/1.1",
+		"TRACE /trace HTTP/1.1",
 	}
 	for _, s := range httpStarts {
-		if !isHTTPRequest([]byte(s)) {
-			t.Errorf("expected %q to be HTTP", s)
+		r := strings.NewReader(s)
+		if !matcher(r) {
+			t.Errorf("expected %q to match HTTP", s)
 		}
 	}
 
 	nonHTTPStarts := []string{
-		"\x16\x03\x01\x00",     // TLS ClientHello
-		"\x00\x00\x00\x45",     // MongoDB wire protocol (length)
-		"\x44\x00\x00\x00",     // Could look like 'D' but not "DELETE "
-		"AMQP\x00\x00",         // RabbitMQ AMQP
-		"\x00\x00\x00\x34",     // PostgreSQL startup
-		"*3\r\n$3\r",           // Redis RESP
-		"HELO srv",             // Not HTTP (HELO != HEAD)
+		"\x16\x03\x01\x00\x01\x00\x00\x00", // TLS ClientHello
+		"\x00\x00\x00\x45\x00\x00\x00\x00", // MongoDB wire protocol
+		"\x44\x00\x00\x00\x00\x00\x00\x00", // Looks like 'D' but not "DELETE "
+		"AMQP\x00\x00\x09\x01",              // RabbitMQ AMQP
+		"\x00\x00\x00\x34\x00\x00\x00\x00", // PostgreSQL startup
+		"*3\r\n$3\r\n",                       // Redis RESP
 	}
 	for _, s := range nonHTTPStarts {
-		if isHTTPRequest([]byte(s)) {
-			t.Errorf("did not expect %q to be HTTP", s)
+		r := strings.NewReader(s)
+		if matcher(r) {
+			t.Errorf("did not expect %q to match HTTP", s)
 		}
 	}
 }

--- a/apps/lane-sidecar/internal/proxy/server_test.go
+++ b/apps/lane-sidecar/internal/proxy/server_test.go
@@ -1,0 +1,119 @@
+package proxy
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/chiwei-platform/lane-sidecar/internal/registry"
+)
+
+type mockResolver struct {
+	services map[string]registry.ServiceInfo
+}
+
+func (m *mockResolver) Lookup(service string) (registry.ServiceInfo, bool) {
+	info, ok := m.services[service]
+	return info, ok
+}
+
+func (m *mockResolver) ResolveHost(host, lane string) string {
+	if lane == "" || lane == "prod" {
+		return host
+	}
+	svc, port := splitHostPort(host)
+	info, ok := m.services[svc]
+	if !ok || !info.HasLane(lane) {
+		return host
+	}
+	if port != "" {
+		return svc + "-" + lane + ":" + port
+	}
+	return svc + "-" + lane
+}
+
+func splitHostPort(host string) (string, string) {
+	for i := len(host) - 1; i >= 0; i-- {
+		if host[i] == ':' {
+			return host[:i], host[i+1:]
+		}
+	}
+	return host, ""
+}
+
+func TestHandler_RoutesToLaneInstance(t *testing.T) {
+	laneBackend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("lane-response"))
+	}))
+	defer laneBackend.Close()
+
+	reg := &mockResolver{
+		services: map[string]registry.ServiceInfo{
+			"agent-service": {Lanes: []string{"dev"}, Port: 8000},
+		},
+	}
+
+	handler := NewHandler(reg, func(host string) string {
+		return laneBackend.Listener.Addr().String()
+	})
+
+	req := httptest.NewRequest("GET", "http://agent-service:8000/api/chat", nil)
+	req.Header.Set("x-ctx-lane", "dev")
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	body, _ := io.ReadAll(w.Result().Body)
+	if string(body) != "lane-response" {
+		t.Fatalf("expected 'lane-response', got %q", string(body))
+	}
+}
+
+func TestHandler_FallbackWhenNoLane(t *testing.T) {
+	prodBackend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("prod-response"))
+	}))
+	defer prodBackend.Close()
+
+	reg := &mockResolver{
+		services: map[string]registry.ServiceInfo{
+			"agent-service": {Lanes: []string{"dev"}, Port: 8000},
+		},
+	}
+
+	handler := NewHandler(reg, func(host string) string {
+		return prodBackend.Listener.Addr().String()
+	})
+
+	req := httptest.NewRequest("GET", "http://agent-service:8000/api/chat", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	body, _ := io.ReadAll(w.Result().Body)
+	if string(body) != "prod-response" {
+		t.Fatalf("expected 'prod-response', got %q", string(body))
+	}
+}
+
+func TestHandler_ExternalTrafficPassthrough(t *testing.T) {
+	externalBackend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("external-response"))
+	}))
+	defer externalBackend.Close()
+
+	reg := &mockResolver{services: map[string]registry.ServiceInfo{}}
+
+	handler := NewHandler(reg, func(host string) string {
+		return externalBackend.Listener.Addr().String()
+	})
+
+	req := httptest.NewRequest("GET", "http://api.openai.com/v1/chat", nil)
+	req.Header.Set("x-ctx-lane", "dev")
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	body, _ := io.ReadAll(w.Result().Body)
+	if string(body) != "external-response" {
+		t.Fatalf("expected 'external-response', got %q", string(body))
+	}
+}

--- a/apps/lane-sidecar/internal/proxy/server_test.go
+++ b/apps/lane-sidecar/internal/proxy/server_test.go
@@ -95,17 +95,29 @@ func TestHandler_FallbackWhenNoLane(t *testing.T) {
 	}
 }
 
-func TestIsHTTPByte(t *testing.T) {
-	httpBytes := []byte{'G', 'P', 'D', 'H', 'O', 'C', 'T'}
-	for _, b := range httpBytes {
-		if !isHTTPByte(b) {
-			t.Errorf("expected %c to be HTTP", b)
+func TestIsHTTPRequest(t *testing.T) {
+	httpStarts := []string{
+		"GET /api", "POST /da", "PUT /foo", "DELETE /",
+		"HEAD /he", "PATCH /p", "OPTIONS ", "CONNECT ", "TRACE /t",
+	}
+	for _, s := range httpStarts {
+		if !isHTTPRequest([]byte(s)) {
+			t.Errorf("expected %q to be HTTP", s)
 		}
 	}
-	nonHTTPBytes := []byte{0x16, 0x00, 'A', 'X', '\n'}
-	for _, b := range nonHTTPBytes {
-		if isHTTPByte(b) {
-			t.Errorf("did not expect %c (0x%02x) to be HTTP", b, b)
+
+	nonHTTPStarts := []string{
+		"\x16\x03\x01\x00",     // TLS ClientHello
+		"\x00\x00\x00\x45",     // MongoDB wire protocol (length)
+		"\x44\x00\x00\x00",     // Could look like 'D' but not "DELETE "
+		"AMQP\x00\x00",         // RabbitMQ AMQP
+		"\x00\x00\x00\x34",     // PostgreSQL startup
+		"*3\r\n$3\r",           // Redis RESP
+		"HELO srv",             // Not HTTP (HELO != HEAD)
+	}
+	for _, s := range nonHTTPStarts {
+		if isHTTPRequest([]byte(s)) {
+			t.Errorf("did not expect %q to be HTTP", s)
 		}
 	}
 }

--- a/apps/lane-sidecar/internal/registry/client.go
+++ b/apps/lane-sidecar/internal/registry/client.go
@@ -1,0 +1,172 @@
+// Package registry provides a polling client for the lite-registry service,
+// which tracks which Kubernetes services have lane-specific instances.
+package registry
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+)
+
+// Resolver abstracts service lookup and host resolution for lane routing.
+// The proxy package uses this interface so it can be mocked in tests.
+type Resolver interface {
+	Lookup(service string) (ServiceInfo, bool)
+	ResolveHost(host, lane string) string
+}
+
+// ServiceInfo describes a service's available lanes and port.
+type ServiceInfo struct {
+	Lanes []string `json:"lanes"`
+	Port  int      `json:"port"`
+}
+
+// HasLane reports whether the service has a deployment in the given lane.
+func (s ServiceInfo) HasLane(lane string) bool {
+	for _, l := range s.Lanes {
+		if l == lane {
+			return true
+		}
+	}
+	return false
+}
+
+// routesResponse is the JSON shape returned by lite-registry /v1/routes.
+type routesResponse struct {
+	Services  map[string]ServiceInfo `json:"services"`
+	UpdatedAt string                 `json:"updated_at"`
+}
+
+// Client polls lite-registry and caches the latest route table in memory.
+// It implements the Resolver interface.
+type Client struct {
+	registryURL  string
+	pollInterval time.Duration
+	httpClient   *http.Client
+
+	mu       sync.RWMutex
+	services map[string]ServiceInfo
+
+	stopCh chan struct{}
+	done   chan struct{}
+}
+
+// compile-time check that *Client satisfies Resolver.
+var _ Resolver = (*Client)(nil)
+
+// NewClient creates a Client that polls registryURL every pollInterval.
+// The first poll is attempted immediately in the background.
+func NewClient(registryURL string, pollInterval time.Duration) *Client {
+	c := &Client{
+		registryURL:  registryURL,
+		pollInterval: pollInterval,
+		httpClient:   &http.Client{Timeout: 5 * time.Second},
+		services:     make(map[string]ServiceInfo),
+		stopCh:       make(chan struct{}),
+		done:         make(chan struct{}),
+	}
+	go c.pollLoop()
+	return c
+}
+
+// Stop terminates the background polling goroutine and waits for it to exit.
+func (c *Client) Stop() {
+	close(c.stopCh)
+	<-c.done
+}
+
+// Lookup returns the ServiceInfo for the given service name.
+// The second return value is false if the service is not in the route table.
+func (c *Client) Lookup(service string) (ServiceInfo, bool) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	info, ok := c.services[service]
+	return info, ok
+}
+
+// ResolveHost rewrites a "host:port" string to target a lane-specific service.
+//
+// Examples:
+//
+//	ResolveHost("agent-service:8000", "dev")     → "agent-service-dev:8000"
+//	ResolveHost("agent-service:8000", "prod")    → "agent-service:8000"
+//	ResolveHost("agent-service:8000", "")        → "agent-service:8000"
+//	ResolveHost("agent-service:8000", "staging") → "agent-service:8000"  (lane not available)
+//	ResolveHost("external-api.com:443", "dev")   → "external-api.com:443" (not in registry)
+func (c *Client) ResolveHost(host, lane string) string {
+	if lane == "" || lane == "prod" {
+		return host
+	}
+
+	svcName, port, ok := splitHostPort(host)
+	if !ok {
+		return host
+	}
+
+	info, found := c.Lookup(svcName)
+	if !found || !info.HasLane(lane) {
+		return host
+	}
+
+	return fmt.Sprintf("%s-%s:%s", svcName, lane, port)
+}
+
+// pollLoop runs until Stop is called, fetching routes on each tick.
+func (c *Client) pollLoop() {
+	defer close(c.done)
+
+	// Immediate first poll.
+	c.fetchRoutes()
+
+	ticker := time.NewTicker(c.pollInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-c.stopCh:
+			return
+		case <-ticker.C:
+			c.fetchRoutes()
+		}
+	}
+}
+
+// fetchRoutes calls lite-registry and updates the cached service map.
+func (c *Client) fetchRoutes() {
+	url := strings.TrimRight(c.registryURL, "/") + "/v1/routes"
+	resp, err := c.httpClient.Get(url)
+	if err != nil {
+		log.Printf("registry: poll failed: %v", err)
+		return
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		log.Printf("registry: poll returned status %d", resp.StatusCode)
+		return
+	}
+
+	var routes routesResponse
+	if err := json.NewDecoder(resp.Body).Decode(&routes); err != nil {
+		log.Printf("registry: decode failed: %v", err)
+		return
+	}
+
+	c.mu.Lock()
+	c.services = routes.Services
+	c.mu.Unlock()
+}
+
+// splitHostPort splits "host:port" into its components.
+// Returns ("", "", false) if there is no colon.
+func splitHostPort(hostport string) (host, port string, ok bool) {
+	idx := strings.LastIndex(hostport, ":")
+	if idx < 0 {
+		return "", "", false
+	}
+	return hostport[:idx], hostport[idx+1:], true
+}

--- a/apps/lane-sidecar/internal/registry/client_test.go
+++ b/apps/lane-sidecar/internal/registry/client_test.go
@@ -1,0 +1,87 @@
+package registry
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestClient_Lookup(t *testing.T) {
+	routes := map[string]any{
+		"services": map[string]any{
+			"agent-service": map[string]any{
+				"lanes": []string{"dev", "feat-test"},
+				"port":  8000,
+			},
+			"lark-server": map[string]any{
+				"lanes": []string{"dev"},
+				"port":  3000,
+			},
+		},
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(routes)
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL, 100*time.Millisecond)
+	defer c.Stop()
+	time.Sleep(200 * time.Millisecond)
+
+	info, ok := c.Lookup("agent-service")
+	if !ok {
+		t.Fatal("expected agent-service to be found")
+	}
+	if info.Port != 8000 {
+		t.Fatalf("expected port 8000, got %d", info.Port)
+	}
+	if !info.HasLane("feat-test") {
+		t.Fatal("expected feat-test lane")
+	}
+	if info.HasLane("staging") {
+		t.Fatal("did not expect staging lane")
+	}
+	_, ok = c.Lookup("unknown-service")
+	if ok {
+		t.Fatal("did not expect unknown-service")
+	}
+}
+
+func TestClient_ResolveHost(t *testing.T) {
+	routes := map[string]any{
+		"services": map[string]any{
+			"agent-service": map[string]any{
+				"lanes": []string{"dev"},
+				"port":  8000,
+			},
+		},
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(routes)
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL, 100*time.Millisecond)
+	defer c.Stop()
+	time.Sleep(200 * time.Millisecond)
+
+	tests := []struct {
+		host string
+		lane string
+		want string
+	}{
+		{"agent-service:8000", "dev", "agent-service-dev:8000"},
+		{"agent-service:8000", "prod", "agent-service:8000"},
+		{"agent-service:8000", "", "agent-service:8000"},
+		{"agent-service:8000", "staging", "agent-service:8000"},
+		{"external-api.com:443", "dev", "external-api.com:443"},
+	}
+	for _, tt := range tests {
+		got := c.ResolveHost(tt.host, tt.lane)
+		if got != tt.want {
+			t.Errorf("ResolveHost(%q, %q) = %q, want %q", tt.host, tt.lane, got, tt.want)
+		}
+	}
+}

--- a/apps/lark-server/src/startup/server.ts
+++ b/apps/lark-server/src/startup/server.ts
@@ -4,6 +4,7 @@ import { bodyLimit } from 'hono/body-limit';
 import { errorHandler } from '@middleware/error-handler';
 import { traceMiddleware } from '@middleware/trace';
 import { botContextMiddleware } from '@middleware/bot-context';
+import { createContextPropagationMiddleware } from '@inner/shared/middleware';
 import { metricsMiddleware, metricsApp } from '@middleware/metrics';
 import { multiBotManager } from '@core/services/bot/multi-bot-manager';
 import internalLarkRoutes from '@api/routes/internal-lark.route';
@@ -40,6 +41,7 @@ export class HttpServerManager {
         this.app.use('*', metricsMiddleware); // Prometheus metrics（最外层）
         this.app.use('*', cors());
         this.app.use('*', traceMiddleware); // 先注入 traceId（为后续日志与错误处理提供上下文）
+        this.app.use('*', createContextPropagationMiddleware()); // x-ctx-* header 透传
         this.app.use('*', botContextMiddleware); // 注入 botName
         this.app.use('*', bodyLimit({
             maxSize: 50 * 1024 * 1024, // 50mb

--- a/apps/monitor-dashboard/src/index.ts
+++ b/apps/monitor-dashboard/src/index.ts
@@ -7,6 +7,7 @@ import { AppDataSource } from './db';
 import { initMongo } from './mongo';
 import { jwtAuth } from './middleware/jwt-auth';
 import { auditMiddleware } from './middleware/audit';
+import { createContextPropagationMiddleware } from '@inner/shared/middleware';
 
 import authRoutes from './routes/auth';
 import configRoutes from './routes/config';
@@ -50,6 +51,9 @@ const bootstrap = async () => {
       : err.message;
     return c.json({ message, status }, status);
   });
+
+  // Context propagation (x-ctx-* headers) — must be before route handlers
+  app.use('*', createContextPropagationMiddleware());
 
   // Auth & audit middleware on API routes
   app.use('/dashboard/api/*', jwtAuth);

--- a/apps/monitor-dashboard/src/paas-client.ts
+++ b/apps/monitor-dashboard/src/paas-client.ts
@@ -33,55 +33,39 @@ function unwrap(data: unknown): unknown {
   return data;
 }
 
-/**
- * 根据 x-lane header 改写 baseURL，将 http://svc:port 变为 http://svc-{lane}:port。
- * 仅对非 prod lane 生效；无 lane 或 prod 时返回原 URL。
- */
-function laneAwareUrl(baseURL: string, lane?: string): string {
-  if (!lane || lane === 'prod') return baseURL;
-  return baseURL.replace(
-    /^(https?:\/\/)([^/:]+)(:\d+)?/,
-    (_, proto, host, port) => `${proto}${host}-${lane}${port || ''}`,
-  );
-}
-
 function createClient(configFn: () => { baseURL: string; headers: Record<string, string> }) {
   return {
     async get(path: string, params?: Record<string, string>, extraHeaders?: Record<string, string>) {
       const { baseURL, headers } = configFn();
-      const url = laneAwareUrl(baseURL, extraHeaders?.['x-lane']);
       const config: AxiosRequestConfig = { headers: { ...headers, ...extraHeaders }, timeout: TIMEOUT, params };
-      const res = await axios.get(`${url}${path}`, config);
+      const res = await axios.get(`${baseURL}${path}`, config);
       return unwrap(res.data);
     },
 
     async post(path: string, body?: unknown, extraHeaders?: Record<string, string>) {
       const { baseURL, headers } = configFn();
-      const url = laneAwareUrl(baseURL, extraHeaders?.['x-lane']);
       const config: AxiosRequestConfig = {
         headers: { ...headers, 'Content-Type': 'application/json', ...extraHeaders },
         timeout: TIMEOUT,
       };
-      const res = await axios.post(`${url}${path}`, body, config);
+      const res = await axios.post(`${baseURL}${path}`, body, config);
       return unwrap(res.data);
     },
 
     async del(path: string, params?: Record<string, string>, extraHeaders?: Record<string, string>) {
       const { baseURL, headers } = configFn();
-      const url = laneAwareUrl(baseURL, extraHeaders?.['x-lane']);
       const config: AxiosRequestConfig = { headers: { ...headers, ...extraHeaders }, timeout: TIMEOUT, params };
-      const res = await axios.delete(`${url}${path}`, config);
+      const res = await axios.delete(`${baseURL}${path}`, config);
       return unwrap(res.data);
     },
 
     async put(path: string, body?: unknown, extraHeaders?: Record<string, string>) {
       const { baseURL, headers } = configFn();
-      const url = laneAwareUrl(baseURL, extraHeaders?.['x-lane']);
       const config: AxiosRequestConfig = {
         headers: { ...headers, 'Content-Type': 'application/json', ...extraHeaders },
         timeout: TIMEOUT,
       };
-      const res = await axios.put(`${url}${path}`, body, config);
+      const res = await axios.put(`${baseURL}${path}`, body, config);
       return unwrap(res.data);
     },
   };

--- a/apps/paas-engine/cmd/paas-engine/main.go
+++ b/apps/paas-engine/cmd/paas-engine/main.go
@@ -50,7 +50,7 @@ func main() {
 	var testExecutor port.TestExecutor
 
 	if cs != nil {
-		deployer = kubernetes.NewK8sDeployer(cs, cfg.DeployNamespace)
+		deployer = kubernetes.NewK8sDeployer(cs, cfg.DeployNamespace, cfg.SidecarImage)
 		buildExecutor = kubernetes.NewKanikoBuildExecutor(cs, kubernetes.KanikoBuildConfig{
 			Namespace:          cfg.KanikoNamespace,
 			KanikoImage:        cfg.KanikoImage,

--- a/apps/paas-engine/internal/adapter/http/middleware.go
+++ b/apps/paas-engine/internal/adapter/http/middleware.go
@@ -1,9 +1,11 @@
 package http
 
 import (
+	"context"
 	"crypto/subtle"
 	"log/slog"
 	"net/http"
+	"strings"
 	"time"
 )
 
@@ -55,4 +57,29 @@ type responseWriter struct {
 func (rw *responseWriter) WriteHeader(status int) {
 	rw.status = status
 	rw.ResponseWriter.WriteHeader(status)
+}
+
+type ctxHeadersKey struct{}
+
+func contextPropagationMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		headers := make(map[string]string)
+		for key, values := range r.Header {
+			lk := strings.ToLower(key)
+			if strings.HasPrefix(lk, "x-ctx-") && len(values) > 0 {
+				headers[lk] = values[0]
+			}
+		}
+		ctx := context.WithValue(r.Context(), ctxHeadersKey{}, headers)
+		next.ServeHTTP(w, r.WithContext(ctx))
+	})
+}
+
+// GetContextHeaders retrieves x-ctx-* headers stored by contextPropagationMiddleware.
+func GetContextHeaders(ctx context.Context) map[string]string {
+	headers, _ := ctx.Value(ctxHeadersKey{}).(map[string]string)
+	if headers == nil {
+		return make(map[string]string)
+	}
+	return headers
 }

--- a/apps/paas-engine/internal/adapter/http/middleware_test.go
+++ b/apps/paas-engine/internal/adapter/http/middleware_test.go
@@ -1,6 +1,7 @@
 package http
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -41,5 +42,41 @@ func TestAuthMiddleware(t *testing.T) {
 				t.Errorf("got status %d, want %d", rec.Code, tt.wantStatus)
 			}
 		})
+	}
+}
+
+func TestContextPropagationMiddleware(t *testing.T) {
+	handler := contextPropagationMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		headers := GetContextHeaders(r.Context())
+		if headers["x-ctx-lane"] != "dev" {
+			t.Errorf("expected x-ctx-lane=dev, got %q", headers["x-ctx-lane"])
+		}
+		if headers["x-ctx-trace-id"] != "abc" {
+			t.Errorf("expected x-ctx-trace-id=abc, got %q", headers["x-ctx-trace-id"])
+		}
+		if _, ok := headers["x-unrelated"]; ok {
+			t.Error("unexpected non-ctx header in context")
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest("GET", "/test", nil)
+	req.Header.Set("x-ctx-lane", "dev")
+	req.Header.Set("x-ctx-trace-id", "abc")
+	req.Header.Set("x-unrelated", "ignored")
+	w := httptest.NewRecorder()
+
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+}
+
+func TestGetContextHeaders_NoContext(t *testing.T) {
+	ctx := context.Background()
+	headers := GetContextHeaders(ctx)
+	if len(headers) != 0 {
+		t.Errorf("expected empty headers, got %v", headers)
 	}
 }

--- a/apps/paas-engine/internal/adapter/http/router.go
+++ b/apps/paas-engine/internal/adapter/http/router.go
@@ -23,6 +23,7 @@ func NewRouter(
 	r.Use(middleware.Recoverer)
 	r.Use(metricsMiddleware)
 	r.Use(loggingMiddleware)
+	r.Use(contextPropagationMiddleware)
 	r.Use(bodySizeLimitMiddleware)
 
 	r.Get("/healthz", func(w http.ResponseWriter, r *http.Request) {

--- a/apps/paas-engine/internal/adapter/kubernetes/deployer.go
+++ b/apps/paas-engine/internal/adapter/kubernetes/deployer.go
@@ -20,16 +20,22 @@ var _ port.Deployer = (*K8sDeployer)(nil)
 
 const defaultNamespace = "default"
 
+const defaultSidecarImage = "harbor.local:30002/inner-bot/lane-sidecar:latest"
+
 type K8sDeployer struct {
-	client    kubernetes.Interface
-	namespace string
+	client       kubernetes.Interface
+	namespace    string
+	sidecarImage string
 }
 
-func NewK8sDeployer(client kubernetes.Interface, namespace string) *K8sDeployer {
+func NewK8sDeployer(client kubernetes.Interface, namespace, sidecarImage string) *K8sDeployer {
 	if namespace == "" {
 		namespace = defaultNamespace
 	}
-	return &K8sDeployer{client: client, namespace: namespace}
+	if sidecarImage == "" {
+		sidecarImage = defaultSidecarImage
+	}
+	return &K8sDeployer{client: client, namespace: namespace, sidecarImage: sidecarImage}
 }
 
 func (d *K8sDeployer) Deploy(ctx context.Context, release *domain.Release, app *domain.App, bundleEnvs map[string]string) error {
@@ -234,7 +240,7 @@ func (d *K8sDeployer) applyDeployment(ctx context.Context, release *domain.Relea
 	var sidecarContainers []corev1.Container
 
 	if app.SidecarEnabled {
-		sidecarImage := "harbor.local:30002/inner-bot/lane-sidecar:1.0.0.6"
+		sidecarImage := d.sidecarImage
 		proxyUID := int64(1337)
 		rootUID := int64(0)
 
@@ -251,8 +257,9 @@ func (d *K8sDeployer) applyDeployment(ctx context.Context, release *domain.Relea
 		})
 
 		sidecarContainers = append(sidecarContainers, corev1.Container{
-			Name:  "lane-sidecar",
-			Image: sidecarImage,
+			Name:            "lane-sidecar",
+			Image:           sidecarImage,
+			ImagePullPolicy: corev1.PullAlways,
 			Env: []corev1.EnvVar{
 				{Name: "REGISTRY_URL", Value: "http://lite-registry:8080"},
 				{Name: "LANE", Value: release.Lane},

--- a/apps/paas-engine/internal/adapter/kubernetes/deployer.go
+++ b/apps/paas-engine/internal/adapter/kubernetes/deployer.go
@@ -234,7 +234,7 @@ func (d *K8sDeployer) applyDeployment(ctx context.Context, release *domain.Relea
 	var sidecarContainers []corev1.Container
 
 	if app.SidecarEnabled {
-		sidecarImage := "harbor.local:30002/inner-bot/lane-sidecar:1.0.0.4"
+		sidecarImage := "harbor.local:30002/inner-bot/lane-sidecar:1.0.0.5"
 		proxyUID := int64(1337)
 		rootUID := int64(0)
 

--- a/apps/paas-engine/internal/adapter/kubernetes/deployer.go
+++ b/apps/paas-engine/internal/adapter/kubernetes/deployer.go
@@ -234,7 +234,7 @@ func (d *K8sDeployer) applyDeployment(ctx context.Context, release *domain.Relea
 	var sidecarContainers []corev1.Container
 
 	if app.SidecarEnabled {
-		sidecarImage := "harbor.local:30002/chiwei/lane-sidecar:latest"
+		sidecarImage := "harbor.local:30002/inner-bot/lane-sidecar:latest"
 		proxyUID := int64(1337)
 		rootUID := int64(0)
 

--- a/apps/paas-engine/internal/adapter/kubernetes/deployer.go
+++ b/apps/paas-engine/internal/adapter/kubernetes/deployer.go
@@ -234,7 +234,7 @@ func (d *K8sDeployer) applyDeployment(ctx context.Context, release *domain.Relea
 	var sidecarContainers []corev1.Container
 
 	if app.SidecarEnabled {
-		sidecarImage := "harbor.local:30002/inner-bot/lane-sidecar:1.0.0.5"
+		sidecarImage := "harbor.local:30002/inner-bot/lane-sidecar:1.0.0.6"
 		proxyUID := int64(1337)
 		rootUID := int64(0)
 

--- a/apps/paas-engine/internal/adapter/kubernetes/deployer.go
+++ b/apps/paas-engine/internal/adapter/kubernetes/deployer.go
@@ -234,7 +234,7 @@ func (d *K8sDeployer) applyDeployment(ctx context.Context, release *domain.Relea
 	var sidecarContainers []corev1.Container
 
 	if app.SidecarEnabled {
-		sidecarImage := "harbor.local:30002/inner-bot/lane-sidecar:1.0.0.3"
+		sidecarImage := "harbor.local:30002/inner-bot/lane-sidecar:1.0.0.4"
 		proxyUID := int64(1337)
 		rootUID := int64(0)
 

--- a/apps/paas-engine/internal/adapter/kubernetes/deployer.go
+++ b/apps/paas-engine/internal/adapter/kubernetes/deployer.go
@@ -234,7 +234,7 @@ func (d *K8sDeployer) applyDeployment(ctx context.Context, release *domain.Relea
 	var sidecarContainers []corev1.Container
 
 	if app.SidecarEnabled {
-		sidecarImage := "harbor.local:30002/inner-bot/lane-sidecar:latest"
+		sidecarImage := "harbor.local:30002/inner-bot/lane-sidecar:1.0.0.3"
 		proxyUID := int64(1337)
 		rootUID := int64(0)
 

--- a/apps/paas-engine/internal/adapter/kubernetes/deployer.go
+++ b/apps/paas-engine/internal/adapter/kubernetes/deployer.go
@@ -230,6 +230,53 @@ func (d *K8sDeployer) applyDeployment(ctx context.Context, release *domain.Relea
 		}
 	}
 
+	var initContainers []corev1.Container
+	var sidecarContainers []corev1.Container
+
+	if app.SidecarEnabled {
+		sidecarImage := "harbor.local:30002/chiwei/lane-sidecar:latest"
+		proxyUID := int64(1337)
+		rootUID := int64(0)
+
+		initContainers = append(initContainers, corev1.Container{
+			Name:    "lane-sidecar-init",
+			Image:   sidecarImage,
+			Command: []string{"lane-sidecar", "--init"},
+			SecurityContext: &corev1.SecurityContext{
+				Capabilities: &corev1.Capabilities{
+					Add: []corev1.Capability{"NET_ADMIN"},
+				},
+				RunAsUser: &rootUID,
+			},
+		})
+
+		sidecarContainers = append(sidecarContainers, corev1.Container{
+			Name:  "lane-sidecar",
+			Image: sidecarImage,
+			Env: []corev1.EnvVar{
+				{Name: "REGISTRY_URL", Value: "http://lite-registry:8080"},
+				{Name: "LANE", Value: release.Lane},
+			},
+			Ports: []corev1.ContainerPort{
+				{Name: "sidecar", ContainerPort: 15001},
+				{Name: "sidecar-health", ContainerPort: 15021},
+			},
+			LivenessProbe: &corev1.Probe{
+				ProbeHandler: corev1.ProbeHandler{
+					HTTPGet: &corev1.HTTPGetAction{
+						Path: "/healthz",
+						Port: intstr.FromInt(15021),
+					},
+				},
+				InitialDelaySeconds: 2,
+				PeriodSeconds:       10,
+			},
+			SecurityContext: &corev1.SecurityContext{
+				RunAsUser: &proxyUID,
+			},
+		})
+	}
+
 	revisionHistoryLimit := int32(2)
 	deploy := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
@@ -246,7 +293,8 @@ func (d *K8sDeployer) applyDeployment(ctx context.Context, release *domain.Relea
 				Spec: corev1.PodSpec{
 					ServiceAccountName: app.ServiceAccount,
 					NodeSelector:       map[string]string{"node-role": "app"},
-					Containers:         []corev1.Container{container},
+					InitContainers:     initContainers,
+					Containers:         append([]corev1.Container{container}, sidecarContainers...),
 				},
 			},
 		},

--- a/apps/paas-engine/internal/adapter/kubernetes/deployer_test.go
+++ b/apps/paas-engine/internal/adapter/kubernetes/deployer_test.go
@@ -102,7 +102,7 @@ func TestDetectPodFailure(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			client := fakeclient.NewSimpleClientset(tt.objects...)
-			deployer := NewK8sDeployer(client, "default")
+			deployer := NewK8sDeployer(client, "default", "")
 
 			deploy := &appsv1.Deployment{
 				Spec: appsv1.DeploymentSpec{
@@ -191,7 +191,7 @@ func contains(s, substr string) bool {
 // - EnvFrom 同时包含 Secret 和 ConfigMap
 func TestApplyDeploymentWorker(t *testing.T) {
 	client := fakeclient.NewSimpleClientset()
-	deployer := NewK8sDeployer(client, "default")
+	deployer := NewK8sDeployer(client, "default", "")
 
 	app := &domain.App{
 		Name:              "arq-worker",
@@ -253,7 +253,7 @@ func TestApplyDeploymentWorker(t *testing.T) {
 // TestApplyDeploymentWebApp 验证常规 Web App（Port>0）仍正常创建端口和无 Command。
 func TestApplyDeploymentWebApp(t *testing.T) {
 	client := fakeclient.NewSimpleClientset()
-	deployer := NewK8sDeployer(client, "default")
+	deployer := NewK8sDeployer(client, "default", "")
 
 	app := &domain.App{
 		Name:           "web-service",
@@ -307,7 +307,7 @@ func TestApplyDeploymentWebApp(t *testing.T) {
 // TestDeployWorkerSkipsService 验证 Worker（Port=0）部署时不创建 Service。
 func TestDeployWorkerSkipsService(t *testing.T) {
 	client := fakeclient.NewSimpleClientset()
-	deployer := NewK8sDeployer(client, "default")
+	deployer := NewK8sDeployer(client, "default", "")
 
 	app := &domain.App{
 		Name:    "recall-worker",
@@ -433,7 +433,7 @@ func TestGetDeploymentStatus(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			client := fakeclient.NewSimpleClientset(tt.objects...)
-			deployer := NewK8sDeployer(client, "default")
+			deployer := NewK8sDeployer(client, "default", "")
 
 			status, err := deployer.GetDeploymentStatus(context.Background(), "myapp-prod")
 			if err != nil {
@@ -471,7 +471,7 @@ func TestGetDeploymentStatus(t *testing.T) {
 
 func TestGetDeploymentStatusNotFound(t *testing.T) {
 	client := fakeclient.NewSimpleClientset()
-	deployer := NewK8sDeployer(client, "default")
+	deployer := NewK8sDeployer(client, "default", "")
 
 	_, err := deployer.GetDeploymentStatus(context.Background(), "nonexistent")
 	if err == nil {

--- a/apps/paas-engine/internal/adapter/repository/app_repo.go
+++ b/apps/paas-engine/internal/adapter/repository/app_repo.go
@@ -107,6 +107,7 @@ func appToModel(a *domain.App) (*AppModel, error) {
 		EnvFromConfigMaps: string(envFromConfigMapsJSON),
 		Envs:              string(envsJSON),
 		ConfigBundles:     string(configBundlesJSON),
+		SidecarEnabled:    a.SidecarEnabled,
 		CreatedAt:         a.CreatedAt,
 		UpdatedAt:         a.UpdatedAt,
 	}, nil
@@ -154,6 +155,7 @@ func modelToApp(m *AppModel) (*domain.App, error) {
 		EnvFromConfigMaps: envFromConfigMaps,
 		Envs:              envs,
 		ConfigBundles:     configBundles,
+		SidecarEnabled:    m.SidecarEnabled,
 		CreatedAt:         m.CreatedAt,
 		UpdatedAt:         m.UpdatedAt,
 	}, nil

--- a/apps/paas-engine/internal/adapter/repository/model.go
+++ b/apps/paas-engine/internal/adapter/repository/model.go
@@ -14,6 +14,7 @@ type AppModel struct {
 	EnvFromConfigMaps string // JSON 序列化的 []string
 	Envs              string // JSON 序列化的 map[string]string
 	ConfigBundles     string // JSON 序列化的 []string
+	SidecarEnabled    bool
 	CreatedAt         time.Time
 	UpdatedAt         time.Time
 }

--- a/apps/paas-engine/internal/config/config.go
+++ b/apps/paas-engine/internal/config/config.go
@@ -23,6 +23,7 @@ type Config struct {
 	APIToken          string
 	LokiURL           string
 	ChiweiDatabaseURL string
+	SidecarImage      string
 
 	// CI Pipeline
 	CINamespace     string        // K8s namespace for CI test jobs
@@ -49,6 +50,7 @@ func Load() *Config {
 		APIToken:          os.Getenv("API_TOKEN"),
 		LokiURL:           getEnv("LOKI_URL", "http://loki-gateway.monitoring.svc.cluster.local"),
 		ChiweiDatabaseURL: os.Getenv("CHIWEI_DATABASE_URL"),
+		SidecarImage:      os.Getenv("SIDECAR_IMAGE"),
 
 		CINamespace:     getEnv("CI_NAMESPACE", "paas-builds"),
 		CIGitRepo:       os.Getenv("CI_GIT_REPO"),

--- a/apps/paas-engine/internal/domain/app.go
+++ b/apps/paas-engine/internal/domain/app.go
@@ -15,6 +15,7 @@ type App struct {
 	EnvFromConfigMaps []string          `json:"env_from_config_maps,omitempty"`
 	Envs              map[string]string `json:"envs,omitempty"`
 	ConfigBundles     []string          `json:"config_bundles,omitempty"` // 关联的 ConfigBundle 名称列表
+	SidecarEnabled    bool              `json:"sidecar_enabled,omitempty"`
 	CreatedAt         time.Time         `json:"created_at"`
 	UpdatedAt         time.Time         `json:"updated_at"`
 }

--- a/apps/paas-engine/internal/service/app_service.go
+++ b/apps/paas-engine/internal/service/app_service.go
@@ -118,6 +118,9 @@ func (s *AppService) UpdateApp(ctx context.Context, name string, body []byte) (*
 	if err := ApplyField(fields, "config_bundles", &app.ConfigBundles); err != nil {
 		return nil, domain.ErrInvalidInput
 	}
+	if err := ApplyField(fields, "sidecar_enabled", &app.SidecarEnabled); err != nil {
+		return nil, domain.ErrInvalidInput
+	}
 	if _, ok := fields["config_bundles"]; ok && len(app.ConfigBundles) > 0 {
 		if err := s.validateConfigBundles(ctx, app.ConfigBundles); err != nil {
 			return nil, err

--- a/docs/superpowers/plans/2026-04-04-sidecar-lane-step1.md
+++ b/docs/superpowers/plans/2026-04-04-sidecar-lane-step1.md
@@ -1,0 +1,1551 @@
+# Sidecar 泳道路由 Step 1：基础设施就绪
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 构建 sidecar 透明代理 + PaaS Engine 注入能力 + 三端（TS/Python/Go）通用上下文传播中间件，此阶段不影响现有服务。
+
+**Architecture:** Go sidecar 通过 iptables 透明拦截 Pod 内出站 HTTP 流量，读取 `x-ctx-lane` header 路由到对应泳道实例。通用上下文传播中间件在框架级自动透传 `x-ctx-*` 前缀 header。PaaS Engine 部署时按 app 配置自动注入 sidecar + init container。
+
+**Tech Stack:** Go 1.25, Hono (TS), FastAPI (Python), chi (Go HTTP router), iptables, Prometheus metrics
+
+**Spec:** `docs/superpowers/specs/2026-04-04-sidecar-lane-routing-design.md`
+
+---
+
+## File Structure
+
+### New files
+```
+apps/lane-sidecar/
+  cmd/lane-sidecar/main.go          # 入口：--init 模式 (iptables) 或 proxy 模式
+  internal/
+    proxy/
+      server.go                      # TCP listener + 协议检测 + HTTP 反向代理
+      server_test.go
+      originaldst_linux.go           # SO_ORIGINAL_DST (Linux)
+      originaldst_other.go           # Stub (非 Linux，开发用)
+    registry/
+      client.go                      # lite-registry 轮询客户端
+      client_test.go
+    iptables/
+      setup.go                       # iptables 规则生成与执行
+  go.mod
+  go.sum
+  Dockerfile
+  Makefile
+
+packages/ts-shared/src/middleware/
+  context-propagation.ts             # x-ctx-* Hono 中间件 + 出站 hook
+  context-propagation.test.ts        # 测试
+
+packages/py-shared/inner_shared/middlewares/
+  context_propagation.py             # x-ctx-* FastAPI 中间件 + httpx hook
+  test_context_propagation.py        # 测试
+```
+
+### Modified files
+```
+apps/paas-engine/internal/domain/app.go              # 加 SidecarEnabled 字段
+apps/paas-engine/internal/adapter/repository/model.go # 加 SidecarEnabled 列
+apps/paas-engine/internal/adapter/repository/app_repo.go # toDomain/toModel 映射
+apps/paas-engine/internal/service/app_service.go      # UpdateApp 支持 sidecar_enabled
+apps/paas-engine/internal/adapter/kubernetes/deployer.go # 注入 sidecar + init container
+apps/paas-engine/internal/adapter/http/middleware.go  # 加 context propagation middleware
+apps/paas-engine/internal/adapter/http/router.go      # 挂载新 middleware
+packages/ts-shared/src/middleware/index.ts            # 导出新中间件
+packages/py-shared/inner_shared/middlewares/__init__.py # 导出新中间件
+```
+
+---
+
+## Task 1: Go sidecar — lite-registry 轮询客户端
+
+**Files:**
+- Create: `apps/lane-sidecar/go.mod`
+- Create: `apps/lane-sidecar/internal/registry/client.go`
+- Create: `apps/lane-sidecar/internal/registry/client_test.go`
+
+- [ ] **Step 1: 初始化 Go module**
+
+```bash
+cd apps/lane-sidecar
+go mod init github.com/chiwei-platform/lane-sidecar
+```
+
+- [ ] **Step 2: 写 registry client 测试**
+
+```go
+// apps/lane-sidecar/internal/registry/client_test.go
+package registry
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestClient_Lookup(t *testing.T) {
+	routes := map[string]any{
+		"services": map[string]any{
+			"agent-service": map[string]any{
+				"lanes": []string{"dev", "feat-test"},
+				"port":  8000,
+			},
+			"lark-server": map[string]any{
+				"lanes": []string{"dev"},
+				"port":  3000,
+			},
+		},
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(routes)
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL, 100*time.Millisecond)
+	defer c.Stop()
+
+	// 等待第一次轮询
+	time.Sleep(200 * time.Millisecond)
+
+	// 已知服务 + 已知泳道
+	info, ok := c.Lookup("agent-service")
+	if !ok {
+		t.Fatal("expected agent-service to be found")
+	}
+	if info.Port != 8000 {
+		t.Fatalf("expected port 8000, got %d", info.Port)
+	}
+	if !info.HasLane("feat-test") {
+		t.Fatal("expected feat-test lane")
+	}
+	if info.HasLane("staging") {
+		t.Fatal("did not expect staging lane")
+	}
+
+	// 未知服务
+	_, ok = c.Lookup("unknown-service")
+	if ok {
+		t.Fatal("did not expect unknown-service")
+	}
+}
+
+func TestClient_ResolveHost(t *testing.T) {
+	routes := map[string]any{
+		"services": map[string]any{
+			"agent-service": map[string]any{
+				"lanes": []string{"dev"},
+				"port":  8000,
+			},
+		},
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(routes)
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL, 100*time.Millisecond)
+	defer c.Stop()
+	time.Sleep(200 * time.Millisecond)
+
+	tests := []struct {
+		host string
+		lane string
+		want string
+	}{
+		{"agent-service:8000", "dev", "agent-service-dev:8000"},
+		{"agent-service:8000", "prod", "agent-service:8000"},    // prod 不改
+		{"agent-service:8000", "", "agent-service:8000"},        // 无 lane 不改
+		{"agent-service:8000", "staging", "agent-service:8000"}, // 泳道不存在 fallback
+		{"external-api.com:443", "dev", "external-api.com:443"}, // 非集群服务不改
+	}
+	for _, tt := range tests {
+		got := c.ResolveHost(tt.host, tt.lane)
+		if got != tt.want {
+			t.Errorf("ResolveHost(%q, %q) = %q, want %q", tt.host, tt.lane, got, tt.want)
+		}
+	}
+}
+```
+
+- [ ] **Step 3: 运行测试，确认失败**
+
+```bash
+cd apps/lane-sidecar && go test ./internal/registry/ -v
+```
+Expected: 编译失败，`NewClient`、`ServiceInfo`、`HasLane`、`ResolveHost` 未定义。
+
+- [ ] **Step 4: 实现 registry client**
+
+```go
+// apps/lane-sidecar/internal/registry/client.go
+package registry
+
+import (
+	"encoding/json"
+	"log"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+)
+
+// ServiceInfo 存储某个服务的路由信息。
+type ServiceInfo struct {
+	Lanes []string `json:"lanes"`
+	Port  int      `json:"port"`
+}
+
+// HasLane 检查是否存在指定泳道。
+func (s *ServiceInfo) HasLane(lane string) bool {
+	for _, l := range s.Lanes {
+		if l == lane {
+			return true
+		}
+	}
+	return false
+}
+
+type routesResponse struct {
+	Services map[string]ServiceInfo `json:"services"`
+}
+
+// Client 轮询 lite-registry 并缓存路由表。
+type Client struct {
+	registryURL string
+	httpClient  *http.Client
+
+	mu       sync.RWMutex
+	services map[string]ServiceInfo
+
+	stopCh chan struct{}
+}
+
+// NewClient 创建 registry client 并启动后台轮询。
+func NewClient(registryURL string, pollInterval time.Duration) *Client {
+	c := &Client{
+		registryURL: strings.TrimRight(registryURL, "/"),
+		httpClient:  &http.Client{Timeout: 5 * time.Second},
+		services:    make(map[string]ServiceInfo),
+		stopCh:      make(chan struct{}),
+	}
+	go c.poll(pollInterval)
+	return c
+}
+
+func (c *Client) poll(interval time.Duration) {
+	c.fetch() // 立即拉取一次
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ticker.C:
+			c.fetch()
+		case <-c.stopCh:
+			return
+		}
+	}
+}
+
+func (c *Client) fetch() {
+	resp, err := c.httpClient.Get(c.registryURL + "/v1/routes")
+	if err != nil {
+		log.Printf("[registry] fetch error: %v", err)
+		return
+	}
+	defer resp.Body.Close()
+
+	var data routesResponse
+	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
+		log.Printf("[registry] decode error: %v", err)
+		return
+	}
+
+	c.mu.Lock()
+	c.services = data.Services
+	c.mu.Unlock()
+}
+
+// Lookup 返回服务的路由信息。
+func (c *Client) Lookup(service string) (ServiceInfo, bool) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	info, ok := c.services[service]
+	return info, ok
+}
+
+// ResolveHost 根据 lane 解析目标 host。
+// 输入: "agent-service:8000", "dev" → "agent-service-dev:8000"
+// 如果 lane 为空、为 "prod"、泳道不存在或服务未知，返回原始 host。
+func (c *Client) ResolveHost(host, lane string) string {
+	if lane == "" || lane == "prod" {
+		return host
+	}
+
+	serviceName, port := splitHostPort(host)
+	info, ok := c.Lookup(serviceName)
+	if !ok || !info.HasLane(lane) {
+		return host
+	}
+
+	if port != "" {
+		return serviceName + "-" + lane + ":" + port
+	}
+	return serviceName + "-" + lane
+}
+
+// Stop 停止后台轮询。
+func (c *Client) Stop() {
+	close(c.stopCh)
+}
+
+func splitHostPort(host string) (string, string) {
+	idx := strings.LastIndex(host, ":")
+	if idx < 0 {
+		return host, ""
+	}
+	return host[:idx], host[idx+1:]
+}
+```
+
+- [ ] **Step 5: 运行测试，确认通过**
+
+```bash
+cd apps/lane-sidecar && go test ./internal/registry/ -v
+```
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/lane-sidecar/
+git commit -m "feat(lane-sidecar): add lite-registry polling client"
+```
+
+---
+
+## Task 2: Go sidecar — 透明代理核心
+
+**Files:**
+- Create: `apps/lane-sidecar/internal/proxy/originaldst_linux.go`
+- Create: `apps/lane-sidecar/internal/proxy/originaldst_other.go`
+- Create: `apps/lane-sidecar/internal/proxy/server.go`
+- Create: `apps/lane-sidecar/internal/proxy/server_test.go`
+
+- [ ] **Step 1: 写 SO_ORIGINAL_DST 平台实现**
+
+```go
+// apps/lane-sidecar/internal/proxy/originaldst_linux.go
+//go:build linux
+
+package proxy
+
+import (
+	"fmt"
+	"net"
+	"syscall"
+	"unsafe"
+)
+
+// GetOriginalDst 通过 SO_ORIGINAL_DST 获取 iptables REDIRECT 前的原始目标地址。
+func GetOriginalDst(conn *net.TCPConn) (net.Addr, error) {
+	raw, err := conn.SyscallConn()
+	if err != nil {
+		return nil, err
+	}
+
+	var addr *syscall.RawSockaddrInet4
+	var callErr error
+
+	err = raw.Control(func(fd uintptr) {
+		var rawAddr syscall.RawSockaddrInet4
+		addrLen := uint32(unsafe.Sizeof(rawAddr))
+		_, _, errno := syscall.Syscall6(
+			syscall.SYS_GETSOCKOPT,
+			fd,
+			syscall.SOL_IP,
+			80, // SO_ORIGINAL_DST
+			uintptr(unsafe.Pointer(&rawAddr)),
+			uintptr(unsafe.Pointer(&addrLen)),
+			0,
+		)
+		if errno != 0 {
+			callErr = fmt.Errorf("getsockopt SO_ORIGINAL_DST: %w", errno)
+			return
+		}
+		addr = &rawAddr
+	})
+	if err != nil {
+		return nil, err
+	}
+	if callErr != nil {
+		return nil, callErr
+	}
+
+	ip := net.IPv4(addr.Addr[0], addr.Addr[1], addr.Addr[2], addr.Addr[3])
+	port := int(addr.Port>>8) | int(addr.Port&0xff)<<8 // network byte order
+	return &net.TCPAddr{IP: ip, Port: port}, nil
+}
+```
+
+```go
+// apps/lane-sidecar/internal/proxy/originaldst_other.go
+//go:build !linux
+
+package proxy
+
+import (
+	"fmt"
+	"net"
+)
+
+// GetOriginalDst 非 Linux 环境的 stub，用于开发和测试。
+func GetOriginalDst(conn *net.TCPConn) (net.Addr, error) {
+	return nil, fmt.Errorf("SO_ORIGINAL_DST not supported on this platform")
+}
+```
+
+- [ ] **Step 2: 写代理服务器测试**
+
+测试核心路由逻辑，不依赖 iptables/SO_ORIGINAL_DST。
+
+```go
+// apps/lane-sidecar/internal/proxy/server_test.go
+package proxy
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/chiwei-platform/lane-sidecar/internal/registry"
+)
+
+// mockRegistry 实现 registry.Resolver 接口用于测试。
+type mockRegistry struct {
+	services map[string]registry.ServiceInfo
+}
+
+func (m *mockRegistry) Lookup(service string) (registry.ServiceInfo, bool) {
+	info, ok := m.services[service]
+	return info, ok
+}
+
+func (m *mockRegistry) ResolveHost(host, lane string) string {
+	if lane == "" || lane == "prod" {
+		return host
+	}
+	svc, port := splitHost(host)
+	info, ok := m.services[svc]
+	if !ok || !info.HasLane(lane) {
+		return host
+	}
+	if port != "" {
+		return svc + "-" + lane + ":" + port
+	}
+	return svc + "-" + lane
+}
+
+func splitHost(host string) (string, string) {
+	for i := len(host) - 1; i >= 0; i-- {
+		if host[i] == ':' {
+			return host[:i], host[i+1:]
+		}
+	}
+	return host, ""
+}
+
+func TestHandler_RoutesToLaneInstance(t *testing.T) {
+	// 模拟泳道实例后端
+	laneBackend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("lane-response"))
+	}))
+	defer laneBackend.Close()
+
+	reg := &mockRegistry{
+		services: map[string]registry.ServiceInfo{
+			"agent-service": {Lanes: []string{"dev"}, Port: 8000},
+		},
+	}
+
+	handler := NewHandler(reg, func(host string) string {
+		// 测试时把 agent-service-dev:8000 映射到实际 test server
+		return laneBackend.Listener.Addr().String()
+	})
+
+	// 请求带 x-ctx-lane: dev，Host: agent-service:8000
+	req := httptest.NewRequest("GET", "http://agent-service:8000/api/chat", nil)
+	req.Header.Set("x-ctx-lane", "dev")
+	w := httptest.NewRecorder()
+
+	handler.ServeHTTP(w, req)
+
+	resp := w.Result()
+	body, _ := io.ReadAll(resp.Body)
+	if string(body) != "lane-response" {
+		t.Fatalf("expected 'lane-response', got %q", string(body))
+	}
+}
+
+func TestHandler_FallbackWhenNoLane(t *testing.T) {
+	prodBackend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("prod-response"))
+	}))
+	defer prodBackend.Close()
+
+	reg := &mockRegistry{
+		services: map[string]registry.ServiceInfo{
+			"agent-service": {Lanes: []string{"dev"}, Port: 8000},
+		},
+	}
+
+	handler := NewHandler(reg, func(host string) string {
+		return prodBackend.Listener.Addr().String()
+	})
+
+	// 无 x-ctx-lane header
+	req := httptest.NewRequest("GET", "http://agent-service:8000/api/chat", nil)
+	w := httptest.NewRecorder()
+
+	handler.ServeHTTP(w, req)
+
+	body, _ := io.ReadAll(w.Result().Body)
+	if string(body) != "prod-response" {
+		t.Fatalf("expected 'prod-response', got %q", string(body))
+	}
+}
+
+func TestHandler_ExternalTrafficPassthrough(t *testing.T) {
+	externalBackend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("external-response"))
+	}))
+	defer externalBackend.Close()
+
+	reg := &mockRegistry{
+		services: map[string]registry.ServiceInfo{},
+	}
+
+	handler := NewHandler(reg, func(host string) string {
+		return externalBackend.Listener.Addr().String()
+	})
+
+	req := httptest.NewRequest("GET", "http://api.openai.com/v1/chat", nil)
+	req.Header.Set("x-ctx-lane", "dev")
+	w := httptest.NewRecorder()
+
+	handler.ServeHTTP(w, req)
+
+	body, _ := io.ReadAll(w.Result().Body)
+	if string(body) != "external-response" {
+		t.Fatalf("expected 'external-response', got %q", string(body))
+	}
+}
+```
+
+- [ ] **Step 3: 运行测试，确认失败**
+
+```bash
+cd apps/lane-sidecar && go test ./internal/proxy/ -v
+```
+Expected: 编译失败，`NewHandler` 等未定义。
+
+- [ ] **Step 4: 实现代理服务器**
+
+```go
+// apps/lane-sidecar/internal/proxy/server.go
+package proxy
+
+import (
+	"context"
+	"log"
+	"net"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/chiwei-platform/lane-sidecar/internal/registry"
+)
+
+// Resolver 是路由表查询接口。
+type Resolver interface {
+	Lookup(service string) (registry.ServiceInfo, bool)
+	ResolveHost(host, lane string) string
+}
+
+// HostMapper 将逻辑 host (如 "agent-service-dev:8000") 映射到实际地址。
+// 生产环境直接返回原值（靠 K8s DNS 解析），测试时映射到 mock server。
+type HostMapper func(host string) string
+
+// DefaultHostMapper 生产环境使用，原样返回。
+func DefaultHostMapper(host string) string { return host }
+
+// Handler 是 sidecar 的 HTTP 请求处理器。
+type Handler struct {
+	resolver   Resolver
+	hostMapper HostMapper
+}
+
+// NewHandler 创建 HTTP handler。
+func NewHandler(resolver Resolver, hostMapper HostMapper) *Handler {
+	if hostMapper == nil {
+		hostMapper = DefaultHostMapper
+	}
+	return &Handler{resolver: resolver, hostMapper: hostMapper}
+}
+
+func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	lane := r.Header.Get("x-ctx-lane")
+	targetHost := h.resolver.ResolveHost(r.Host, lane)
+	actualHost := h.hostMapper(targetHost)
+
+	target := &url.URL{
+		Scheme: "http",
+		Host:   actualHost,
+	}
+
+	proxy := &httputil.ReverseProxy{
+		Director: func(req *http.Request) {
+			req.URL.Scheme = target.Scheme
+			req.URL.Host = target.Host
+			req.Host = r.Host // 保留原始 Host header
+		},
+		ErrorHandler: func(w http.ResponseWriter, r *http.Request, err error) {
+			log.Printf("[proxy] error forwarding to %s: %v", actualHost, err)
+			http.Error(w, "sidecar proxy error", http.StatusBadGateway)
+		},
+	}
+	proxy.ServeHTTP(w, r)
+}
+
+// Server 是 sidecar 的 TCP 服务器，支持 HTTP 和非 HTTP 流量。
+type Server struct {
+	handler    *Handler
+	listenAddr string
+	httpServer *http.Server
+}
+
+// NewServer 创建 sidecar server。
+func NewServer(listenAddr string, resolver Resolver) *Server {
+	handler := NewHandler(resolver, nil)
+	s := &Server{
+		handler:    handler,
+		listenAddr: listenAddr,
+	}
+	s.httpServer = &http.Server{
+		Handler:      handler,
+		ReadTimeout:  30 * time.Second,
+		WriteTimeout: 60 * time.Second,
+	}
+	return s
+}
+
+// ListenAndServe 启动 sidecar 监听。
+func (s *Server) ListenAndServe() error {
+	ln, err := net.Listen("tcp", s.listenAddr)
+	if err != nil {
+		return err
+	}
+	log.Printf("[proxy] listening on %s", s.listenAddr)
+	return s.httpServer.Serve(ln)
+}
+
+// Shutdown 优雅关闭。
+func (s *Server) Shutdown(ctx context.Context) error {
+	return s.httpServer.Shutdown(ctx)
+}
+```
+
+- [ ] **Step 5: registry client 需要导出 Resolver 接口**
+
+在 `apps/lane-sidecar/internal/registry/client.go` 顶部加：
+
+```go
+// Resolver 定义路由查询接口，方便测试 mock。
+type Resolver interface {
+	Lookup(service string) (ServiceInfo, bool)
+	ResolveHost(host, lane string) string
+}
+```
+
+并确保 `Client` 实现了 `Resolver`（它已有 `Lookup` 和 `ResolveHost` 方法）。
+
+同时更新 `proxy/server.go` 中的 `Resolver` 引用——直接使用 `registry.Resolver`：
+
+```go
+// 修改 server.go 中的 Resolver 定义
+// 删除 proxy 包中的 Resolver interface，改为使用 registry.Resolver
+import "github.com/chiwei-platform/lane-sidecar/internal/registry"
+```
+
+Handler 和 Server 中的 `Resolver` 改为 `registry.Resolver`。
+
+- [ ] **Step 6: 运行测试，确认通过**
+
+```bash
+cd apps/lane-sidecar && go test ./... -v
+```
+Expected: PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/lane-sidecar/
+git commit -m "feat(lane-sidecar): implement transparent HTTP proxy with lane routing"
+```
+
+---
+
+## Task 3: Go sidecar — iptables init 模式 + Dockerfile
+
+**Files:**
+- Create: `apps/lane-sidecar/internal/iptables/setup.go`
+- Create: `apps/lane-sidecar/cmd/lane-sidecar/main.go`
+- Create: `apps/lane-sidecar/Dockerfile`
+- Create: `apps/lane-sidecar/Makefile`
+
+- [ ] **Step 1: 实现 iptables 规则生成**
+
+```go
+// apps/lane-sidecar/internal/iptables/setup.go
+package iptables
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+const (
+	ProxyUID  = 1337
+	ProxyPort = 15001
+)
+
+// Rules 返回 sidecar 需要的 iptables 规则命令。
+func Rules(proxyPort, proxyUID int) [][]string {
+	return [][]string{
+		// 新建自定义链
+		{"iptables", "-t", "nat", "-N", "LANE_SIDECAR_OUTPUT"},
+
+		// sidecar 自身流量不拦截（避免死循环）
+		{"iptables", "-t", "nat", "-A", "LANE_SIDECAR_OUTPUT",
+			"-m", "owner", "--uid-owner", fmt.Sprint(proxyUID), "-j", "RETURN"},
+
+		// localhost 不拦截
+		{"iptables", "-t", "nat", "-A", "LANE_SIDECAR_OUTPUT",
+			"-d", "127.0.0.1/32", "-j", "RETURN"},
+
+		// 其余出站 TCP 重定向到 sidecar
+		{"iptables", "-t", "nat", "-A", "LANE_SIDECAR_OUTPUT",
+			"-p", "tcp", "-j", "REDIRECT", "--to-port", fmt.Sprint(proxyPort)},
+
+		// 挂到 OUTPUT 链
+		{"iptables", "-t", "nat", "-A", "OUTPUT", "-j", "LANE_SIDECAR_OUTPUT"},
+	}
+}
+
+// Setup 执行 iptables 规则设置。
+func Setup(proxyPort, proxyUID int) error {
+	for _, args := range Rules(proxyPort, proxyUID) {
+		cmd := exec.Command(args[0], args[1:]...)
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			return fmt.Errorf("failed to run %s: %w\noutput: %s",
+				strings.Join(args, " "), err, string(out))
+		}
+	}
+	return nil
+}
+```
+
+- [ ] **Step 2: 实现 main 入口**
+
+```go
+// apps/lane-sidecar/cmd/lane-sidecar/main.go
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/chiwei-platform/lane-sidecar/internal/iptables"
+	"github.com/chiwei-platform/lane-sidecar/internal/proxy"
+	"github.com/chiwei-platform/lane-sidecar/internal/registry"
+)
+
+func main() {
+	initMode := flag.Bool("init", false, "run iptables setup and exit (init container mode)")
+	proxyPort := flag.Int("port", 15001, "proxy listen port")
+	healthPort := flag.Int("health-port", 15021, "health check port")
+	registryURL := flag.String("registry-url", envOrDefault("REGISTRY_URL", "http://lite-registry:8080"), "lite-registry URL")
+	pollInterval := flag.Duration("poll-interval", 30*time.Second, "registry poll interval")
+	flag.Parse()
+
+	if *initMode {
+		log.Println("[init] setting up iptables rules")
+		if err := iptables.Setup(*proxyPort, iptables.ProxyUID); err != nil {
+			log.Fatalf("[init] iptables setup failed: %v", err)
+		}
+		log.Println("[init] iptables rules applied successfully")
+		return
+	}
+
+	// Proxy 模式
+	reg := registry.NewClient(*registryURL, *pollInterval)
+	defer reg.Stop()
+
+	srv := proxy.NewServer(fmt.Sprintf(":%d", *proxyPort), reg)
+
+	// 健康检查
+	healthSrv := &http.Server{
+		Addr: fmt.Sprintf(":%d", *healthPort),
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte("ok"))
+		}),
+	}
+	go healthSrv.ListenAndServe()
+
+	// 优雅关闭
+	go func() {
+		sigCh := make(chan os.Signal, 1)
+		signal.Notify(sigCh, syscall.SIGTERM, syscall.SIGINT)
+		<-sigCh
+		log.Println("[proxy] shutting down...")
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		srv.Shutdown(ctx)
+		healthSrv.Shutdown(ctx)
+	}()
+
+	log.Printf("[proxy] starting on :%d, health on :%d", *proxyPort, *healthPort)
+	if err := srv.ListenAndServe(); err != http.ErrServerClosed {
+		log.Fatalf("[proxy] server error: %v", err)
+	}
+}
+
+func envOrDefault(key, fallback string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return fallback
+}
+```
+
+- [ ] **Step 3: 确认编译通过**
+
+```bash
+cd apps/lane-sidecar && go build ./cmd/lane-sidecar/
+```
+Expected: 无错误（在 Linux 上编译）
+
+- [ ] **Step 4: 写 Dockerfile**
+
+```dockerfile
+# apps/lane-sidecar/Dockerfile
+FROM harbor.local:30002/library/golang:1.25-alpine AS builder
+WORKDIR /app
+ENV GOPROXY=https://goproxy.cn,direct
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+RUN CGO_ENABLED=0 go build -ldflags="-s -w" -o /bin/lane-sidecar ./cmd/lane-sidecar
+
+FROM harbor.local:30002/library/alpine:3.21
+RUN apk add --no-cache ca-certificates iptables
+COPY --from=builder /bin/lane-sidecar /usr/local/bin/lane-sidecar
+# 非 root 运行代理模式（UID 1337）
+# init 模式需要 root（设置 iptables）
+ENTRYPOINT ["lane-sidecar"]
+```
+
+- [ ] **Step 5: 写 Makefile**
+
+```makefile
+# apps/lane-sidecar/Makefile
+.PHONY: build test lint
+
+build:
+	go build -o output/lane-sidecar ./cmd/lane-sidecar
+
+test:
+	go test ./... -v -count=1
+
+lint:
+	go vet ./...
+```
+
+- [ ] **Step 6: 运行全量测试**
+
+```bash
+cd apps/lane-sidecar && make test
+```
+Expected: PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/lane-sidecar/
+git commit -m "feat(lane-sidecar): add iptables init mode, main entry, and Dockerfile"
+```
+
+---
+
+## Task 4: PaaS Engine — sidecar 注入
+
+**Files:**
+- Modify: `apps/paas-engine/internal/domain/app.go`
+- Modify: `apps/paas-engine/internal/adapter/repository/model.go`
+- Modify: `apps/paas-engine/internal/adapter/repository/app_repo.go`
+- Modify: `apps/paas-engine/internal/service/app_service.go`
+- Modify: `apps/paas-engine/internal/adapter/kubernetes/deployer.go`
+
+- [ ] **Step 1: 域模型加 SidecarEnabled 字段**
+
+在 `apps/paas-engine/internal/domain/app.go` 的 `App` struct 中添加：
+
+```go
+SidecarEnabled bool `json:"sidecar_enabled,omitempty"`
+```
+
+- [ ] **Step 2: 数据库模型加字段**
+
+在 `apps/paas-engine/internal/adapter/repository/model.go` 的 `AppModel` struct 中添加：
+
+```go
+SidecarEnabled bool
+```
+
+- [ ] **Step 3: 更新 app_repo.go 的 toDomain/toModel 映射**
+
+在 `toDomain` 方法中添加：
+```go
+app.SidecarEnabled = m.SidecarEnabled
+```
+
+在 `toModel` 方法中添加：
+```go
+model.SidecarEnabled = app.SidecarEnabled
+```
+
+- [ ] **Step 4: 更新 app_service.go 的 UpdateApp**
+
+在 `UpdateApp` 方法的字段映射区域添加：
+```go
+if err := ApplyField(fields, "sidecar_enabled", &app.SidecarEnabled); err != nil {
+    return nil, domain.ErrInvalidInput
+}
+```
+
+- [ ] **Step 5: 数据库加列**
+
+通过 `/ops-db` 执行：
+```sql
+ALTER TABLE apps ADD COLUMN IF NOT EXISTS sidecar_enabled BOOLEAN NOT NULL DEFAULT false;
+```
+
+- [ ] **Step 6: 写 deployer sidecar 注入测试**
+
+在 `apps/paas-engine/internal/adapter/kubernetes/deployer_test.go` 中添加测试（如果文件不存在则创建）。测试 `applyDeployment` 生成的 Deployment spec 在 `app.SidecarEnabled=true` 时包含 sidecar container 和 init container：
+
+```go
+func TestApplyDeployment_WithSidecar(t *testing.T) {
+    // 使用现有的 fake k8s client 模式
+    // 构造 app.SidecarEnabled = true 的场景
+    // 验证生成的 Deployment 有 2 个 containers + 1 个 initContainer
+    // 验证 sidecar container: name=lane-sidecar, port=15001, runAsUser=1337
+    // 验证 init container: name=lane-sidecar-init, command 包含 --init
+}
+```
+
+具体测试代码需参照项目现有测试模式编写。
+
+- [ ] **Step 7: 实现 deployer sidecar 注入**
+
+在 `apps/paas-engine/internal/adapter/kubernetes/deployer.go` 的 `applyDeployment` 方法中，在构造 `deploy` 变量之前（约第 233 行），加入 sidecar 注入逻辑：
+
+```go
+// Sidecar injection
+var initContainers []corev1.Container
+var sidecarContainers []corev1.Container
+
+if app.SidecarEnabled {
+    sidecarImage := "harbor.local:30002/chiwei/lane-sidecar:latest"
+    proxyUID := int64(1337)
+
+    // Init container: 设置 iptables 规则
+    initContainers = append(initContainers, corev1.Container{
+        Name:    "lane-sidecar-init",
+        Image:   sidecarImage,
+        Command: []string{"lane-sidecar", "--init"},
+        SecurityContext: &corev1.SecurityContext{
+            Capabilities: &corev1.Capabilities{
+                Add: []corev1.Capability{"NET_ADMIN"},
+            },
+            RunAsUser: func() *int64 { uid := int64(0); return &uid }(),
+        },
+    })
+
+    // Sidecar container: 透明代理
+    sidecarContainers = append(sidecarContainers, corev1.Container{
+        Name:  "lane-sidecar",
+        Image: sidecarImage,
+        Env: []corev1.EnvVar{
+            {Name: "REGISTRY_URL", Value: "http://lite-registry:8080"},
+            {Name: "LANE", Value: release.Lane},
+        },
+        Ports: []corev1.ContainerPort{
+            {Name: "sidecar", ContainerPort: 15001},
+            {Name: "sidecar-health", ContainerPort: 15021},
+        },
+        LivenessProbe: &corev1.Probe{
+            ProbeHandler: corev1.ProbeHandler{
+                HTTPGet: &corev1.HTTPGetAction{
+                    Path: "/healthz",
+                    Port: intstr.FromInt(15021),
+                },
+            },
+            InitialDelaySeconds: 2,
+            PeriodSeconds:       10,
+        },
+        SecurityContext: &corev1.SecurityContext{
+            RunAsUser: &proxyUID,
+        },
+    })
+}
+```
+
+然后在 Deployment spec 中注入：
+
+```go
+Spec: corev1.PodSpec{
+    ServiceAccountName: app.ServiceAccount,
+    NodeSelector:       map[string]string{"node-role": "app"},
+    InitContainers:     initContainers,
+    Containers:         append([]corev1.Container{container}, sidecarContainers...),
+},
+```
+
+需要在文件顶部添加 import：
+```go
+"k8s.io/apimachinery/pkg/util/intstr"
+```
+
+- [ ] **Step 8: 运行测试**
+
+```bash
+cd apps/paas-engine && make test
+```
+Expected: PASS
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add apps/paas-engine/
+git commit -m "feat(paas-engine): support sidecar injection in deployment spec"
+```
+
+---
+
+## Task 5: TS — 通用上下文传播中间件
+
+**Files:**
+- Create: `packages/ts-shared/src/middleware/context-propagation.ts`
+- Create: `packages/ts-shared/src/middleware/context-propagation.test.ts`
+- Modify: `packages/ts-shared/src/middleware/index.ts`
+
+- [ ] **Step 1: 写测试**
+
+```typescript
+// packages/ts-shared/src/middleware/context-propagation.test.ts
+import { describe, test, expect } from 'bun:test';
+import { Hono } from 'hono';
+import { createContextPropagationMiddleware, getContextHeaders } from './context-propagation';
+import { asyncLocalStorage } from './context';
+
+describe('contextPropagationMiddleware', () => {
+    const middleware = createContextPropagationMiddleware();
+
+    test('extracts x-ctx-* headers into AsyncLocalStorage', async () => {
+        const app = new Hono();
+        app.use('*', middleware);
+        app.get('/test', (c) => {
+            const store = asyncLocalStorage.getStore();
+            return c.json({
+                lane: store?.['ctx:lane'],
+                gray: store?.['ctx:gray-group'],
+            });
+        });
+
+        const res = await app.request('/test', {
+            headers: {
+                'x-ctx-lane': 'feat-test',
+                'x-ctx-gray-group': 'beta',
+                'x-unrelated': 'ignored',
+            },
+        });
+
+        const body = await res.json();
+        expect(body.lane).toBe('feat-test');
+        expect(body.gray).toBe('beta');
+    });
+
+    test('getContextHeaders returns all x-ctx-* values from store', async () => {
+        const app = new Hono();
+        app.use('*', middleware);
+        app.get('/test', (c) => {
+            const headers = getContextHeaders();
+            return c.json(headers);
+        });
+
+        const res = await app.request('/test', {
+            headers: {
+                'x-ctx-lane': 'dev',
+                'x-ctx-trace-id': 'abc-123',
+            },
+        });
+
+        const body = await res.json();
+        expect(body['x-ctx-lane']).toBe('dev');
+        expect(body['x-ctx-trace-id']).toBe('abc-123');
+    });
+
+    test('works with no x-ctx-* headers', async () => {
+        const app = new Hono();
+        app.use('*', middleware);
+        app.get('/test', (c) => {
+            return c.json(getContextHeaders());
+        });
+
+        const res = await app.request('/test');
+        const body = await res.json();
+        expect(Object.keys(body).length).toBe(0);
+    });
+});
+```
+
+- [ ] **Step 2: 运行测试，确认失败**
+
+```bash
+cd packages/ts-shared && bun test src/middleware/context-propagation.test.ts
+```
+Expected: 模块不存在错误。
+
+- [ ] **Step 3: 实现中间件**
+
+```typescript
+// packages/ts-shared/src/middleware/context-propagation.ts
+import type { Context, Next } from 'hono';
+import { asyncLocalStorage, type BaseRequestContext } from './context';
+
+const CTX_PREFIX = 'x-ctx-';
+const STORE_PREFIX = 'ctx:';
+
+/**
+ * Create a Hono middleware that propagates x-ctx-* headers via AsyncLocalStorage.
+ *
+ * Inbound: extracts all x-ctx-* headers, stores as ctx:* keys in AsyncLocalStorage.
+ * Outbound: use getContextHeaders() to read them back for injection into outbound requests.
+ */
+export function createContextPropagationMiddleware() {
+    return async (c: Context, next: Next) => {
+        // 收集 x-ctx-* headers
+        const ctxFields: Record<string, unknown> = {};
+        for (const [key, value] of Object.entries(c.req.header())) {
+            if (key.startsWith(CTX_PREFIX)) {
+                const fieldName = STORE_PREFIX + key.slice(CTX_PREFIX.length);
+                ctxFields[fieldName] = value;
+            }
+        }
+
+        // 合并到当前 context（如果已有 trace middleware 创建的 store）
+        const existing = asyncLocalStorage.getStore();
+        if (existing) {
+            Object.assign(existing, ctxFields);
+            await next();
+        } else {
+            // 独立使用（没有 trace middleware 在外层）
+            const store: BaseRequestContext = { traceId: '', ...ctxFields };
+            await asyncLocalStorage.run(store, () => next());
+        }
+    };
+}
+
+/**
+ * Get all x-ctx-* values from the current AsyncLocalStorage context.
+ * Returns a header map ready to attach to outbound HTTP requests.
+ */
+export function getContextHeaders(): Record<string, string> {
+    const store = asyncLocalStorage.getStore();
+    if (!store) return {};
+
+    const headers: Record<string, string> = {};
+    for (const [key, value] of Object.entries(store)) {
+        if (key.startsWith(STORE_PREFIX) && value != null) {
+            const headerName = CTX_PREFIX + key.slice(STORE_PREFIX.length);
+            headers[headerName] = String(value);
+        }
+    }
+    return headers;
+}
+```
+
+- [ ] **Step 4: 运行测试，确认通过**
+
+```bash
+cd packages/ts-shared && bun test src/middleware/context-propagation.test.ts
+```
+Expected: PASS
+
+- [ ] **Step 5: 更新 index.ts 导出**
+
+在 `packages/ts-shared/src/middleware/index.ts` 末尾添加：
+
+```typescript
+// context-propagation
+export { createContextPropagationMiddleware, getContextHeaders } from './context-propagation';
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/ts-shared/
+git commit -m "feat(ts-shared): add x-ctx-* context propagation middleware for Hono"
+```
+
+---
+
+## Task 6: Python — 通用上下文传播中间件
+
+**Files:**
+- Create: `packages/py-shared/inner_shared/middlewares/context_propagation.py`
+- Create: `packages/py-shared/tests/test_context_propagation.py`
+- Modify: `packages/py-shared/inner_shared/middlewares/__init__.py`
+
+- [ ] **Step 1: 写测试**
+
+```python
+# packages/py-shared/tests/test_context_propagation.py
+import pytest
+from inner_shared.middlewares.context_propagation import (
+    ctx_vars,
+    get_context_headers,
+    init_ctx_vars,
+)
+
+# 测试需要 fastapi + httpx
+pytest.importorskip("fastapi")
+pytest.importorskip("httpx")
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture
+def app():
+    """Create a FastAPI app with context propagation middleware."""
+    from inner_shared.middlewares.context_propagation import (
+        create_context_propagation_middleware,
+    )
+
+    app = FastAPI()
+    app.add_middleware(create_context_propagation_middleware())
+
+    @app.get("/test")
+    async def test_endpoint():
+        return get_context_headers()
+
+    return app
+
+
+@pytest.fixture
+def client(app):
+    return TestClient(app)
+
+
+def test_extracts_ctx_headers(client):
+    resp = client.get(
+        "/test",
+        headers={
+            "x-ctx-lane": "feat-test",
+            "x-ctx-gray-group": "beta",
+            "x-unrelated": "ignored",
+        },
+    )
+    body = resp.json()
+    assert body["x-ctx-lane"] == "feat-test"
+    assert body["x-ctx-gray-group"] == "beta"
+    assert "x-unrelated" not in body
+
+
+def test_no_ctx_headers(client):
+    resp = client.get("/test")
+    body = resp.json()
+    assert body == {}
+
+
+def test_ctx_headers_in_response(client):
+    resp = client.get("/test", headers={"x-ctx-lane": "dev"})
+    assert resp.headers.get("x-ctx-lane") == "dev"
+```
+
+- [ ] **Step 2: 运行测试，确认失败**
+
+```bash
+cd packages/py-shared && uv run pytest tests/test_context_propagation.py -v
+```
+Expected: ImportError
+
+- [ ] **Step 3: 实现中间件**
+
+```python
+# packages/py-shared/inner_shared/middlewares/context_propagation.py
+"""
+Generic x-ctx-* context propagation middleware for FastAPI.
+Captures all x-ctx-* headers from inbound requests and stores them in contextvars.
+Provides get_context_headers() for outbound request injection.
+"""
+
+import contextvars
+from collections.abc import Callable
+from typing import Any
+
+CTX_PREFIX = "x-ctx-"
+
+# Dynamic context variable storage for x-ctx-* headers
+ctx_vars: dict[str, contextvars.ContextVar[str | None]] = {}
+
+
+def init_ctx_vars():
+    """Reset ctx_vars (mainly for testing)."""
+    global ctx_vars
+    ctx_vars = {}
+
+
+def _get_or_create_var(name: str) -> contextvars.ContextVar[str | None]:
+    """Get or create a contextvar for a given x-ctx-* header."""
+    if name not in ctx_vars:
+        ctx_vars[name] = contextvars.ContextVar(f"ctx_{name}", default=None)
+    return ctx_vars[name]
+
+
+def get_context_headers() -> dict[str, str]:
+    """
+    Read all x-ctx-* values from contextvars.
+    Returns a dict ready to attach to outbound HTTP requests.
+    """
+    headers: dict[str, str] = {}
+    for header_name, var in ctx_vars.items():
+        value = var.get()
+        if value is not None:
+            headers[header_name] = value
+    return headers
+
+
+def create_context_propagation_middleware():
+    """
+    Create a FastAPI middleware that propagates x-ctx-* headers.
+    """
+    try:
+        from starlette.middleware.base import BaseHTTPMiddleware
+        from fastapi import Request, Response
+    except ImportError:
+        raise ImportError("FastAPI/Starlette required for context propagation middleware")
+
+    class ContextPropagationMiddleware(BaseHTTPMiddleware):
+        async def dispatch(self, request: Request, call_next: Callable) -> Response:
+            # Extract all x-ctx-* headers
+            for key, value in request.headers.items():
+                if key.lower().startswith(CTX_PREFIX):
+                    var = _get_or_create_var(key.lower())
+                    var.set(value)
+
+            response = await call_next(request)
+
+            # Echo x-ctx-* headers in response
+            for header_name, var in ctx_vars.items():
+                value = var.get()
+                if value is not None:
+                    response.headers[header_name] = value
+
+            return response
+
+    return ContextPropagationMiddleware
+```
+
+- [ ] **Step 4: 运行测试，确认通过**
+
+```bash
+cd packages/py-shared && uv run pytest tests/test_context_propagation.py -v
+```
+Expected: PASS
+
+- [ ] **Step 5: 更新 __init__.py 导出**
+
+在 `packages/py-shared/inner_shared/middlewares/__init__.py` 中添加（如果文件存在）或创建：
+
+```python
+from .context_propagation import (
+    create_context_propagation_middleware,
+    get_context_headers,
+)
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/py-shared/
+git commit -m "feat(py-shared): add x-ctx-* context propagation middleware for FastAPI"
+```
+
+---
+
+## Task 7: Go (paas-engine) — 上下文传播 middleware
+
+**Files:**
+- Modify: `apps/paas-engine/internal/adapter/http/middleware.go`
+- Modify: `apps/paas-engine/internal/adapter/http/router.go`
+
+- [ ] **Step 1: 读取现有 middleware.go 确认结构**
+
+```bash
+cat apps/paas-engine/internal/adapter/http/middleware.go
+```
+
+确认现有 middleware 的模式（chi middleware 签名）。
+
+- [ ] **Step 2: 写上下文传播 middleware 测试**
+
+在 `apps/paas-engine/internal/adapter/http/` 下新建或追加测试：
+
+```go
+// apps/paas-engine/internal/adapter/http/middleware_test.go
+package http
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestContextPropagationMiddleware(t *testing.T) {
+	// 模拟 handler 读取 context 中的 x-ctx-* 值
+	handler := contextPropagationMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		headers := GetContextHeaders(r.Context())
+		if headers["x-ctx-lane"] != "dev" {
+			t.Errorf("expected x-ctx-lane=dev, got %q", headers["x-ctx-lane"])
+		}
+		if _, ok := headers["x-unrelated"]; ok {
+			t.Error("unexpected non-ctx header in context")
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest("GET", "/test", nil)
+	req.Header.Set("x-ctx-lane", "dev")
+	req.Header.Set("x-ctx-trace-id", "abc")
+	req.Header.Set("x-unrelated", "ignored")
+	w := httptest.NewRecorder()
+
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+}
+```
+
+- [ ] **Step 3: 运行测试，确认失败**
+
+```bash
+cd apps/paas-engine && go test ./internal/adapter/http/ -run TestContextPropagation -v
+```
+Expected: 编译失败
+
+- [ ] **Step 4: 实现 middleware**
+
+在 `apps/paas-engine/internal/adapter/http/middleware.go` 中添加：
+
+```go
+// context key for x-ctx-* headers
+type ctxHeadersKey struct{}
+
+// contextPropagationMiddleware 提取入站请求的 x-ctx-* header 存入 context。
+func contextPropagationMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		headers := make(map[string]string)
+		for key, values := range r.Header {
+			lk := strings.ToLower(key)
+			if strings.HasPrefix(lk, "x-ctx-") && len(values) > 0 {
+				headers[lk] = values[0]
+			}
+		}
+		ctx := context.WithValue(r.Context(), ctxHeadersKey{}, headers)
+		next.ServeHTTP(w, r.WithContext(ctx))
+	})
+}
+
+// GetContextHeaders 从 context 中读取 x-ctx-* headers。
+// 用于注入到出站 HTTP 请求中。
+func GetContextHeaders(ctx context.Context) map[string]string {
+	headers, _ := ctx.Value(ctxHeadersKey{}).(map[string]string)
+	if headers == nil {
+		return make(map[string]string)
+	}
+	return headers
+}
+```
+
+确保文件顶部有 `"context"` 和 `"strings"` 的 import。
+
+- [ ] **Step 5: 在 router.go 中挂载 middleware**
+
+在 `apps/paas-engine/internal/adapter/http/router.go` 的 `NewRouter` 函数中，在现有 middleware 之后添加：
+
+```go
+r.Use(contextPropagationMiddleware)
+```
+
+加在 `loggingMiddleware` 之后、`bodySizeLimitMiddleware` 之前。
+
+- [ ] **Step 6: 运行测试**
+
+```bash
+cd apps/paas-engine && make test
+```
+Expected: PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/paas-engine/
+git commit -m "feat(paas-engine): add x-ctx-* context propagation middleware"
+```
+
+---
+
+## Dependencies
+
+```
+Task 1 (registry client) ←── Task 2 (proxy server) ←── Task 3 (main + Dockerfile)
+Task 4 (PaaS Engine sidecar injection) — 独立于 Task 1-3
+Task 5 (TS middleware) — 完全独立
+Task 6 (Python middleware) — 完全独立
+Task 7 (Go middleware) — 完全独立
+```
+
+**可并行执行：**
+- Task 1→2→3 串行（sidecar 构建链）
+- Task 4, 5, 6, 7 各自独立，可与 Task 1-3 并行

--- a/docs/superpowers/specs/2026-04-04-sidecar-lane-routing-design.md
+++ b/docs/superpowers/specs/2026-04-04-sidecar-lane-routing-design.md
@@ -1,0 +1,121 @@
+# Sidecar 泳道路由设计
+
+## 背景
+
+当前泳道系统对业务代码侵入过强。每个服务需要：引入 LaneRouter SDK、手动注入 `x-lane` header、MQ 消息体塞 lane 字段。改 dashboard/monitor 等纯业务功能时也被迫处理泳道逻辑。
+
+本设计用 sidecar 模式重构 HTTP 层泳道路由，目标：**业务代码零感知泳道**。
+
+## 架构：两层分离
+
+### 第一层：通用上下文传播中间件（框架级）
+
+自动透传 `x-ctx-*` 前缀 header，lane 只是其中一个 case。
+
+**Header 规范**：
+- 前缀：`x-ctx-`
+- 泳道：`x-ctx-lane`
+- 可扩展：`x-ctx-trace-id`、`x-ctx-gray-group` 等，不需要改业务代码
+
+**TS 侧**（`packages/ts-shared`）：
+- Hono 中间件：入站提取所有 `x-ctx-*` header → 存入 AsyncLocalStorage context（扩展 BaseRequestContext）
+- 出站 hook：从 AsyncLocalStorage 自动读出 `x-ctx-*` 附到出站请求
+
+**Python 侧**（`packages/py-shared`）：
+- 复用现有 `create_header_context_middleware()` 配置化映射，加入 `x-ctx-*`
+- httpx client hook 从 contextvars 读出全量 `x-ctx-*` 附上
+
+**Go 侧**（`apps/paas-engine`）：
+- HTTP middleware：入站提取 `x-ctx-*` → 存入 `context.Context`
+- 出站 HTTP client：从 `context.Context` 读出 `x-ctx-*` 自动附上
+
+### 第二层：Go Sidecar（基础设施级）
+
+透明拦截 Pod 内出站 HTTP，根据 `x-ctx-lane` header 路由到对应泳道实例。
+
+**技术选型**：Go，`net/http/httputil.ReverseProxy`，轻量单二进制。
+
+**核心流程**：
+```
+业务容器发出 HTTP 请求
+  → iptables 重定向到 sidecar (localhost:15001)
+  → sidecar 解析 original destination (SO_ORIGINAL_DST)
+  → 判断是否集群内服务（目标是 K8s Service ClusterIP）
+  → 是：读 x-ctx-lane header
+       → 有泳道实例 → 转发到 {service}-{lane}:{port}
+       → 无泳道实例 → 转发到 {service}:{port}（prod fallback）
+  → 否（外部流量）：直接转发，不干预
+```
+
+**路由数据来源**：
+- 启动时从 lite-registry 拉 `/v1/routes`，后台定期轮询
+- 本地缓存，lite-registry 不可达时用缓存兜底
+
+**不拦截的流量**：
+- sidecar 自身的出站（UID 1337 排除，避免死循环）
+- localhost 回环流量
+- 健康检查探针
+
+**端口**：
+- `15001` — 出站流量拦截
+- `15021` — sidecar 自身健康检查
+
+**可观测性**：
+- Prometheus metrics：请求数、延迟、路由命中/fallback 计数
+- 请求日志（可配置开关）
+
+## iptables Init Container
+
+轻量 init container，设置 iptables 规则：
+
+```bash
+# sidecar 进程自身不拦截（避免死循环）
+-A OUTPUT -m owner --uid-owner 1337 -j RETURN
+# localhost 不拦截
+-A OUTPUT -d 127.0.0.1/32 -j RETURN
+# 其余出站 TCP 重定向到 sidecar
+-A OUTPUT -p tcp -j REDIRECT --to-port 15001
+```
+
+需要 `NET_ADMIN` capability。
+
+## PaaS Engine 注入
+
+- 应用级开关：`sidecar: true`
+- 开启后 PaaS Engine 生成 Deployment spec 时自动：
+  1. 加 init container（iptables 规则）
+  2. 加 sidecar container（Go proxy，共享网络 namespace）
+  3. 设 sidecar container `runAsUser: 1337`
+  4. 注入 `LANE` 环境变量（Pod 所属泳道）
+  5. 注入 `REGISTRY_URL` 环境变量
+
+## 迁移路径
+
+### Step 1：基础设施就绪
+- 开发 Go sidecar + init container 镜像
+- PaaS Engine 支持 `sidecar: true` 注入
+- TS/Python/Go 三端实现 `x-ctx-*` 通用上下文传播中间件
+- 不影响现有服务
+
+### Step 2：灰度接入
+- `monitor-dashboard` 作为第一个试点
+- 开启 `sidecar: true`，部署到测试泳道验证
+- 验证通过后删除手工 URL 改写逻辑
+- 逐步推到 `lark-server`、`agent-service`
+
+### Step 3：收尾清理
+- 删除 LaneRouter SDK 中的路由逻辑
+- `x-lane` 迁移为 `x-ctx-lane`
+- LaneRouter 降级或删除
+
+**向前兼容**：Step 2 期间 sidecar 和 LaneRouter 共存无冲突——sidecar 在网络层路由，LaneRouter 多注入的 header 不影响。
+
+## MQ 层
+
+本设计不涉及 MQ 层的泳道路由。MQ 的 lane 传播（队列名拼接、消息体 lane 字段）保持现状，后续单独处理。
+
+## 不在范围内
+
+- Istio / Envoy：过重，本项目只需泳道路由，不需要完整 service mesh
+- MQ sidecar：sidecar 不适合处理 MQ 的队列名拼接逻辑
+- DNS 劫持 / HTTP_PROXY 方案：iptables 更可靠，且 PaaS Engine 完全掌控部署

--- a/packages/py-shared/inner_shared/middlewares/__init__.py
+++ b/packages/py-shared/inner_shared/middlewares/__init__.py
@@ -1,5 +1,9 @@
 """Middlewares module."""
 
+from .context_propagation import (
+    create_context_propagation_middleware,
+    get_context_headers,
+)
 from .trace import (
     create_header_context_middleware,
     get_app_name,
@@ -10,7 +14,9 @@ from .trace import (
 )
 
 __all__ = [
+    "create_context_propagation_middleware",
     "create_header_context_middleware",
+    "get_context_headers",
     "get_header_var",
     "get_trace_id",
     "get_app_name",

--- a/packages/py-shared/inner_shared/middlewares/context_propagation.py
+++ b/packages/py-shared/inner_shared/middlewares/context_propagation.py
@@ -1,0 +1,70 @@
+"""
+Generic x-ctx-* context propagation middleware for FastAPI.
+
+Separate from the existing trace.py header system — this handles
+dynamic x-ctx-* headers that flow between services for lane routing,
+gray groups, and other cross-cutting concerns.
+"""
+
+import contextvars
+from collections.abc import Callable
+
+CTX_PREFIX = "x-ctx-"
+
+ctx_vars: dict[str, contextvars.ContextVar[str | None]] = {}
+
+
+def _get_or_create_var(name: str) -> contextvars.ContextVar[str | None]:
+    """Get or lazily create a context var for the given header name."""
+    if name not in ctx_vars:
+        ctx_vars[name] = contextvars.ContextVar(f"ctx_{name}", default=None)
+    return ctx_vars[name]
+
+
+def get_context_headers() -> dict[str, str]:
+    """Read all stored x-ctx-* values, return dict for outbound requests."""
+    headers: dict[str, str] = {}
+    for header_name, var in ctx_vars.items():
+        value = var.get()
+        if value is not None:
+            headers[header_name] = value
+    return headers
+
+
+def create_context_propagation_middleware():
+    """
+    Create a ContextPropagationMiddleware class for FastAPI.
+
+    Returns:
+        ContextPropagationMiddleware class to be used with app.add_middleware()
+    """
+    try:
+        from starlette.middleware.base import BaseHTTPMiddleware
+        from fastapi import Request, Response
+    except ImportError:
+        raise ImportError("FastAPI/Starlette required for ContextPropagationMiddleware")
+
+    class ContextPropagationMiddleware(BaseHTTPMiddleware):
+        """
+        Inbound: extract all x-ctx-* headers, store in contextvars.
+        Outbound: echo x-ctx-* headers back in response headers.
+        """
+
+        async def dispatch(self, request: Request, call_next: Callable) -> Response:
+            # Extract inbound x-ctx-* headers
+            for key, value in request.headers.items():
+                if key.lower().startswith(CTX_PREFIX):
+                    var = _get_or_create_var(key.lower())
+                    var.set(value)
+
+            response = await call_next(request)
+
+            # Echo x-ctx-* headers in response
+            for header_name, var in ctx_vars.items():
+                value = var.get()
+                if value is not None:
+                    response.headers[header_name] = value
+
+            return response
+
+    return ContextPropagationMiddleware

--- a/packages/py-shared/tests/test_context_propagation.py
+++ b/packages/py-shared/tests/test_context_propagation.py
@@ -1,0 +1,54 @@
+import pytest
+
+pytest.importorskip("fastapi")
+pytest.importorskip("httpx")
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from inner_shared.middlewares.context_propagation import (
+    create_context_propagation_middleware,
+    get_context_headers,
+)
+
+
+@pytest.fixture
+def app():
+    app = FastAPI()
+    app.add_middleware(create_context_propagation_middleware())
+
+    @app.get("/test")
+    async def test_endpoint():
+        return get_context_headers()
+
+    return app
+
+
+@pytest.fixture
+def client(app):
+    return TestClient(app)
+
+
+def test_extracts_ctx_headers(client):
+    resp = client.get(
+        "/test",
+        headers={
+            "x-ctx-lane": "feat-test",
+            "x-ctx-gray-group": "beta",
+            "x-unrelated": "ignored",
+        },
+    )
+    body = resp.json()
+    assert body["x-ctx-lane"] == "feat-test"
+    assert body["x-ctx-gray-group"] == "beta"
+    assert "x-unrelated" not in body
+
+
+def test_no_ctx_headers(client):
+    resp = client.get("/test")
+    body = resp.json()
+    assert body == {}
+
+
+def test_ctx_headers_in_response(client):
+    resp = client.get("/test", headers={"x-ctx-lane": "dev"})
+    assert resp.headers.get("x-ctx-lane") == "dev"

--- a/packages/py-shared/uv.lock
+++ b/packages/py-shared/uv.lock
@@ -1,0 +1,297 @@
+version = 1
+revision = 3
+requires-python = ">=3.11"
+
+[[package]]
+name = "annotated-doc"
+version = "0.0.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/57/ba/046ceea27344560984e26a590f90bc7f4a75b06701f653222458922b558c/annotated_doc-0.0.4.tar.gz", hash = "sha256:fbcda96e87e9c92ad167c2e53839e57503ecfda18804ea28102353485033faa4", size = 7288, upload-time = "2025-11-10T22:07:42.062Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/d3/26bf1008eb3d2daa8ef4cacc7f3bfdc11818d111f7e2d0201bc6e3b49d45/annotated_doc-0.0.4-py3-none-any.whl", hash = "sha256:571ac1dc6991c450b25a9c2d84a3705e2ae7a53467b5d111c24fa8baabbed320", size = 5303, upload-time = "2025-11-10T22:07:40.673Z" },
+]
+
+[[package]]
+name = "annotated-types"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2024-05-20T21:33:25.928Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload-time = "2024-05-20T21:33:24.1Z" },
+]
+
+[[package]]
+name = "anyio"
+version = "4.13.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/14/2c5dd9f512b66549ae92767a9c7b330ae88e1932ca57876909410251fe13/anyio-4.13.0.tar.gz", hash = "sha256:334b70e641fd2221c1505b3890c69882fe4a2df910cba14d97019b90b24439dc", size = 231622, upload-time = "2026-03-24T12:59:09.671Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/42/e921fccf5015463e32a3cf6ee7f980a6ed0f395ceeaa45060b61d86486c2/anyio-4.13.0-py3-none-any.whl", hash = "sha256:08b310f9e24a9594186fd75b4f73f4a4152069e3853f1ed8bfbf58369f4ad708", size = 114353, upload-time = "2026-03-24T12:59:08.246Z" },
+]
+
+[[package]]
+name = "certifi"
+version = "2026.2.25"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/af/2d/7bf41579a8986e348fa033a31cdd0e4121114f6bce2457e8876010b092dd/certifi-2026.2.25.tar.gz", hash = "sha256:e887ab5cee78ea814d3472169153c2d12cd43b14bd03329a39a9c6e2e80bfba7", size = 155029, upload-time = "2026-02-25T02:54:17.342Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9a/3c/c17fb3ca2d9c3acff52e30b309f538586f9f5b9c9cf454f3845fc9af4881/certifi-2026.2.25-py3-none-any.whl", hash = "sha256:027692e4402ad994f1c42e52a4997a9763c646b73e4096e4d5d6db8af1d6f0fa", size = 153684, upload-time = "2026-02-25T02:54:15.766Z" },
+]
+
+[[package]]
+name = "fastapi"
+version = "0.135.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-doc" },
+    { name = "pydantic" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f7/e6/7adb4c5fa231e82c35b8f5741a9f2d055f520c29af5546fd70d3e8e1cd2e/fastapi-0.135.3.tar.gz", hash = "sha256:bd6d7caf1a2bdd8d676843cdcd2287729572a1ef524fc4d65c17ae002a1be654", size = 396524, upload-time = "2026-04-01T16:23:58.188Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/a4/5caa2de7f917a04ada20018eccf60d6cc6145b0199d55ca3711b0fc08312/fastapi-0.135.3-py3-none-any.whl", hash = "sha256:9b0f590c813acd13d0ab43dd8494138eb58e484bfac405db1f3187cfc5810d98", size = 117734, upload-time = "2026-04-01T16:23:59.328Z" },
+]
+
+[[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
+name = "idna"
+version = "3.11"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
+]
+
+[[package]]
+name = "inner-shared"
+version = "1.0.0"
+source = { editable = "." }
+dependencies = [
+    { name = "httpx" },
+    { name = "pydantic" },
+    { name = "python-json-logger" },
+    { name = "pytz" },
+]
+
+[package.optional-dependencies]
+fastapi = [
+    { name = "fastapi" },
+    { name = "starlette" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "fastapi", marker = "extra == 'fastapi'", specifier = ">=0.100.0" },
+    { name = "httpx", specifier = ">=0.27.0" },
+    { name = "pydantic", specifier = ">=2.0.0" },
+    { name = "python-json-logger", specifier = ">=3.0.0" },
+    { name = "pytz", specifier = ">=2024.1" },
+    { name = "starlette", marker = "extra == 'fastapi'", specifier = ">=0.27.0" },
+]
+provides-extras = ["fastapi"]
+
+[[package]]
+name = "pydantic"
+version = "2.12.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-types" },
+    { name = "pydantic-core" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/69/44/36f1a6e523abc58ae5f928898e4aca2e0ea509b5aa6f6f392a5d882be928/pydantic-2.12.5.tar.gz", hash = "sha256:4d351024c75c0f085a9febbb665ce8c0c6ec5d30e903bdb6394b7ede26aebb49", size = 821591, upload-time = "2025-11-26T15:11:46.471Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/87/b70ad306ebb6f9b585f114d0ac2137d792b48be34d732d60e597c2f8465a/pydantic-2.12.5-py3-none-any.whl", hash = "sha256:e561593fccf61e8a20fc46dfc2dfe075b8be7d0188df33f221ad1f0139180f9d", size = 463580, upload-time = "2025-11-26T15:11:44.605Z" },
+]
+
+[[package]]
+name = "pydantic-core"
+version = "2.41.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/71/70/23b021c950c2addd24ec408e9ab05d59b035b39d97cdc1130e1bce647bb6/pydantic_core-2.41.5.tar.gz", hash = "sha256:08daa51ea16ad373ffd5e7606252cc32f07bc72b28284b6bc9c6df804816476e", size = 460952, upload-time = "2025-11-04T13:43:49.098Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e8/72/74a989dd9f2084b3d9530b0915fdda64ac48831c30dbf7c72a41a5232db8/pydantic_core-2.41.5-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:a3a52f6156e73e7ccb0f8cced536adccb7042be67cb45f9562e12b319c119da6", size = 2105873, upload-time = "2025-11-04T13:39:31.373Z" },
+    { url = "https://files.pythonhosted.org/packages/12/44/37e403fd9455708b3b942949e1d7febc02167662bf1a7da5b78ee1ea2842/pydantic_core-2.41.5-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:7f3bf998340c6d4b0c9a2f02d6a400e51f123b59565d74dc60d252ce888c260b", size = 1899826, upload-time = "2025-11-04T13:39:32.897Z" },
+    { url = "https://files.pythonhosted.org/packages/33/7f/1d5cab3ccf44c1935a359d51a8a2a9e1a654b744b5e7f80d41b88d501eec/pydantic_core-2.41.5-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:378bec5c66998815d224c9ca994f1e14c0c21cb95d2f52b6021cc0b2a58f2a5a", size = 1917869, upload-time = "2025-11-04T13:39:34.469Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/6a/30d94a9674a7fe4f4744052ed6c5e083424510be1e93da5bc47569d11810/pydantic_core-2.41.5-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e7b576130c69225432866fe2f4a469a85a54ade141d96fd396dffcf607b558f8", size = 2063890, upload-time = "2025-11-04T13:39:36.053Z" },
+    { url = "https://files.pythonhosted.org/packages/50/be/76e5d46203fcb2750e542f32e6c371ffa9b8ad17364cf94bb0818dbfb50c/pydantic_core-2.41.5-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:6cb58b9c66f7e4179a2d5e0f849c48eff5c1fca560994d6eb6543abf955a149e", size = 2229740, upload-time = "2025-11-04T13:39:37.753Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/ee/fed784df0144793489f87db310a6bbf8118d7b630ed07aa180d6067e653a/pydantic_core-2.41.5-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:88942d3a3dff3afc8288c21e565e476fc278902ae4d6d134f1eeda118cc830b1", size = 2350021, upload-time = "2025-11-04T13:39:40.94Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/be/8fed28dd0a180dca19e72c233cbf58efa36df055e5b9d90d64fd1740b828/pydantic_core-2.41.5-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f31d95a179f8d64d90f6831d71fa93290893a33148d890ba15de25642c5d075b", size = 2066378, upload-time = "2025-11-04T13:39:42.523Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/3b/698cf8ae1d536a010e05121b4958b1257f0b5522085e335360e53a6b1c8b/pydantic_core-2.41.5-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:c1df3d34aced70add6f867a8cf413e299177e0c22660cc767218373d0779487b", size = 2175761, upload-time = "2025-11-04T13:39:44.553Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/ba/15d537423939553116dea94ce02f9c31be0fa9d0b806d427e0308ec17145/pydantic_core-2.41.5-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:4009935984bd36bd2c774e13f9a09563ce8de4abaa7226f5108262fa3e637284", size = 2146303, upload-time = "2025-11-04T13:39:46.238Z" },
+    { url = "https://files.pythonhosted.org/packages/58/7f/0de669bf37d206723795f9c90c82966726a2ab06c336deba4735b55af431/pydantic_core-2.41.5-cp311-cp311-musllinux_1_1_armv7l.whl", hash = "sha256:34a64bc3441dc1213096a20fe27e8e128bd3ff89921706e83c0b1ac971276594", size = 2340355, upload-time = "2025-11-04T13:39:48.002Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/de/e7482c435b83d7e3c3ee5ee4451f6e8973cff0eb6007d2872ce6383f6398/pydantic_core-2.41.5-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:c9e19dd6e28fdcaa5a1de679aec4141f691023916427ef9bae8584f9c2fb3b0e", size = 2319875, upload-time = "2025-11-04T13:39:49.705Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/e6/8c9e81bb6dd7560e33b9053351c29f30c8194b72f2d6932888581f503482/pydantic_core-2.41.5-cp311-cp311-win32.whl", hash = "sha256:2c010c6ded393148374c0f6f0bf89d206bf3217f201faa0635dcd56bd1520f6b", size = 1987549, upload-time = "2025-11-04T13:39:51.842Z" },
+    { url = "https://files.pythonhosted.org/packages/11/66/f14d1d978ea94d1bc21fc98fcf570f9542fe55bfcc40269d4e1a21c19bf7/pydantic_core-2.41.5-cp311-cp311-win_amd64.whl", hash = "sha256:76ee27c6e9c7f16f47db7a94157112a2f3a00e958bc626e2f4ee8bec5c328fbe", size = 2011305, upload-time = "2025-11-04T13:39:53.485Z" },
+    { url = "https://files.pythonhosted.org/packages/56/d8/0e271434e8efd03186c5386671328154ee349ff0354d83c74f5caaf096ed/pydantic_core-2.41.5-cp311-cp311-win_arm64.whl", hash = "sha256:4bc36bbc0b7584de96561184ad7f012478987882ebf9f9c389b23f432ea3d90f", size = 1972902, upload-time = "2025-11-04T13:39:56.488Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/5d/5f6c63eebb5afee93bcaae4ce9a898f3373ca23df3ccaef086d0233a35a7/pydantic_core-2.41.5-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:f41a7489d32336dbf2199c8c0a215390a751c5b014c2c1c5366e817202e9cdf7", size = 2110990, upload-time = "2025-11-04T13:39:58.079Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/32/9c2e8ccb57c01111e0fd091f236c7b371c1bccea0fa85247ac55b1e2b6b6/pydantic_core-2.41.5-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:070259a8818988b9a84a449a2a7337c7f430a22acc0859c6b110aa7212a6d9c0", size = 1896003, upload-time = "2025-11-04T13:39:59.956Z" },
+    { url = "https://files.pythonhosted.org/packages/68/b8/a01b53cb0e59139fbc9e4fda3e9724ede8de279097179be4ff31f1abb65a/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e96cea19e34778f8d59fe40775a7a574d95816eb150850a85a7a4c8f4b94ac69", size = 1919200, upload-time = "2025-11-04T13:40:02.241Z" },
+    { url = "https://files.pythonhosted.org/packages/38/de/8c36b5198a29bdaade07b5985e80a233a5ac27137846f3bc2d3b40a47360/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ed2e99c456e3fadd05c991f8f437ef902e00eedf34320ba2b0842bd1c3ca3a75", size = 2052578, upload-time = "2025-11-04T13:40:04.401Z" },
+    { url = "https://files.pythonhosted.org/packages/00/b5/0e8e4b5b081eac6cb3dbb7e60a65907549a1ce035a724368c330112adfdd/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:65840751b72fbfd82c3c640cff9284545342a4f1eb1586ad0636955b261b0b05", size = 2208504, upload-time = "2025-11-04T13:40:06.072Z" },
+    { url = "https://files.pythonhosted.org/packages/77/56/87a61aad59c7c5b9dc8caad5a41a5545cba3810c3e828708b3d7404f6cef/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e536c98a7626a98feb2d3eaf75944ef6f3dbee447e1f841eae16f2f0a72d8ddc", size = 2335816, upload-time = "2025-11-04T13:40:07.835Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/76/941cc9f73529988688a665a5c0ecff1112b3d95ab48f81db5f7606f522d3/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:eceb81a8d74f9267ef4081e246ffd6d129da5d87e37a77c9bde550cb04870c1c", size = 2075366, upload-time = "2025-11-04T13:40:09.804Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/43/ebef01f69baa07a482844faaa0a591bad1ef129253ffd0cdaa9d8a7f72d3/pydantic_core-2.41.5-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d38548150c39b74aeeb0ce8ee1d8e82696f4a4e16ddc6de7b1d8823f7de4b9b5", size = 2171698, upload-time = "2025-11-04T13:40:12.004Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/87/41f3202e4193e3bacfc2c065fab7706ebe81af46a83d3e27605029c1f5a6/pydantic_core-2.41.5-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:c23e27686783f60290e36827f9c626e63154b82b116d7fe9adba1fda36da706c", size = 2132603, upload-time = "2025-11-04T13:40:13.868Z" },
+    { url = "https://files.pythonhosted.org/packages/49/7d/4c00df99cb12070b6bccdef4a195255e6020a550d572768d92cc54dba91a/pydantic_core-2.41.5-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:482c982f814460eabe1d3bb0adfdc583387bd4691ef00b90575ca0d2b6fe2294", size = 2329591, upload-time = "2025-11-04T13:40:15.672Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/6a/ebf4b1d65d458f3cda6a7335d141305dfa19bdc61140a884d165a8a1bbc7/pydantic_core-2.41.5-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:bfea2a5f0b4d8d43adf9d7b8bf019fb46fdd10a2e5cde477fbcb9d1fa08c68e1", size = 2319068, upload-time = "2025-11-04T13:40:17.532Z" },
+    { url = "https://files.pythonhosted.org/packages/49/3b/774f2b5cd4192d5ab75870ce4381fd89cf218af999515baf07e7206753f0/pydantic_core-2.41.5-cp312-cp312-win32.whl", hash = "sha256:b74557b16e390ec12dca509bce9264c3bbd128f8a2c376eaa68003d7f327276d", size = 1985908, upload-time = "2025-11-04T13:40:19.309Z" },
+    { url = "https://files.pythonhosted.org/packages/86/45/00173a033c801cacf67c190fef088789394feaf88a98a7035b0e40d53dc9/pydantic_core-2.41.5-cp312-cp312-win_amd64.whl", hash = "sha256:1962293292865bca8e54702b08a4f26da73adc83dd1fcf26fbc875b35d81c815", size = 2020145, upload-time = "2025-11-04T13:40:21.548Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/22/91fbc821fa6d261b376a3f73809f907cec5ca6025642c463d3488aad22fb/pydantic_core-2.41.5-cp312-cp312-win_arm64.whl", hash = "sha256:1746d4a3d9a794cacae06a5eaaccb4b8643a131d45fbc9af23e353dc0a5ba5c3", size = 1976179, upload-time = "2025-11-04T13:40:23.393Z" },
+    { url = "https://files.pythonhosted.org/packages/87/06/8806241ff1f70d9939f9af039c6c35f2360cf16e93c2ca76f184e76b1564/pydantic_core-2.41.5-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:941103c9be18ac8daf7b7adca8228f8ed6bb7a1849020f643b3a14d15b1924d9", size = 2120403, upload-time = "2025-11-04T13:40:25.248Z" },
+    { url = "https://files.pythonhosted.org/packages/94/02/abfa0e0bda67faa65fef1c84971c7e45928e108fe24333c81f3bfe35d5f5/pydantic_core-2.41.5-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:112e305c3314f40c93998e567879e887a3160bb8689ef3d2c04b6cc62c33ac34", size = 1896206, upload-time = "2025-11-04T13:40:27.099Z" },
+    { url = "https://files.pythonhosted.org/packages/15/df/a4c740c0943e93e6500f9eb23f4ca7ec9bf71b19e608ae5b579678c8d02f/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0cbaad15cb0c90aa221d43c00e77bb33c93e8d36e0bf74760cd00e732d10a6a0", size = 1919307, upload-time = "2025-11-04T13:40:29.806Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/e3/6324802931ae1d123528988e0e86587c2072ac2e5394b4bc2bc34b61ff6e/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:03ca43e12fab6023fc79d28ca6b39b05f794ad08ec2feccc59a339b02f2b3d33", size = 2063258, upload-time = "2025-11-04T13:40:33.544Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/d4/2230d7151d4957dd79c3044ea26346c148c98fbf0ee6ebd41056f2d62ab5/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:dc799088c08fa04e43144b164feb0c13f9a0bc40503f8df3e9fde58a3c0c101e", size = 2214917, upload-time = "2025-11-04T13:40:35.479Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/9f/eaac5df17a3672fef0081b6c1bb0b82b33ee89aa5cec0d7b05f52fd4a1fa/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:97aeba56665b4c3235a0e52b2c2f5ae9cd071b8a8310ad27bddb3f7fb30e9aa2", size = 2332186, upload-time = "2025-11-04T13:40:37.436Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/4e/35a80cae583a37cf15604b44240e45c05e04e86f9cfd766623149297e971/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:406bf18d345822d6c21366031003612b9c77b3e29ffdb0f612367352aab7d586", size = 2073164, upload-time = "2025-11-04T13:40:40.289Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/e3/f6e262673c6140dd3305d144d032f7bd5f7497d3871c1428521f19f9efa2/pydantic_core-2.41.5-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:b93590ae81f7010dbe380cdeab6f515902ebcbefe0b9327cc4804d74e93ae69d", size = 2179146, upload-time = "2025-11-04T13:40:42.809Z" },
+    { url = "https://files.pythonhosted.org/packages/75/c7/20bd7fc05f0c6ea2056a4565c6f36f8968c0924f19b7d97bbfea55780e73/pydantic_core-2.41.5-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:01a3d0ab748ee531f4ea6c3e48ad9dac84ddba4b0d82291f87248f2f9de8d740", size = 2137788, upload-time = "2025-11-04T13:40:44.752Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/8d/34318ef985c45196e004bc46c6eab2eda437e744c124ef0dbe1ff2c9d06b/pydantic_core-2.41.5-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:6561e94ba9dacc9c61bce40e2d6bdc3bfaa0259d3ff36ace3b1e6901936d2e3e", size = 2340133, upload-time = "2025-11-04T13:40:46.66Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/59/013626bf8c78a5a5d9350d12e7697d3d4de951a75565496abd40ccd46bee/pydantic_core-2.41.5-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:915c3d10f81bec3a74fbd4faebe8391013ba61e5a1a8d48c4455b923bdda7858", size = 2324852, upload-time = "2025-11-04T13:40:48.575Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/d9/c248c103856f807ef70c18a4f986693a46a8ffe1602e5d361485da502d20/pydantic_core-2.41.5-cp313-cp313-win32.whl", hash = "sha256:650ae77860b45cfa6e2cdafc42618ceafab3a2d9a3811fcfbd3bbf8ac3c40d36", size = 1994679, upload-time = "2025-11-04T13:40:50.619Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/8b/341991b158ddab181cff136acd2552c9f35bd30380422a639c0671e99a91/pydantic_core-2.41.5-cp313-cp313-win_amd64.whl", hash = "sha256:79ec52ec461e99e13791ec6508c722742ad745571f234ea6255bed38c6480f11", size = 2019766, upload-time = "2025-11-04T13:40:52.631Z" },
+    { url = "https://files.pythonhosted.org/packages/73/7d/f2f9db34af103bea3e09735bb40b021788a5e834c81eedb541991badf8f5/pydantic_core-2.41.5-cp313-cp313-win_arm64.whl", hash = "sha256:3f84d5c1b4ab906093bdc1ff10484838aca54ef08de4afa9de0f5f14d69639cd", size = 1981005, upload-time = "2025-11-04T13:40:54.734Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/28/46b7c5c9635ae96ea0fbb779e271a38129df2550f763937659ee6c5dbc65/pydantic_core-2.41.5-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:3f37a19d7ebcdd20b96485056ba9e8b304e27d9904d233d7b1015db320e51f0a", size = 2119622, upload-time = "2025-11-04T13:40:56.68Z" },
+    { url = "https://files.pythonhosted.org/packages/74/1a/145646e5687e8d9a1e8d09acb278c8535ebe9e972e1f162ed338a622f193/pydantic_core-2.41.5-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:1d1d9764366c73f996edd17abb6d9d7649a7eb690006ab6adbda117717099b14", size = 1891725, upload-time = "2025-11-04T13:40:58.807Z" },
+    { url = "https://files.pythonhosted.org/packages/23/04/e89c29e267b8060b40dca97bfc64a19b2a3cf99018167ea1677d96368273/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:25e1c2af0fce638d5f1988b686f3b3ea8cd7de5f244ca147c777769e798a9cd1", size = 1915040, upload-time = "2025-11-04T13:41:00.853Z" },
+    { url = "https://files.pythonhosted.org/packages/84/a3/15a82ac7bd97992a82257f777b3583d3e84bdb06ba6858f745daa2ec8a85/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:506d766a8727beef16b7adaeb8ee6217c64fc813646b424d0804d67c16eddb66", size = 2063691, upload-time = "2025-11-04T13:41:03.504Z" },
+    { url = "https://files.pythonhosted.org/packages/74/9b/0046701313c6ef08c0c1cf0e028c67c770a4e1275ca73131563c5f2a310a/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:4819fa52133c9aa3c387b3328f25c1facc356491e6135b459f1de698ff64d869", size = 2213897, upload-time = "2025-11-04T13:41:05.804Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/cd/6bac76ecd1b27e75a95ca3a9a559c643b3afcd2dd62086d4b7a32a18b169/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2b761d210c9ea91feda40d25b4efe82a1707da2ef62901466a42492c028553a2", size = 2333302, upload-time = "2025-11-04T13:41:07.809Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/d2/ef2074dc020dd6e109611a8be4449b98cd25e1b9b8a303c2f0fca2f2bcf7/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:22f0fb8c1c583a3b6f24df2470833b40207e907b90c928cc8d3594b76f874375", size = 2064877, upload-time = "2025-11-04T13:41:09.827Z" },
+    { url = "https://files.pythonhosted.org/packages/18/66/e9db17a9a763d72f03de903883c057b2592c09509ccfe468187f2a2eef29/pydantic_core-2.41.5-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:2782c870e99878c634505236d81e5443092fba820f0373997ff75f90f68cd553", size = 2180680, upload-time = "2025-11-04T13:41:12.379Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/9e/3ce66cebb929f3ced22be85d4c2399b8e85b622db77dad36b73c5387f8f8/pydantic_core-2.41.5-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:0177272f88ab8312479336e1d777f6b124537d47f2123f89cb37e0accea97f90", size = 2138960, upload-time = "2025-11-04T13:41:14.627Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/62/205a998f4327d2079326b01abee48e502ea739d174f0a89295c481a2272e/pydantic_core-2.41.5-cp314-cp314-musllinux_1_1_armv7l.whl", hash = "sha256:63510af5e38f8955b8ee5687740d6ebf7c2a0886d15a6d65c32814613681bc07", size = 2339102, upload-time = "2025-11-04T13:41:16.868Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/0d/f05e79471e889d74d3d88f5bd20d0ed189ad94c2423d81ff8d0000aab4ff/pydantic_core-2.41.5-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:e56ba91f47764cc14f1daacd723e3e82d1a89d783f0f5afe9c364b8bb491ccdb", size = 2326039, upload-time = "2025-11-04T13:41:18.934Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/e1/e08a6208bb100da7e0c4b288eed624a703f4d129bde2da475721a80cab32/pydantic_core-2.41.5-cp314-cp314-win32.whl", hash = "sha256:aec5cf2fd867b4ff45b9959f8b20ea3993fc93e63c7363fe6851424c8a7e7c23", size = 1995126, upload-time = "2025-11-04T13:41:21.418Z" },
+    { url = "https://files.pythonhosted.org/packages/48/5d/56ba7b24e9557f99c9237e29f5c09913c81eeb2f3217e40e922353668092/pydantic_core-2.41.5-cp314-cp314-win_amd64.whl", hash = "sha256:8e7c86f27c585ef37c35e56a96363ab8de4e549a95512445b85c96d3e2f7c1bf", size = 2015489, upload-time = "2025-11-04T13:41:24.076Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/bb/f7a190991ec9e3e0ba22e4993d8755bbc4a32925c0b5b42775c03e8148f9/pydantic_core-2.41.5-cp314-cp314-win_arm64.whl", hash = "sha256:e672ba74fbc2dc8eea59fb6d4aed6845e6905fc2a8afe93175d94a83ba2a01a0", size = 1977288, upload-time = "2025-11-04T13:41:26.33Z" },
+    { url = "https://files.pythonhosted.org/packages/92/ed/77542d0c51538e32e15afe7899d79efce4b81eee631d99850edc2f5e9349/pydantic_core-2.41.5-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:8566def80554c3faa0e65ac30ab0932b9e3a5cd7f8323764303d468e5c37595a", size = 2120255, upload-time = "2025-11-04T13:41:28.569Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/3d/6913dde84d5be21e284439676168b28d8bbba5600d838b9dca99de0fad71/pydantic_core-2.41.5-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:b80aa5095cd3109962a298ce14110ae16b8c1aece8b72f9dafe81cf597ad80b3", size = 1863760, upload-time = "2025-11-04T13:41:31.055Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/f0/e5e6b99d4191da102f2b0eb9687aaa7f5bea5d9964071a84effc3e40f997/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3006c3dd9ba34b0c094c544c6006cc79e87d8612999f1a5d43b769b89181f23c", size = 1878092, upload-time = "2025-11-04T13:41:33.21Z" },
+    { url = "https://files.pythonhosted.org/packages/71/48/36fb760642d568925953bcc8116455513d6e34c4beaa37544118c36aba6d/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:72f6c8b11857a856bcfa48c86f5368439f74453563f951e473514579d44aa612", size = 2053385, upload-time = "2025-11-04T13:41:35.508Z" },
+    { url = "https://files.pythonhosted.org/packages/20/25/92dc684dd8eb75a234bc1c764b4210cf2646479d54b47bf46061657292a8/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5cb1b2f9742240e4bb26b652a5aeb840aa4b417c7748b6f8387927bc6e45e40d", size = 2218832, upload-time = "2025-11-04T13:41:37.732Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/09/f53e0b05023d3e30357d82eb35835d0f6340ca344720a4599cd663dca599/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:bd3d54f38609ff308209bd43acea66061494157703364ae40c951f83ba99a1a9", size = 2327585, upload-time = "2025-11-04T13:41:40Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/4e/2ae1aa85d6af35a39b236b1b1641de73f5a6ac4d5a7509f77b814885760c/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2ff4321e56e879ee8d2a879501c8e469414d948f4aba74a2d4593184eb326660", size = 2041078, upload-time = "2025-11-04T13:41:42.323Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/13/2e215f17f0ef326fc72afe94776edb77525142c693767fc347ed6288728d/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d0d2568a8c11bf8225044aa94409e21da0cb09dcdafe9ecd10250b2baad531a9", size = 2173914, upload-time = "2025-11-04T13:41:45.221Z" },
+    { url = "https://files.pythonhosted.org/packages/02/7a/f999a6dcbcd0e5660bc348a3991c8915ce6599f4f2c6ac22f01d7a10816c/pydantic_core-2.41.5-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:a39455728aabd58ceabb03c90e12f71fd30fa69615760a075b9fec596456ccc3", size = 2129560, upload-time = "2025-11-04T13:41:47.474Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/b1/6c990ac65e3b4c079a4fb9f5b05f5b013afa0f4ed6780a3dd236d2cbdc64/pydantic_core-2.41.5-cp314-cp314t-musllinux_1_1_armv7l.whl", hash = "sha256:239edca560d05757817c13dc17c50766136d21f7cd0fac50295499ae24f90fdf", size = 2329244, upload-time = "2025-11-04T13:41:49.992Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/02/3c562f3a51afd4d88fff8dffb1771b30cfdfd79befd9883ee094f5b6c0d8/pydantic_core-2.41.5-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:2a5e06546e19f24c6a96a129142a75cee553cc018ffee48a460059b1185f4470", size = 2331955, upload-time = "2025-11-04T13:41:54.079Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/96/5fb7d8c3c17bc8c62fdb031c47d77a1af698f1d7a406b0f79aaa1338f9ad/pydantic_core-2.41.5-cp314-cp314t-win32.whl", hash = "sha256:b4ececa40ac28afa90871c2cc2b9ffd2ff0bf749380fbdf57d165fd23da353aa", size = 1988906, upload-time = "2025-11-04T13:41:56.606Z" },
+    { url = "https://files.pythonhosted.org/packages/22/ed/182129d83032702912c2e2d8bbe33c036f342cc735737064668585dac28f/pydantic_core-2.41.5-cp314-cp314t-win_amd64.whl", hash = "sha256:80aa89cad80b32a912a65332f64a4450ed00966111b6615ca6816153d3585a8c", size = 1981607, upload-time = "2025-11-04T13:41:58.889Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/ed/068e41660b832bb0b1aa5b58011dea2a3fe0ba7861ff38c4d4904c1c1a99/pydantic_core-2.41.5-cp314-cp314t-win_arm64.whl", hash = "sha256:35b44f37a3199f771c3eaa53051bc8a70cd7b54f333531c59e29fd4db5d15008", size = 1974769, upload-time = "2025-11-04T13:42:01.186Z" },
+    { url = "https://files.pythonhosted.org/packages/11/72/90fda5ee3b97e51c494938a4a44c3a35a9c96c19bba12372fb9c634d6f57/pydantic_core-2.41.5-graalpy311-graalpy242_311_native-macosx_10_12_x86_64.whl", hash = "sha256:b96d5f26b05d03cc60f11a7761a5ded1741da411e7fe0909e27a5e6a0cb7b034", size = 2115441, upload-time = "2025-11-04T13:42:39.557Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/53/8942f884fa33f50794f119012dc6a1a02ac43a56407adaac20463df8e98f/pydantic_core-2.41.5-graalpy311-graalpy242_311_native-macosx_11_0_arm64.whl", hash = "sha256:634e8609e89ceecea15e2d61bc9ac3718caaaa71963717bf3c8f38bfde64242c", size = 1930291, upload-time = "2025-11-04T13:42:42.169Z" },
+    { url = "https://files.pythonhosted.org/packages/79/c8/ecb9ed9cd942bce09fc888ee960b52654fbdbede4ba6c2d6e0d3b1d8b49c/pydantic_core-2.41.5-graalpy311-graalpy242_311_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:93e8740d7503eb008aa2df04d3b9735f845d43ae845e6dcd2be0b55a2da43cd2", size = 1948632, upload-time = "2025-11-04T13:42:44.564Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/1b/687711069de7efa6af934e74f601e2a4307365e8fdc404703afc453eab26/pydantic_core-2.41.5-graalpy311-graalpy242_311_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f15489ba13d61f670dcc96772e733aad1a6f9c429cc27574c6cdaed82d0146ad", size = 2138905, upload-time = "2025-11-04T13:42:47.156Z" },
+    { url = "https://files.pythonhosted.org/packages/09/32/59b0c7e63e277fa7911c2fc70ccfb45ce4b98991e7ef37110663437005af/pydantic_core-2.41.5-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:7da7087d756b19037bc2c06edc6c170eeef3c3bafcb8f532ff17d64dc427adfd", size = 2110495, upload-time = "2025-11-04T13:42:49.689Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/81/05e400037eaf55ad400bcd318c05bb345b57e708887f07ddb2d20e3f0e98/pydantic_core-2.41.5-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:aabf5777b5c8ca26f7824cb4a120a740c9588ed58df9b2d196ce92fba42ff8dc", size = 1915388, upload-time = "2025-11-04T13:42:52.215Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/0d/e3549b2399f71d56476b77dbf3cf8937cec5cd70536bdc0e374a421d0599/pydantic_core-2.41.5-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c007fe8a43d43b3969e8469004e9845944f1a80e6acd47c150856bb87f230c56", size = 1942879, upload-time = "2025-11-04T13:42:56.483Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/07/34573da085946b6a313d7c42f82f16e8920bfd730665de2d11c0c37a74b5/pydantic_core-2.41.5-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:76d0819de158cd855d1cbb8fcafdf6f5cf1eb8e470abe056d5d161106e38062b", size = 2139017, upload-time = "2025-11-04T13:42:59.471Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/9b/1b3f0e9f9305839d7e84912f9e8bfbd191ed1b1ef48083609f0dabde978c/pydantic_core-2.41.5-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:b2379fa7ed44ddecb5bfe4e48577d752db9fc10be00a6b7446e9663ba143de26", size = 2101980, upload-time = "2025-11-04T13:43:25.97Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/ed/d71fefcb4263df0da6a85b5d8a7508360f2f2e9b3bf5814be9c8bccdccc1/pydantic_core-2.41.5-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:266fb4cbf5e3cbd0b53669a6d1b039c45e3ce651fd5442eff4d07c2cc8d66808", size = 1923865, upload-time = "2025-11-04T13:43:28.763Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/3a/626b38db460d675f873e4444b4bb030453bbe7b4ba55df821d026a0493c4/pydantic_core-2.41.5-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:58133647260ea01e4d0500089a8c4f07bd7aa6ce109682b1426394988d8aaacc", size = 2134256, upload-time = "2025-11-04T13:43:31.71Z" },
+    { url = "https://files.pythonhosted.org/packages/83/d9/8412d7f06f616bbc053d30cb4e5f76786af3221462ad5eee1f202021eb4e/pydantic_core-2.41.5-pp311-pypy311_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:287dad91cfb551c363dc62899a80e9e14da1f0e2b6ebde82c806612ca2a13ef1", size = 2174762, upload-time = "2025-11-04T13:43:34.744Z" },
+    { url = "https://files.pythonhosted.org/packages/55/4c/162d906b8e3ba3a99354e20faa1b49a85206c47de97a639510a0e673f5da/pydantic_core-2.41.5-pp311-pypy311_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:03b77d184b9eb40240ae9fd676ca364ce1085f203e1b1256f8ab9984dca80a84", size = 2143141, upload-time = "2025-11-04T13:43:37.701Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/f2/f11dd73284122713f5f89fc940f370d035fa8e1e078d446b3313955157fe/pydantic_core-2.41.5-pp311-pypy311_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:a668ce24de96165bb239160b3d854943128f4334822900534f2fe947930e5770", size = 2330317, upload-time = "2025-11-04T13:43:40.406Z" },
+    { url = "https://files.pythonhosted.org/packages/88/9d/b06ca6acfe4abb296110fb1273a4d848a0bfb2ff65f3ee92127b3244e16b/pydantic_core-2.41.5-pp311-pypy311_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:f14f8f046c14563f8eb3f45f499cc658ab8d10072961e07225e507adb700e93f", size = 2316992, upload-time = "2025-11-04T13:43:43.602Z" },
+    { url = "https://files.pythonhosted.org/packages/36/c7/cfc8e811f061c841d7990b0201912c3556bfeb99cdcb7ed24adc8d6f8704/pydantic_core-2.41.5-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:56121965f7a4dc965bff783d70b907ddf3d57f6eba29b6d2e5dabfaf07799c51", size = 2145302, upload-time = "2025-11-04T13:43:46.64Z" },
+]
+
+[[package]]
+name = "python-json-logger"
+version = "4.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f7/ff/3cc9165fd44106973cd7ac9facb674a65ed853494592541d339bdc9a30eb/python_json_logger-4.1.0.tar.gz", hash = "sha256:b396b9e3ed782b09ff9d6e4f1683d46c83ad0d35d2e407c09a9ebbf038f88195", size = 17573, upload-time = "2026-03-29T04:39:56.805Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/27/be/0631a861af4d1c875f096c07d34e9a63639560a717130e7a87cbc82b7e3f/python_json_logger-4.1.0-py3-none-any.whl", hash = "sha256:132994765cf75bf44554be9aa49b06ef2345d23661a96720262716438141b6b2", size = 15021, upload-time = "2026-03-29T04:39:55.266Z" },
+]
+
+[[package]]
+name = "pytz"
+version = "2026.1.post1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/56/db/b8721d71d945e6a8ac63c0fc900b2067181dbb50805958d4d4661cf7d277/pytz-2026.1.post1.tar.gz", hash = "sha256:3378dde6a0c3d26719182142c56e60c7f9af7e968076f31aae569d72a0358ee1", size = 321088, upload-time = "2026-03-03T07:47:50.683Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/99/781fe0c827be2742bcc775efefccb3b048a3a9c6ce9aec0cbf4a101677e5/pytz-2026.1.post1-py2.py3-none-any.whl", hash = "sha256:f2fd16142fda348286a75e1a524be810bb05d444e5a081f37f7affc635035f7a", size = 510489, upload-time = "2026-03-03T07:47:49.167Z" },
+]
+
+[[package]]
+name = "starlette"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/81/69/17425771797c36cded50b7fe44e850315d039f28b15901ab44839e70b593/starlette-1.0.0.tar.gz", hash = "sha256:6a4beaf1f81bb472fd19ea9b918b50dc3a77a6f2e190a12954b25e6ed5eea149", size = 2655289, upload-time = "2026-03-22T18:29:46.779Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/c9/584bc9651441b4ba60cc4d557d8a547b5aff901af35bda3a4ee30c819b82/starlette-1.0.0-py3-none-any.whl", hash = "sha256:d3ec55e0bb321692d275455ddfd3df75fff145d009685eb40dc91fc66b03d38b", size = 72651, upload-time = "2026-03-22T18:29:45.111Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]
+
+[[package]]
+name = "typing-inspection"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]

--- a/packages/ts-shared/src/middleware/context-propagation.test.ts
+++ b/packages/ts-shared/src/middleware/context-propagation.test.ts
@@ -1,0 +1,64 @@
+import { describe, test, expect } from 'bun:test';
+import { Hono } from 'hono';
+import { createContextPropagationMiddleware, getContextHeaders } from './context-propagation';
+import { asyncLocalStorage } from './context';
+
+describe('contextPropagationMiddleware', () => {
+    const middleware = createContextPropagationMiddleware();
+
+    test('extracts x-ctx-* headers into AsyncLocalStorage', async () => {
+        const app = new Hono();
+        app.use('*', middleware);
+        app.get('/test', (c) => {
+            const store = asyncLocalStorage.getStore();
+            return c.json({
+                lane: store?.['ctx:lane'],
+                gray: store?.['ctx:gray-group'],
+            });
+        });
+
+        const res = await app.request('/test', {
+            headers: {
+                'x-ctx-lane': 'feat-test',
+                'x-ctx-gray-group': 'beta',
+                'x-unrelated': 'ignored',
+            },
+        });
+
+        const body = await res.json();
+        expect(body.lane).toBe('feat-test');
+        expect(body.gray).toBe('beta');
+    });
+
+    test('getContextHeaders returns all x-ctx-* values from store', async () => {
+        const app = new Hono();
+        app.use('*', middleware);
+        app.get('/test', (c) => {
+            const headers = getContextHeaders();
+            return c.json(headers);
+        });
+
+        const res = await app.request('/test', {
+            headers: {
+                'x-ctx-lane': 'dev',
+                'x-ctx-trace-id': 'abc-123',
+            },
+        });
+
+        const body = await res.json();
+        expect(body['x-ctx-lane']).toBe('dev');
+        expect(body['x-ctx-trace-id']).toBe('abc-123');
+    });
+
+    test('works with no x-ctx-* headers', async () => {
+        const app = new Hono();
+        app.use('*', middleware);
+        app.get('/test', (c) => {
+            return c.json(getContextHeaders());
+        });
+
+        const res = await app.request('/test');
+        const body = await res.json();
+        expect(Object.keys(body).length).toBe(0);
+    });
+});

--- a/packages/ts-shared/src/middleware/context-propagation.ts
+++ b/packages/ts-shared/src/middleware/context-propagation.ts
@@ -1,0 +1,40 @@
+import type { Context, Next } from 'hono';
+import { asyncLocalStorage, type BaseRequestContext } from './context';
+
+const CTX_PREFIX = 'x-ctx-';
+const STORE_PREFIX = 'ctx:';
+
+export function createContextPropagationMiddleware() {
+    return async (c: Context, next: Next) => {
+        const ctxFields: Record<string, unknown> = {};
+        for (const [key, value] of Object.entries(c.req.header())) {
+            if (key.startsWith(CTX_PREFIX)) {
+                const fieldName = STORE_PREFIX + key.slice(CTX_PREFIX.length);
+                ctxFields[fieldName] = value;
+            }
+        }
+
+        const existing = asyncLocalStorage.getStore();
+        if (existing) {
+            Object.assign(existing, ctxFields);
+            await next();
+        } else {
+            const store: BaseRequestContext = { traceId: '', ...ctxFields };
+            await asyncLocalStorage.run(store, () => next());
+        }
+    };
+}
+
+export function getContextHeaders(): Record<string, string> {
+    const store = asyncLocalStorage.getStore();
+    if (!store) return {};
+
+    const headers: Record<string, string> = {};
+    for (const [key, value] of Object.entries(store)) {
+        if (key.startsWith(STORE_PREFIX) && value != null) {
+            const headerName = CTX_PREFIX + key.slice(STORE_PREFIX.length);
+            headers[headerName] = String(value);
+        }
+    }
+    return headers;
+}

--- a/packages/ts-shared/src/middleware/index.ts
+++ b/packages/ts-shared/src/middleware/index.ts
@@ -17,3 +17,6 @@ export { createBearerAuthMiddleware, bearerAuthMiddleware } from './auth';
 // validation
 export type { ValidationRule, ValidationRules } from './validation';
 export { ValidationError, validateBody, validateQuery } from './validation';
+
+// context-propagation
+export { createContextPropagationMiddleware, getContextHeaders } from './context-propagation';


### PR DESCRIPTION
## Summary
- 新增 `lane-sidecar` Go 服务：透明 HTTP 代理 + cmux 协议检测 + iptables 流量拦截，自动根据 `x-ctx-lane` header 路由到泳道实例
- PaaS Engine 支持 `sidecar_enabled` 开关，部署时自动注入 sidecar + init container
- TS/Python/Go 三端实现 `x-ctx-*` 通用上下文传播中间件
- monitor-dashboard 删除手工 `laneAwareUrl` 改写，改由 sidecar 处理
- 三个服务（lark-server、agent-service、monitor-dashboard）已接入中间件

## Test plan
- [x] lane-sidecar: 6 个单元测试通过（registry client + proxy handler + protocol matcher）
- [x] paas-engine: 全量测试通过
- [x] ts-shared: 3 个 context propagation 测试通过
- [x] py-shared: 3 个 context propagation 测试通过
- [x] feat-sidecar 泳道灰度验证：3 个服务全部 Running/0 重启

🤖 Generated with [Claude Code](https://claude.com/claude-code)