### PR TITLE
docs(dataflow): Phase 7 gap analysis + Phase 6 historical correction

### DIFF
--- a/docs/guides/dataflow-framework.md
+++ b/docs/guides/dataflow-framework.md
@@ -8,6 +8,19 @@
 
 ---
 
+## 0. 终态原则
+
+**终态不是"业务代码从 `mq.publish` 换成 `wire(...)`"。终态是：无论写 chat、tool、memory、schedule、long task，业务作者都不需要理解底层 transport / worker / retry / outbox / lane / trace / DLQ。**
+
+判断一个改动是否还在正确方向上：
+
+- 业务代码只表达 Data、业务处理和业务能力调用；不表达 RabbitMQ、Redis、ARQ、FastAPI route、trace/lane header、DLQ replay、事务后补 emit。
+- 如果需要一种底层能力，先扩 `app/runtime/*` 或 `app/capabilities/*`，再让业务使用新的公开 API；不要在业务里临时手写绕过。
+- 如果业务作者必须读 `app/runtime/*` 才知道怎么正确使用某个能力，说明文档或框架 surface 还不够，应该补框架/补手册。
+- 当前仍存在的终态 gap 见 `docs/superpowers/specs/2026-05-07-dataflow-phase-7-gap-analysis.md`。
+
+---
+
 ## 1. 心智模型
 
 **Data 流驱动,不是函数调用链。**
@@ -150,7 +163,7 @@ async def summarize(msg: Message) -> SummaryFragment | None:
 | `async def f(x: M, y: User) -> F` —— 多输入 | `async def f(x: str)` —— 非 Data 参数 |
 |  | `async def f(x: Message) -> (Fragment, Log)` —— 不能返回 tuple |
 
-**注意**:装饰器只装最顶层。在 @node 里**不要**手写 `await emit(...)` 或 `await mq.publish(...)`。见「常见坑 #1」。
+**注意**:单输出 `@node` 直接 `return Data`，wrapper 会自动 emit。fan-out / streaming segment / 循环产出多个 Data 这种多输出场景允许在 node 内 `await emit(...)`，但不要再 `return` 同一个 Data 造成重复 emit。任何场景都不要手写 `mq.publish(...)`。见「常见坑 #1」。
 
 ### 2.3 `wire()` —— 声明边
 
@@ -180,12 +193,12 @@ wire(SummaryFragment).to(save_summary)      # 默认 = 同进程直调
 | `.durable()` | 跨进程:RabbitMQ + consumer 侧 `insert_idempotent` dedup;handler 异常 → DLQ(无自动 retry,人工 replay) | 跨 Deployment、要重启续跑、失败需可回放时 |
 | `.as_latest()` | `emit()` 持久化新版本(append + version),下游 `with_latest` / `query()` 读最新 | Data 是"状态快照",需要被后续节点引用 |
 | `.when(predicate)` | 谓词过滤 | Data 到了但某些场景不想触发 |
-| `.debounce(seconds=, max_buffer=)` | 防抖合流 | ⚠️ **未实现**：声明会让 `compile_graph()` 启动报错。引擎尚未支持，节点签名侧的 `Batched[T]` 配套也未设计 |
+| `.debounce(seconds=, max_buffer=, key_by=...)` | 防抖合流 | 已实现；适合 drift / afterthought 这类"同一 key 短时间多次触发只跑最后一次" |
 | `.with_latest(*types)` | 自动 join 最新的 `T`(按同名 Key) | consumer 需要同一上下文的另一种 Data。⚠️ **只在 in-process 边支持**:`.durable().with_latest(...)` 会被 `compile_graph()` 拒绝(durable handler 是单参分派,不会注入 latest 参数) |
 
 > **fan-out 默认是 broadcast 语义**：`wire(T).to(a, b).durable()` 让每个 consumer 在 RabbitMQ 上各自一个独立队列(`durable_<data>_<consumer>`)，各自 dedup、各自 ack，互不影响。无须显式声明。
 
