### PR TITLE
fix(agent-service): exclude proactive messages from supplemental context

### DIFF
--- a/apps/agent-service/app/chat/quick_search.py
+++ b/apps/agent-service/app/chat/quick_search.py
@@ -143,6 +143,7 @@ async def quick_search(
                     ConversationMessage.root_message_id != current_msg.root_message_id,
                     ConversationMessage.create_time >= time_threshold,
                     ConversationMessage.create_time < current_msg.create_time,
+                    ConversationMessage.user_id != "__proactive__",
                 )
                 .order_by(ConversationMessage.create_time.desc())
                 .limit(needed)


### PR DESCRIPTION
## Summary
- `quick_search` 的补充查询（supplemental）会拉取同群 30 分钟内其他 root 的消息
- 其中可能包含其他 persona 遗留的 proactive 消息（`user_id = '__proactive__'`）
- `build_chat_context` 检测到该消息后误入 proactive 分支，`effective_trigger_id` 被设为该 proactive 消息的 reply_message_id（即另一个 persona 的目标消息）
- 导致 ⭐ 打在错误的消息上，LLM 回复完全偏离实际触发消息

## Fix
在 supplemental 查询加 `user_id != '__proactive__'` 过滤。proactive 消息只在真正的 proactive 请求时出现于 root_messages，不应污染其他请求的 supplemental。

## Test plan
- [ ] 群聊中 @千凪 后，千凪回复的是被 @ 的那条消息，而非同群其他 persona 的 proactive 目标消息