### PR TITLE
chore(safety): drop SAFETY_CHECK route + queue declaration

### DIFF
--- a/apps/agent-service/app/chat/post_actions.py
+++ b/apps/agent-service/app/chat/post_actions.py
@@ -35,10 +35,9 @@ async def _publish_post_check(
     chat_id: str,
     trigger_message_id: str,
 ) -> None:
-    """Emit PostSafetyRequest into the dataflow graph (Phase 2).
+    """Emit PostSafetyRequest into the dataflow graph.
 
-    Replaces ``mq.publish(SAFETY_CHECK, ...)``: the wire
-    ``wire(PostSafetyRequest).to(run_post_safety).durable()`` in
+    The wire ``wire(PostSafetyRequest).to(run_post_safety).durable()`` in
     ``app/wiring/safety.py`` queues the request and the durable consumer
     bound on agent-service runs the audit.
     """

--- a/apps/agent-service/app/infra/rabbitmq.py
+++ b/apps/agent-service/app/infra/rabbitmq.py
@@ -43,7 +43,6 @@ class Route(NamedTuple):
 
 CHAT_REQUEST = Route("chat_request", "chat.request")
 CHAT_RESPONSE = Route("chat_response", "chat.response")
-SAFETY_CHECK = Route("safety_check", "post.safety.check")
 RECALL = Route("recall", "action.recall")
 # ``vectorize`` is published by lark-server (TS, identical
 # ``buildQueueArgs``/``DLX_NAME``/``EXCHANGE_NAME`` constants) and
@@ -71,7 +70,6 @@ MEMORY_ABSTRACT_VECTORIZE = Route(
 ALL_ROUTES = [
     CHAT_REQUEST,
     CHAT_RESPONSE,
-    SAFETY_CHECK,
     RECALL,
     VECTORIZE,
     MEMORY_FRAGMENT_VECTORIZE,

--- a/apps/agent-service/tests/unit/chat/test_post_actions.py
+++ b/apps/agent-service/tests/unit/chat/test_post_actions.py
@@ -1,4 +1,4 @@
-"""Tests for chat/post_actions.py — Phase 2 emit(PostSafetyRequest)."""
+"""Tests for chat/post_actions.py."""
 from __future__ import annotations
 
 from unittest.mock import patch
@@ -10,7 +10,7 @@ from app.domain.safety import PostSafetyRequest
 
 @pytest.mark.asyncio
 async def test_publish_post_check_emits_post_safety_request():
-    """旧 mq.publish(SAFETY_CHECK,...) 替换为 emit(PostSafetyRequest(...))."""
+    """_publish_post_check emits PostSafetyRequest into the dataflow graph."""
     from app.chat.post_actions import _publish_post_check
 
     captured: list[PostSafetyRequest] = []

--- a/apps/agent-service/tests/unit/infra/test_rabbitmq.py
+++ b/apps/agent-service/tests/unit/infra/test_rabbitmq.py
@@ -13,7 +13,6 @@ from app.infra.rabbitmq import (
     MEMORY_ABSTRACT_VECTORIZE,
     MEMORY_FRAGMENT_VECTORIZE,
     RECALL,
-    SAFETY_CHECK,
     VECTORIZE,
     Route,
     _build_queue_args,
@@ -183,7 +182,6 @@ class TestRouteConstants:
         expected = {
             CHAT_REQUEST,
             CHAT_RESPONSE,
-            SAFETY_CHECK,
             RECALL,
             VECTORIZE,
             MEMORY_FRAGMENT_VECTORIZE,
@@ -191,8 +189,8 @@ class TestRouteConstants:
         }
         assert set(ALL_ROUTES) == expected
 
-    def test_all_routes_have_seven_entries(self):
-        assert len(ALL_ROUTES) == 7
+    def test_all_routes_have_six_entries(self):
+        assert len(ALL_ROUTES) == 6
 
     def test_each_route_has_queue_and_rk(self):
         for route in ALL_ROUTES:

--- a/apps/lark-server/src/infrastructure/integrations/rabbitmq.ts
+++ b/apps/lark-server/src/infrastructure/integrations/rabbitmq.ts
@@ -12,12 +12,11 @@ export interface Route {
 
 export const CHAT_REQUEST: Route = { queue: 'chat_request', rk: 'chat.request' };
 export const CHAT_RESPONSE: Route = { queue: 'chat_response', rk: 'chat.response' };
-export const SAFETY_CHECK: Route = { queue: 'safety_check', rk: 'post.safety.check' };
 export const RECALL: Route = { queue: 'recall', rk: 'action.recall' };
 export const VECTORIZE: Route = { queue: 'vectorize', rk: 'task.vectorize' };
 export const PROACTIVE_EVAL: Route = { queue: 'proactive_eval', rk: 'proactive.eval' };
 
-const ALL_ROUTES: Route[] = [CHAT_REQUEST, CHAT_RESPONSE, SAFETY_CHECK, RECALL, VECTORIZE, PROACTIVE_EVAL];
+const ALL_ROUTES: Route[] = [CHAT_REQUEST, CHAT_RESPONSE, RECALL, VECTORIZE, PROACTIVE_EVAL];
 
 const NON_PROD_EXPIRES_MS = 86_400_000;
 const LANE_FALLBACK_TTL_MS = 10_000;

--- a/infra/k8s/monitoring/alert-rules.yaml
+++ b/infra/k8s/monitoring/alert-rules.yaml
@@ -236,7 +236,7 @@ spec:
 
         # RabbitMQ - 已知业务队列 consumer 断开
         - alert: RabbitmqConsumerDown
-          expr: rabbitmq_queue_consumers{namespace="prod", queue=~"(recall|safety_check|vectorize|chat_response|durable_.*|memory_fragment_vectorize|memory_abstract_vectorize).*"} == 0
+          expr: rabbitmq_queue_consumers{namespace="prod", queue=~"(recall|vectorize|chat_response|durable_.*|memory_fragment_vectorize|memory_abstract_vectorize).*"} == 0
           for: 1m
           labels:
             severity: critical


### PR DESCRIPTION
## Summary

Phase 2 dataflow cutover (PR #203) replaced `mq.publish(SAFETY_CHECK, ...)` with the durable wire `PostSafetyRequest -> run_post_safety`. The legacy `safety_check` queue has had zero publishers/consumers in prod for 24h+. This PR removes the leftover declaration from both producers, drops the alert rule entry, and clears stale doc/test references.

- agent-service `app/infra/rabbitmq.py`: drop `SAFETY_CHECK` constant and `ALL_ROUTES` entry
- lark-server `apps/lark-server/src/infrastructure/integrations/rabbitmq.ts`: same
- `infra/k8s/monitoring/alert-rules.yaml`: drop `safety_check` from `RabbitmqConsumerDown` queue regex
- agent-service `app/chat/post_actions.py` + tests: clear stale `SAFETY_CHECK` references in docstrings

## Post-merge ops

- `kubectl apply -f infra/k8s/monitoring/alert-rules.yaml` to refresh PrometheusRule (no GitOps sync)
- Delete prod queue `safety_check` on RabbitMQ — it is `durable` with no `x-expires`, so it will not vanish on its own

## Test plan

- [x] `pytest tests/unit/infra/test_rabbitmq.py tests/unit/chat/test_post_actions.py` — 28 passed
- [x] `rg SAFETY_CHECK|safety_check` in code/config — zero residue
- [x] `bunx tsc --noEmit` in lark-server — same 3 preexisting errors as main HEAD, no new errors introduced