### PR TITLE
fix(agent-service): stabilize langfuse traces and remove main history search tools

### DIFF
--- a/apps/agent-service/app/agent/core.py
+++ b/apps/agent-service/app/agent/core.py
@@ -111,10 +111,12 @@ class Agent:
         *,
         tools: list[Any] | None = None,
         model_kwargs: dict[str, Any] | None = None,
+        update_trace: bool = True,
     ) -> None:
         self._cfg = config
         self._tools = tools or []
         self._model_kwargs = model_kwargs or {}
+        self._update_trace = update_trace
 
     # ------------------------------------------------------------------
     # internal
@@ -146,7 +148,7 @@ class Agent:
 
     def _build_config(self) -> dict[str, Any]:
         """Build LangChain config with Langfuse tracing."""
-        handler = CallbackHandler(update_trace=True)
+        handler = CallbackHandler(update_trace=self._update_trace)
         config: dict[str, Any] = {
             "callbacks": [handler],
             "recursion_limit": self._cfg.recursion_limit,

--- a/apps/agent-service/app/agent/tools/__init__.py
+++ b/apps/agent-service/app/agent/tools/__init__.py
@@ -3,7 +3,7 @@
 Exports two tool lists:
 
 - ``BASE_TOOLS`` — available to all agents including sub-agents.
-- ``ALL_TOOLS`` — only for the main agent (adds delegation, skill, sandbox, history).
+- ``ALL_TOOLS`` — only for the main agent.
 """
 
 from app.agent.tools.commit_abstract import commit_abstract_memory
@@ -35,11 +35,11 @@ BASE_TOOLS = [
     update_schedule,
 ]
 
-# All tools: only for the main agent
+# All tools: only for the main agent.
+# History search tools are intentionally excluded: current-chat and cross-chat
+# context should be injected up front rather than searched ad hoc at reply time.
 ALL_TOOLS = [
     *BASE_TOOLS,
-    check_chat_history,
-    search_group_history,
     list_group_members,
     deep_research,
     load_skill,

--- a/apps/agent-service/app/agent/tools/delegation.py
+++ b/apps/agent-service/app/agent/tools/delegation.py
@@ -39,7 +39,7 @@ async def deep_research(task: str) -> str:
 
     _RESEARCH_CFG = AgentConfig("research_agent", "research-model", "research")
     context = get_runtime(AgentContext).context
-    agent = Agent(_RESEARCH_CFG, tools=[search_web])
+    agent = Agent(_RESEARCH_CFG, tools=[search_web], update_trace=False)
     result = await agent.run(
         [HumanMessage(content=task)],
         context=context,

--- a/apps/agent-service/app/chat/safety.py
+++ b/apps/agent-service/app/chat/safety.py
@@ -129,7 +129,9 @@ async def _check_banned_word(text: str) -> str | None:
 async def _check_injection(message: str) -> PreCheckResult:
     try:
         result: _InjectionResult = await Agent(
-            _GUARD_INJECTION, model_kwargs={"reasoning_effort": "low"}
+            _GUARD_INJECTION,
+            model_kwargs={"reasoning_effort": "low"},
+            update_trace=False,
         ).extract(_InjectionResult, messages=[], prompt_vars={"message": message})
         if result.is_injection and result.confidence >= 0.85:
             logger.warning(
@@ -148,7 +150,9 @@ async def _check_injection(message: str) -> PreCheckResult:
 async def _check_politics(message: str) -> PreCheckResult:
     try:
         result: _PoliticsResult = await Agent(
-            _GUARD_POLITICS, model_kwargs={"reasoning_effort": "low"}
+            _GUARD_POLITICS,
+            model_kwargs={"reasoning_effort": "low"},
+            update_trace=False,
         ).extract(_PoliticsResult, messages=[], prompt_vars={"message": message})
         if result.is_sensitive and result.confidence >= 0.85:
             logger.warning(
@@ -167,7 +171,9 @@ async def _check_politics(message: str) -> PreCheckResult:
 async def _check_nsfw(message: str, persona_id: str) -> PreCheckResult:
     try:
         result: _NsfwResult = await Agent(
-            _GUARD_NSFW, model_kwargs={"reasoning_effort": "low"}
+            _GUARD_NSFW,
+            model_kwargs={"reasoning_effort": "low"},
+            update_trace=False,
         ).extract(_NsfwResult, messages=[], prompt_vars={"message": message})
         if result.is_nsfw and result.confidence >= 0.75:
             if persona_id in _NSFW_BLOCKED_PERSONAS:
@@ -269,7 +275,9 @@ async def run_post_check(response_text: str) -> PostCheckResult:
     # Step 2: LLM audit
     try:
         result: _OutputSafetyResult = await Agent(
-            _GUARD_OUTPUT, model_kwargs={"reasoning_effort": "low"}
+            _GUARD_OUTPUT,
+            model_kwargs={"reasoning_effort": "low"},
+            update_trace=False,
         ).extract(
             _OutputSafetyResult, messages=[], prompt_vars={"response": response_text}
         )

--- a/apps/agent-service/app/memory/cross_chat.py
+++ b/apps/agent-service/app/memory/cross_chat.py
@@ -190,7 +190,7 @@ async def build_cross_chat_context(
 
         max_total = _max_total_messages()
         if max_total > 0:
-            messages = messages[:max_total]
+            messages = messages[-max_total:]
 
         if not messages:
             return ""

--- a/apps/agent-service/tests/unit/agent/test_core.py
+++ b/apps/agent-service/tests/unit/agent/test_core.py
@@ -77,13 +77,14 @@ def mock_deps(fake_agent, mock_prompt):
         patch(
             "app.agent.core.CallbackHandler",
             return_value=MagicMock(),
-        ),
+        ) as mock_callback,
     ):
         yield {
             "build_chat_model": mock_build,
             "get_prompt": mock_get_prompt,
             "create_agent": mock_create,
             "compile_to_messages": mock_compile,
+            "callback_handler": mock_callback,
             "agent": fake_agent,
             "model": mock_model,
             "prompt": mock_prompt,
@@ -202,6 +203,16 @@ class TestRun:
 
         call_kwargs = mock_deps["agent"].ainvoke.call_args.kwargs
         assert call_kwargs["config"]["run_name"] == "test-agent"
+
+    async def test_updates_trace_by_default(self, mock_deps):
+        await Agent(_CFG).run(messages=[HumanMessage(content="hi")])
+
+        mock_deps["callback_handler"].assert_called_once_with(update_trace=True)
+
+    async def test_can_disable_trace_updates(self, mock_deps):
+        await Agent(_CFG, update_trace=False).run(messages=[HumanMessage(content="hi")])
+
+        mock_deps["callback_handler"].assert_called_once_with(update_trace=False)
 
     async def test_passes_context(self, mock_deps):
         from app.agent.context import AgentContext

--- a/apps/agent-service/tests/unit/agent/tools/test_tool_sets.py
+++ b/apps/agent-service/tests/unit/agent/tools/test_tool_sets.py
@@ -1,0 +1,22 @@
+"""Tests for exported tool sets."""
+
+
+def test_main_agent_excludes_history_search_tools():
+    from app.agent.tools import ALL_TOOLS
+    from app.agent.tools.history import check_chat_history, search_group_history
+
+    assert check_chat_history not in ALL_TOOLS
+    assert search_group_history not in ALL_TOOLS
+
+
+def test_main_agent_keeps_supported_main_tools():
+    from app.agent.tools import ALL_TOOLS
+    from app.agent.tools.delegation import deep_research
+    from app.agent.tools.history import list_group_members
+    from app.agent.tools.sandbox import sandbox_bash
+    from app.agent.tools.skill import load_skill
+
+    assert list_group_members in ALL_TOOLS
+    assert deep_research in ALL_TOOLS
+    assert load_skill in ALL_TOOLS
+    assert sandbox_bash in ALL_TOOLS

--- a/apps/agent-service/tests/unit/memory/test_cross_chat.py
+++ b/apps/agent-service/tests/unit/memory/test_cross_chat.py
@@ -317,3 +317,49 @@ async def test_build_cross_chat_context_excludes_other_users_private_content():
     assert "这是我的私聊" in result
     assert "只回复你" in result
     assert "别人的私聊内容" not in result
+
+
+@pytest.mark.asyncio
+async def test_build_cross_chat_context_keeps_most_recent_messages():
+    from app.memory.cross_chat import build_cross_chat_context
+
+    old_msg = _make_msg(
+        "user",
+        "user_1",
+        "chat_old",
+        1000,
+        '{"v":2,"text":"旧消息","items":[]}',
+    )
+    new_msg = _make_msg(
+        "user",
+        "user_1",
+        "chat_new",
+        2000,
+        '{"v":2,"text":"新消息","items":[]}',
+    )
+
+    with (
+        patch(
+            "app.memory.cross_chat.find_bot_names_for_persona",
+            AsyncMock(return_value=["chiwei"]),
+        ),
+        patch(
+            "app.memory.cross_chat.find_cross_chat_messages",
+            AsyncMock(return_value=[old_msg, new_msg]),
+        ),
+        patch("app.memory.cross_chat._max_total_messages", return_value=1),
+        patch("app.memory.cross_chat.find_group_name", AsyncMock(return_value="测试群")),
+        patch("app.memory.cross_chat.get_session") as mock_gs,
+    ):
+        mock_gs.return_value.__aenter__ = AsyncMock(return_value=AsyncMock())
+        mock_gs.return_value.__aexit__ = AsyncMock(return_value=None)
+
+        result = await build_cross_chat_context(
+            persona_id="akao",
+            trigger_user_id="user_1",
+            trigger_username="测试用户A",
+            current_chat_id="chat_current",
+        )
+
+    assert "新消息" in result
+    assert "旧消息" not in result


### PR DESCRIPTION
## Summary
This PR fixes the specific failure mode behind the Langfuse `session_id = 5260be42-ef21-4ea2-af15-ab2e3f9d8190` investigation.

The root problem was not just a bad trace. It was a broken chat path:
- nested guard / research agents were updating the same root Langfuse trace as the main chat agent, so the trace `output` could be overwritten by safety-check JSON instead of the real chat result
- the main agent still exposed `search_group_history` and `check_chat_history`, even though those tools do not solve cross-group recall
- `search_group_history` only searches the current chat, so when the model tried to answer a cross-group question, it could loop on a tool that could never produce the missing answer
- cross-chat prompt injection was also truncating the oldest messages instead of the newest ones, which made the injected context less useful than intended

This PR addresses that failure mode in three ways:
- prevent nested guard / research agents from mutating the root Langfuse trace
- remove history-search tools from the main agent tool set so the model cannot take the wrong recovery path
- keep the newest cross-chat messages when building injected context

## Root Cause
Observed during trace review:
- the Langfuse root trace was polluted by nested `pre-injection-check` / `post-safety-check` style outputs
- the main chat path hit `GRAPH_RECURSION_LIMIT`
- the model repeatedly called `search_group_history`, but that tool is scoped to `chat_id = context.chat_id`, so it cannot fetch messages from other groups
- the cross-chat context builder queried recent messages but then sliced from the front, keeping older entries

## Changes
### 1. Stop nested agents from overwriting the root trace
- add an `update_trace` flag to `Agent`
- keep the default as `True` so existing callers are unchanged
- set `update_trace=False` for:
  - pre-injection guard
  - pre-politics guard
  - pre-nsfw guard
  - post-safety guard
  - nested `deep_research` agent

### 2. Remove misleading history-search tools from the main agent
- remove `search_group_history` and `check_chat_history` from `ALL_TOOLS`
- leave the tool implementations intact; this change only removes them from the main chat agent’s tool set
- document the intended behavior inline: chat history should be injected up front instead of searched ad hoc during reply generation

### 3. Fix cross-chat truncation
- change cross-chat message truncation from `messages[:max_total]` to `messages[-max_total:]`
- this makes the injected cross-chat context keep the most recent messages rather than the oldest slice of the 24h window

### 4. Add regression coverage
- verify `Agent` still defaults to `update_trace=True`
- verify callers can explicitly disable trace updates
- verify main-agent tool sets exclude the history-search tools while retaining the expected non-history tools
- verify cross-chat context keeps the newest messages

## Files Changed
- `apps/agent-service/app/agent/core.py`
- `apps/agent-service/app/agent/tools/__init__.py`
- `apps/agent-service/app/agent/tools/delegation.py`
- `apps/agent-service/app/chat/safety.py`
- `apps/agent-service/app/memory/cross_chat.py`
- `apps/agent-service/tests/unit/agent/test_core.py`
- `apps/agent-service/tests/unit/agent/tools/test_tool_sets.py`
- `apps/agent-service/tests/unit/memory/test_cross_chat.py`

## Verification
Ran in `apps/agent-service`:
- `uv run pytest tests/unit/agent/test_core.py -q`
- `uv run pytest tests/unit/agent/tools/test_tool_sets.py tests/unit/agent/tools/test_history.py tests/unit/memory/test_cross_chat.py -q`
- `uv run pytest tests/unit/life/test_proactive.py tests/unit/workers/test_chat_consumer.py -q`

All passed: `61 passed`.

## Risks / Follow-ups
This PR removes the original failure path, but it does not claim that every cross-group question is now perfectly answered. The remaining quality question is whether prompt-injected cross-chat context and recall are always sufficient for hard cross-group queries. That should be evaluated separately from this structural fix.

## Notes
This PR intentionally supersedes the earlier bad WIP PR history. I am not merging it here.