-> **未实现的边语义会启动报错**：runtime 故意把"surface 暴露但引擎未接入"的修饰符做成"用了就 `GraphError`"，避免静默 noop。当前覆盖的是 `.debounce(...)` 和 `.to(Sink.xxx)`。等引擎接入后会同步放开。
+> **不支持的组合会启动报错**：runtime 故意把"surface 暴露但引擎未接入/未定义"的组合做成 `GraphError`，避免静默 noop。典型例子：`.durable().with_latest(...)`、`.debounce().durable()`、`.debounce().to(Sink.xxx)`。
 
 **默认边 vs durable 边**:
 
@@ -199,7 +212,7 @@ durable(跨进程): emit Data ──RabbitMQ 发到 consumer 所在 App──▶
 - 跨 Deployment(比如 vectorize-worker → chat-response-worker) → `.durable()`。
 - 做状态机、事件源、要回放、失败需进 DLQ 由运维 replay → `.durable()`。
 
-> **关于"重试":durable 边不做自动 retry。** consumer 抛异常时 runtime 调 `message.process(requeue=False)`,broker 路由到 DLX/DLQ 就停下了 —— 没有指数退避、没有自动重发。叠加 consumer 侧 `insert_idempotent`,语义是 **at-least-once via dedup**:运维从 DLQ 手动 replay 一条已经处理过的消息,在 consumer 侧是 no-op。如果你想要的是"多试几次再放弃",请在 @node 内部自己做(LLM 调用层面的重试),不要指望边语义。
+> **关于"重试":durable 边当前不做自动 retry。** consumer 抛异常时 runtime 调 `message.process(requeue=False)`,broker 路由到 DLX/DLQ 就停下了 —— 没有指数退避、没有自动重发。叠加 consumer 侧 `insert_idempotent`,语义是 **at-least-once via dedup**:运维从 DLQ 手动 replay 一条已经处理过的消息,在 consumer 侧是 no-op。业务 node 不允许用 `try/except + sleep` 自实现边级 retry；只有 capability 内部的 provider retry（如 LLM/HTTP client）是例外。需要边级 retry 等 Phase 7 的 `wire.retry(...)`。
 
 ### 2.4 `Source` —— 图的入口
 
@@ -224,7 +237,8 @@ wire(MessageRequest).to(hydrate_message).from_(Source.mq("vectorize"))
 - 目标 @node 必须**单参数**(第一个 Data 就是 decode 目标)。
 - runtime 读 MQ body 时会**过滤掉**不在 `req_cls.model_fields` 里的字段(适配老 publisher 带额外字段),所以 Data 保持严格 `extra="forbid"` 不会误伤。
 - Queue 名按 lane 自动加后缀:`"vectorize"` 在 df-v0 lane 变成 `"vectorize_df-v0"`。
-- **队列由 publisher 拥有**:`Source.mq("name")` 在 consumer 侧是 *passive* 拿队列(`channel.get_queue`),自己不 declare,也不在 `ALL_ROUTES` 里。语义是 "我跟 publisher 约定了这个队列名,publisher 负责建"。**部署约束**:新 lane 必须先起 publisher(比如 lark-server) 让它 declare 队列,再起 consumer(比如 vectorize-worker);顺序错了 consumer 会 `get_queue` 失败 → CrashLoopBackoff。这是隐式跨语言约定,确保新增 `Source.mq(...)` 用例时同步去 publisher 那一侧加 declare。
+- **队列由 publisher 拥有**:`Source.mq("name")` 在 consumer 侧是 *passive* 拿队列(`channel.get_queue`),自己不 declare。语义是 "我跟 publisher 约定了这个队列名,publisher 负责建"。**部署约束**:新 lane 必须先起 publisher(比如 lark-server) 让它 declare 队列,再起 consumer(比如 vectorize-worker);顺序错了 consumer 会 `get_queue` 失败 → CrashLoopBackoff。
+- 如果这个 `Source.mq` 还被 `emit()` 当作跨进程 publish bridge（producer 在 dataflow 图内，consumer 在另一个 app），queue 必须能在 `ALL_ROUTES` 中找到 `Route`，否则 runtime 不知道 routing key。纯外部 publisher source 和 dataflow 内部 bridge 要分开判断。
 
 ### 2.5 `Sink` —— 图的出口
 
