### PR TITLE
fix(lark-proxy): use sidecar for lane routing instead of manual URL construction

### DIFF
--- a/apps/lark-proxy/src/forwarder.ts
+++ b/apps/lark-proxy/src/forwarder.ts
@@ -32,7 +32,7 @@ export class EventForwarder {
             (chatId ? await this.laneResolver.resolve('chat', chatId) : null) ??
             (await this.laneResolver.resolve('bot', botName));
 
-        const url = this.buildUrl(lane);
+        const url = this.buildUrl();
         const traceId = randomUUID();
 
         console.info(
@@ -45,7 +45,7 @@ export class EventForwarder {
             'x-trace-id': traceId,
             Authorization: `Bearer ${this.secret}`,
         };
-        if (lane) {
+        if (lane && lane !== 'prod') {
             headers['x-ctx-lane'] = lane;
         }
 
@@ -64,18 +64,10 @@ export class EventForwarder {
     }
 
     /**
-     * 构造 lark-server URL（lark-proxy 无 sidecar，需自主路由）
+     * 构造 lark-server URL（sidecar 根据 x-ctx-lane header 自动路由到泳道实例）
      */
-    private buildUrl(lane: string | null): string {
-        const base = new URL(LARK_SERVER_BASE);
-        const service = base.hostname;
-        const port = base.port;
-
-        const host = lane && lane !== 'prod'
-            ? `${service}-${lane}`
-            : service;
-
-        return `http://${host}${port ? ':' + port : ''}/api/internal/lark-event`;
+    private buildUrl(): string {
+        return `${LARK_SERVER_BASE}/api/internal/lark-event`;
     }
 
     /**

--- a/apps/lark-proxy/tests/forwarder.test.ts
+++ b/apps/lark-proxy/tests/forwarder.test.ts
@@ -56,13 +56,13 @@ describe('EventForwarder', () => {
         expect(body.params).toEqual({ test: 1 });
     });
 
-    it('should forward to lane-specific instance with x-ctx-lane', async () => {
+    it('should forward to same URL with x-ctx-lane when lane binding exists (sidecar routes)', async () => {
         mockResolver.resolve.mockImplementation(() => Promise.resolve('feat-xxx'));
 
         await (forwarder as any).doForward('im.message.receive_v1', 'dev-bot', {});
 
         expect(mockFetch).toHaveBeenCalledWith(
-            'http://lark-server-feat-xxx:3000/api/internal/lark-event',
+            'http://lark-server:3000/api/internal/lark-event',
             expect.objectContaining({
                 headers: expect.objectContaining({
                     'x-ctx-lane': 'feat-xxx',
@@ -71,7 +71,7 @@ describe('EventForwarder', () => {
         );
     });
 
-    it('should forward to prod when lane is prod', async () => {
+    it('should forward to prod URL without x-ctx-lane when lane is prod', async () => {
         mockResolver.resolve.mockImplementation(() => Promise.resolve('prod'));
 
         await (forwarder as any).doForward('im.message.receive_v1', 'dev-bot', {});
@@ -80,6 +80,8 @@ describe('EventForwarder', () => {
             'http://lark-server:3000/api/internal/lark-event',
             expect.anything(),
         );
+        const headers = mockFetch.mock.calls[0][1].headers;
+        expect(headers['x-ctx-lane']).toBeUndefined();
     });
 
     it('createHandler should return {} immediately', () => {
@@ -116,7 +118,7 @@ describe('EventForwarder', () => {
         consoleSpy.mockRestore();
     });
 
-    it('should extract chat_id from message events', async () => {
+    it('should extract chat_id and set x-ctx-lane (sidecar routes to lane instance)', async () => {
         mockResolver.resolve.mockImplementation((_type: string, key: string) =>
             key === 'oc_test_chat' ? Promise.resolve('feat-chat') : Promise.resolve(null),
         );
@@ -125,11 +127,14 @@ describe('EventForwarder', () => {
             message: { chat_id: 'oc_test_chat' },
         });
 
-        // Should have resolved with the chat_id first
         expect(mockResolver.resolve).toHaveBeenCalledWith('chat', 'oc_test_chat');
         expect(mockFetch).toHaveBeenCalledWith(
-            'http://lark-server-feat-chat:3000/api/internal/lark-event',
-            expect.anything(),
+            'http://lark-server:3000/api/internal/lark-event',
+            expect.objectContaining({
+                headers: expect.objectContaining({
+                    'x-ctx-lane': 'feat-chat',
+                }),
+            }),
         );
     });
 });


### PR DESCRIPTION
## Summary
- lark-proxy 删除手动泳道 URL 拼接（`lark-server-{lane}:3000`），改为始终指向 `lark-server:3000`，由 sidecar 根据 `x-ctx-lane` header 自动路由
- 修复泳道部署不存在时 DNS 解析失败导致消息丢失的问题
- PaaS 已开启 lark-proxy 的 `sidecar_enabled`

## Test plan
- [x] 部署到 fix-lane-msg 泳道，确认 sidecar 注入（iptables + proxy :15001）
- [x] 通过 NodePort 发送消息，确认 sidecar 正确路由到 lark-server
- [x] 单元测试全部通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)