### PR TITLE
fix(agent-service): remove main history search tools and stabilize langfuse traces

### DIFF
--- a/apps/agent-service/app/agent/core.py
+++ b/apps/agent-service/app/agent/core.py
@@ -111,10 +111,12 @@ class Agent:
         *,
         tools: list[Any] | None = None,
         model_kwargs: dict[str, Any] | None = None,
+        update_trace: bool = True,
     ) -> None:
         self._cfg = config
         self._tools = tools or []
         self._model_kwargs = model_kwargs or {}
+        self._update_trace = update_trace
 
     # ------------------------------------------------------------------
     # internal
@@ -146,7 +148,7 @@ class Agent:
 
     def _build_config(self) -> dict[str, Any]:
         """Build LangChain config with Langfuse tracing."""
-        handler = CallbackHandler(update_trace=True)
+        handler = CallbackHandler(update_trace=self._update_trace)
         config: dict[str, Any] = {
             "callbacks": [handler],
             "recursion_limit": self._cfg.recursion_limit,

--- a/apps/agent-service/app/agent/tools/__init__.py
+++ b/apps/agent-service/app/agent/tools/__init__.py
@@ -3,7 +3,7 @@
 Exports two tool lists:
 
 - ``BASE_TOOLS`` — available to all agents including sub-agents.
-- ``ALL_TOOLS`` — only for the main agent (adds delegation, skill, sandbox, history).
+- ``ALL_TOOLS`` — only for the main agent.
 """
 
 from app.agent.tools.commit_abstract import commit_abstract_memory
@@ -35,11 +35,11 @@ BASE_TOOLS = [
     update_schedule,
 ]
 
-# All tools: only for the main agent
+# All tools: only for the main agent.
+# History search tools are intentionally excluded: current-chat and cross-chat
+# context should be injected up front rather than searched ad hoc at reply time.
 ALL_TOOLS = [
     *BASE_TOOLS,
-    check_chat_history,
-    search_group_history,
     list_group_members,
     deep_research,
     load_skill,

--- a/apps/agent-service/app/agent/tools/delegation.py
+++ b/apps/agent-service/app/agent/tools/delegation.py
@@ -39,7 +39,7 @@ async def deep_research(task: str) -> str:
 
     _RESEARCH_CFG = AgentConfig("research_agent", "research-model", "research")
     context = get_runtime(AgentContext).context
-    agent = Agent(_RESEARCH_CFG, tools=[search_web])
+    agent = Agent(_RESEARCH_CFG, tools=[search_web], update_trace=False)
     result = await agent.run(
         [HumanMessage(content=task)],
         context=context,

--- a/apps/agent-service/app/chat/safety.py
+++ b/apps/agent-service/app/chat/safety.py
@@ -129,7 +129,9 @@ async def _check_banned_word(text: str) -> str | None:
 async def _check_injection(message: str) -> PreCheckResult:
     try:
         result: _InjectionResult = await Agent(
-            _GUARD_INJECTION, model_kwargs={"reasoning_effort": "low"}
+            _GUARD_INJECTION,
+            model_kwargs={"reasoning_effort": "low"},
+            update_trace=False,
         ).extract(_InjectionResult, messages=[], prompt_vars={"message": message})
         if result.is_injection and result.confidence >= 0.85:
             logger.warning(
@@ -148,7 +150,9 @@ async def _check_injection(message: str) -> PreCheckResult:
 async def _check_politics(message: str) -> PreCheckResult:
     try:
         result: _PoliticsResult = await Agent(
-            _GUARD_POLITICS, model_kwargs={"reasoning_effort": "low"}
+            _GUARD_POLITICS,
+            model_kwargs={"reasoning_effort": "low"},
+            update_trace=False,
         ).extract(_PoliticsResult, messages=[], prompt_vars={"message": message})
         if result.is_sensitive and result.confidence >= 0.85:
             logger.warning(
@@ -167,7 +171,9 @@ async def _check_politics(message: str) -> PreCheckResult:
 async def _check_nsfw(message: str, persona_id: str) -> PreCheckResult:
     try:
         result: _NsfwResult = await Agent(
-            _GUARD_NSFW, model_kwargs={"reasoning_effort": "low"}
+            _GUARD_NSFW,
+            model_kwargs={"reasoning_effort": "low"},
+            update_trace=False,
         ).extract(_NsfwResult, messages=[], prompt_vars={"message": message})
         if result.is_nsfw and result.confidence >= 0.75:
             if persona_id in _NSFW_BLOCKED_PERSONAS:
@@ -269,7 +275,9 @@ async def run_post_check(response_text: str) -> PostCheckResult:
     # Step 2: LLM audit
     try:
         result: _OutputSafetyResult = await Agent(
-            _GUARD_OUTPUT, model_kwargs={"reasoning_effort": "low"}
+            _GUARD_OUTPUT,
+            model_kwargs={"reasoning_effort": "low"},
+            update_trace=False,
         ).extract(
             _OutputSafetyResult, messages=[], prompt_vars={"response": response_text}
         )

--- a/apps/agent-service/app/memory/cross_chat.py
+++ b/apps/agent-service/app/memory/cross_chat.py
@@ -190,7 +190,7 @@ async def build_cross_chat_context(
 
         max_total = _max_total_messages()
         if max_total > 0:
-            messages = messages[:max_total]
+            messages = messages[-max_total:]
 
         if not messages:
             return ""

--- a/apps/agent-service/tests/unit/agent/test_core.py
+++ b/apps/agent-service/tests/unit/agent/test_core.py
@@ -77,13 +77,14 @@ def mock_deps(fake_agent, mock_prompt):
         patch(
             "app.agent.core.CallbackHandler",
             return_value=MagicMock(),
-        ),
+        ) as mock_callback,
     ):
         yield {
             "build_chat_model": mock_build,
             "get_prompt": mock_get_prompt,
             "create_agent": mock_create,
             "compile_to_messages": mock_compile,
+            "callback_handler": mock_callback,
             "agent": fake_agent,
             "model": mock_model,
             "prompt": mock_prompt,
@@ -202,6 +203,16 @@ class TestRun:
 
         call_kwargs = mock_deps["agent"].ainvoke.call_args.kwargs
         assert call_kwargs["config"]["run_name"] == "test-agent"
+
+    async def test_updates_trace_by_default(self, mock_deps):
+        await Agent(_CFG).run(messages=[HumanMessage(content="hi")])
+
+        mock_deps["callback_handler"].assert_called_once_with(update_trace=True)
+
+    async def test_can_disable_trace_updates(self, mock_deps):
+        await Agent(_CFG, update_trace=False).run(messages=[HumanMessage(content="hi")])
+
+        mock_deps["callback_handler"].assert_called_once_with(update_trace=False)
 
     async def test_passes_context(self, mock_deps):
         from app.agent.context import AgentContext

--- a/apps/agent-service/tests/unit/agent/tools/test_tool_sets.py
+++ b/apps/agent-service/tests/unit/agent/tools/test_tool_sets.py
@@ -1,0 +1,22 @@
+"""Tests for exported tool sets."""
+
+
+def test_main_agent_excludes_history_search_tools():
+    from app.agent.tools import ALL_TOOLS
+    from app.agent.tools.history import check_chat_history, search_group_history
+
+    assert check_chat_history not in ALL_TOOLS
+    assert search_group_history not in ALL_TOOLS
+
+
+def test_main_agent_keeps_supported_main_tools():
+    from app.agent.tools import ALL_TOOLS
+    from app.agent.tools.delegation import deep_research
+    from app.agent.tools.history import list_group_members
+    from app.agent.tools.sandbox import sandbox_bash
+    from app.agent.tools.skill import load_skill
+
+    assert list_group_members in ALL_TOOLS
+    assert deep_research in ALL_TOOLS
+    assert load_skill in ALL_TOOLS
+    assert sandbox_bash in ALL_TOOLS

--- a/apps/agent-service/tests/unit/memory/test_cross_chat.py
+++ b/apps/agent-service/tests/unit/memory/test_cross_chat.py
@@ -317,3 +317,49 @@ async def test_build_cross_chat_context_excludes_other_users_private_content():
     assert "这是我的私聊" in result
     assert "只回复你" in result
     assert "别人的私聊内容" not in result
+
+
+@pytest.mark.asyncio
+async def test_build_cross_chat_context_keeps_most_recent_messages():
+    from app.memory.cross_chat import build_cross_chat_context
+
+    old_msg = _make_msg(
+        "user",
+        "user_1",
+        "chat_old",
+        1000,
+        '{"v":2,"text":"旧消息","items":[]}',
+    )
+    new_msg = _make_msg(
+        "user",
+        "user_1",
+        "chat_new",
+        2000,
+        '{"v":2,"text":"新消息","items":[]}',
+    )
+
+    with (
+        patch(
+            "app.memory.cross_chat.find_bot_names_for_persona",
+            AsyncMock(return_value=["chiwei"]),
+        ),
+        patch(
+            "app.memory.cross_chat.find_cross_chat_messages",
+            AsyncMock(return_value=[old_msg, new_msg]),
+        ),
+        patch("app.memory.cross_chat._max_total_messages", return_value=1),
+        patch("app.memory.cross_chat.find_group_name", AsyncMock(return_value="测试群")),
+        patch("app.memory.cross_chat.get_session") as mock_gs,
+    ):
+        mock_gs.return_value.__aenter__ = AsyncMock(return_value=AsyncMock())
+        mock_gs.return_value.__aexit__ = AsyncMock(return_value=None)
+
+        result = await build_cross_chat_context(
+            persona_id="akao",
+            trigger_user_id="user_1",
+            trigger_username="测试用户A",
+            current_chat_id="chat_current",
+        )
+
+    assert "新消息" in result
+    assert "旧消息" not in result


### PR DESCRIPTION
## Summary
- remove `search_group_history` and `check_chat_history` from the main agent toolset
- prevent nested safety/delegation agents from overwriting the root Langfuse trace
- keep the most recent cross-chat messages when injecting cross-chat context

## Verification
- `cd apps/agent-service && uv run pytest tests/unit/agent/test_core.py -q`
- `cd apps/agent-service && uv run pytest tests/unit/agent/tools/test_tool_sets.py tests/unit/agent/tools/test_history.py tests/unit/agent/test_core.py -q`
- `cd apps/agent-service && uv run pytest tests/unit/memory/test_cross_chat.py tests/unit/agent/tools/test_tool_sets.py tests/unit/agent/test_core.py -q`
- deployed to lane `fix-langfuse-sessio` and verified `agent-service`, `arq-worker`, `vectorize-worker` pods were Running before prod ship

## Notes
- this removes the old history-search failure mode from the main chat agent; cross-chat answer quality still depends on prompt/context quality rather than ad-hoc history lookup