@@ -245,7 +259,7 @@ wire(Reply).to(Sink.mq("chat_response"))
 
 > Lane 后缀:`"chat_response"` 在 df-v0 lane 变成 `"chat_response_df-v0"`,跟 `Source.mq` 同规则。
 
-> ⚠️ **当前未实现**:`Sink.mq` 的 surface 已经定下来,但引擎尚未实现 sink dispatch —— 在 wire 上声明任何 `Sink.xxx` 会让 `compile_graph()` 启动 `GraphError`。这是**故意的**:防止"声明了静默 noop"。等引擎接入第一个 sink 用例时同步开通。
+> `Sink.mq` 已接入 sink dispatch。`compile_graph()` 会校验 queue 是否在 `ALL_ROUTES` 中；未知 queue 启动即失败。
 
 ### 2.6 `Bridge` —— 过渡层
 
@@ -330,7 +344,7 @@ wire(Message).to(summarize).durable()  # 和 vectorize 共享 Message durable,fa
 
 **注意**:`Message` 已经有一条 `wire(Message).to(vectorize).durable()`。再加 `.to(summarize)` 就是 fan-out —— 两个消费者各自独立队列 + 各自 dedup + 各自 ack,互不影响。任一边 handler 失败只影响自己的 DLQ。
 
-### Step 4 — 绑定 Deployment
+### Step 4 — Deployment placement（仅框架维护者）
 
 ```python
 # app/deployment.py 追加:
@@ -339,7 +353,7 @@ from app.nodes.summarize import summarize
 bind(summarize).to_app("vectorize-worker")  # 和 vectorize/save_fragment 同 pod
 ```
 
-不绑定 = 默认 `agent-service`(HTTP 主服务)。绑到 `vectorize-worker` 意味着在 worker pod 里跑,主 HTTP pod 不启动此 node。
+普通业务作者只定义 Data / node / wire；placement 由 graph/framework owner 按既有域策略维护。不绑定 = 默认 `agent-service`(HTTP 主服务)。绑到 `vectorize-worker` 意味着在 worker pod 里跑,主 HTTP pod 不启动此 node。只有新增跨 Deployment 执行域或调整 worker 拓扑时才改 `app/deployment.py`。
 
 ### Step 5 — 单元测试
 
@@ -497,22 +511,30 @@ structured = await runner.extract(MyPydanticModel, messages=[...])
 
 ## 5. 常见坑(AI 最容易错的地方)
 
-### #1 手写 emit / 手写 mq.publish
+### #1 重复 emit / 手写 mq.publish
 
-@node 已经被 wrapper 包了,返回 Data 就自动 emit。**不要再手写**。
+单输出 @node 已经被 wrapper 包了,返回 Data 就自动 emit。**不要再手写同一个 Data**。多输出场景可以 `await emit(...)` 多次，但函数应 `return None` 或只返回测试需要的非重复结果。
 
 ```python
 # ❌
 @node
 async def summarize(msg: Message) -> None:
     frag = SummaryFragment(...)
-    await emit(frag)             # 重复 emit,下游会收到两次
+    await emit(frag)
+    return frag                  # 重复 emit,下游会收到两次
     await mq.publish(VECTORIZE, ...)   # 直接捅 infra,绕过图
 
 # ✅
 @node
 async def summarize(msg: Message) -> SummaryFragment:
     return SummaryFragment(...)  # wrapper 自动 emit
+
+# ✅ 多输出/fan-out
+@node
+async def fan_out(req: BatchRequest) -> None:
+    for item in req.items:
+        await emit(ItemRequest(item_id=item.id))
+    return None
 ```
 
 ### #2 直接 import infra

--- a/docs/superpowers/specs/2026-05-07-dataflow-phase-6-cleanup-design.md
+++ b/docs/superpowers/specs/2026-05-07-dataflow-phase-6-cleanup-design.md
@@ -2,7 +2,11 @@
 
 **状态**: Draft v4 (2026-05-07，重定 scope 到原 dataflow design line 543 "终结清扫")
 **前置**: PR #209 (Phase 5b) shipped to prod 1.0.0.328；本期分支 `refactor/flow-parse-6` 已落 v3 4 commits（PR #210）作为 v4 baseline
