### PR TITLE
chore: sync project skills for Claude and agents

### DIFF
--- a/.agents/skills/api-test
+++ b/.agents/skills/api-test
@@ -1,0 +1,1 @@
+../../.claude/skills/api-test

--- a/.agents/skills/deploy-test
+++ b/.agents/skills/deploy-test
@@ -1,0 +1,1 @@
+../../.claude/skills/deploy-test

--- a/.agents/skills/expose-service
+++ b/.agents/skills/expose-service
@@ -1,0 +1,1 @@
+../../.claude/skills/expose-service

--- a/.agents/skills/ops
+++ b/.agents/skills/ops
@@ -1,0 +1,1 @@
+../../.claude/skills/ops

--- a/.agents/skills/ops-db
+++ b/.agents/skills/ops-db
@@ -1,0 +1,1 @@
+../../.claude/skills/ops-db

--- a/.agents/skills/ship
+++ b/.agents/skills/ship
@@ -1,0 +1,1 @@
+../../.claude/skills/ship

--- a/.claude/skills/api-test/SKILL.md
+++ b/.claude/skills/api-test/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: api-test
 description: 标准化 HTTP API 调用工具。禁止直接写 curl 命令，所有 HTTP 请求必须通过此 skill 的 scripts/http.sh 脚本执行。当需要调用、测试、调试、验证任何 HTTP API 端点时使用。
+user_invocable: true
 ---
 
 # /api-test

--- a/.claude/skills/deploy-test/SKILL.md
+++ b/.claude/skills/deploy-test/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: deploy-test
 description: 将当前分支部署到测试泳道，验证改动
 user_invocable: true
 ---

--- a/.claude/skills/expose-service/SKILL.md
+++ b/.claude/skills/expose-service/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: expose-service
 description: 让服务的 API 能从集群外部通过 $PAAS_API 访问。当需要添加新的外部可达路由、排查"从外面访问不到 API"问题、或有人试图使用 Ingress/LoadBalancer/NodePort/port-forward 时触发此 skill。本项目没有 Ingress Controller，外部访问的唯一通路是 api-gateway 反向代理。
+user_invocable: true
 ---
 
 # Expose Service

--- a/.claude/skills/ops-db/SKILL.md
+++ b/.claude/skills/ops-db/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: ops-db
 description: 安全查询 PaaS Engine PostgreSQL 数据库，以及提交 DDL/DML 变更申请
 user_invocable: true
 ---

--- a/.claude/skills/ops/SKILL.md
+++ b/.claude/skills/ops/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: ops
 description: 统一运维查询和操作。替代 make status/pods/lane-bind 等命令，所有操作自动审计。
 user_invocable: true
 ---

--- a/.claude/skills/ship/SKILL.md
+++ b/.claude/skills/ship/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: ship
 description: 合并当前分支到 main 并部署到生产环境
 user_invocable: true
 ---


### PR DESCRIPTION
## Summary

This PR makes the Chiwei project skills usable from both Claude and agent/Codex-style skill discovery without keeping any Chiwei skill copies in the global home-level skill directories.

Changes included:
- Keep `.claude/skills/<name>` as the canonical project-local skill content.
- Add `.agents/skills/<same-name>` symlinks pointing to the matching `.claude/skills/<same-name>` directories.
- Use the same skill names on both sides: `api-test`, `deploy-test`, `expose-service`, `ops`, `ops-db`, and `ship`.
- Preserve Claude behavior by keeping `user_invocable: true` and the existing slash-command documentation.

## Why

The previous setup allowed project skills to drift between Claude-local copies and global agent skill copies. Keeping the skills in the repository makes the project self-contained, while same-name symlinks avoid introducing `chiwei-*` aliases that would change Claude's visible skill names.

This keeps scope local to the app: another app can have its own `.agents/skills/api-test` with different behavior without conflicting with this repository.

## Validation

- Ran `git diff --check` successfully before amending the commit.
- Verified there are no `chiwei-*` strings under `.claude/skills` or `.agents`.
- Verified the new `.agents/skills/*` entries are symlinks to the matching `.claude/skills/*` directories.
