### PR TITLE
perf: stabilize lark-server runtime image builds

### DIFF
--- a/apps/lark-server/Dockerfile
+++ b/apps/lark-server/Dockerfile
@@ -30,11 +30,9 @@ RUN bun build src/index.ts --compile --outfile=server & \
     wait && \
     test -f server && test -f recall-worker && test -f chat-response-worker
 
-# --- Runtime（同样基于 Debian/glibc）---
-FROM harbor.local:30002/library/debian:bookworm-slim
+# --- Runtime（同样基于 Debian/glibc，预装 ca-certificates/tzdata）---
+FROM harbor.local:30002/inner-bot/lark-server-runtime@sha256:e25a0e85ea61dba92b3df8acaff2e1c532bd2235463302d827ed6f1a4d6101cc
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    ca-certificates tzdata && rm -rf /var/lib/apt/lists/*
 ENV TZ=Asia/Shanghai
 
 ARG GIT_SHA=unknown

--- a/infra/k8s/build/lark-server-runtime/Dockerfile
+++ b/infra/k8s/build/lark-server-runtime/Dockerfile
@@ -1,0 +1,7 @@
+FROM harbor.local:30002/library/debian:bookworm-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates tzdata \
+    && rm -rf /var/lib/apt/lists/*
+
+ENV TZ=Asia/Shanghai

--- a/infra/k8s/build/lark-server-runtime/README.md
+++ b/infra/k8s/build/lark-server-runtime/README.md
@@ -1,0 +1,21 @@
+# lark-server runtime base image
+
+`apps/lark-server/Dockerfile` uses this image as its runtime stage to avoid
+running `apt-get` during every Kaniko business image build.
+
+Build and push:
+
+```bash
+docker build \
+  -t harbor.local:30002/inner-bot/lark-server-runtime:bookworm-ca-tz-20260427 \
+  infra/k8s/build/lark-server-runtime
+
+docker push harbor.local:30002/inner-bot/lark-server-runtime:bookworm-ca-tz-20260427
+```
+
+Current pushed image:
+
+```text
+harbor.local:30002/inner-bot/lark-server-runtime:bookworm-ca-tz-20260427
+sha256:e25a0e85ea61dba92b3df8acaff2e1c532bd2235463302d827ed6f1a4d6101cc
+```


### PR DESCRIPTION
## Background

While investigating intermittent slow lark-server builds, the bottleneck turned out not to be Bun or TypeScript compilation. The slow path was the runtime Docker stage running Debian apt downloads.

Recent build history showed most successful lark-server builds finishing in roughly 45-80 seconds, while some outliers took 4-20 minutes. In the slow logs, apt-get downloaded a 9,350 kB package index from deb.debian.org in about 10 minutes at roughly 15 kB/s.

## Changes

- Add infra/k8s/build/lark-server-runtime/ to keep the runtime base image build recipe in the same infra build area as the existing auxiliary images.
- Build and push the runtime base image:
  harbor.local:30002/inner-bot/lark-server-runtime:bookworm-ca-tz-20260427
- Pin lark-server's runtime stage to the pushed digest:
  sha256:e25a0e85ea61dba92b3df8acaff2e1c532bd2235463302d827ed6f1a4d6101cc
- Remove apt-get update/install from the lark-server business image build path.

## Verification

- Built and pushed the runtime base image successfully.
- Verified the business image locally:
  docker build -f apps/lark-server/Dockerfile -t lark-server:runtime-base-verify .
- Confirmed the runtime stage no longer runs apt-get and only pulls the Harbor digest.
- Bun remained fast in the verification build: bun install was about 587 ms, and the three bun build --compile entries completed in about 2.5 seconds for the Docker step.
- PaaS/Kaniko build succeeded:
  build 4b275453-ff64-49d1-80d9-53a2b9e7a9b3, version 1.1.0.95, duration 71.1 seconds.
- Deployed test lane perf-investigate-lar:
  lark-server, recall-worker, and chat-response-worker are all Ready=1 with restarts=0.
- Bound the dev bot to perf-investigate-lar for real traffic validation.

## Expected Impact

- Removes lark-server business builds' dependency on deb.debian.org during the runtime stage.
- Keeps Kaniko builds in the normal stable range and avoids 10+ minute outliers caused by Debian mirror/network slowness.

## Risk

- The runtime base is digest-pinned. Future ca-certificates or tzdata upgrades require rebuilding and pushing the image under infra/k8s/build/lark-server-runtime/, then updating the digest in apps/lark-server/Dockerfile.
- Runtime remains Debian/glibc-based as before; this change only preinstalls ca-certificates and tzdata in the base image.

## Test Deployment

- Lane: perf-investigate-lar
- Image: harbor.local:30002/inner-bot/lark-server:1.1.0.95
- lark-server: Running, ready=True, restarts=0
- recall-worker: Running, ready=True, restarts=0
- chat-response-worker: Running, ready=True, restarts=0