-**后续**: v5/v6 继续闭合 capability gap，Gap 1-12 的全 surface 见 §1
+**后续**: 本文是 Phase 6 历史 spec。Phase 6 v4 已 ship；后续统一进入 `docs/superpowers/specs/2026-05-07-dataflow-phase-7-gap-analysis.md`。本文中的 "v5/v6/v7" 说法已废弃，Gap 7+ 由 Phase 7 明确承接。
+
+> **2026-05-08 事实校正**: Phase 6 只关闭了 state_sync 的 arq 绕路；`long_tasks/task_executor` 仍由 `arq-worker` 承载，作为 Phase 7 Gap 15 / partial close 跟踪。不得按本文早期验收描述直接删除 `app/workers/arq_settings.py`、arq 依赖或 `arq-worker` Deployment。
+>
+> `api/routes.py` 当前只保留 `/health` 手写 route，作为 app lifecycle/infra 例外；`Source.http_health` builtin 尚未实现，归 Phase 7 Gap 17 决定。
 
 ## 0. v4 vs v3 的关系
 

--- a/docs/superpowers/specs/2026-05-07-dataflow-phase-7-gap-analysis.md
+++ b/docs/superpowers/specs/2026-05-07-dataflow-phase-7-gap-analysis.md
@@ -1,0 +1,277 @@
+# Dataflow Phase 7 — 终态 Gap Analysis
+
+**状态**: Draft v2 (2026-05-08，吸收 subagent 两轮扫描)
+**前置**: Phase 0-6 shipped；Phase 6 v4 已完成 HTTP source / cross-process emit / tool events / arq state-sync removal / fire-and-forget cleanup / main chat graph cutover。
+**核心校正**: 终态不是"业务代码改用 dataflow API"；终态是**无论写什么业务，作者都不需要理解底层框架**。
+
+## 1. 终态判定标准
+
+一个业务改动合格，不是因为它用了 `wire(...)`，而是因为业务作者只需要回答：
+
+1. 这个业务产生 / 消费什么 Data？
+2. 哪个 Node 处理它？
+3. 需要哪些业务能力（LLM / HTTP / VectorStore / Agent / state query）？
+
+业务作者不应该知道：
+
+- RabbitMQ queue / routing key / DLX / DLQ / replay
+- Redis key / lock / delayed message
+- ARQ worker / cron poller / pod placement
+- trace / lane header propagation
+- DB commit 后才能 emit
+- retry/backoff/outbox 细节
+- FastAPI route 注册细节
+
+如果新增业务需要上述知识，先扩 `app/runtime/*` 或 `app/capabilities/*`，再写业务。
+
+## 2. 已闭合的能力面（Phase 0-6）
+
+| 面 | 当前状态 | 证据 |
+|---|---|---|
+| Data / Node / Wire 图 | 已有 runtime 核心抽象 | `app/runtime/{data,node,wire,emit,graph}.py` |
+| HTTP source | GET / POST / DELETE / path params / query / RPC 已支持 | `tests/runtime/test_http_source.py` |
+| cross-process emit | consumer 在其它 app + `Source.mq` 时自动 publish | `tests/runtime/test_emit_cross_process.py` |
+| Sink.mq | Data 出图到 MQ queue | `tests/runtime/test_sink_dispatch.py` |
+| durable edge | RabbitMQ + consumer-side idempotent + trace/lane header | `tests/runtime/test_durable.py` |
+| debounce | Redis + delayed MQ + compile-time shape validation | `tests/runtime/test_debounce.py`, `tests/runtime/test_graph_debounce.py` |
+| chat pipeline | `ChatTrigger -> ChatRequest -> ChatResponseSegment -> Sink.mq` | `app/wiring/chat.py` |
+| tool side effects | 部分 mutation tool emit event Data | `app/domain/agent_tool_events.py`, `app/wiring/agent_tool_events.py` |
+
+这些能力让业务从手写 `mq.publish` / `@router` / `asyncio.create_task` 迁到统一图里，但还没有达到"不需要理解底层"。
+
+## 3. Phase 7 Gap Surface（Gap 7-19）
+
+Phase 7 不只包含 memory 中的 Gap 7-12。Gap 7-12 关闭 transport / reliability primitive；Gap 13-19 关闭"业务作者仍要理解底层"的实际泄漏面。若 13-19 不在本轮实现，也必须有 owner、约束和禁止 workaround，不能只叫"遗漏面"。
+
+### Gap 7 — durable retry 策略仍泄漏
+
+**现状**: `.durable()` 固定 fail-to-DLQ，`runtime/durable.py` 明确无自动 retry。
+
+**为什么未达终态**: 业务/运维需要知道 transient error 会直接进 DLQ，且不能在业务里手写 retry。
+
+**目标**: `wire(T).to(node).durable().retry(n=3, backoff="exponential")` 或等价策略对象。业务声明失败策略，runtime 负责 delayed retry / DLQ。
+
+**验收**:
+- 业务代码 grep `try.*sleep.*retry` / `await asyncio.sleep` 自实现 retry 为 0（agent capability 内部 LLM retry 作为 capability 例外）。
+- durable retry contract test 覆盖：前 N-1 次失败重投，最后成功 ack；超过次数进 DLQ。
+
+### Gap 8 — outbox / 事务边界仍泄漏
+
+**现状**: 业务仍靠"commit 后 emit"纪律；`life/proactive.py` 等处显式提醒。
+
+**代表位置**: `life/proactive.py` 注释要求 `get_session()` 退出后 emit；`agent/tools/update_schedule.py` 在已提交 schedule revision 后再 emit，并要考虑 emit 失败后的已提交状态。
+
+**为什么未达终态**: 业务作者必须理解 DB transaction 和 emit 的顺序，否则会出现 DB rollback 但事件已发，或 DB commit 成功但 emit 失败。
+
+**目标**: outbox 模式。业务在同一事务里写状态 + append outbox，runtime publisher 在 commit 后统一 emit。
+
+**验收**:
+- 新 mutation 业务不需要写"commit 后 emit"注释。
+- 失败注入测试覆盖：DB rollback 不发事件；MQ publish 失败不会丢事件，outbox 可重试。
+
+### Gap 9 — delayed / scheduled emit 仍不是通用 primitive
+
+**现状**: debounce 内部有 delayed MQ，但业务没有 `emit_delayed` / `emit_at`。
+
+**为什么未达终态**: 新业务如果想"10 分钟后再做"，会被迫理解 RabbitMQ delayed exchange 或手写 sleep。
+
+**目标**: `await emit_delayed(data, delay=...)` / `await emit_at(data, at=...)`，或 `wire(...).delay(...)`。底层由 runtime 决定用 delayed MQ、outbox scheduler 或 cron wheel。
+
+**验收**:
+- 业务代码 grep `asyncio.sleep.*emit` 为 0。
+- delayed emit 测试覆盖 lane/trace propagation、进程重启后仍可投递。
+
+### Gap 10 — streaming/segment 协议仍泄漏
+
+**现状**: chat 用 `ChatResponseSegment(part_index, is_last)`，能跑，但新流式业务仍要懂这套字段协议。
+
+**为什么未达终态**: 业务作者要自己设计 chunk key、final marker、full_content 等约定。
+
+**目标**: 标准化 segment/stream capability。可以不恢复旧 `Stream[T]`，但必须把 part index、final、dedup、sink fan-out 变成共享协议或 helper。
+
+**验收**:
+- 新流式业务不自定义 `part_index/is_last` 字段名。
+- chat 现有协议通过 shared abstraction 表达，飞书侧 body 兼容。
+
+### Gap 11 — trace / lane propagation 散在多处
+
+**现状**: durable、debounce、Source.mq、HTTP capability 各自处理 trace/lane。
+
+**为什么未达终态**: 每新增一种 Source/Sink/transport 都可能漏传 context；业务偶尔还会读 `current_lane()` 补字段。更麻烦的是 lane 还有历史 body-level contract：`ChatResponseSegment` / lark-server `chat-response-worker` 读 payload 里的 `lane`，不能只把 lane 收进 header 而漏掉兼容迁移。
+
+**目标**: runtime-level propagation hook：publish/consume/sink/source 统一 encode/decode context。
+
+**验收**:
+- `trace_id_var` / `lane_var` 只在 runtime/capability 边界出现。
+- cross-process / debounce / sink / HTTP source contract tests 共享同一 propagation helper。
+- 明确列出并迁移/兼容 body-level lane contract；验收包含 proactive/chat_response lane 路由 e2e。
+
+### Gap 12 — DLQ replay 语义不闭合
+
+**现状**: durable consumer 先 `insert_idempotent` 再跑 handler；直接 replay 同一 DLQ 消息可能被 dedup 拦下成 no-op。
+
+**为什么未达终态**: 运维必须知道清哪张 data table / idempotent row 后才能 replay。
+
+**目标**: runtime 提供 replay 工具和策略：inspect、clear idempotent、requeue、dry-run。业务 Data 暴露 replay identity，工具负责底层动作。
+
+**验收**:
+- 有 CLI/API runbook：给 DLQ message id 或 Data key，可 dry-run 展示会清什么、重投什么。
+- replay integration test 覆盖 no-op 模式和 clear-idempotent 模式。
+
+### Gap 13 — DB/session/query 仍大面积泄漏到业务
+
+**扫描结果**: 排除 `runtime/` 和 `infra/` 后，`get_session()` / `AsyncSessionLocal` / `app.data.session` 仍约 140 处。
+
+**代表位置**:
+- `app/nodes/memory_pipelines.py`
+- `app/nodes/admin.py`
+- `app/life/glimpse.py`
+- `app/life/proactive.py`
+- `app/memory/*`
+- `app/long_tasks/crud.py`
+
+**为什么未达终态**: Node 作者仍要知道 SQLAlchemy session、commit、row shape、查询 helper 分布。原始 dataflow 设计里 Node 应优先使用 `query(T)` / capability，而不是直接碰 DB。
+
+**目标方向**:
+- 读：扩 `runtime/query.py`，提供 typed query / latest / list / join 能力。
+- 写：Data-native write 或 domain repository capability；需要副作用时走 outbox。
+- 旧表 adoption mode 继续保留，但 ORM 细节收进 capability/repository。
+
+**验收**:
+- 新 Node 禁止直接 import `get_session`。
+- 业务目录中 DB 访问逐域收敛到少数 capability/repository 文件。
+
+### Gap 14 — Redis lock / single-flight 泄漏到业务
+
+**扫描结果**: `nodes/memory_pipelines.py` 直接使用 Redis SETNX + Lua release；`chat/context.py` 使用 Redis-backed `ImageRegistry`；`nodes/safety.py` 直接从 Redis set 读取 banned words。
+
+**为什么未达终态**: 业务作者需要理解 Redis key、TTL、Lua compare-delete，甚至知道某个业务 registry/config 存在 Redis set 里。
+
+**目标方向**:
+- runtime/capability 提供 `SingleFlight(key, ttl)` / `Registry` primitive。
+- 业务只表达"同一 persona/chat 同时只能跑一个 reviewer"。
+- Redis-backed business registry/config 收敛为 typed capability，业务不直接读 Redis key。
+
+**验收**:
+- 业务 node 中无 `redis.set(... nx=True ...)` / `redis.eval(...)`。
+- 业务 node 中无 `redis.smembers(...)` 这类直接读业务配置集合。
+- lock contention 行为有 capability contract tests。
+
+### Gap 15 — long_tasks / arq 子系统仍是第二套执行框架
+
+**现状**: `arq-worker` 仍存在，只剩 `task_executor_job` 每分钟 poll `long_tasks`。
+
+**为什么未达终态**: 写 long task 仍要理解 arq worker、SQL poller、retry_count/max_retries，而不是 Dataflow runtime。
+
+**目标方向**:
+- 把 `LongTaskRequested/LongTaskStep/LongTaskCompleted` 建模成 Data。
+- 用 `Source.cron("* * * * *")` 或 outbox scheduler 驱动 executor node。
+- 统一 retry / status / observability，不再由 arq cron 独立实现。
+
+**验收**:
+- 删除 `app/workers/arq_settings.py` 和 arq 依赖。
+- K8s 不再有 `arq-worker`；或改名为 dataflow worker 并跑 `runtime_entry.py`。
+
+### Gap 16 — 外部 / 内部 HTTP client 仍绕 capability
+
+**扫描结果**: `agent/tools/search.py`、`agent/tools/image_search.py` 直接用 httpx headers/API key；`skills/sandbox_client.py` 自己组 lane/trace/auth headers。
+
+**为什么未达终态**: tool/client 作者要知道 headers、auth、trace/lane 是否需要注入。内部服务 client 绕过 `HTTPClient` 时尤其容易漏 lane/trace。
+
+**目标方向**:
+- 把外部搜索/图片搜索变成 capability。
+- HTTPClient 负责 trace/lane；搜索 capability 负责 auth/header/schema。
+- 内部 service client 统一用 HTTP capability 或 service-specific capability，禁止业务手写 lane_router / get_trace_id headers。
+
+**验收**:
+- agent tool / skills client 不直接 new HTTP client 或手写 auth/lane/trace headers（外部 provider SDK 作为 capability 内部例外）。
+
+### Gap 17 — 健康检查 / lifecycle 仍是 route 例外
+
+**现状**: `app/api/routes.py` 只剩 `/health` 手写 route；这是合理例外，但仍说明 HTTP source 没有 builtin lifecycle surface。
+
+**目标方向**:
+- `runtime/http_source.py` 提供 builtin health/liveness/readiness 注册，或者明确把 health 归为 app lifecycle 不属于业务 framework。
+
+**验收**:
+- 文档和测试固定 `/health` 是唯一允许的 hand-written route。
+
+### Gap 18 — node error policy / DLQ 语义泄漏到业务
+
+**扫描结果**: `nodes/life_dataflow.py`、`nodes/safety.py`、`nodes/save_fragment.py` 的注释和控制流要求业务作者知道"不要 catch，否则不会 nack/DLQ"、"row missing 要 raise 进 DLQ"。
+
+**为什么未达终态**: 业务节点在表达错误语义时必须理解 RabbitMQ ack/nack 和 DLQ，而不是声明"这个错误可重试/不可重试/进入人工处理"。
+
+**目标方向**:
+- 给 node 或 wire 增加 error policy：fail-to-DLQ、retryable、ignore duplicate、manual-review 等。
+- runtime 负责把异常映射到 ack/nack/retry/DLQ；业务只抛 typed domain error 或返回 typed failure Data。
+
+**验收**:
+- 新 node 不需要写"不要 catch 否则不进 DLQ"这类注释。
+- error policy contract tests 覆盖 typed error -> retry/DLQ/no-op 的映射。
+
+### Gap 19 — graph request/reply / async join 仍手写 event-loop 编排
+
+**扫描结果**: `nodes/chat_node.py` 和 `chat/pre_safety_gate.py` 通过 `asyncio.create_task` / Future / race 方式等待 pre-safety verdict。它不是 fire-and-forget，但仍是业务层 event-loop orchestration。
+
+**为什么未达终态**: 业务作者要理解 task 生命周期、取消、timeout、并发 race，而不是声明"ChatRequest 需要等待 SafetyVerdict，直到段边界再决策"。
+
+**目标方向**:
+- runtime 提供 graph request/reply、join、barrier 或 awaitable Data primitive。
+- pre-safety 这种"先发请求，后在业务边界等待 verdict"成为声明式 pattern。
+
+**验收**:
+- 除 runtime/capability 内部外，业务 node 不直接用 `asyncio.create_task` 管 graph 子流程。
+- pre-safety tests 从 task/future 细节转为 request/reply contract tests。
+
+## 5. 有效性保障
+
+### 5.1 CI / grep gate
+
+Phase 7 后应新增一个 framework guard test。不要用粗暴全文 grep 清零；按 allowlist 区分 runtime/capability/infra 边界和业务目录，避免命中文档、README、注释后误删代码。
+
+```bash
+rg "mq\.publish|enqueue_job|create_pool|from arq|asyncio\.create_task" apps/agent-service/app \
+  --glob '!apps/agent-service/app/runtime/**' --glob '!**/README.md'
+rg "await asyncio\.sleep\(.*emit|emit_delayed TODO|outbox TODO" apps/agent-service/app \
+  --glob '!apps/agent-service/app/runtime/**'
+rg "trace_id_var|lane_var|current_lane|headers=.*x-lane" apps/agent-service/app \
+  --glob '!apps/agent-service/app/runtime/**' --glob '!apps/agent-service/app/capabilities/**' \
+  --glob '!apps/agent-service/app/infra/**' --glob '!apps/agent-service/app/api/middleware.py'
+rg "get_session\(|AsyncSessionLocal" apps/agent-service/app/nodes apps/agent-service/app/agent/tools
+rg "redis\.set\(.*nx=True|redis\.eval\(|redis\.smembers\(" apps/agent-service/app/nodes
+```
+
+不是所有命中都必须立刻归零，但每个例外必须有 owner 和 close path。否则框架会重新被业务绕开。
+
+### 5.2 Contract tests
+
+每个 runtime primitive 必须有三类测试：
+
+- compile-time validation：错误组合启动失败，不静默 noop。
+- unit contract：不依赖真实服务时能证明 API 语义。
+- integration / lane test：真实 RabbitMQ/Postgres 时证明 trace/lane/retry/idempotent 行为。
+
+### 5.3 E2E 证据
+
+框架有效性最终靠真实链路证明：
+
+- dev bot 群聊 + p2p chat
+- proactive / glimpse
+- update_schedule tool -> state sync
+- vectorize-worker 消费
+- admin HTTP RPC
+- durable failure -> DLQ -> replay drill
+- Langfuse trace 中能看到完整上下文
+
+## 6. 建议切分
+
+| PR | 范围 | 原因 |
+|---|---|---|
+| Phase 7a | Gap 7, 9, 11 | transport 语义：retry / delayed / propagation 同属 MQ/runtime 层 |
+| Phase 7b | Gap 8, 12, 18 | reliability 语义：outbox / replay / error policy 共享 idempotent 与状态表设计 |
+| Phase 7c | Gap 15 | arq partial close，独立 blast radius |
+| Phase 7d | Gap 13, 14, 16 | capability 收敛，按业务域逐步迁移 |
+| Phase 7e | Gap 10, 19 | streaming / request-reply / async join，收敛 chat/pre-safety 特例 |
+
+Phase 7a/7b 是"框架是否可信"的关键；Phase 7c/7d/7e 是"业务作者是否真的不用懂底层"的关键。


