### PR TITLE
refactor: drop vector_status field after dataflow cutover

### DIFF
--- a/apps/lark-server/src/infrastructure/dal/entities/conversation-message.ts
+++ b/apps/lark-server/src/infrastructure/dal/entities/conversation-message.ts
@@ -36,15 +36,6 @@ export class ConversationMessage {
     @Column({ length: 30, nullable: true, default: 'text' })
     message_type?: string;
 
-    /**
-     * 向量化状态
-     * - pending: 待处理
-     * - completed: 已完成
-     * - failed: 失败
-     */
-    @Column({ length: 20, default: 'pending' })
-    vector_status!: string;
-
     @Column({ length: 50, nullable: true })
     bot_name?: string;
 

--- a/apps/lark-server/src/infrastructure/integrations/memory.ts
+++ b/apps/lark-server/src/infrastructure/integrations/memory.ts
@@ -4,10 +4,6 @@ import { context } from '@middleware/context';
 import { rabbitmqClient, VECTORIZE } from '@integrations/rabbitmq';
 import AppDataSource from 'ormconfig';
 
-/**
- * 判断消息内容是否为空
- * 空消息定义：content 为空或仅包含空白字符
- */
 function isEmptyContent(content: string | undefined | null): boolean {
     return !content || content.trim() === '';
 }
@@ -24,7 +20,6 @@ export async function storeMessage(message: ChatMessage): Promise<void> {
         const botName = message.bot_name || context.getBotName() || 'chiwei';
         const isEmpty = isEmptyContent(message.content);
 
-        // INSERT ... ON CONFLICT (message_id) DO NOTHING
         const result = await AppDataSource.createQueryBuilder()
             .insert()
             .into(ConversationMessage)
@@ -39,17 +34,14 @@ export async function storeMessage(message: ChatMessage): Promise<void> {
                 chat_type: message.chat_type,
                 create_time: message.create_time,
                 message_type: message.message_type || 'text',
-                vector_status: isEmpty ? 'skipped' : 'pending',
                 bot_name: botName,
                 response_id: message.response_id,
             })
             .orIgnore()
             .execute();
 
-        // orIgnore: identifiers 为空数组表示冲突未插入
         const inserted = result.identifiers.length > 0;
 
-        // 仅首次插入成功且非空消息时推送向量化
         if (inserted && !isEmpty) {
             const lane = context.getLane() || undefined;
             await rabbitmqClient.publish(

--- a/apps/monitor-dashboard-web/src/pages/Messages.tsx
+++ b/apps/monitor-dashboard-web/src/pages/Messages.tsx
@@ -43,7 +43,6 @@ interface MessageRow {
   root_message_id: string;
   reply_message_id?: string | null;
   create_time: string;
-  vector_status: string;
 }
 
 // --- Enum maps ---
@@ -51,13 +50,6 @@ interface MessageRow {
 const chatTypeMap: Record<string, string> = {
   p2p: '私聊',
   group: '群聊',
-};
-
-const vectorStatusMap: Record<string, { label: string; color: string }> = {
-  pending: { label: '待处理', color: 'default' },
-  completed: { label: '已完成', color: 'green' },
-  failed: { label: '失败', color: 'red' },
-  skipped: { label: '已跳过', color: 'orange' },
 };
 
 const messageTypeMap: Record<string, string> = {
@@ -118,7 +110,6 @@ const ALL_COLUMNS: ColumnDef[] = [
   { key: 'root_message_id', title: '根消息 ID', defaultVisible: false },
   { key: 'reply_message_id', title: '父消息 ID', defaultVisible: false },
   { key: 'create_time', title: '创建时间', defaultVisible: true },
-  { key: 'vector_status', title: '向量状态', defaultVisible: true },
 ];
 
 const DEFAULT_VISIBLE_KEYS = ALL_COLUMNS.filter((c) => c.defaultVisible).map((c) => c.key);
@@ -559,15 +550,6 @@ export default function Messages() {
         dataIndex: 'create_time',
         width: 180,
         render: (text) => (text ? dayjs(Number(text)).format('YYYY-MM-DD HH:mm:ss') : '-'),
-      },
-      vector_status: {
-        title: '向量状态',
-        dataIndex: 'vector_status',
-        width: 100,
-        render: (status: string) => {
-          const info = vectorStatusMap[status] || { label: status, color: 'default' };
-          return <Tag color={info.color}>{info.label}</Tag>;
-        },
       },
     };
 

--- a/packages/ts-shared/src/entities/conversation-message.ts
+++ b/packages/ts-shared/src/entities/conversation-message.ts
@@ -32,9 +32,6 @@ export class ConversationMessage {
     @Column({ length: 30, nullable: true, default: 'text' })
     message_type?: string;
 
-    @Column({ length: 20, default: 'pending' })
-    vector_status!: string;
-
     @Column({ length: 50, nullable: true })
     bot_name?: string;
 


### PR DESCRIPTION
## Summary

- PR #198 ship 后 `vector_status` 已不再被读写，idempotency 改由 qdrant point_id + RabbitMQ DLQ 承担
- lark-server / ts-shared 删字段定义；lark-server `storeMessage` INSERT 不再写该列
- monitor-dashboard-web 移除「向量状态」列、map、render
- 38 行纯删除，无新增

## Test plan

- [x] lark-server `bun run build` + 62 tests pass
- [x] monitor-dashboard-web `vite build` pass
- [x] ts-shared `tsc` pass
- [x] 泳道 e2e（df-fu）：飞书 dev bot 发消息，DB row 成功入库（`vector_status` default `'pending'` 兜底），无 column 报错
- [x] monitor-dashboard-web df-fu 页面无「向量状态」列

## Follow-ups（合码后）

- prod 部署稳定后单独提交 `ALTER TABLE conversation_messages DROP COLUMN vector_status`
- paas-engine `make self-deploy` 完成 APP_NAME 注入闭环（PR #198 ship checklist #1）