### PR DESCRIPTION
## Summary

- Add Phase 7 spec `docs/superpowers/specs/2026-05-07-dataflow-phase-7-gap-analysis.md`. Defines the terminal state ("business authors should not need to understand transport / worker / retry / outbox / lane / trace / DLQ") and expands the gap surface from Gap 7-12 to Gap 7-19, covering DB/session, Redis lock, long_tasks/arq, HTTP capability, /health builtin, node error policy, and graph request-reply / async join.
- Update `docs/guides/dataflow-framework.md`: add terminal-state principle; mark `.debounce()` and `Sink.mq` as shipped; single-output `@node` returns `Data` while multi-output / fan-out / streaming may emit; forbid business-code retry loops; note `Source.mq` needs `ALL_ROUTES` for cross-process emit bridge; deployment placement is a framework-maintainer step.
- Correct header of `docs/superpowers/specs/2026-05-07-dataflow-phase-6-cleanup-design.md`: Phase 6 v4 already shipped (PR #210, prod 1.0.1.2); v5/v6/v7 nomenclature deprecated; Gap 7+ tracked under the new Phase 7 spec; `long_tasks/task_executor` still runs on arq-worker, so `arq_settings.py` / arq dependency / arq-worker Deployment must NOT be removed per the old v4 acceptance; `/health` remains a lifecycle exception pending Phase 7 Gap 17.

## Test plan

- [x] Docs-only change. No code, no infrastructure, no deployment risk.
- [x] Verify the three files render correctly on GitHub after merge.