### PR TITLE
feat(notes): redesign chiwei notes — upsert/list/delete tools + windowed context injection

### DIFF
--- a/apps/agent-service/app/agent/tools/__init__.py
+++ b/apps/agent-service/app/agent/tools/__init__.py
@@ -15,7 +15,7 @@ from app.agent.tools.history import (
 )
 from app.agent.tools.image import generate_image, read_images
 from app.agent.tools.image_search import search_images
-from app.agent.tools.notes import resolve_note, write_note
+from app.agent.tools.notes import delete_note, list_note, resolve_note, upsert_note
 from app.agent.tools.recall import recall
 from app.agent.tools.sandbox import sandbox_bash
 from app.agent.tools.search import search_web
@@ -30,8 +30,10 @@ BASE_TOOLS = [
     read_images,
     recall,
     commit_abstract_memory,
-    write_note,
+    upsert_note,
+    list_note,
     resolve_note,
+    delete_note,
     update_schedule,
 ]
 
@@ -56,8 +58,10 @@ __all__ = [
     "read_images",
     "recall",
     "commit_abstract_memory",
-    "write_note",
+    "upsert_note",
+    "list_note",
     "resolve_note",
+    "delete_note",
     "update_schedule",
     "check_chat_history",
     "search_group_history",

--- a/apps/agent-service/app/agent/tools/notes.py
+++ b/apps/agent-service/app/agent/tools/notes.py
@@ -1,54 +1,111 @@
-"""write_note / resolve_note tools — 赤尾自己的主动清单。"""
+"""Notes tool set — 赤尾自己的主动清单 (CRUD)。
+
+Tools exposed:
+- ``upsert_note`` (create / update content / update when_at / clear when_at)
+- ``list_note``  (full active list, with when_label)
+- ``resolve_note`` (mark as completed)
+- ``delete_note`` (soft delete with mandatory reason)
+"""
 
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import datetime, timezone
 
 from langchain.tools import tool
 from langgraph.runtime import get_runtime
 
 from app.agent.context import AgentContext
 from app.agent.tools._common import tool_error
-from app.data.ids import new_id
-from app.data.queries import resolve_note as resolve_note_query
-from app.data.queries.memory_edges import get_active_notes, insert_note
+from app.data.queries import (
+    delete_note as delete_note_query,
+)
+from app.data.queries import (
+    list_active_notes as list_active_notes_query,
+)
+from app.data.queries import (
+    resolve_note as resolve_note_query,
+)
+from app.data.queries import (
+    upsert_note as upsert_note_query,
+)
+from app.data.queries.memory_edges import _UNSET
 from app.domain.agent_tool_events import NoteCreated
+from app.memory.notes_format import format_when_label
 from app.runtime.db import emit_tx, tx
 
 
-async def _write_note_impl(
+def _serialize(n) -> dict:
+    return {
+        "note_id": n.id,
+        "content": n.content,
+        "when_at": n.when_at.isoformat() if n.when_at else None,
+        "created_at": n.created_at.isoformat() if n.created_at else None,
+        "when_label": format_when_label(
+            when_at=n.when_at,
+            created_at=n.created_at,
+            now=datetime.now(timezone.utc),
+        ),
+    }
+
+
+# ---------------------------------------------------------------------------
+# upsert_note
+# ---------------------------------------------------------------------------
+
+async def _upsert_note_impl(
     *,
     persona_id: str,
     content: str,
-    when_at: datetime | None,
+    when_at_raw: str | None,
+    note_id: str | None,
 ) -> dict:
     content = (content or "").strip()
     if not content:
         return {"error": "content 不能为空"}
 
-    nid = new_id("n")
+    # Translate when_at_raw into the query-layer sentinel pattern:
+    # - None       → _UNSET (don't touch column on update; default NULL on create)
+    # - "clear"    → None   (explicit clear on update)
+    # - ISO string → datetime
+    if when_at_raw is None:
+        when_at: datetime | None | object = _UNSET
+    elif when_at_raw.strip().lower() == "clear":
+        when_at = None
+    else:
+        try:
+            when_at = datetime.fromisoformat(when_at_raw)
+        except ValueError:
+            return {"error": f"when_at 格式无效: {when_at_raw}"}
+
+    is_create = note_id is None
     async with tx():
-        await insert_note(
-            id=nid,
-            persona_id=persona_id,
-            content=content,
-            when_at=when_at,
-        )
-        rows = await get_active_notes(persona_id=persona_id)
-        await emit_tx(NoteCreated(note_id=nid, persona_id=persona_id))
+        try:
+            row = await upsert_note_query(
+                persona_id=persona_id,
+                content=content,
+                when_at=when_at,
+                note_id=note_id,
+            )
+        except LookupError as e:
+            return {"error": str(e)}
+        if is_create:
+            await emit_tx(NoteCreated(note_id=row.id, persona_id=persona_id))
 
-    return {
-        "id": nid,
-        "active_notes": [
-            {
-                "id": n.id,
-                "content": n.content,
-                "when_at": n.when_at.isoformat() if n.when_at else None,
-            }
-            for n in rows
-        ],
-    }
+    return {"id": row.id, "note": _serialize(row)}
 
+
+# ---------------------------------------------------------------------------
+# list_note
+# ---------------------------------------------------------------------------
+
+async def _list_note_impl(*, persona_id: str) -> dict:
+    rows = await list_active_notes_query(persona_id=persona_id)
+    return {"items": [_serialize(n) for n in rows]}
+
+
+# ---------------------------------------------------------------------------
+# resolve_note
+# ---------------------------------------------------------------------------
 
 async def _resolve_note_impl(
     *,
@@ -61,35 +118,84 @@ async def _resolve_note_impl(
         return {"error": "note_id 和 resolution 都不能为空"}
 
     await resolve_note_query(note_id=note_id, resolution=resolution)
-
     return {"ok": True}
 
 
+# ---------------------------------------------------------------------------
+# delete_note
+# ---------------------------------------------------------------------------
+
+async def _delete_note_impl(
+    *,
+    persona_id: str,
+    note_id: str,
+    reason: str,
+) -> dict:
+    reason = (reason or "").strip()
+    if not note_id:
+        return {"error": "note_id 不能为空"}
+    if not reason:
+        return {"error": "reason 不能为空，请说明为什么删"}
+
+    await delete_note_query(note_id=note_id, reason=reason)
+    return {"ok": True}
+
+
+# ---------------------------------------------------------------------------
+# @tool wrappers — exposed to the LLM
+# ---------------------------------------------------------------------------
+
 @tool
 @tool_error("笔记保存失败")
-async def write_note(content: str, when_at: str | None = None) -> dict:
-    """把一件你觉得必须记住的事写进清单。
+async def upsert_note(
+    content: str,
+    when_at: str | None = None,
+    note_id: str | None = None,
+) -> dict:
+    """把一件你觉得必须记住的事写进清单，或者更新已有的一条。
 
     这是你自己的清单，不是系统强加的承诺列表。只有你觉得"不能忘"、"需要专门记住"的
-    事才写。当时间相关的（比如"周五和浩南看电影"），传 when_at（ISO 8601 格式）。
-    普通的备忘、情绪留痕也行。
+    事才写。
+
+    什么时候用：
+    - 第一次提到一件想记住的事 → 不传 note_id，会创建新的一条
+    - 用户重复提到同一件事（比如"那家餐厅改成下周去了"）→ 传清单里看到的 note_id，会更新
 
     Args:
-        content: 笔记内容
-        when_at: 可选，ISO 8601 时间戳（"2026-04-18T19:00:00+08:00"）
+        content: 笔记内容（必填）。
+        when_at: ISO 8601 时间戳（"2026-05-15T19:00:00+08:00"）。**如果这件事和某个时间相关
+            （"明天"/"周五"/"下个月"/具体日子），强烈建议填**。没明确时间线索就别硬填。
+            想清空已有的 when_at 传 "clear"（仅在更新场景有意义）。
+        note_id: 已有 note 的 id（形如 "n_xxx"，从清单里看到）；不传则新建。
     """
     context = get_runtime(AgentContext).context
-    parsed_when_at: datetime | None = None
-    if when_at is not None:
-        try:
-            parsed_when_at = datetime.fromisoformat(when_at)
-        except ValueError:
-            return {"error": f"when_at 格式无效: {when_at}"}
-    return await _write_note_impl(
+    return await _upsert_note_impl(
         persona_id=context.persona_id,
         content=content,
-        when_at=parsed_when_at,
+        when_at_raw=when_at,
+        note_id=note_id,
     )
+
+
+@tool
+@tool_error("清单查询失败")
+async def list_note() -> dict:
+    """列出你目前的全部清单（没完成、没删除的）。
+
+    什么时候用：
+    - 用户问起"你都记了啥"
+    - 你想盘点一下有没有重复的、可以合并的
+    - 你想看看有没有挂了很久该处理的事
+
+    注意：context 里通常已经有"最近活跃"的几条了。需要看全量、找特定 id、
+    清盘的时候才用这个。
+
+    Returns:
+        ``{"items": [{"note_id": "n_xxx", "content": "...", "when_at": "...|null",
+        "created_at": "...", "when_label": "还有 2 天"}, ...]}``
+    """
+    context = get_runtime(AgentContext).context
+    return await _list_note_impl(persona_id=context.persona_id)
 
 
 @tool
@@ -97,16 +203,41 @@ async def write_note(content: str, when_at: str | None = None) -> dict:
 async def resolve_note(note_id: str, resolution: str) -> dict:
     """把一条已经完结的笔记划掉。
 
-    比如电影看了、想法落实了、或者你改主意不做了。resolution 写一句话说明结果
-    （"看完了"/"改了主意"/"忘了"）。
+    比如电影看了、想法落实了。resolution 写一句话说明结果（"看完了"/"做完了"）。
+
+    这是"完成"，不是"删除"。如果是改主意了 / 记错了 / 重复了，用 delete_note。
 
     Args:
         note_id: 笔记 id（形如 "n_xxxxxx"）
-        resolution: 结果描述
+        resolution: 结果描述（必填）
     """
     context = get_runtime(AgentContext).context
     return await _resolve_note_impl(
         persona_id=context.persona_id,
         note_id=note_id,
         resolution=resolution,
+    )
+
+
+@tool
+@tool_error("清单删除失败")
+async def delete_note(note_id: str, reason: str) -> dict:
+    """真删除一条清单项。
+
+    和 resolve 不同 —— resolve 是"做完了"留个痕，delete 是"这条本来就不该存在"。
+
+    什么时候用：
+    - 改主意了，不打算做这件事了
+    - 当时记错了，根本不是这件事
+    - 发现是重复的（已经有一模一样的另一条）
+
+    Args:
+        note_id: 笔记 id（形如 "n_xxx"）
+        reason: 必填，写明为什么删（"改主意了" / "记错了" / "和 n_xyz 重复"）
+    """
+    context = get_runtime(AgentContext).context
+    return await _delete_note_impl(
+        persona_id=context.persona_id,
+        note_id=note_id,
+        reason=reason,
     )

--- a/apps/agent-service/app/agent/tools/notes.py
+++ b/apps/agent-service/app/agent/tools/notes.py
@@ -9,7 +9,7 @@ Tools exposed:
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 
 from langchain.tools import tool
 from langgraph.runtime import get_runtime
@@ -43,7 +43,7 @@ def _serialize(n) -> dict:
         "when_label": format_when_label(
             when_at=n.when_at,
             created_at=n.created_at,
-            now=datetime.now(timezone.utc),
+            now=datetime.now(UTC),
         ),
     }
 

--- a/apps/agent-service/app/agent/tools/notes.py
+++ b/apps/agent-service/app/agent/tools/notes.py
@@ -10,8 +10,8 @@ from langgraph.runtime import get_runtime
 from app.agent.context import AgentContext
 from app.agent.tools._common import tool_error
 from app.data.ids import new_id
-from app.data.queries import get_active_notes, insert_note
 from app.data.queries import resolve_note as resolve_note_query
+from app.data.queries.memory_edges import get_active_notes, insert_note
 from app.domain.agent_tool_events import NoteCreated
 from app.runtime.db import emit_tx, tx
 

--- a/apps/agent-service/app/data/models.py
+++ b/apps/agent-service/app/data/models.py
@@ -374,6 +374,10 @@ class Note(Base):
         DateTime(timezone=True), nullable=True
     )
     resolution: Mapped[str | None] = mapped_column(Text, nullable=True)
+    deleted_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    delete_reason: Mapped[str | None] = mapped_column(Text, nullable=True)
 
 
 class ScheduleRevision(Base):

--- a/apps/agent-service/app/data/queries/memory_edges.py
+++ b/apps/agent-service/app/data/queries/memory_edges.py
@@ -9,6 +9,7 @@ from datetime import datetime
 from sqlalchemy import func, update
 from sqlalchemy.future import select
 
+from app.data.ids import new_id
 from app.data.models import MemoryEdge, Note
 from app.runtime.db import auto_tx, current_session
 
@@ -18,9 +19,13 @@ __all__ = [
     "list_edges_to",
     "list_edges_from",
     "insert_note",
+    "upsert_note",
     "get_active_notes",
     "resolve_note",
 ]
+
+
+_UNSET: object = object()
 
 
 async def insert_memory_edge(
@@ -118,6 +123,49 @@ async def get_active_notes(persona_id: str) -> list[Note]:
             .order_by(Note.created_at.desc())
         )
         return list(result.scalars().all())
+
+
+async def upsert_note(
+    *,
+    persona_id: str,
+    content: str,
+    when_at: datetime | None | object = _UNSET,
+    note_id: str | None = None,
+) -> Note:
+    """Create or update a Note.
+
+    - ``note_id is None`` → create new note (id auto-generated as ``n_<hex>``)
+    - ``note_id`` provided + ``when_at is _UNSET`` → update content only
+    - ``note_id`` provided + ``when_at is None`` → clear when_at column
+    - ``note_id`` provided + ``when_at`` is datetime → update when_at column
+
+    Returns the persisted Note. Raises ``LookupError`` if updating an unknown id.
+    """
+    async with auto_tx():
+        s = current_session()
+        if note_id is None:
+            nid = new_id("n")
+            when_value = None if when_at is _UNSET else when_at
+            n = Note(
+                id=nid,
+                persona_id=persona_id,
+                content=content,
+                when_at=when_value,
+            )
+            s.add(n)
+            await s.flush()
+            return n
+
+        result = await s.execute(select(Note).where(Note.id == note_id))
+        existing = result.scalar_one_or_none()
+        if existing is None:
+            raise LookupError(f"note not found: {note_id}")
+
+        existing.content = content
+        if when_at is not _UNSET:
+            existing.when_at = when_at  # type: ignore[assignment]
+        await s.flush()
+        return existing
 
 
 async def resolve_note(*, note_id: str, resolution: str) -> None:

--- a/apps/agent-service/app/data/queries/memory_edges.py
+++ b/apps/agent-service/app/data/queries/memory_edges.py
@@ -18,9 +18,8 @@ __all__ = [
     "delete_edge",
     "list_edges_to",
     "list_edges_from",
-    "insert_note",
     "upsert_note",
-    "get_active_notes",
+    "delete_note",
     "resolve_note",
 ]
 
@@ -166,6 +165,20 @@ async def upsert_note(
             existing.when_at = when_at  # type: ignore[assignment]
         await s.flush()
         return existing
+
+
+async def delete_note(*, note_id: str, reason: str) -> None:
+    """Soft-delete a note (sets deleted_at + delete_reason).
+
+    Does not raise if note_id does not exist; the UPDATE simply affects 0 rows.
+    The tool layer is responsible for verifying existence if needed.
+    """
+    async with auto_tx():
+        await current_session().execute(
+            update(Note)
+            .where(Note.id == note_id)
+            .values(deleted_at=func.now(), delete_reason=reason)
+        )
 
 
 async def resolve_note(*, note_id: str, resolution: str) -> None:

--- a/apps/agent-service/app/data/queries/memory_edges.py
+++ b/apps/agent-service/app/data/queries/memory_edges.py
@@ -4,7 +4,7 @@ Operates on tables: ``MemoryEdge``, ``Note``.
 """
 from __future__ import annotations
 
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 
 from sqlalchemy import func, update
 from sqlalchemy.future import select
@@ -181,7 +181,7 @@ async def select_notes_for_context(persona_id: str) -> list[Note]:
     Order: notes with ``when_at`` first (ascending — soonest first), then
     notes without ``when_at`` (most recent created first). Capped at 15 rows.
     """
-    now = datetime.now(timezone.utc)
+    now = datetime.now(UTC)
     overdue_cutoff = now - timedelta(days=_CONTEXT_RECENT_OVERDUE_DAYS)
     memo_cutoff = now - timedelta(days=_CONTEXT_NEW_MEMO_DAYS)
 

--- a/apps/agent-service/app/data/queries/memory_edges.py
+++ b/apps/agent-service/app/data/queries/memory_edges.py
@@ -4,7 +4,7 @@ Operates on tables: ``MemoryEdge``, ``Note``.
 """
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import datetime, timedelta, timezone
 
 from sqlalchemy import func, update
 from sqlalchemy.future import select
@@ -21,6 +21,7 @@ __all__ = [
     "upsert_note",
     "delete_note",
     "list_active_notes",
+    "select_notes_for_context",
     "resolve_note",
 ]
 
@@ -184,6 +185,46 @@ async def list_active_notes(persona_id: str) -> list[Note]:
                 Note.when_at.asc().nulls_last(),
                 Note.created_at.desc(),
             )
+        )
+        return list(result.scalars().all())
+
+
+_CONTEXT_RECENT_OVERDUE_DAYS = 3
+_CONTEXT_NEW_MEMO_DAYS = 7
+_CONTEXT_NOTES_LIMIT = 15
+
+
+async def select_notes_for_context(persona_id: str) -> list[Note]:
+    """Return notes appropriate for live context injection.
+
+    Filters:
+    - Notes with ``when_at`` are kept if ``when_at >= now - 3 days``
+      (upcoming + recently overdue).
+    - Notes without ``when_at`` are kept if ``created_at >= now - 7 days``
+      (fresh memos).
+
+    Order: notes with ``when_at`` first (ascending — soonest first), then
+    notes without ``when_at`` (most recent created first). Capped at 15 rows.
+    """
+    now = datetime.now(timezone.utc)
+    overdue_cutoff = now - timedelta(days=_CONTEXT_RECENT_OVERDUE_DAYS)
+    memo_cutoff = now - timedelta(days=_CONTEXT_NEW_MEMO_DAYS)
+
+    async with auto_tx():
+        result = await current_session().execute(
+            select(Note)
+            .where(Note.persona_id == persona_id)
+            .where(Note.resolved_at.is_(None))
+            .where(Note.deleted_at.is_(None))
+            .where(
+                (Note.when_at.is_not(None) & (Note.when_at >= overdue_cutoff))
+                | (Note.when_at.is_(None) & (Note.created_at >= memo_cutoff))
+            )
+            .order_by(
+                Note.when_at.asc().nulls_last(),
+                Note.created_at.desc(),
+            )
+            .limit(_CONTEXT_NOTES_LIMIT)
         )
         return list(result.scalars().all())
 

--- a/apps/agent-service/app/data/queries/memory_edges.py
+++ b/apps/agent-service/app/data/queries/memory_edges.py
@@ -101,31 +101,6 @@ async def list_edges_from(
         return list(result.scalars().all())
 
 
-async def insert_note(
-    *,
-    id: str,
-    persona_id: str,
-    content: str,
-    when_at: datetime | None = None,
-) -> None:
-    async with auto_tx():
-        s = current_session()
-        n = Note(id=id, persona_id=persona_id, content=content, when_at=when_at)
-        s.add(n)
-        await s.flush()
-
-
-async def get_active_notes(persona_id: str) -> list[Note]:
-    async with auto_tx():
-        result = await current_session().execute(
-            select(Note)
-            .where(Note.persona_id == persona_id)
-            .where(Note.resolved_at.is_(None))
-            .order_by(Note.created_at.desc())
-        )
-        return list(result.scalars().all())
-
-
 async def upsert_note(
     *,
     persona_id: str,

--- a/apps/agent-service/app/data/queries/memory_edges.py
+++ b/apps/agent-service/app/data/queries/memory_edges.py
@@ -20,6 +20,7 @@ __all__ = [
     "list_edges_from",
     "upsert_note",
     "delete_note",
+    "list_active_notes",
     "resolve_note",
 ]
 
@@ -165,6 +166,26 @@ async def upsert_note(
             existing.when_at = when_at  # type: ignore[assignment]
         await s.flush()
         return existing
+
+
+async def list_active_notes(persona_id: str) -> list[Note]:
+    """Return all notes that are neither resolved nor deleted.
+
+    Ordered: notes with ``when_at`` first (ascending — soonest first),
+    then notes without ``when_at`` (most recently created first).
+    """
+    async with auto_tx():
+        result = await current_session().execute(
+            select(Note)
+            .where(Note.persona_id == persona_id)
+            .where(Note.resolved_at.is_(None))
+            .where(Note.deleted_at.is_(None))
+            .order_by(
+                Note.when_at.asc().nulls_last(),
+                Note.created_at.desc(),
+            )
+        )
+        return list(result.scalars().all())
 
 
 async def delete_note(*, note_id: str, reason: str) -> None:

--- a/apps/agent-service/app/memory/notes_format.py
+++ b/apps/agent-service/app/memory/notes_format.py
@@ -1,0 +1,49 @@
+"""Format a Note's when_at / created_at into a human-readable Chinese label.
+
+Used both by ``list_note`` tool output and ``build_active_notes_section``
+context injection. Day boundaries are computed in CST (UTC+8) so "今天" /
+"明天" align with the user's lived day, not UTC.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+_CST = timezone(timedelta(hours=8))
+
+
+def _to_local_date(dt: datetime) -> datetime:
+    return dt.astimezone(_CST).replace(hour=0, minute=0, second=0, microsecond=0)
+
+
+def format_when_label(
+    *,
+    when_at: datetime | None,
+    created_at: datetime,
+    now: datetime,
+) -> str:
+    """Return a Chinese relative-time label.
+
+    - ``when_at`` set: "今天" / "明天" / "还有 N 天" / "昨天就该做" / "已过期 N 天"
+    - ``when_at`` None: "今天记的，没说时间" / "N 天前记的，没说时间"
+    """
+    today = _to_local_date(now)
+
+    if when_at is not None:
+        target = _to_local_date(when_at)
+        delta_days = (target - today).days
+        if delta_days == 0:
+            return "今天"
+        if delta_days == 1:
+            return "明天"
+        if delta_days >= 2:
+            return f"还有 {delta_days} 天"
+        if delta_days == -1:
+            return "昨天就该做"
+        return f"已过期 {-delta_days} 天"
+
+    created_local = _to_local_date(created_at)
+    delta_days = (today - created_local).days
+    if delta_days <= 0:
+        return "今天记的，没说时间"
+    return f"{delta_days} 天前记的，没说时间"

--- a/apps/agent-service/app/memory/reviewer/light.py
+++ b/apps/agent-service/app/memory/reviewer/light.py
@@ -14,10 +14,10 @@ from langchain_core.messages import HumanMessage
 from app.agent.context import AgentContext
 from app.agent.core import Agent, AgentConfig
 from app.data.queries import (
-    get_active_notes,
     list_abstracts_window,
     list_fragments_window,
 )
+from app.data.queries.memory_edges import get_active_notes
 from app.memory.reviewer.tools import make_reviewer_tools
 from app.runtime.db import tx
 

--- a/apps/agent-service/app/memory/reviewer/light.py
+++ b/apps/agent-service/app/memory/reviewer/light.py
@@ -15,9 +15,9 @@ from app.agent.context import AgentContext
 from app.agent.core import Agent, AgentConfig
 from app.data.queries import (
     list_abstracts_window,
+    list_active_notes,
     list_fragments_window,
 )
-from app.data.queries.memory_edges import get_active_notes
 from app.memory.reviewer.tools import make_reviewer_tools
 from app.runtime.db import tx
 
@@ -71,7 +71,7 @@ async def run_light_review(*, persona_id: str, window_minutes: int) -> None:
     async with tx():
         fragments = await list_fragments_window(persona_id=persona_id, since=since)
         abstracts = await list_abstracts_window(persona_id=persona_id, since=since)
-        notes = await get_active_notes(persona_id=persona_id)
+        notes = await list_active_notes(persona_id=persona_id)
 
     if not fragments and not abstracts and not notes:
         logger.info("[%s] light review: empty window, skip", persona_id)

--- a/apps/agent-service/app/memory/sections/active_notes.py
+++ b/apps/agent-service/app/memory/sections/active_notes.py
@@ -1,37 +1,49 @@
-"""Always-on injection: 未 resolve 的 notes。"""
+"""Always-on injection: active notes (windowed + capped + remainder hint).
+
+The section pulls a limited set of "live-ish" notes via
+``select_notes_for_context`` (3-day overdue / 7-day memo window, 15 rows max)
+plus the total active count via ``list_active_notes`` so we can append a
+truncation hint pointing the agent at ``list_note`` for the full picture.
+"""
 
 from __future__ import annotations
 
 import logging
-from datetime import timedelta, timezone
+from datetime import datetime, timezone
 
-from app.data.queries.memory_edges import get_active_notes
+from app.data.queries import list_active_notes, select_notes_for_context
+from app.memory.notes_format import format_when_label
 
 logger = logging.getLogger(__name__)
-
-_CST = timezone(timedelta(hours=8))
-
-
-def _fmt_when(dt) -> str:
-    if dt is None:
-        return ""
-    local = dt.astimezone(_CST)
-    return local.strftime("%m-%d %H:%M")
 
 
 async def build_active_notes_section(*, persona_id: str) -> str:
     try:
-        notes = await get_active_notes(persona_id=persona_id)
+        injected = await select_notes_for_context(persona_id=persona_id)
+        all_active = await list_active_notes(persona_id=persona_id)
     except Exception as e:
         logger.warning("active_notes failed: %s", e)
         return ""
 
-    if not notes:
+    if not all_active:
         return ""
 
-    lines = ["你的清单（没处理的事）："]
-    for n in notes:
-        when = _fmt_when(n.when_at)
-        suffix = f" [{when}]" if when else ""
-        lines.append(f"- {n.content}{suffix} (id: {n.id})")
+    total = len(all_active)
+    shown = len(injected)
+
+    if shown == 0:
+        return f"你的清单里还有 {total} 条没动的事（用 list_note 看）。"
+
+    now = datetime.now(timezone.utc)
+    lines = ["你的清单（最近活跃，全部用 list_note 查）："]
+    for n in injected:
+        label = format_when_label(when_at=n.when_at, created_at=n.created_at, now=now)
+        lines.append(f"- {n.content} [{label}] (id: {n.id})")
+
+    remainder = total - shown
+    if remainder > 0:
+        lines.append(
+            f"（清单里还有 {remainder} 条更老的没列出来，用 list_note 看全部。）"
+        )
+
     return "\n".join(lines)

--- a/apps/agent-service/app/memory/sections/active_notes.py
+++ b/apps/agent-service/app/memory/sections/active_notes.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 from datetime import timedelta, timezone
 
-from app.data.queries import get_active_notes
+from app.data.queries.memory_edges import get_active_notes
 
 logger = logging.getLogger(__name__)
 

--- a/apps/agent-service/app/memory/sections/active_notes.py
+++ b/apps/agent-service/app/memory/sections/active_notes.py
@@ -9,7 +9,7 @@ truncation hint pointing the agent at ``list_note`` for the full picture.
 from __future__ import annotations
 
 import logging
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 
 from app.data.queries import list_active_notes, select_notes_for_context
 from app.memory.notes_format import format_when_label
@@ -34,7 +34,7 @@ async def build_active_notes_section(*, persona_id: str) -> str:
     if shown == 0:
         return f"你的清单里还有 {total} 条没动的事（用 list_note 看）。"
 
-    now = datetime.now(timezone.utc)
+    now = datetime.now(UTC)
     lines = ["你的清单（最近活跃，全部用 list_note 查）："]
     for n in injected:
         label = format_when_label(when_at=n.when_at, created_at=n.created_at, now=now)

--- a/apps/agent-service/tests/unit/agent/tools/test_notes.py
+++ b/apps/agent-service/tests/unit/agent/tools/test_notes.py
@@ -1,13 +1,19 @@
-"""Test write_note / resolve_note tools."""
+"""Test upsert_note / list_note / resolve_note / delete_note tool implementations."""
 
 from __future__ import annotations
 
 from contextlib import asynccontextmanager
+from datetime import UTC, datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from app.agent.tools.notes import _resolve_note_impl, _write_note_impl
+from app.agent.tools.notes import (
+    _delete_note_impl,
+    _list_note_impl,
+    _resolve_note_impl,
+    _upsert_note_impl,
+)
 
 
 @asynccontextmanager
@@ -24,41 +30,213 @@ def _make_emit_tx_mock():
     return _fake_emit_tx, captured
 
 
+# ----- upsert_note: create -----
+
 @pytest.mark.asyncio
-async def test_write_note_creates_and_returns_id_with_active_list():
+async def test_upsert_note_create_emits_note_created():
     from app.domain.agent_tool_events import NoteCreated
 
-    active = [MagicMock(id="n_existing", content="已有笔记", when_at=None)]
+    created = MagicMock(
+        id="n_new", content="周五看电影", when_at=None,
+        created_at=datetime(2026, 5, 10, tzinfo=UTC),
+    )
     fake_emit, captured = _make_emit_tx_mock()
-    with patch("app.agent.tools.notes.insert_note", new=AsyncMock()) as ins:
-        with patch("app.agent.tools.notes.get_active_notes", new=AsyncMock(return_value=active)):
-            with patch("app.agent.tools.notes.tx", _fake_tx):
-                with patch("app.agent.tools.notes.emit_tx", fake_emit):
-                    out = await _write_note_impl(
-                        persona_id="chiwei", content="周五看电影", when_at=None,
-                    )
-    assert "id" in out
-    assert out["id"].startswith("n_")
-    assert len(out["active_notes"]) == 1
-    ins.assert_awaited_once()
+    with patch("app.agent.tools.notes.upsert_note_query",
+               new=AsyncMock(return_value=created)) as up:
+        with patch("app.agent.tools.notes.tx", _fake_tx):
+            with patch("app.agent.tools.notes.emit_tx", fake_emit):
+                out = await _upsert_note_impl(
+                    persona_id="chiwei",
+                    content="周五看电影",
+                    when_at_raw=None,
+                    note_id=None,
+                )
+    assert out["id"] == "n_new"
+    up.assert_awaited_once()
     assert len(captured) == 1
-    emitted = captured[0]
-    assert isinstance(emitted, NoteCreated)
-    assert emitted.note_id == out["id"]
-    assert emitted.persona_id == "chiwei"
+    ev = captured[0]
+    assert isinstance(ev, NoteCreated)
+    assert ev.note_id == "n_new"
 
 
 @pytest.mark.asyncio
-async def test_write_note_rejects_empty_content():
+async def test_upsert_note_rejects_empty_content():
     fake_emit, captured = _make_emit_tx_mock()
-    with patch("app.agent.tools.notes.insert_note", new=AsyncMock()) as ins:
+    with patch("app.agent.tools.notes.upsert_note_query",
+               new=AsyncMock()) as up:
         with patch("app.agent.tools.notes.tx", _fake_tx):
             with patch("app.agent.tools.notes.emit_tx", fake_emit):
-                out = await _write_note_impl(persona_id="chiwei", content="  ", when_at=None)
+                out = await _upsert_note_impl(
+                    persona_id="chiwei",
+                    content="  ",
+                    when_at_raw=None,
+                    note_id=None,
+                )
     assert "error" in out
-    ins.assert_not_awaited()
-    assert len(captured) == 0
+    up.assert_not_awaited()
+    assert captured == []
 
+
+@pytest.mark.asyncio
+async def test_upsert_note_parses_iso_when_at():
+    when_iso = "2026-05-15T19:00:00+08:00"
+    created = MagicMock(id="n_x", content="x", when_at=None,
+                        created_at=datetime(2026, 5, 10, tzinfo=UTC))
+    fake_emit, _ = _make_emit_tx_mock()
+    with patch("app.agent.tools.notes.upsert_note_query",
+               new=AsyncMock(return_value=created)) as up:
+        with patch("app.agent.tools.notes.tx", _fake_tx):
+            with patch("app.agent.tools.notes.emit_tx", fake_emit):
+                await _upsert_note_impl(
+                    persona_id="chiwei", content="x",
+                    when_at_raw=when_iso, note_id=None,
+                )
+    kwargs = up.await_args.kwargs
+    assert kwargs["when_at"] == datetime.fromisoformat(when_iso)
+
+
+@pytest.mark.asyncio
+async def test_upsert_note_rejects_bad_when_at():
+    fake_emit, _ = _make_emit_tx_mock()
+    with patch("app.agent.tools.notes.upsert_note_query",
+               new=AsyncMock()) as up:
+        with patch("app.agent.tools.notes.tx", _fake_tx):
+            with patch("app.agent.tools.notes.emit_tx", fake_emit):
+                out = await _upsert_note_impl(
+                    persona_id="chiwei", content="x",
+                    when_at_raw="not-a-date", note_id=None,
+                )
+    assert "error" in out
+    up.assert_not_awaited()
+
+
+# ----- upsert_note: update -----
+
+@pytest.mark.asyncio
+async def test_upsert_note_update_passes_note_id_and_does_not_emit():
+    updated = MagicMock(
+        id="n_abc", content="改后", when_at=None,
+        created_at=datetime(2026, 5, 10, tzinfo=UTC),
+    )
+    fake_emit, captured = _make_emit_tx_mock()
+    with patch("app.agent.tools.notes.upsert_note_query",
+               new=AsyncMock(return_value=updated)) as up:
+        with patch("app.agent.tools.notes.tx", _fake_tx):
+            with patch("app.agent.tools.notes.emit_tx", fake_emit):
+                out = await _upsert_note_impl(
+                    persona_id="chiwei", content="改后",
+                    when_at_raw=None, note_id="n_abc",
+                )
+    assert out["id"] == "n_abc"
+    kwargs = up.await_args.kwargs
+    assert kwargs["note_id"] == "n_abc"
+    assert "when_at" in kwargs
+    assert captured == []
+
+
+@pytest.mark.asyncio
+async def test_upsert_note_clear_when_at_translates_to_explicit_none():
+    """when_at_raw='clear' → query receives when_at=None (not _UNSET)."""
+    updated = MagicMock(id="n_abc", content="x", when_at=None,
+                        created_at=datetime(2026, 5, 10, tzinfo=UTC))
+    fake_emit, _ = _make_emit_tx_mock()
+    with patch("app.agent.tools.notes.upsert_note_query",
+               new=AsyncMock(return_value=updated)) as up:
+        with patch("app.agent.tools.notes.tx", _fake_tx):
+            with patch("app.agent.tools.notes.emit_tx", fake_emit):
+                await _upsert_note_impl(
+                    persona_id="chiwei", content="x",
+                    when_at_raw="clear", note_id="n_abc",
+                )
+    assert up.await_args.kwargs["when_at"] is None
+
+
+@pytest.mark.asyncio
+async def test_upsert_note_unknown_id_returns_error():
+    fake_emit, _ = _make_emit_tx_mock()
+    with patch(
+        "app.agent.tools.notes.upsert_note_query",
+        new=AsyncMock(side_effect=LookupError("note not found: n_x")),
+    ):
+        with patch("app.agent.tools.notes.tx", _fake_tx):
+            with patch("app.agent.tools.notes.emit_tx", fake_emit):
+                out = await _upsert_note_impl(
+                    persona_id="chiwei", content="x",
+                    when_at_raw=None, note_id="n_x",
+                )
+    assert "error" in out
+    assert "n_x" in out["error"]
+
+
+# ----- list_note -----
+
+@pytest.mark.asyncio
+async def test_list_note_returns_items_with_when_label():
+    rows = [
+        MagicMock(
+            id="n_1", content="周五看电影",
+            when_at=datetime(2026, 5, 15, 19, 0, tzinfo=UTC),
+            created_at=datetime(2026, 5, 9, tzinfo=UTC),
+        ),
+        MagicMock(
+            id="n_2", content="想问妈妈那件事",
+            when_at=None,
+            created_at=datetime(2026, 5, 8, tzinfo=UTC),
+        ),
+    ]
+    with patch("app.agent.tools.notes.list_active_notes_query",
+               new=AsyncMock(return_value=rows)):
+        out = await _list_note_impl(persona_id="chiwei")
+    assert len(out["items"]) == 2
+    assert out["items"][0]["note_id"] == "n_1"
+    assert "when_label" in out["items"][0]
+    assert out["items"][1]["when_at"] is None
+
+
+@pytest.mark.asyncio
+async def test_list_note_empty():
+    with patch("app.agent.tools.notes.list_active_notes_query",
+               new=AsyncMock(return_value=[])):
+        out = await _list_note_impl(persona_id="chiwei")
+    assert out == {"items": []}
+
+
+# ----- delete_note -----
+
+@pytest.mark.asyncio
+async def test_delete_note_passes_reason():
+    with patch("app.agent.tools.notes.delete_note_query",
+               new=AsyncMock()) as dn:
+        out = await _delete_note_impl(
+            persona_id="chiwei", note_id="n_abc", reason="改主意了",
+        )
+    assert out == {"ok": True}
+    dn.assert_awaited_once_with(note_id="n_abc", reason="改主意了")
+
+
+@pytest.mark.asyncio
+async def test_delete_note_rejects_empty_reason():
+    with patch("app.agent.tools.notes.delete_note_query",
+               new=AsyncMock()) as dn:
+        out = await _delete_note_impl(
+            persona_id="chiwei", note_id="n_abc", reason="  ",
+        )
+    assert "error" in out
+    dn.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_delete_note_rejects_empty_note_id():
+    with patch("app.agent.tools.notes.delete_note_query",
+               new=AsyncMock()) as dn:
+        out = await _delete_note_impl(
+            persona_id="chiwei", note_id="", reason="改主意了",
+        )
+    assert "error" in out
+    dn.assert_not_awaited()
+
+
+# ----- resolve_note (logic unchanged) -----
 
 @pytest.mark.asyncio
 async def test_resolve_note_calls_query():
@@ -66,7 +244,7 @@ async def test_resolve_note_calls_query():
         out = await _resolve_note_impl(
             persona_id="chiwei", note_id="n_1", resolution="看完了",
         )
-    assert out.get("ok") is True
+    assert out == {"ok": True}
     rn.assert_awaited_once()
 
 
@@ -88,26 +266,3 @@ async def test_resolve_note_rejects_empty_note_id():
         )
     assert "error" in out
     rn.assert_not_awaited()
-
-
-@pytest.mark.asyncio
-async def test_write_note_passes_when_at_through():
-    from datetime import UTC, datetime
-
-    from app.domain.agent_tool_events import NoteCreated
-
-    when = datetime(2026, 4, 18, 19, 0, tzinfo=UTC)
-    fake_emit, captured = _make_emit_tx_mock()
-    with patch("app.agent.tools.notes.insert_note", new=AsyncMock()) as ins:
-        with patch("app.agent.tools.notes.get_active_notes", new=AsyncMock(return_value=[])):
-            with patch("app.agent.tools.notes.tx", _fake_tx):
-                with patch("app.agent.tools.notes.emit_tx", fake_emit):
-                    out = await _write_note_impl(
-                        persona_id="chiwei", content="周五看电影", when_at=when,
-                    )
-    assert ins.await_args.kwargs["when_at"] == when
-    assert len(captured) == 1
-    emitted = captured[0]
-    assert isinstance(emitted, NoteCreated)
-    assert emitted.note_id == out["id"]
-    assert emitted.persona_id == "chiwei"

--- a/apps/agent-service/tests/unit/data/test_queries_split.py
+++ b/apps/agent-service/tests/unit/data/test_queries_split.py
@@ -6,7 +6,7 @@ memory_search.py，所以本测试覆盖 9 个 domain 模块。
 from __future__ import annotations
 
 # 来自 spec §3.3 + §3.6 memory 细拆 + Phase 7d Task 5 hoist (6 个新增 messages
-# query) + Notes redesign 2026-05-10，硬编码作为期望基线（81 函数）。
+# query) + Notes redesign 2026-05-10，硬编码作为期望基线（82 函数）。
 EXPECTED_FUNCTIONS = {
     # model_provider (3)
     "parse_model_id", "find_model_mapping", "find_provider_by_name",
@@ -41,9 +41,10 @@ EXPECTED_FUNCTIONS = {
     "get_fragments_by_ids", "touch_fragments_bulk", "insert_abstract_memory",
     "touch_abstract", "touch_abstracts_bulk", "count_abstracts_by_persona",
     "update_abstract_content_query", "set_clarity", "delete_fragment_query",
-    # memory_edges (8) — edges + notes
+    # memory_edges (9) — edges + notes
     "insert_memory_edge", "delete_edge", "list_edges_to", "list_edges_from",
-    "upsert_note", "delete_note", "list_active_notes", "resolve_note",
+    "upsert_note", "delete_note", "list_active_notes", "select_notes_for_context",
+    "resolve_note",
     # memory_search (9) — read helpers
     "list_today_fragments", "find_fragments_since", "list_fragments_window",
     "list_abstracts_window", "get_abstracts_by_subject", "get_abstracts_by_subjects",

--- a/apps/agent-service/tests/unit/data/test_queries_split.py
+++ b/apps/agent-service/tests/unit/data/test_queries_split.py
@@ -6,7 +6,7 @@ memory_search.py，所以本测试覆盖 9 个 domain 模块。
 from __future__ import annotations
 
 # 来自 spec §3.3 + §3.6 memory 细拆 + Phase 7d Task 5 hoist (6 个新增 messages
-# query) + Notes redesign 2026-05-10，硬编码作为期望基线（80 函数）。
+# query) + Notes redesign 2026-05-10，硬编码作为期望基线（81 函数）。
 EXPECTED_FUNCTIONS = {
     # model_provider (3)
     "parse_model_id", "find_model_mapping", "find_provider_by_name",
@@ -41,9 +41,9 @@ EXPECTED_FUNCTIONS = {
     "get_fragments_by_ids", "touch_fragments_bulk", "insert_abstract_memory",
     "touch_abstract", "touch_abstracts_bulk", "count_abstracts_by_persona",
     "update_abstract_content_query", "set_clarity", "delete_fragment_query",
-    # memory_edges (7) — edges + notes
+    # memory_edges (8) — edges + notes
     "insert_memory_edge", "delete_edge", "list_edges_to", "list_edges_from",
-    "upsert_note", "delete_note", "resolve_note",
+    "upsert_note", "delete_note", "list_active_notes", "resolve_note",
     # memory_search (9) — read helpers
     "list_today_fragments", "find_fragments_since", "list_fragments_window",
     "list_abstracts_window", "get_abstracts_by_subject", "get_abstracts_by_subjects",

--- a/apps/agent-service/tests/unit/data/test_queries_split.py
+++ b/apps/agent-service/tests/unit/data/test_queries_split.py
@@ -6,7 +6,7 @@ memory_search.py，所以本测试覆盖 9 个 domain 模块。
 from __future__ import annotations
 
 # 来自 spec §3.3 + §3.6 memory 细拆 + Phase 7d Task 5 hoist (6 个新增 messages
-# query)，硬编码作为期望基线（80 函数）。
+# query) + Notes redesign 2026-05-10，硬编码作为期望基线（81 函数）。
 EXPECTED_FUNCTIONS = {
     # model_provider (3)
     "parse_model_id", "find_model_mapping", "find_provider_by_name",
@@ -41,9 +41,9 @@ EXPECTED_FUNCTIONS = {
     "get_fragments_by_ids", "touch_fragments_bulk", "insert_abstract_memory",
     "touch_abstract", "touch_abstracts_bulk", "count_abstracts_by_persona",
     "update_abstract_content_query", "set_clarity", "delete_fragment_query",
-    # memory_edges (7) — edges + notes
+    # memory_edges (8) — edges + notes
     "insert_memory_edge", "delete_edge", "list_edges_to", "list_edges_from",
-    "insert_note", "get_active_notes", "resolve_note",
+    "insert_note", "upsert_note", "get_active_notes", "resolve_note",
     # memory_search (9) — read helpers
     "list_today_fragments", "find_fragments_since", "list_fragments_window",
     "list_abstracts_window", "get_abstracts_by_subject", "get_abstracts_by_subjects",

--- a/apps/agent-service/tests/unit/data/test_queries_split.py
+++ b/apps/agent-service/tests/unit/data/test_queries_split.py
@@ -6,7 +6,7 @@ memory_search.py，所以本测试覆盖 9 个 domain 模块。
 from __future__ import annotations
 
 # 来自 spec §3.3 + §3.6 memory 细拆 + Phase 7d Task 5 hoist (6 个新增 messages
-# query) + Notes redesign 2026-05-10，硬编码作为期望基线（81 函数）。
+# query) + Notes redesign 2026-05-10，硬编码作为期望基线（80 函数）。
 EXPECTED_FUNCTIONS = {
     # model_provider (3)
     "parse_model_id", "find_model_mapping", "find_provider_by_name",
@@ -41,9 +41,9 @@ EXPECTED_FUNCTIONS = {
     "get_fragments_by_ids", "touch_fragments_bulk", "insert_abstract_memory",
     "touch_abstract", "touch_abstracts_bulk", "count_abstracts_by_persona",
     "update_abstract_content_query", "set_clarity", "delete_fragment_query",
-    # memory_edges (8) — edges + notes
+    # memory_edges (7) — edges + notes
     "insert_memory_edge", "delete_edge", "list_edges_to", "list_edges_from",
-    "insert_note", "upsert_note", "get_active_notes", "resolve_note",
+    "upsert_note", "delete_note", "resolve_note",
     # memory_search (9) — read helpers
     "list_today_fragments", "find_fragments_since", "list_fragments_window",
     "list_abstracts_window", "get_abstracts_by_subject", "get_abstracts_by_subjects",

--- a/apps/agent-service/tests/unit/data/test_v4_queries.py
+++ b/apps/agent-service/tests/unit/data/test_v4_queries.py
@@ -290,6 +290,39 @@ async def test_list_active_notes_filters_resolved_and_deleted():
         _stop(patches)
 
 
+# memory_edges.py — select_notes_for_context (Notes redesign 2026-05-10)
+@pytest.mark.asyncio
+async def test_select_notes_for_context_window_and_limit():
+    """SQL has the 3-day / 7-day window + 15-row limit."""
+    session = AsyncMock()
+    session.execute = AsyncMock(return_value=_IterResult([]))
+    patches = _patch_module("app.data.queries.memory_edges", session)
+    try:
+        from app.data.queries import select_notes_for_context
+        await select_notes_for_context(persona_id="chiwei")
+        stmt = session.execute.await_args.args[0]
+        compiled = str(stmt.compile(compile_kwargs={"literal_binds": True}))
+        assert "LIMIT 15" in compiled
+        assert "when_at" in compiled
+        assert "created_at" in compiled
+    finally:
+        _stop(patches)
+
+
+@pytest.mark.asyncio
+async def test_select_notes_for_context_returns_results():
+    n = Note(id="n_1", persona_id="chiwei", content="x")
+    session = AsyncMock()
+    session.execute = AsyncMock(return_value=_IterResult([n]))
+    patches = _patch_module("app.data.queries.memory_edges", session)
+    try:
+        from app.data.queries import select_notes_for_context
+        result = await select_notes_for_context(persona_id="chiwei")
+        assert result == [n]
+    finally:
+        _stop(patches)
+
+
 # memory_edges.py — delete_note (Notes redesign 2026-05-10)
 @pytest.mark.asyncio
 async def test_delete_note_soft_deletes():

--- a/apps/agent-service/tests/unit/data/test_v4_queries.py
+++ b/apps/agent-service/tests/unit/data/test_v4_queries.py
@@ -10,12 +10,10 @@ import pytest
 from app.data.models import AbstractMemory, Fragment, MemoryEdge, Note
 from app.data.queries import (
     count_abstracts_by_persona,
-    get_active_notes,
     get_current_schedule,
     insert_abstract_memory,
     insert_fragment,
     insert_memory_edge,
-    insert_note,
     insert_schedule_revision,
     resolve_note,
     touch_abstract,
@@ -153,38 +151,6 @@ async def test_insert_memory_edge_adds_to_session():
 
 # memory_edges.py — notes
 @pytest.mark.asyncio
-async def test_insert_note_adds_to_session():
-    session = AsyncMock()
-    session.add = lambda obj: setattr(session, "_added", obj)
-    patches = _patch_module("app.data.queries.memory_edges", session)
-    try:
-        await insert_note(
-            id="n1",
-            persona_id="chiwei",
-            content="周五看电影",
-        )
-        added = session._added
-        assert isinstance(added, Note)
-        assert added.content == "周五看电影"
-        assert added.when_at is None
-    finally:
-        _stop(patches)
-
-
-@pytest.mark.asyncio
-async def test_get_active_notes_returns_list():
-    note = Note(id="n1", persona_id="chiwei", content="x")
-    session = AsyncMock()
-    session.execute = AsyncMock(return_value=_IterResult([note]))
-    patches = _patch_module("app.data.queries.memory_edges", session)
-    try:
-        result = await get_active_notes(persona_id="chiwei")
-        assert result == [note]
-    finally:
-        _stop(patches)
-
-
-@pytest.mark.asyncio
 async def test_resolve_note_executes_update():
     session = AsyncMock()
     session.execute = AsyncMock()
@@ -300,6 +266,25 @@ async def test_upsert_note_unknown_id_raises():
                 content="x",
                 note_id="n_does_not_exist",
             )
+    finally:
+        _stop(patches)
+
+
+# memory_edges.py — delete_note (Notes redesign 2026-05-10)
+@pytest.mark.asyncio
+async def test_delete_note_soft_deletes():
+    session = AsyncMock()
+    session.execute = AsyncMock()
+    patches = _patch_module("app.data.queries.memory_edges", session)
+    try:
+        from app.data.queries import delete_note
+        await delete_note(note_id="n_abc", reason="改主意了")
+        session.execute.assert_awaited_once()
+        stmt = session.execute.await_args.args[0]
+        compiled = str(stmt)
+        assert "UPDATE notes" in compiled
+        assert "deleted_at" in compiled
+        assert "delete_reason" in compiled
     finally:
         _stop(patches)
 

--- a/apps/agent-service/tests/unit/data/test_v4_queries.py
+++ b/apps/agent-service/tests/unit/data/test_v4_queries.py
@@ -270,6 +270,26 @@ async def test_upsert_note_unknown_id_raises():
         _stop(patches)
 
 
+# memory_edges.py — list_active_notes (Notes redesign 2026-05-10)
+@pytest.mark.asyncio
+async def test_list_active_notes_filters_resolved_and_deleted():
+    n_active = Note(id="n_active", persona_id="chiwei", content="alive")
+    session = AsyncMock()
+    session.execute = AsyncMock(return_value=_IterResult([n_active]))
+    patches = _patch_module("app.data.queries.memory_edges", session)
+    try:
+        from app.data.queries import list_active_notes
+        result = await list_active_notes(persona_id="chiwei")
+        assert result == [n_active]
+        # WHERE clause filters both resolved_at and deleted_at IS NULL.
+        stmt = session.execute.await_args.args[0]
+        compiled = str(stmt.compile(compile_kwargs={"literal_binds": True}))
+        assert "resolved_at IS NULL" in compiled
+        assert "deleted_at IS NULL" in compiled
+    finally:
+        _stop(patches)
+
+
 # memory_edges.py — delete_note (Notes redesign 2026-05-10)
 @pytest.mark.asyncio
 async def test_delete_note_soft_deletes():

--- a/apps/agent-service/tests/unit/data/test_v4_queries.py
+++ b/apps/agent-service/tests/unit/data/test_v4_queries.py
@@ -196,6 +196,114 @@ async def test_resolve_note_executes_update():
         _stop(patches)
 
 
+# memory_edges.py — upsert_note (Notes redesign 2026-05-10)
+@pytest.mark.asyncio
+async def test_upsert_note_create_when_no_id():
+    session = AsyncMock()
+    session.add = lambda obj: setattr(session, "_added", obj)
+    session.flush = AsyncMock()
+    patches = _patch_module("app.data.queries.memory_edges", session)
+    try:
+        from app.data.queries import upsert_note
+        added = await upsert_note(
+            persona_id="chiwei",
+            content="周五看电影",
+        )
+        assert isinstance(added, Note)
+        assert added.id.startswith("n_")
+        assert added.content == "周五看电影"
+        assert added.when_at is None
+    finally:
+        _stop(patches)
+
+
+@pytest.mark.asyncio
+async def test_upsert_note_update_content_only():
+    existing = Note(id="n_abc", persona_id="chiwei", content="old", when_at=None)
+    session = AsyncMock()
+    session.execute = AsyncMock(return_value=_ScalarResult(existing))
+    session.flush = AsyncMock()
+    patches = _patch_module("app.data.queries.memory_edges", session)
+    try:
+        from app.data.queries import upsert_note
+        out = await upsert_note(
+            persona_id="chiwei",
+            content="new content",
+            note_id="n_abc",
+        )
+        assert out.content == "new content"
+        assert out.when_at is None  # _UNSET = don't change; was None, stays None
+    finally:
+        _stop(patches)
+
+
+@pytest.mark.asyncio
+async def test_upsert_note_update_when_at():
+    from datetime import UTC
+    from datetime import datetime as _dt
+    existing = Note(id="n_abc", persona_id="chiwei", content="old", when_at=None)
+    session = AsyncMock()
+    session.execute = AsyncMock(return_value=_ScalarResult(existing))
+    session.flush = AsyncMock()
+    patches = _patch_module("app.data.queries.memory_edges", session)
+    try:
+        from app.data.queries import upsert_note
+        new_when = _dt(2026, 5, 17, 12, 0, tzinfo=UTC)
+        out = await upsert_note(
+            persona_id="chiwei",
+            content="old",
+            when_at=new_when,
+            note_id="n_abc",
+        )
+        assert out.when_at == new_when
+    finally:
+        _stop(patches)
+
+
+@pytest.mark.asyncio
+async def test_upsert_note_clear_when_at_with_explicit_none():
+    from datetime import UTC
+    from datetime import datetime as _dt
+    existing = Note(
+        id="n_abc",
+        persona_id="chiwei",
+        content="old",
+        when_at=_dt(2026, 5, 1, 12, 0, tzinfo=UTC),
+    )
+    session = AsyncMock()
+    session.execute = AsyncMock(return_value=_ScalarResult(existing))
+    session.flush = AsyncMock()
+    patches = _patch_module("app.data.queries.memory_edges", session)
+    try:
+        from app.data.queries import upsert_note
+        out = await upsert_note(
+            persona_id="chiwei",
+            content="old",
+            when_at=None,  # explicit None = clear
+            note_id="n_abc",
+        )
+        assert out.when_at is None
+    finally:
+        _stop(patches)
+
+
+@pytest.mark.asyncio
+async def test_upsert_note_unknown_id_raises():
+    session = AsyncMock()
+    session.execute = AsyncMock(return_value=_ScalarResult(None))
+    patches = _patch_module("app.data.queries.memory_edges", session)
+    try:
+        from app.data.queries import upsert_note
+        with pytest.raises(LookupError, match="note not found"):
+            await upsert_note(
+                persona_id="chiwei",
+                content="x",
+                note_id="n_does_not_exist",
+            )
+    finally:
+        _stop(patches)
+
+
 # schedule.py
 @pytest.mark.asyncio
 async def test_insert_schedule_revision_adds_to_session():

--- a/apps/agent-service/tests/unit/memory/reviewer/test_light.py
+++ b/apps/agent-service/tests/unit/memory/reviewer/test_light.py
@@ -35,7 +35,7 @@ async def test_noop_when_empty_window():
         patch(f"{MODULE}.tx", _fake_tx),
         patch(f"{MODULE}.list_fragments_window", new=AsyncMock(return_value=[])),
         patch(f"{MODULE}.list_abstracts_window", new=AsyncMock(return_value=[])),
-        patch(f"{MODULE}.get_active_notes", new=AsyncMock(return_value=[])),
+        patch(f"{MODULE}.list_active_notes", new=AsyncMock(return_value=[])),
         patch(f"{MODULE}._run_reviewer_agent", new=AsyncMock()) as agent,
     ):
         result = await run_light_review(persona_id="chiwei", window_minutes=30)
@@ -59,7 +59,7 @@ async def test_runs_agent_with_window_summary():
         patch(f"{MODULE}.tx", _fake_tx),
         patch(f"{MODULE}.list_fragments_window", new=AsyncMock(return_value=[frag])),
         patch(f"{MODULE}.list_abstracts_window", new=AsyncMock(return_value=[])),
-        patch(f"{MODULE}.get_active_notes", new=AsyncMock(return_value=[])),
+        patch(f"{MODULE}.list_active_notes", new=AsyncMock(return_value=[])),
         patch(f"{MODULE}._run_reviewer_agent", new=AsyncMock()) as agent,
     ):
         await run_light_review(persona_id="chiwei", window_minutes=30)
@@ -88,7 +88,7 @@ async def test_runs_when_only_notes_present():
         patch(f"{MODULE}.tx", _fake_tx),
         patch(f"{MODULE}.list_fragments_window", new=AsyncMock(return_value=[])),
         patch(f"{MODULE}.list_abstracts_window", new=AsyncMock(return_value=[])),
-        patch(f"{MODULE}.get_active_notes", new=AsyncMock(return_value=[note])),
+        patch(f"{MODULE}.list_active_notes", new=AsyncMock(return_value=[note])),
         patch(f"{MODULE}._run_reviewer_agent", new=AsyncMock()) as agent,
     ):
         await run_light_review(persona_id="chiwei", window_minutes=60)

--- a/apps/agent-service/tests/unit/memory/sections/test_active_notes.py
+++ b/apps/agent-service/tests/unit/memory/sections/test_active_notes.py
@@ -1,28 +1,146 @@
-"""Test active_notes section."""
+"""Test active_notes section after windowed-injection redesign."""
 
 from __future__ import annotations
 
-from datetime import UTC, datetime
-from unittest.mock import AsyncMock, MagicMock, patch
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
+from app.data.models import Note
 from app.memory.sections.active_notes import build_active_notes_section
 
 
+def _note(*, id: str, content: str, when_at=None, created_at=None) -> Note:
+    n = Note(
+        id=id,
+        persona_id="chiwei",
+        content=content,
+        when_at=when_at,
+    )
+    if created_at is not None:
+        n.created_at = created_at
+    return n
+
+
+_NOW = datetime(2026, 5, 10, 12, 0, tzinfo=UTC)
+
+
+def _patch_now(monkeypatch):
+    """Pin datetime.now in active_notes module to _NOW."""
+    import app.memory.sections.active_notes as mod
+
+    class _FixedDt:
+        @staticmethod
+        def now(tz=None):
+            return _NOW.astimezone(tz) if tz else _NOW
+
+    monkeypatch.setattr(mod, "datetime", _FixedDt)
+
+
 @pytest.mark.asyncio
-async def test_empty_when_no_notes():
-    with patch("app.memory.sections.active_notes.get_active_notes", new=AsyncMock(return_value=[])):
-        text = await build_active_notes_section(persona_id="chiwei")
+async def test_section_empty_when_no_active(monkeypatch):
+    _patch_now(monkeypatch)
+    with patch(
+        "app.memory.sections.active_notes.select_notes_for_context",
+        new=AsyncMock(return_value=[]),
+    ):
+        with patch(
+            "app.memory.sections.active_notes.list_active_notes",
+            new=AsyncMock(return_value=[]),
+        ):
+            text = await build_active_notes_section(persona_id="chiwei")
     assert text == ""
 
 
 @pytest.mark.asyncio
-async def test_renders_with_and_without_when_at():
-    n1 = MagicMock(id="n_1", content="周五看电影", when_at=datetime(2026, 4, 24, 19, 0, tzinfo=UTC))
-    n2 = MagicMock(id="n_2", content="想一下要不要学Rust", when_at=None)
-    with patch("app.memory.sections.active_notes.get_active_notes", new=AsyncMock(return_value=[n1, n2])):
+async def test_section_renders_active_with_when_label(monkeypatch):
+    _patch_now(monkeypatch)
+    n1 = _note(
+        id="n_1",
+        content="周五和浩南看电影",
+        when_at=_NOW + timedelta(days=2),
+        created_at=_NOW - timedelta(hours=1),
+    )
+    n2 = _note(
+        id="n_2",
+        content="想问妈妈那件事",
+        when_at=None,
+        created_at=_NOW - timedelta(days=1),
+    )
+    with patch(
+        "app.memory.sections.active_notes.select_notes_for_context",
+        new=AsyncMock(return_value=[n1, n2]),
+    ):
+        with patch(
+            "app.memory.sections.active_notes.list_active_notes",
+            new=AsyncMock(return_value=[n1, n2]),
+        ):
+            text = await build_active_notes_section(persona_id="chiwei")
+    assert "周五和浩南看电影 [还有 2 天] (id: n_1)" in text
+    assert "想问妈妈那件事 [1 天前记的，没说时间] (id: n_2)" in text
+    assert text.startswith("你的清单")
+
+
+@pytest.mark.asyncio
+async def test_section_appends_remainder_when_truncated(monkeypatch):
+    """active_total > injected_count → append truncation hint."""
+    _patch_now(monkeypatch)
+    injected = [
+        _note(id=f"n_{i}", content=f"事 {i}", when_at=None,
+              created_at=_NOW - timedelta(hours=i))
+        for i in range(15)
+    ]
+    all_active = injected + [
+        _note(id="n_old", content="老事", when_at=None,
+              created_at=_NOW - timedelta(days=30)),
+        _note(id="n_old2", content="更老的", when_at=None,
+              created_at=_NOW - timedelta(days=40)),
+    ]
+    with patch(
+        "app.memory.sections.active_notes.select_notes_for_context",
+        new=AsyncMock(return_value=injected),
+    ):
+        with patch(
+            "app.memory.sections.active_notes.list_active_notes",
+            new=AsyncMock(return_value=all_active),
+        ):
+            text = await build_active_notes_section(persona_id="chiwei")
+    assert "（清单里还有 2 条更老的没列出来，用 list_note 看全部。）" in text
+
+
+@pytest.mark.asyncio
+async def test_section_only_remainder_hint_when_all_old(monkeypatch):
+    """Active notes exist but none meet injection window → show only remainder hint."""
+    _patch_now(monkeypatch)
+    old = [
+        _note(id="n_old", content="老事", when_at=None,
+              created_at=_NOW - timedelta(days=30)),
+        _note(id="n_old2", content="更老", when_at=None,
+              created_at=_NOW - timedelta(days=40)),
+        _note(id="n_old3", content="最老",
+              when_at=_NOW - timedelta(days=10),
+              created_at=_NOW - timedelta(days=12)),
+    ]
+    with patch(
+        "app.memory.sections.active_notes.select_notes_for_context",
+        new=AsyncMock(return_value=[]),
+    ):
+        with patch(
+            "app.memory.sections.active_notes.list_active_notes",
+            new=AsyncMock(return_value=old),
+        ):
+            text = await build_active_notes_section(persona_id="chiwei")
+    assert text == "你的清单里还有 3 条没动的事（用 list_note 看）。"
+
+
+@pytest.mark.asyncio
+async def test_section_swallows_query_errors(monkeypatch):
+    """Section must not crash if query layer fails."""
+    _patch_now(monkeypatch)
+    with patch(
+        "app.memory.sections.active_notes.select_notes_for_context",
+        new=AsyncMock(side_effect=RuntimeError("db down")),
+    ):
         text = await build_active_notes_section(persona_id="chiwei")
-    assert "周五看电影" in text
-    assert "Rust" in text
-    assert "n_1" in text
+    assert text == ""

--- a/apps/agent-service/tests/unit/memory/test_notes_format.py
+++ b/apps/agent-service/tests/unit/memory/test_notes_format.py
@@ -1,0 +1,37 @@
+"""Test format_when_label helper for Notes context injection / list_note tool."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from app.memory.notes_format import format_when_label
+
+
+_NOW = datetime(2026, 5, 10, 12, 0, tzinfo=UTC)
+
+
+def _at(days: int, hour: int = 12) -> datetime:
+    return _NOW + timedelta(days=days, hours=hour - 12)
+
+
+@pytest.mark.parametrize(
+    ("when_at", "created_at", "expected"),
+    [
+        # when_at present
+        (_at(0), _at(0), "今天"),
+        (_at(1), _at(0), "明天"),
+        (_at(2), _at(0), "还有 2 天"),
+        (_at(7), _at(0), "还有 7 天"),
+        (_at(-1), _at(0), "昨天就该做"),
+        (_at(-2), _at(0), "已过期 2 天"),
+        (_at(-5), _at(0), "已过期 5 天"),
+        # when_at None
+        (None, _NOW, "今天记的，没说时间"),
+        (None, _NOW - timedelta(days=1), "1 天前记的，没说时间"),
+        (None, _NOW - timedelta(days=14), "14 天前记的，没说时间"),
+    ],
+)
+def test_format_when_label(when_at, created_at, expected):
+    assert format_when_label(when_at=when_at, created_at=created_at, now=_NOW) == expected

--- a/docs/superpowers/plans/2026-05-10-chiwei-notes-redesign.md
+++ b/docs/superpowers/plans/2026-05-10-chiwei-notes-redesign.md
@@ -1,0 +1,1871 @@
+# 赤尾 Notes 体验重设计 — 实施计划
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 重设计赤尾 Notes 的 CRUD 工具集 + context 注入策略，解决"无日期/无法更新/全量注入"三个体验问题。
+
+**Architecture:** SQLAlchemy `Note` 表加 `deleted_at` / `delete_reason` 软删字段；queries 层用 `upsert_note` / `delete_note` / `list_active_notes` / `select_notes_for_context` 替代旧 `insert_note` / `get_active_notes`；tool 层用 `upsert_note` / `list_note` / `delete_note` 替代 `write_note`；context 注入按 3 天 / 7 天窗口 + 15 条上限过滤，显示相对时间。
+
+**Tech Stack:** Python 3.12 + SQLAlchemy async + LangChain `@tool` + pytest + asyncio。
+
+**Spec:** `docs/superpowers/specs/2026-05-10-chiwei-notes-redesign-design.md`
+
+---
+
+## File Structure
+
+| 文件 | 改动类型 | 责任 |
+|------|---------|------|
+| `apps/agent-service/app/data/models.py` | Modify (lines 359-377) | `Note` 类加 `deleted_at` / `delete_reason` |
+| `apps/agent-service/app/data/queries/memory_edges.py` | Modify (lines 98-129) | 删 `insert_note` / `get_active_notes`，新增 4 个 query |
+| `apps/agent-service/app/agent/tools/notes.py` | Rewrite | 删 `write_note` / `_write_note_impl`，新增 `upsert_note` / `list_note` / `delete_note`，改 `resolve_note` description |
+| `apps/agent-service/app/agent/tools/__init__.py` | Modify | 工具注册更新 |
+| `apps/agent-service/app/memory/sections/active_notes.py` | Rewrite | 改造注入逻辑 + 时间格式化 |
+| `apps/agent-service/app/memory/notes_format.py` | Create | 公共 `format_when_label` helper（section + tool 共享） |
+| `apps/agent-service/tests/unit/data/test_v4_queries.py` | Modify | 替换 note 相关测试 |
+| `apps/agent-service/tests/unit/data/test_queries_split.py` | Modify (lines 44-46) | 更新 `EXPECTED_FUNCTIONS` |
+| `apps/agent-service/tests/unit/agent/tools/test_notes.py` | Rewrite | 新工具的测试 |
+| `apps/agent-service/tests/unit/memory/sections/test_active_notes.py` | Rewrite | section 改造测试 |
+| `apps/agent-service/tests/unit/memory/test_notes_format.py` | Create | format helper 测试 |
+
+---
+
+## Task 1: DB schema — 加 `deleted_at` + `delete_reason` 字段
+
+**Files:**
+- Modify: `apps/agent-service/app/data/models.py:359-377`
+- DDL: 通过 `/ops-db submit @chiwei` 提交
+
+- [ ] **Step 1: 改 ORM model**
+
+编辑 `apps/agent-service/app/data/models.py`，在 `Note` 类（359-377 行）末尾追加两个字段：
+
+```python
+class Note(Base):
+    """赤尾主动清单 — 她自己决定记下来的事。"""
+
+    __tablename__ = "notes"
+
+    id: Mapped[str] = mapped_column(Text, primary_key=True)
+    persona_id: Mapped[str] = mapped_column(Text, nullable=False)
+    content: Mapped[str] = mapped_column(Text, nullable=False)
+    when_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now()
+    )
+    resolved_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    resolution: Mapped[str | None] = mapped_column(Text, nullable=True)
+    deleted_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    delete_reason: Mapped[str | None] = mapped_column(Text, nullable=True)
+```
+
+- [ ] **Step 2: 跑现有测试确认 model 改动不破坏**
+
+Run: `cd apps/agent-service && uv run pytest tests/unit/data/test_v4_queries.py -v`
+Expected: 全部 PASS（model 加字段是 additive，旧测试应仍通过）。
+
+- [ ] **Step 3: 提交 DDL**
+
+Run（不要带前导 `--` 注释，会被 ops-db submit 吞掉）：
+
+```
+/ops-db submit @chiwei ALTER TABLE notes ADD COLUMN deleted_at TIMESTAMPTZ NULL, ADD COLUMN delete_reason TEXT NULL;
+```
+
+Expected: 提交成功，等用户审批后执行。
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/agent-service/app/data/models.py
+git commit -m "feat(notes): add deleted_at and delete_reason columns to Note"
+```
+
+---
+
+## Task 2: queries 层 — 新增 `upsert_note`
+
+**Files:**
+- Modify: `apps/agent-service/app/data/queries/memory_edges.py`
+- Test: `apps/agent-service/tests/unit/data/test_v4_queries.py`
+
+- [ ] **Step 1: 写失败测试 — create 路径**
+
+在 `apps/agent-service/tests/unit/data/test_v4_queries.py` 末尾追加（替换原 `test_insert_note_adds_to_session`，因为 `insert_note` 将被 `upsert_note` 替代；保留为新测试）：
+
+```python
+@pytest.mark.asyncio
+async def test_upsert_note_create_when_no_id():
+    session = AsyncMock()
+    session.add = lambda obj: setattr(session, "_added", obj)
+    session.flush = AsyncMock()
+    patches = _patch_module("app.data.queries.memory_edges", session)
+    try:
+        from app.data.queries import upsert_note
+        added = await upsert_note(
+            persona_id="chiwei",
+            content="周五看电影",
+        )
+        assert isinstance(added, Note)
+        assert added.id.startswith("n_")
+        assert added.content == "周五看电影"
+        assert added.when_at is None
+    finally:
+        _stop(patches)
+```
+
+- [ ] **Step 2: Run test — 确认 fail**
+
+Run: `cd apps/agent-service && uv run pytest tests/unit/data/test_v4_queries.py::test_upsert_note_create_when_no_id -v`
+Expected: FAIL `ImportError: cannot import name 'upsert_note'`
+
+- [ ] **Step 3: 实现 `upsert_note`（create 分支）**
+
+编辑 `apps/agent-service/app/data/queries/memory_edges.py`：
+
+文件顶部 `from sqlalchemy import func, update` 后追加 import（如果尚未引入）：
+
+```python
+from app.data.ids import new_id
+```
+
+并在 `__all__` 列表里追加 `"upsert_note"`（保留 `insert_note` 和 `get_active_notes` 直到 Task 9 删除）：
+
+```python
+__all__ = [
+    "insert_memory_edge",
+    "delete_edge",
+    "list_edges_to",
+    "list_edges_from",
+    "insert_note",
+    "upsert_note",
+    "get_active_notes",
+    "resolve_note",
+]
+```
+
+在文件末尾、`resolve_note` 之前追加 `_UNSET` 哨兵和 `upsert_note`：
+
+```python
+_UNSET: object = object()
+
+
+async def upsert_note(
+    *,
+    persona_id: str,
+    content: str,
+    when_at: datetime | None | object = _UNSET,
+    note_id: str | None = None,
+) -> Note:
+    """Create or update a Note.
+
+    - ``note_id is None`` → create new note (id auto-generated as ``n_<hex>``)
+    - ``note_id`` provided + ``when_at is _UNSET`` → update content only
+    - ``note_id`` provided + ``when_at is None`` → clear when_at column
+    - ``note_id`` provided + ``when_at`` is datetime → update when_at column
+
+    Returns the persisted Note. Raises ``LookupError`` if updating an unknown id.
+    """
+    async with auto_tx():
+        s = current_session()
+        if note_id is None:
+            nid = new_id("n")
+            when_value = None if when_at is _UNSET else when_at
+            n = Note(
+                id=nid,
+                persona_id=persona_id,
+                content=content,
+                when_at=when_value,
+            )
+            s.add(n)
+            await s.flush()
+            return n
+
+        result = await s.execute(select(Note).where(Note.id == note_id))
+        existing = result.scalar_one_or_none()
+        if existing is None:
+            raise LookupError(f"note not found: {note_id}")
+
+        existing.content = content
+        if when_at is not _UNSET:
+            existing.when_at = when_at  # type: ignore[assignment]
+        await s.flush()
+        return existing
+```
+
+- [ ] **Step 4: Run test — 确认 pass**
+
+Run: `cd apps/agent-service && uv run pytest tests/unit/data/test_v4_queries.py::test_upsert_note_create_when_no_id -v`
+Expected: PASS
+
+- [ ] **Step 5: 写 update 路径测试**
+
+在同一文件追加：
+
+```python
+@pytest.mark.asyncio
+async def test_upsert_note_update_content_only():
+    existing = Note(id="n_abc", persona_id="chiwei", content="old", when_at=None)
+    session = AsyncMock()
+    session.execute = AsyncMock(return_value=_ScalarResult(existing))
+    session.flush = AsyncMock()
+    patches = _patch_module("app.data.queries.memory_edges", session)
+    try:
+        from app.data.queries import upsert_note
+        out = await upsert_note(
+            persona_id="chiwei",
+            content="new content",
+            note_id="n_abc",
+        )
+        assert out.content == "new content"
+        assert out.when_at is None  # untouched (was None, stays None; _UNSET means don't change)
+    finally:
+        _stop(patches)
+
+
+@pytest.mark.asyncio
+async def test_upsert_note_update_when_at():
+    from datetime import UTC, datetime as _dt
+    existing = Note(id="n_abc", persona_id="chiwei", content="old", when_at=None)
+    session = AsyncMock()
+    session.execute = AsyncMock(return_value=_ScalarResult(existing))
+    session.flush = AsyncMock()
+    patches = _patch_module("app.data.queries.memory_edges", session)
+    try:
+        from app.data.queries import upsert_note
+        new_when = _dt(2026, 5, 17, 12, 0, tzinfo=UTC)
+        out = await upsert_note(
+            persona_id="chiwei",
+            content="old",
+            when_at=new_when,
+            note_id="n_abc",
+        )
+        assert out.when_at == new_when
+    finally:
+        _stop(patches)
+
+
+@pytest.mark.asyncio
+async def test_upsert_note_clear_when_at_with_explicit_none():
+    from datetime import UTC, datetime as _dt
+    existing = Note(
+        id="n_abc",
+        persona_id="chiwei",
+        content="old",
+        when_at=_dt(2026, 5, 1, 12, 0, tzinfo=UTC),
+    )
+    session = AsyncMock()
+    session.execute = AsyncMock(return_value=_ScalarResult(existing))
+    session.flush = AsyncMock()
+    patches = _patch_module("app.data.queries.memory_edges", session)
+    try:
+        from app.data.queries import upsert_note
+        out = await upsert_note(
+            persona_id="chiwei",
+            content="old",
+            when_at=None,  # explicit None = clear
+            note_id="n_abc",
+        )
+        assert out.when_at is None
+    finally:
+        _stop(patches)
+
+
+@pytest.mark.asyncio
+async def test_upsert_note_unknown_id_raises():
+    session = AsyncMock()
+    session.execute = AsyncMock(return_value=_ScalarResult(None))
+    patches = _patch_module("app.data.queries.memory_edges", session)
+    try:
+        from app.data.queries import upsert_note
+        with pytest.raises(LookupError, match="note not found"):
+            await upsert_note(
+                persona_id="chiwei",
+                content="x",
+                note_id="n_does_not_exist",
+            )
+    finally:
+        _stop(patches)
+```
+
+- [ ] **Step 6: Run all upsert tests**
+
+Run: `cd apps/agent-service && uv run pytest tests/unit/data/test_v4_queries.py -k upsert_note -v`
+Expected: 4 个测试全部 PASS
+
+- [ ] **Step 7: 同步 `EXPECTED_FUNCTIONS` 基线**
+
+编辑 `apps/agent-service/tests/unit/data/test_queries_split.py:44-46`，把 memory_edges 段从 7 改成 8（加 `upsert_note`）：
+
+```python
+    # memory_edges (8) — edges + notes
+    "insert_memory_edge", "delete_edge", "list_edges_to", "list_edges_from",
+    "insert_note", "upsert_note", "get_active_notes", "resolve_note",
+```
+
+并把文件第 9 行注释 "硬编码作为期望基线（80 函数）" 改成 "（81 函数）"。
+
+Run: `cd apps/agent-service && uv run pytest tests/unit/data/test_queries_split.py -v`
+Expected: 3 个测试全部 PASS
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add apps/agent-service/app/data/queries/memory_edges.py \
+        apps/agent-service/tests/unit/data/test_v4_queries.py \
+        apps/agent-service/tests/unit/data/test_queries_split.py
+git commit -m "feat(notes): add upsert_note query (create + update)"
+```
+
+---
+
+## Task 3: queries 层 — 新增 `delete_note`
+
+**Files:**
+- Modify: `apps/agent-service/app/data/queries/memory_edges.py`
+- Test: `apps/agent-service/tests/unit/data/test_v4_queries.py`
+
+- [ ] **Step 1: 写失败测试**
+
+在 `tests/unit/data/test_v4_queries.py` 追加：
+
+```python
+@pytest.mark.asyncio
+async def test_delete_note_soft_deletes():
+    session = AsyncMock()
+    session.execute = AsyncMock()
+    patches = _patch_module("app.data.queries.memory_edges", session)
+    try:
+        from app.data.queries import delete_note
+        await delete_note(note_id="n_abc", reason="改主意了")
+        # _stop verified the patch ran; assert that execute() was called once
+        # and the SQL is an UPDATE setting deleted_at + delete_reason
+        session.execute.assert_awaited_once()
+        stmt = session.execute.await_args.args[0]
+        compiled = str(stmt)
+        assert "UPDATE notes" in compiled
+        assert "deleted_at" in compiled
+        assert "delete_reason" in compiled
+    finally:
+        _stop(patches)
+```
+
+- [ ] **Step 2: Run test — 确认 fail**
+
+Run: `cd apps/agent-service && uv run pytest tests/unit/data/test_v4_queries.py::test_delete_note_soft_deletes -v`
+Expected: FAIL `ImportError: cannot import name 'delete_note'`
+
+- [ ] **Step 3: 实现 `delete_note`**
+
+在 `apps/agent-service/app/data/queries/memory_edges.py` 末尾追加，并在 `__all__` 加 `"delete_note"`：
+
+```python
+async def delete_note(*, note_id: str, reason: str) -> None:
+    """Soft-delete a note (sets deleted_at + delete_reason).
+
+    Does not raise if note_id does not exist; the UPDATE simply affects 0 rows.
+    The tool layer is responsible for verifying existence if needed.
+    """
+    async with auto_tx():
+        await current_session().execute(
+            update(Note)
+            .where(Note.id == note_id)
+            .values(deleted_at=func.now(), delete_reason=reason)
+        )
+```
+
+`__all__` 现在应为：
+
+```python
+__all__ = [
+    "insert_memory_edge",
+    "delete_edge",
+    "list_edges_to",
+    "list_edges_from",
+    "insert_note",
+    "upsert_note",
+    "delete_note",
+    "get_active_notes",
+    "resolve_note",
+]
+```
+
+- [ ] **Step 4: Run test — 确认 pass**
+
+Run: `cd apps/agent-service && uv run pytest tests/unit/data/test_v4_queries.py::test_delete_note_soft_deletes -v`
+Expected: PASS
+
+- [ ] **Step 5: 同步 `EXPECTED_FUNCTIONS` 基线**
+
+编辑 `apps/agent-service/tests/unit/data/test_queries_split.py`，把 memory_edges 段从 8 改成 9（加 `delete_note`）：
+
+```python
+    # memory_edges (9) — edges + notes
+    "insert_memory_edge", "delete_edge", "list_edges_to", "list_edges_from",
+    "insert_note", "upsert_note", "delete_note", "get_active_notes", "resolve_note",
+```
+
+把文件顶部注释 "（81 函数）" 改成 "（82 函数）"。
+
+Run: `cd apps/agent-service && uv run pytest tests/unit/data/test_queries_split.py -v`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/agent-service/app/data/queries/memory_edges.py \
+        apps/agent-service/tests/unit/data/test_v4_queries.py \
+        apps/agent-service/tests/unit/data/test_queries_split.py
+git commit -m "feat(notes): add delete_note query (soft delete)"
+```
+
+---
+
+## Task 4: queries 层 — 新增 `list_active_notes`
+
+**Files:**
+- Modify: `apps/agent-service/app/data/queries/memory_edges.py`
+- Test: `apps/agent-service/tests/unit/data/test_v4_queries.py`
+
+- [ ] **Step 1: 写失败测试**
+
+```python
+@pytest.mark.asyncio
+async def test_list_active_notes_filters_resolved_and_deleted():
+    n_active = Note(id="n_active", persona_id="chiwei", content="alive")
+    session = AsyncMock()
+    session.execute = AsyncMock(return_value=_IterResult([n_active]))
+    patches = _patch_module("app.data.queries.memory_edges", session)
+    try:
+        from app.data.queries import list_active_notes
+        result = await list_active_notes(persona_id="chiwei")
+        assert result == [n_active]
+        # Assert WHERE clause filters both resolved_at and deleted_at IS NULL.
+        stmt = session.execute.await_args.args[0]
+        compiled = str(stmt.compile(compile_kwargs={"literal_binds": True}))
+        assert "resolved_at IS NULL" in compiled
+        assert "deleted_at IS NULL" in compiled
+    finally:
+        _stop(patches)
+```
+
+- [ ] **Step 2: Run test — 确认 fail**
+
+Run: `cd apps/agent-service && uv run pytest tests/unit/data/test_v4_queries.py::test_list_active_notes_filters_resolved_and_deleted -v`
+Expected: FAIL `ImportError`
+
+- [ ] **Step 3: 实现 `list_active_notes`**
+
+在 `apps/agent-service/app/data/queries/memory_edges.py` 追加（同时把 `"list_active_notes"` 加入 `__all__`）：
+
+```python
+async def list_active_notes(persona_id: str) -> list[Note]:
+    """Return all notes that are neither resolved nor deleted.
+
+    Ordered: notes with ``when_at`` first (ascending — soonest first),
+    then notes without ``when_at`` (most recently created first).
+    """
+    async with auto_tx():
+        result = await current_session().execute(
+            select(Note)
+            .where(Note.persona_id == persona_id)
+            .where(Note.resolved_at.is_(None))
+            .where(Note.deleted_at.is_(None))
+            .order_by(
+                Note.when_at.asc().nulls_last(),
+                Note.created_at.desc(),
+            )
+        )
+        return list(result.scalars().all())
+```
+
+- [ ] **Step 4: Run test — 确认 pass**
+
+Run: `cd apps/agent-service && uv run pytest tests/unit/data/test_v4_queries.py::test_list_active_notes_filters_resolved_and_deleted -v`
+Expected: PASS
+
+- [ ] **Step 5: 同步 `EXPECTED_FUNCTIONS` 基线**
+
+编辑 `apps/agent-service/tests/unit/data/test_queries_split.py`，memory_edges 段 (9) → (10)，加 `"list_active_notes"`；顶部注释 "（82 函数）" → "（83 函数）"。
+
+```python
+    # memory_edges (10) — edges + notes
+    "insert_memory_edge", "delete_edge", "list_edges_to", "list_edges_from",
+    "insert_note", "upsert_note", "delete_note", "list_active_notes",
+    "get_active_notes", "resolve_note",
+```
+
+Run: `cd apps/agent-service && uv run pytest tests/unit/data/test_queries_split.py -v`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/agent-service/app/data/queries/memory_edges.py \
+        apps/agent-service/tests/unit/data/test_v4_queries.py \
+        apps/agent-service/tests/unit/data/test_queries_split.py
+git commit -m "feat(notes): add list_active_notes query"
+```
+
+---
+
+## Task 5: queries 层 — 新增 `select_notes_for_context`
+
+**Files:**
+- Modify: `apps/agent-service/app/data/queries/memory_edges.py`
+- Test: `apps/agent-service/tests/unit/data/test_v4_queries.py`
+
+阈值常量：
+- `_RECENT_OVERDUE_DAYS = 3`（带 `when_at` 的，过期 ≤3 天还注入）
+- `_NEW_MEMO_DAYS = 7`（无 `when_at` 的，创建 ≤7 天还注入）
+- `_CONTEXT_NOTES_LIMIT = 15`
+
+- [ ] **Step 1: 写失败测试 — 窗口过滤**
+
+```python
+@pytest.mark.asyncio
+async def test_select_notes_for_context_window_and_limit():
+    """Verify SQL has the 3-day / 7-day window + 15-row limit."""
+    session = AsyncMock()
+    session.execute = AsyncMock(return_value=_IterResult([]))
+    patches = _patch_module("app.data.queries.memory_edges", session)
+    try:
+        from app.data.queries import select_notes_for_context
+        await select_notes_for_context(persona_id="chiwei")
+        stmt = session.execute.await_args.args[0]
+        compiled = str(stmt.compile(compile_kwargs={"literal_binds": True}))
+        # Window cutoffs are computed in Python, so SQL contains literal timestamps;
+        # what matters is LIMIT and the OR-shape with when_at + created_at.
+        assert "LIMIT 15" in compiled
+        assert "when_at" in compiled
+        assert "created_at" in compiled
+    finally:
+        _stop(patches)
+
+
+@pytest.mark.asyncio
+async def test_select_notes_for_context_returns_results():
+    n = Note(id="n_1", persona_id="chiwei", content="x")
+    session = AsyncMock()
+    session.execute = AsyncMock(return_value=_IterResult([n]))
+    patches = _patch_module("app.data.queries.memory_edges", session)
+    try:
+        from app.data.queries import select_notes_for_context
+        result = await select_notes_for_context(persona_id="chiwei")
+        assert result == [n]
+    finally:
+        _stop(patches)
+```
+
+- [ ] **Step 2: Run test — 确认 fail**
+
+Run: `cd apps/agent-service && uv run pytest tests/unit/data/test_v4_queries.py -k select_notes_for_context -v`
+Expected: FAIL `ImportError`
+
+- [ ] **Step 3: 实现 `select_notes_for_context`**
+
+在 `apps/agent-service/app/data/queries/memory_edges.py`：
+
+文件顶部 import 区把 `from datetime import datetime` 改为：
+
+```python
+from datetime import datetime, timedelta, timezone
+```
+
+把 `"select_notes_for_context"` 加入 `__all__`（最终 5 个旧 + 4 个新 + 2 个待删 = 11 个）。
+
+在文件末尾追加常量和函数：
+
+```python
+_CONTEXT_RECENT_OVERDUE_DAYS = 3
+_CONTEXT_NEW_MEMO_DAYS = 7
+_CONTEXT_NOTES_LIMIT = 15
+
+
+async def select_notes_for_context(persona_id: str) -> list[Note]:
+    """Return notes appropriate for live context injection.
+
+    Filters:
+    - Notes with ``when_at`` are kept if ``when_at >= now - 3 days``
+      (upcoming + recently overdue).
+    - Notes without ``when_at`` are kept if ``created_at >= now - 7 days``
+      (fresh memos).
+
+    Order: notes with ``when_at`` first (ascending — soonest first), then
+    notes without ``when_at`` (most recent created first). Capped at 15 rows.
+    """
+    now = datetime.now(timezone.utc)
+    overdue_cutoff = now - timedelta(days=_CONTEXT_RECENT_OVERDUE_DAYS)
+    memo_cutoff = now - timedelta(days=_CONTEXT_NEW_MEMO_DAYS)
+
+    async with auto_tx():
+        result = await current_session().execute(
+            select(Note)
+            .where(Note.persona_id == persona_id)
+            .where(Note.resolved_at.is_(None))
+            .where(Note.deleted_at.is_(None))
+            .where(
+                # (when_at IS NOT NULL AND when_at >= overdue_cutoff)
+                # OR (when_at IS NULL AND created_at >= memo_cutoff)
+                (Note.when_at.is_not(None) & (Note.when_at >= overdue_cutoff))
+                | (Note.when_at.is_(None) & (Note.created_at >= memo_cutoff))
+            )
+            .order_by(
+                Note.when_at.asc().nulls_last(),
+                Note.created_at.desc(),
+            )
+            .limit(_CONTEXT_NOTES_LIMIT)
+        )
+        return list(result.scalars().all())
+```
+
+- [ ] **Step 4: Run test — 确认 pass**
+
+Run: `cd apps/agent-service && uv run pytest tests/unit/data/test_v4_queries.py -k select_notes_for_context -v`
+Expected: PASS（2 个测试）
+
+- [ ] **Step 5: 同步 `EXPECTED_FUNCTIONS` 基线**
+
+编辑 `apps/agent-service/tests/unit/data/test_queries_split.py`，memory_edges 段 (10) → (11)，加 `"select_notes_for_context"`；顶部注释 "（83 函数）" → "（84 函数）"。
+
+```python
+    # memory_edges (11) — edges + notes
+    "insert_memory_edge", "delete_edge", "list_edges_to", "list_edges_from",
+    "insert_note", "upsert_note", "delete_note", "list_active_notes",
+    "select_notes_for_context", "get_active_notes", "resolve_note",
+```
+
+Run: `cd apps/agent-service && uv run pytest tests/unit/data/test_queries_split.py -v`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/agent-service/app/data/queries/memory_edges.py \
+        apps/agent-service/tests/unit/data/test_v4_queries.py \
+        apps/agent-service/tests/unit/data/test_queries_split.py
+git commit -m "feat(notes): add select_notes_for_context with 3d/7d window + 15 cap"
+```
+
+---
+
+## Task 6: 公共 helper — `format_when_label`
+
+**Files:**
+- Create: `apps/agent-service/app/memory/notes_format.py`
+- Test: `apps/agent-service/tests/unit/memory/test_notes_format.py`
+
+`format_when_label(when_at, created_at, now)` 接收 3 个 datetime 参数（when_at 可选），返回中文相对时间标签字符串。
+
+- [ ] **Step 1: 写失败测试**
+
+创建 `apps/agent-service/tests/unit/memory/test_notes_format.py`：
+
+```python
+"""Test format_when_label helper for Notes context injection / list_note tool."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from app.memory.notes_format import format_when_label
+
+
+_NOW = datetime(2026, 5, 10, 12, 0, tzinfo=UTC)
+
+
+def _at(days: int, hour: int = 12) -> datetime:
+    return _NOW + timedelta(days=days, hours=hour - 12)
+
+
+@pytest.mark.parametrize(
+    ("when_at", "created_at", "expected"),
+    [
+        # when_at present
+        (_at(0), _at(0), "今天"),
+        (_at(1), _at(0), "明天"),
+        (_at(2), _at(0), "还有 2 天"),
+        (_at(7), _at(0), "还有 7 天"),
+        (_at(-1), _at(0), "昨天就该做"),
+        (_at(-2), _at(0), "已过期 2 天"),
+        (_at(-5), _at(0), "已过期 5 天"),
+        # when_at None
+        (None, _NOW, "今天记的，没说时间"),
+        (None, _NOW - timedelta(days=1), "1 天前记的，没说时间"),
+        (None, _NOW - timedelta(days=14), "14 天前记的，没说时间"),
+    ],
+)
+def test_format_when_label(when_at, created_at, expected):
+    assert format_when_label(when_at=when_at, created_at=created_at, now=_NOW) == expected
+```
+
+- [ ] **Step 2: Run test — 确认 fail**
+
+Run: `cd apps/agent-service && uv run pytest tests/unit/memory/test_notes_format.py -v`
+Expected: FAIL `ModuleNotFoundError: No module named 'app.memory.notes_format'`
+
+- [ ] **Step 3: 实现 `format_when_label`**
+
+创建 `apps/agent-service/app/memory/notes_format.py`：
+
+```python
+"""Format a Note's when_at / created_at into a human-readable Chinese label.
+
+Used both by ``list_note`` tool output and ``build_active_notes_section``
+context injection. Day boundaries are computed in CST (UTC+8) so "今天" /
+"明天" align with the user's lived day, not UTC.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+_CST = timezone(timedelta(hours=8))
+
+
+def _to_local_date(dt: datetime) -> datetime:
+    return dt.astimezone(_CST).replace(hour=0, minute=0, second=0, microsecond=0)
+
+
+def format_when_label(
+    *,
+    when_at: datetime | None,
+    created_at: datetime,
+    now: datetime,
+) -> str:
+    """Return a Chinese relative-time label.
+
+    - ``when_at`` set: "今天" / "明天" / "还有 N 天" / "昨天就该做" / "已过期 N 天"
+    - ``when_at`` None: "今天记的，没说时间" / "N 天前记的，没说时间"
+    """
+    today = _to_local_date(now)
+
+    if when_at is not None:
+        target = _to_local_date(when_at)
+        delta_days = (target - today).days
+        if delta_days == 0:
+            return "今天"
+        if delta_days == 1:
+            return "明天"
+        if delta_days >= 2:
+            return f"还有 {delta_days} 天"
+        if delta_days == -1:
+            return "昨天就该做"
+        return f"已过期 {-delta_days} 天"
+
+    created_local = _to_local_date(created_at)
+    delta_days = (today - created_local).days
+    if delta_days <= 0:
+        return "今天记的，没说时间"
+    return f"{delta_days} 天前记的，没说时间"
+```
+
+- [ ] **Step 4: Run test — 确认 pass**
+
+Run: `cd apps/agent-service && uv run pytest tests/unit/memory/test_notes_format.py -v`
+Expected: 10 个 parametrize case 全部 PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/agent-service/app/memory/notes_format.py \
+        apps/agent-service/tests/unit/memory/test_notes_format.py
+git commit -m "feat(notes): add format_when_label helper for relative-time display"
+```
+
+---
+
+## Task 7: section 层 — 改造 `build_active_notes_section`
+
+**Files:**
+- Rewrite: `apps/agent-service/app/memory/sections/active_notes.py`
+- Rewrite: `apps/agent-service/tests/unit/memory/sections/test_active_notes.py`
+
+新逻辑：
+1. 从 `select_notes_for_context` 拿"活跃"列表（已经按窗口 + 上限过滤）
+2. 同时调 `list_active_notes` 拿全量数量（用于截断提示）
+3. 渲染成"清单 + 数量提示"
+
+- [ ] **Step 1: 写失败测试**
+
+完全重写 `apps/agent-service/tests/unit/memory/sections/test_active_notes.py`：
+
+```python
+"""Test active_notes section after windowed-injection redesign."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.data.models import Note
+from app.memory.sections.active_notes import build_active_notes_section
+
+
+def _note(*, id: str, content: str, when_at=None, created_at=None) -> Note:
+    n = Note(
+        id=id,
+        persona_id="chiwei",
+        content=content,
+        when_at=when_at,
+    )
+    if created_at is not None:
+        n.created_at = created_at
+    return n
+
+
+_NOW = datetime(2026, 5, 10, 12, 0, tzinfo=UTC)
+
+
+def _patch_now(monkeypatch):
+    """Pin datetime.now in active_notes module to _NOW."""
+    import app.memory.sections.active_notes as mod
+
+    class _FixedDt:
+        @staticmethod
+        def now(tz=None):
+            return _NOW.astimezone(tz) if tz else _NOW
+
+    monkeypatch.setattr(mod, "datetime", _FixedDt)
+
+
+@pytest.mark.asyncio
+async def test_section_empty_when_no_active(monkeypatch):
+    _patch_now(monkeypatch)
+    with patch(
+        "app.memory.sections.active_notes.select_notes_for_context",
+        new=AsyncMock(return_value=[]),
+    ):
+        with patch(
+            "app.memory.sections.active_notes.list_active_notes",
+            new=AsyncMock(return_value=[]),
+        ):
+            text = await build_active_notes_section(persona_id="chiwei")
+    assert text == ""
+
+
+@pytest.mark.asyncio
+async def test_section_renders_active_with_when_label(monkeypatch):
+    _patch_now(monkeypatch)
+    n1 = _note(
+        id="n_1",
+        content="周五和浩南看电影",
+        when_at=_NOW + timedelta(days=2),
+        created_at=_NOW - timedelta(hours=1),
+    )
+    n2 = _note(
+        id="n_2",
+        content="想问妈妈那件事",
+        when_at=None,
+        created_at=_NOW - timedelta(days=1),
+    )
+    with patch(
+        "app.memory.sections.active_notes.select_notes_for_context",
+        new=AsyncMock(return_value=[n1, n2]),
+    ):
+        with patch(
+            "app.memory.sections.active_notes.list_active_notes",
+            new=AsyncMock(return_value=[n1, n2]),
+        ):
+            text = await build_active_notes_section(persona_id="chiwei")
+    assert "周五和浩南看电影 [还有 2 天] (id: n_1)" in text
+    assert "想问妈妈那件事 [1 天前记的，没说时间] (id: n_2)" in text
+    assert text.startswith("你的清单")
+
+
+@pytest.mark.asyncio
+async def test_section_appends_remainder_when_truncated(monkeypatch):
+    """active_total > injected_count → append truncation hint."""
+    _patch_now(monkeypatch)
+    injected = [
+        _note(id=f"n_{i}", content=f"事 {i}", when_at=None,
+              created_at=_NOW - timedelta(hours=i))
+        for i in range(15)
+    ]
+    all_active = injected + [
+        _note(id="n_old", content="老事", when_at=None,
+              created_at=_NOW - timedelta(days=30)),
+        _note(id="n_old2", content="更老的", when_at=None,
+              created_at=_NOW - timedelta(days=40)),
+    ]
+    with patch(
+        "app.memory.sections.active_notes.select_notes_for_context",
+        new=AsyncMock(return_value=injected),
+    ):
+        with patch(
+            "app.memory.sections.active_notes.list_active_notes",
+            new=AsyncMock(return_value=all_active),
+        ):
+            text = await build_active_notes_section(persona_id="chiwei")
+    assert "（清单里还有 2 条更老的没列出来，用 list_note 看全部。）" in text
+
+
+@pytest.mark.asyncio
+async def test_section_only_remainder_hint_when_all_old(monkeypatch):
+    """Active notes exist but none meet injection window → show only remainder hint."""
+    _patch_now(monkeypatch)
+    old = [
+        _note(id="n_old", content="老事", when_at=None,
+              created_at=_NOW - timedelta(days=30)),
+        _note(id="n_old2", content="更老", when_at=None,
+              created_at=_NOW - timedelta(days=40)),
+        _note(id="n_old3", content="最老",
+              when_at=_NOW - timedelta(days=10),
+              created_at=_NOW - timedelta(days=12)),
+    ]
+    with patch(
+        "app.memory.sections.active_notes.select_notes_for_context",
+        new=AsyncMock(return_value=[]),
+    ):
+        with patch(
+            "app.memory.sections.active_notes.list_active_notes",
+            new=AsyncMock(return_value=old),
+        ):
+            text = await build_active_notes_section(persona_id="chiwei")
+    assert text == "你的清单里还有 3 条没动的事（用 list_note 看）。"
+
+
+@pytest.mark.asyncio
+async def test_section_swallows_query_errors(monkeypatch):
+    """Section must not crash if query layer fails (resilience)."""
+    _patch_now(monkeypatch)
+    with patch(
+        "app.memory.sections.active_notes.select_notes_for_context",
+        new=AsyncMock(side_effect=RuntimeError("db down")),
+    ):
+        text = await build_active_notes_section(persona_id="chiwei")
+    assert text == ""
+```
+
+- [ ] **Step 2: Run test — 确认 fail**
+
+Run: `cd apps/agent-service && uv run pytest tests/unit/memory/sections/test_active_notes.py -v`
+Expected: FAIL — current implementation imports `get_active_notes`，新测试 import `select_notes_for_context` / `list_active_notes`
+
+- [ ] **Step 3: 实现新 section**
+
+完全重写 `apps/agent-service/app/memory/sections/active_notes.py`：
+
+```python
+"""Always-on injection: active notes (windowed + capped + remainder hint).
+
+The section pulls a limited set of "live-ish" notes via
+``select_notes_for_context`` (3-day overdue / 7-day memo window, 15 rows max)
+plus the total active count via ``list_active_notes`` so we can append a
+truncation hint pointing the agent at ``list_note`` for the full picture.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+
+from app.data.queries import list_active_notes, select_notes_for_context
+from app.memory.notes_format import format_when_label
+
+logger = logging.getLogger(__name__)
+
+
+async def build_active_notes_section(*, persona_id: str) -> str:
+    try:
+        injected = await select_notes_for_context(persona_id=persona_id)
+        all_active = await list_active_notes(persona_id=persona_id)
+    except Exception as e:
+        logger.warning("active_notes failed: %s", e)
+        return ""
+
+    if not all_active:
+        return ""
+
+    total = len(all_active)
+    shown = len(injected)
+
+    # All active notes are old enough that none made the injection window.
+    if shown == 0:
+        return f"你的清单里还有 {total} 条没动的事（用 list_note 看）。"
+
+    now = datetime.now(timezone.utc)
+    lines = ["你的清单（最近活跃，全部用 list_note 查）："]
+    for n in injected:
+        label = format_when_label(when_at=n.when_at, created_at=n.created_at, now=now)
+        lines.append(f"- {n.content} [{label}] (id: {n.id})")
+
+    remainder = total - shown
+    if remainder > 0:
+        lines.append(
+            f"（清单里还有 {remainder} 条更老的没列出来，用 list_note 看全部。）"
+        )
+
+    return "\n".join(lines)
+```
+
+- [ ] **Step 4: Run test — 确认 pass**
+
+Run: `cd apps/agent-service && uv run pytest tests/unit/memory/sections/test_active_notes.py -v`
+Expected: 5 个测试全部 PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/agent-service/app/memory/sections/active_notes.py \
+        apps/agent-service/tests/unit/memory/sections/test_active_notes.py
+git commit -m "feat(notes): redesign active_notes section with windowed injection + remainder hint"
+```
+
+---
+
+## Task 8: tool 层 — 重写 `notes.py`（4 个工具）
+
+**Files:**
+- Rewrite: `apps/agent-service/app/agent/tools/notes.py`
+- Rewrite: `apps/agent-service/tests/unit/agent/tools/test_notes.py`
+- Modify: `apps/agent-service/app/agent/tools/__init__.py`
+
+工具集：
+- `upsert_note(content, when_at?, note_id?)` — 替代 `write_note`
+- `list_note()` — 新增
+- `delete_note(note_id, reason)` — 新增
+- `resolve_note(note_id, resolution)` — description 调整，逻辑不变
+
+- [ ] **Step 1: 写失败测试**
+
+完全重写 `apps/agent-service/tests/unit/agent/tools/test_notes.py`：
+
+```python
+"""Test upsert_note / list_note / resolve_note / delete_note tool implementations."""
+
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.agent.tools.notes import (
+    _delete_note_impl,
+    _list_note_impl,
+    _resolve_note_impl,
+    _upsert_note_impl,
+)
+
+
+@asynccontextmanager
+async def _fake_tx():
+    yield
+
+
+def _make_emit_tx_mock():
+    captured: list = []
+
+    async def _fake_emit_tx(ev):
+        captured.append(ev)
+
+    return _fake_emit_tx, captured
+
+
+# ----- upsert_note: create -----
+
+@pytest.mark.asyncio
+async def test_upsert_note_create_emits_note_created():
+    from app.domain.agent_tool_events import NoteCreated
+
+    created = MagicMock(
+        id="n_new", content="周五看电影", when_at=None,
+        created_at=datetime(2026, 5, 10, tzinfo=UTC),
+    )
+    fake_emit, captured = _make_emit_tx_mock()
+    with patch("app.agent.tools.notes.upsert_note_query",
+               new=AsyncMock(return_value=created)) as up:
+        with patch("app.agent.tools.notes.tx", _fake_tx):
+            with patch("app.agent.tools.notes.emit_tx", fake_emit):
+                out = await _upsert_note_impl(
+                    persona_id="chiwei",
+                    content="周五看电影",
+                    when_at_raw=None,
+                    note_id=None,
+                )
+    assert out["id"] == "n_new"
+    up.assert_awaited_once()
+    assert len(captured) == 1
+    ev = captured[0]
+    assert isinstance(ev, NoteCreated)
+    assert ev.note_id == "n_new"
+
+
+@pytest.mark.asyncio
+async def test_upsert_note_rejects_empty_content():
+    fake_emit, captured = _make_emit_tx_mock()
+    with patch("app.agent.tools.notes.upsert_note_query",
+               new=AsyncMock()) as up:
+        with patch("app.agent.tools.notes.tx", _fake_tx):
+            with patch("app.agent.tools.notes.emit_tx", fake_emit):
+                out = await _upsert_note_impl(
+                    persona_id="chiwei",
+                    content="  ",
+                    when_at_raw=None,
+                    note_id=None,
+                )
+    assert "error" in out
+    up.assert_not_awaited()
+    assert captured == []
+
+
+@pytest.mark.asyncio
+async def test_upsert_note_parses_iso_when_at():
+    when_iso = "2026-05-15T19:00:00+08:00"
+    created = MagicMock(id="n_x", content="x", when_at=None,
+                        created_at=datetime(2026, 5, 10, tzinfo=UTC))
+    fake_emit, _ = _make_emit_tx_mock()
+    with patch("app.agent.tools.notes.upsert_note_query",
+               new=AsyncMock(return_value=created)) as up:
+        with patch("app.agent.tools.notes.tx", _fake_tx):
+            with patch("app.agent.tools.notes.emit_tx", fake_emit):
+                await _upsert_note_impl(
+                    persona_id="chiwei", content="x",
+                    when_at_raw=when_iso, note_id=None,
+                )
+    kwargs = up.await_args.kwargs
+    assert kwargs["when_at"] == datetime.fromisoformat(when_iso)
+
+
+@pytest.mark.asyncio
+async def test_upsert_note_rejects_bad_when_at():
+    fake_emit, _ = _make_emit_tx_mock()
+    with patch("app.agent.tools.notes.upsert_note_query",
+               new=AsyncMock()) as up:
+        with patch("app.agent.tools.notes.tx", _fake_tx):
+            with patch("app.agent.tools.notes.emit_tx", fake_emit):
+                out = await _upsert_note_impl(
+                    persona_id="chiwei", content="x",
+                    when_at_raw="not-a-date", note_id=None,
+                )
+    assert "error" in out
+    up.assert_not_awaited()
+
+
+# ----- upsert_note: update -----
+
+@pytest.mark.asyncio
+async def test_upsert_note_update_passes_note_id_and_does_not_emit():
+    updated = MagicMock(
+        id="n_abc", content="改后", when_at=None,
+        created_at=datetime(2026, 5, 10, tzinfo=UTC),
+    )
+    fake_emit, captured = _make_emit_tx_mock()
+    with patch("app.agent.tools.notes.upsert_note_query",
+               new=AsyncMock(return_value=updated)) as up:
+        with patch("app.agent.tools.notes.tx", _fake_tx):
+            with patch("app.agent.tools.notes.emit_tx", fake_emit):
+                out = await _upsert_note_impl(
+                    persona_id="chiwei", content="改后",
+                    when_at_raw=None, note_id="n_abc",
+                )
+    assert out["id"] == "n_abc"
+    kwargs = up.await_args.kwargs
+    assert kwargs["note_id"] == "n_abc"
+    # update path: when_at_raw is None (no instruction) → query gets _UNSET
+    assert "when_at" in kwargs
+    # NoteCreated must NOT fire on update
+    assert captured == []
+
+
+@pytest.mark.asyncio
+async def test_upsert_note_clear_when_at_translates_to_explicit_none():
+    """when_at_raw='clear' → query receives when_at=None (not _UNSET)."""
+    from app.data.queries.memory_edges import _UNSET
+    updated = MagicMock(id="n_abc", content="x", when_at=None,
+                        created_at=datetime(2026, 5, 10, tzinfo=UTC))
+    fake_emit, _ = _make_emit_tx_mock()
+    with patch("app.agent.tools.notes.upsert_note_query",
+               new=AsyncMock(return_value=updated)) as up:
+        with patch("app.agent.tools.notes.tx", _fake_tx):
+            with patch("app.agent.tools.notes.emit_tx", fake_emit):
+                await _upsert_note_impl(
+                    persona_id="chiwei", content="x",
+                    when_at_raw="clear", note_id="n_abc",
+                )
+    assert up.await_args.kwargs["when_at"] is None
+    assert up.await_args.kwargs["when_at"] is not _UNSET
+
+
+@pytest.mark.asyncio
+async def test_upsert_note_unknown_id_returns_error():
+    fake_emit, _ = _make_emit_tx_mock()
+    with patch(
+        "app.agent.tools.notes.upsert_note_query",
+        new=AsyncMock(side_effect=LookupError("note not found: n_x")),
+    ):
+        with patch("app.agent.tools.notes.tx", _fake_tx):
+            with patch("app.agent.tools.notes.emit_tx", fake_emit):
+                out = await _upsert_note_impl(
+                    persona_id="chiwei", content="x",
+                    when_at_raw=None, note_id="n_x",
+                )
+    assert "error" in out
+    assert "n_x" in out["error"]
+
+
+# ----- list_note -----
+
+@pytest.mark.asyncio
+async def test_list_note_returns_items_with_when_label():
+    rows = [
+        MagicMock(
+            id="n_1", content="周五看电影",
+            when_at=datetime(2026, 5, 15, 19, 0, tzinfo=UTC),
+            created_at=datetime(2026, 5, 9, tzinfo=UTC),
+        ),
+        MagicMock(
+            id="n_2", content="想问妈妈那件事",
+            when_at=None,
+            created_at=datetime(2026, 5, 8, tzinfo=UTC),
+        ),
+    ]
+    with patch("app.agent.tools.notes.list_active_notes_query",
+               new=AsyncMock(return_value=rows)):
+        out = await _list_note_impl(persona_id="chiwei")
+    assert len(out["items"]) == 2
+    assert out["items"][0]["note_id"] == "n_1"
+    assert "when_label" in out["items"][0]
+    assert out["items"][1]["when_at"] is None
+
+
+@pytest.mark.asyncio
+async def test_list_note_empty():
+    with patch("app.agent.tools.notes.list_active_notes_query",
+               new=AsyncMock(return_value=[])):
+        out = await _list_note_impl(persona_id="chiwei")
+    assert out == {"items": []}
+
+
+# ----- delete_note -----
+
+@pytest.mark.asyncio
+async def test_delete_note_passes_reason():
+    with patch("app.agent.tools.notes.delete_note_query",
+               new=AsyncMock()) as dn:
+        out = await _delete_note_impl(
+            persona_id="chiwei", note_id="n_abc", reason="改主意了",
+        )
+    assert out == {"ok": True}
+    dn.assert_awaited_once_with(note_id="n_abc", reason="改主意了")
+
+
+@pytest.mark.asyncio
+async def test_delete_note_rejects_empty_reason():
+    with patch("app.agent.tools.notes.delete_note_query",
+               new=AsyncMock()) as dn:
+        out = await _delete_note_impl(
+            persona_id="chiwei", note_id="n_abc", reason="  ",
+        )
+    assert "error" in out
+    dn.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_delete_note_rejects_empty_note_id():
+    with patch("app.agent.tools.notes.delete_note_query",
+               new=AsyncMock()) as dn:
+        out = await _delete_note_impl(
+            persona_id="chiwei", note_id="", reason="改主意了",
+        )
+    assert "error" in out
+    dn.assert_not_awaited()
+
+
+# ----- resolve_note (logic unchanged) -----
+
+@pytest.mark.asyncio
+async def test_resolve_note_calls_query():
+    with patch("app.agent.tools.notes.resolve_note_query", new=AsyncMock()) as rn:
+        out = await _resolve_note_impl(
+            persona_id="chiwei", note_id="n_1", resolution="看完了",
+        )
+    assert out == {"ok": True}
+    rn.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_resolve_note_rejects_whitespace_resolution():
+    with patch("app.agent.tools.notes.resolve_note_query", new=AsyncMock()) as rn:
+        out = await _resolve_note_impl(
+            persona_id="chiwei", note_id="n_1", resolution="  ",
+        )
+    assert "error" in out
+    rn.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_resolve_note_rejects_empty_note_id():
+    with patch("app.agent.tools.notes.resolve_note_query", new=AsyncMock()) as rn:
+        out = await _resolve_note_impl(
+            persona_id="chiwei", note_id="", resolution="看完了",
+        )
+    assert "error" in out
+    rn.assert_not_awaited()
+```
+
+- [ ] **Step 2: Run test — 确认 fail**
+
+Run: `cd apps/agent-service && uv run pytest tests/unit/agent/tools/test_notes.py -v`
+Expected: FAIL `ImportError` （`_upsert_note_impl` / `_list_note_impl` / `_delete_note_impl` 未定义）
+
+- [ ] **Step 3: 重写 `apps/agent-service/app/agent/tools/notes.py`**
+
+```python
+"""Notes tool set — 赤尾自己的主动清单 (CRUD)。
+
+Tools exposed:
+- ``upsert_note`` (create / update content / update when_at / clear when_at)
+- ``list_note``  (full active list, with when_label)
+- ``resolve_note`` (mark as completed)
+- ``delete_note`` (soft delete with mandatory reason)
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from langchain.tools import tool
+from langgraph.runtime import get_runtime
+
+from app.agent.context import AgentContext
+from app.agent.tools._common import tool_error
+from app.data.queries import list_active_notes as list_active_notes_query
+from app.data.queries import upsert_note as upsert_note_query
+from app.data.queries import delete_note as delete_note_query
+from app.data.queries import resolve_note as resolve_note_query
+from app.data.queries.memory_edges import _UNSET
+from app.domain.agent_tool_events import NoteCreated
+from app.memory.notes_format import format_when_label
+from app.runtime.db import emit_tx, tx
+
+
+def _serialize(n) -> dict:
+    return {
+        "note_id": n.id,
+        "content": n.content,
+        "when_at": n.when_at.isoformat() if n.when_at else None,
+        "created_at": n.created_at.isoformat() if n.created_at else None,
+        "when_label": format_when_label(
+            when_at=n.when_at,
+            created_at=n.created_at,
+            now=datetime.now(timezone.utc),
+        ),
+    }
+
+
+# ---------------------------------------------------------------------------
+# upsert_note
+# ---------------------------------------------------------------------------
+
+async def _upsert_note_impl(
+    *,
+    persona_id: str,
+    content: str,
+    when_at_raw: str | None,
+    note_id: str | None,
+) -> dict:
+    content = (content or "").strip()
+    if not content:
+        return {"error": "content 不能为空"}
+
+    # Translate when_at_raw into the query-layer sentinel pattern:
+    # - None       → _UNSET (don't touch column on update; default NULL on create)
+    # - "clear"    → None   (explicit clear on update)
+    # - ISO string → datetime
+    if when_at_raw is None:
+        when_at: datetime | None | object = _UNSET
+    elif when_at_raw.strip().lower() == "clear":
+        when_at = None
+    else:
+        try:
+            when_at = datetime.fromisoformat(when_at_raw)
+        except ValueError:
+            return {"error": f"when_at 格式无效: {when_at_raw}"}
+
+    is_create = note_id is None
+    async with tx():
+        try:
+            row = await upsert_note_query(
+                persona_id=persona_id,
+                content=content,
+                when_at=when_at,
+                note_id=note_id,
+            )
+        except LookupError as e:
+            return {"error": str(e)}
+        if is_create:
+            await emit_tx(NoteCreated(note_id=row.id, persona_id=persona_id))
+
+    return {"id": row.id, "note": _serialize(row)}
+
+
+# ---------------------------------------------------------------------------
+# list_note
+# ---------------------------------------------------------------------------
+
+async def _list_note_impl(*, persona_id: str) -> dict:
+    rows = await list_active_notes_query(persona_id=persona_id)
+    return {"items": [_serialize(n) for n in rows]}
+
+
+# ---------------------------------------------------------------------------
+# resolve_note
+# ---------------------------------------------------------------------------
+
+async def _resolve_note_impl(
+    *,
+    persona_id: str,
+    note_id: str,
+    resolution: str,
+) -> dict:
+    resolution = (resolution or "").strip()
+    if not note_id or not resolution:
+        return {"error": "note_id 和 resolution 都不能为空"}
+
+    await resolve_note_query(note_id=note_id, resolution=resolution)
+    return {"ok": True}
+
+
+# ---------------------------------------------------------------------------
+# delete_note
+# ---------------------------------------------------------------------------
+
+async def _delete_note_impl(
+    *,
+    persona_id: str,
+    note_id: str,
+    reason: str,
+) -> dict:
+    reason = (reason or "").strip()
+    if not note_id:
+        return {"error": "note_id 不能为空"}
+    if not reason:
+        return {"error": "reason 不能为空，请说明为什么删"}
+
+    await delete_note_query(note_id=note_id, reason=reason)
+    return {"ok": True}
+
+
+# ---------------------------------------------------------------------------
+# @tool wrappers — exposed to the LLM
+# ---------------------------------------------------------------------------
+
+@tool
+@tool_error("笔记保存失败")
+async def upsert_note(
+    content: str,
+    when_at: str | None = None,
+    note_id: str | None = None,
+) -> dict:
+    """把一件你觉得必须记住的事写进清单，或者更新已有的一条。
+
+    这是你自己的清单，不是系统强加的承诺列表。只有你觉得"不能忘"、"需要专门记住"的
+    事才写。
+
+    什么时候用：
+    - 第一次提到一件想记住的事 → 不传 note_id，会创建新的一条
+    - 用户重复提到同一件事（比如"那家餐厅改成下周去了"）→ 传清单里看到的 note_id，会更新
+
+    Args:
+        content: 笔记内容（必填）。
+        when_at: ISO 8601 时间戳（"2026-05-15T19:00:00+08:00"）。**如果这件事和某个时间相关
+            （"明天"/"周五"/"下个月"/具体日子），强烈建议填**。没明确时间线索就别硬填。
+            想清空已有的 when_at 传 "clear"（仅在更新场景有意义）。
+        note_id: 已有 note 的 id（形如 "n_xxx"，从清单里看到）；不传则新建。
+    """
+    context = get_runtime(AgentContext).context
+    return await _upsert_note_impl(
+        persona_id=context.persona_id,
+        content=content,
+        when_at_raw=when_at,
+        note_id=note_id,
+    )
+
+
+@tool
+@tool_error("清单查询失败")
+async def list_note() -> dict:
+    """列出你目前的全部清单（没完成、没删除的）。
+
+    什么时候用：
+    - 用户问起"你都记了啥"
+    - 你想盘点一下有没有重复的、可以合并的
+    - 你想看看有没有挂了很久该处理的事
+
+    注意：context 里通常已经有"最近活跃"的几条了。需要看全量、找特定 id、
+    清盘的时候才用这个。
+
+    Returns:
+        ``{"items": [{"note_id": "n_xxx", "content": "...", "when_at": "...|null",
+        "created_at": "...", "when_label": "还有 2 天"}, ...]}``
+    """
+    context = get_runtime(AgentContext).context
+    return await _list_note_impl(persona_id=context.persona_id)
+
+
+@tool
+@tool_error("清单更新失败")
+async def resolve_note(note_id: str, resolution: str) -> dict:
+    """把一条已经完结的笔记划掉。
+
+    比如电影看了、想法落实了。resolution 写一句话说明结果（"看完了"/"做完了"）。
+
+    这是"完成"，不是"删除"。如果是改主意了 / 记错了 / 重复了，用 delete_note。
+
+    Args:
+        note_id: 笔记 id（形如 "n_xxxxxx"）
+        resolution: 结果描述（必填）
+    """
+    context = get_runtime(AgentContext).context
+    return await _resolve_note_impl(
+        persona_id=context.persona_id,
+        note_id=note_id,
+        resolution=resolution,
+    )
+
+
+@tool
+@tool_error("清单删除失败")
+async def delete_note(note_id: str, reason: str) -> dict:
+    """真删除一条清单项。
+
+    和 resolve 不同 —— resolve 是"做完了"留个痕，delete 是"这条本来就不该存在"。
+
+    什么时候用：
+    - 改主意了，不打算做这件事了
+    - 当时记错了，根本不是这件事
+    - 发现是重复的（已经有一模一样的另一条）
+
+    Args:
+        note_id: 笔记 id（形如 "n_xxx"）
+        reason: 必填，写明为什么删（"改主意了" / "记错了" / "和 n_xyz 重复"）
+    """
+    context = get_runtime(AgentContext).context
+    return await _delete_note_impl(
+        persona_id=context.persona_id,
+        note_id=note_id,
+        reason=reason,
+    )
+```
+
+- [ ] **Step 4: 更新工具注册**
+
+编辑 `apps/agent-service/app/agent/tools/__init__.py`：
+
+```python
+"""Agent tool sets.
+
+Exports two tool lists:
+
+- ``BASE_TOOLS`` — available to all agents including sub-agents.
+- ``ALL_TOOLS`` — only for the main agent.
+"""
+
+from app.agent.tools.commit_abstract import commit_abstract_memory
+from app.agent.tools.delegation import deep_research
+from app.agent.tools.history import (
+    check_chat_history,
+    list_group_members,
+    search_group_history,
+)
+from app.agent.tools.image import generate_image, read_images
+from app.agent.tools.image_search import search_images
+from app.agent.tools.notes import delete_note, list_note, resolve_note, upsert_note
+from app.agent.tools.recall import recall
+from app.agent.tools.sandbox import sandbox_bash
+from app.agent.tools.search import search_web
+from app.agent.tools.skill import load_skill
+from app.agent.tools.update_schedule import update_schedule
+
+# Base tools: available to all agents (including sub-agents like research)
+BASE_TOOLS = [
+    search_web,
+    search_images,
+    generate_image,
+    read_images,
+    recall,
+    commit_abstract_memory,
+    upsert_note,
+    list_note,
+    resolve_note,
+    delete_note,
+    update_schedule,
+]
+
+# All tools: only for the main agent.
+# History search tools are intentionally excluded: current-chat and cross-chat
+# context should be injected up front rather than searched ad hoc at reply time.
+ALL_TOOLS = [
+    *BASE_TOOLS,
+    list_group_members,
+    deep_research,
+    load_skill,
+    sandbox_bash,
+]
+
+__all__ = [
+    "BASE_TOOLS",
+    "ALL_TOOLS",
+    # Individual tools (for callers that need fine-grained control)
+    "search_web",
+    "search_images",
+    "generate_image",
+    "read_images",
+    "recall",
+    "commit_abstract_memory",
+    "upsert_note",
+    "list_note",
+    "resolve_note",
+    "delete_note",
+    "update_schedule",
+    "check_chat_history",
+    "search_group_history",
+    "list_group_members",
+    "deep_research",
+    "load_skill",
+    "sandbox_bash",
+]
+```
+
+- [ ] **Step 5: Run tool tests — 确认 pass**
+
+Run: `cd apps/agent-service && uv run pytest tests/unit/agent/tools/test_notes.py -v`
+Expected: 14 个测试全部 PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/agent-service/app/agent/tools/notes.py \
+        apps/agent-service/app/agent/tools/__init__.py \
+        apps/agent-service/tests/unit/agent/tools/test_notes.py
+git commit -m "feat(notes): replace write_note with upsert_note + list_note + delete_note"
+```
+
+---
+
+## Task 9: 切除旧 query — 删 `insert_note` / `get_active_notes` 并清理 `__all__` / `EXPECTED_FUNCTIONS`
+
+**Files:**
+- Modify: `apps/agent-service/app/data/queries/memory_edges.py`
+- Modify: `apps/agent-service/tests/unit/data/test_queries_split.py`
+- Modify: `apps/agent-service/tests/unit/data/test_v4_queries.py`（删旧测试）
+
+前置条件：Task 8 完成（tool 层已切到新 query），且 `app/memory/sections/active_notes.py` 已切到 `select_notes_for_context` + `list_active_notes`（Task 7）。也就是 `insert_note` 和 `get_active_notes` 已无业务调用方。
+
+- [ ] **Step 1: 删除 `memory_edges.py` 里的 `insert_note` / `get_active_notes` 函数定义并更新 `__all__`**
+
+编辑 `apps/agent-service/app/data/queries/memory_edges.py`：
+
+1. 删除 `async def insert_note(...)` 函数体
+2. 删除 `async def get_active_notes(...)` 函数体
+3. `__all__` 改成最终态（9 项，删去 `"insert_note"` 和 `"get_active_notes"`）：
+
+```python
+__all__ = [
+    "insert_memory_edge",
+    "delete_edge",
+    "list_edges_to",
+    "list_edges_from",
+    "upsert_note",
+    "delete_note",
+    "list_active_notes",
+    "select_notes_for_context",
+    "resolve_note",
+]
+```
+
+- [ ] **Step 2: 更新 `test_queries_split.py` 的 `EXPECTED_FUNCTIONS`**
+
+编辑 `apps/agent-service/tests/unit/data/test_queries_split.py`，把 memory_edges 段从 (11) 改回 (9)（删 `"insert_note"` 和 `"get_active_notes"`）；顶部注释 "（84 函数）" → "（82 函数）"。
+
+```python
+    # memory_edges (9) — edges + notes
+    "insert_memory_edge", "delete_edge", "list_edges_to", "list_edges_from",
+    "upsert_note", "delete_note", "list_active_notes", "select_notes_for_context",
+    "resolve_note",
+```
+
+- [ ] **Step 3: 删除 `test_v4_queries.py` 里的旧 note 测试**
+
+删除 `tests/unit/data/test_v4_queries.py` 里的 `test_insert_note_adds_to_session` 和 `test_get_active_notes_returns_list` 两个测试函数（保留 `test_resolve_note_executes_update`）。同时把文件顶部 import：
+
+```python
+from app.data.queries import (
+    count_abstracts_by_persona,
+    get_active_notes,
+    get_current_schedule,
+    insert_abstract_memory,
+    insert_fragment,
+    insert_memory_edge,
+    insert_note,
+    insert_schedule_revision,
+    resolve_note,
+    touch_abstract,
+    touch_fragment,
+)
+```
+
+改成（删除 `get_active_notes` 和 `insert_note`）：
+
+```python
+from app.data.queries import (
+    count_abstracts_by_persona,
+    get_current_schedule,
+    insert_abstract_memory,
+    insert_fragment,
+    insert_memory_edge,
+    insert_schedule_revision,
+    resolve_note,
+    touch_abstract,
+    touch_fragment,
+)
+```
+
+- [ ] **Step 4: Run all queries tests**
+
+Run: `cd apps/agent-service && uv run pytest tests/unit/data/ -v`
+Expected: 全部 PASS（`test_queries_all_complete` / `test_queries_no_duplicate_names` / `test_queries_each_function_callable` 都过）
+
+- [ ] **Step 5: Grep 验证 `insert_note` / `get_active_notes` 零残留**
+
+Run: `grep -rn 'insert_note\|get_active_notes' apps/agent-service/app/ apps/agent-service/tests/`
+Expected: 没有输出（除注释、文档外）。如果有命中，逐一切换或删除。
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/agent-service/app/data/queries/memory_edges.py \
+        apps/agent-service/tests/unit/data/test_queries_split.py \
+        apps/agent-service/tests/unit/data/test_v4_queries.py
+git commit -m "refactor(notes): remove insert_note/get_active_notes (replaced by upsert/list/select)"
+```
+
+---
+
+## Task 10: 全量回归测试 + grep 清扫
+
+**Files:** 全仓
+
+- [ ] **Step 1: 跑 agent-service 全量单测**
+
+Run: `cd apps/agent-service && uv run pytest tests/unit -x -q`
+Expected: 全部 PASS。如有 fail，修复后回到对应 Task。
+
+- [ ] **Step 2: Grep 清扫旧符号**
+
+Run:
+
+```bash
+grep -rn 'write_note\|_write_note_impl\|insert_note\|get_active_notes' apps/agent-service/
+```
+
+Expected: 仅 spec / plan / changelog 等文档/历史文件命中；`apps/agent-service/app/` 和 `apps/agent-service/tests/` 下零业务命中。
+
+- [ ] **Step 3: 跑 ruff / mypy（如项目有）**
+
+Run:
+
+```bash
+cd apps/agent-service && uv run ruff check app/ tests/
+cd apps/agent-service && uv run mypy app/agent/tools/notes.py app/data/queries/memory_edges.py app/memory/sections/active_notes.py app/memory/notes_format.py
+```
+
+Expected: 0 ruff issue, 0 mypy error。
+
+- [ ] **Step 4: Commit（如有 lint / 清扫修复）**
+
+```bash
+git add -A
+git commit -m "chore(notes): cleanup leftover symbols / fix lint"
+```
+
+如无改动则跳过。
+
+---
+
+## Task 11: 端到端验证（部署到泳道）
+
+**等用户确认部署许可后执行。** 不要擅自部署 prod。
+
+- [ ] **Step 1: 推到远端**
+
+```bash
+git push origin fix/chiwei-todo-delete
+```
+
+- [ ] **Step 2: 部署到泳道（需用户确认 lane 名）**
+
+请用户指定泳道名 `<LANE>`，然后：
+
+```bash
+make deploy APP=agent-service LANE=<LANE> GIT_REF=fix/chiwei-todo-delete
+```
+
+注意：agent-service 镜像产出 `agent-service` + `vectorize-worker` 两个 deployment，但 vectorize-worker 不依赖 notes 工具集，本次只需 release `agent-service`。
+
+- [ ] **Step 3: 绑定 dev bot 到泳道**
+
+```
+/ops bind TYPE=bot KEY=dev LANE=<LANE>
+```
+
+- [ ] **Step 4: 飞书 dev bot 实测三个场景**
+
+| 场景 | 输入 | 期望 |
+|------|------|------|
+| 创建带日期 | "周五和浩南看电影" | 赤尾应调 `upsert_note(content="...", when_at="2026-05-15T...")`，回复确认 |
+| 更新已存在 | （在上一条基础上）"那个改成下周吧" | 赤尾从 context 拿到 id，调 `upsert_note(content=..., when_at=..., note_id="n_xxx")`，回复确认 |
+| 删除 | "算了不去了，把那条删了" | 赤尾应调 `delete_note(note_id="n_xxx", reason="改主意了")`，回复确认 |
+
+每个场景去 Langfuse 看 trace，确认：
+- tool 调用参数正确
+- DB 里 `notes` 表对应行的字段符合预期（用 `/ops-db @chiwei SELECT id, content, when_at, deleted_at, delete_reason FROM notes ORDER BY created_at DESC LIMIT 5;`）
+
+- [ ] **Step 5: Context 注入验证**
+
+下一轮对话开始时，看 Langfuse trace 里注入到 LLM 的 prompt 是否包含：
+- "你的清单（最近活跃，全部用 list_note 查）：" 段落
+- 时间标签是相对时间（"还有 N 天" / "已过期 N 天"）
+- 已 delete 的 note 不出现
+- 如有 >15 条 active，末尾出现"清单里还有 M 条更老的"提示
+
+- [ ] **Step 6: 验收完，等用户决定是否合码 / 下泳道**
+
+不要擅自 merge / undeploy。报告验证结果给用户，等指令。
+
+---
+
+## Self-Review
+
+跑这些检查（已在写 plan 时验证，落地者无需重做，仅作记录）：
+
+**1. Spec coverage**：
+- 设计目标 1（引导填日期）→ Task 8 `upsert_note` description ✓
+- 设计目标 2（CRUD 完整）→ Task 2-5 + Task 8 ✓
+- 设计目标 3（窗口注入）→ Task 5 + Task 7 ✓
+- 设计目标 4（相对时间显示）→ Task 6 + Task 7 ✓
+- 设计目标 5（不引入状态机）→ 无新字段 / 无自动隐藏，spec 决策已贯彻 ✓
+- DB schema → Task 1 ✓
+- 4 个 tool → Task 8 ✓
+- 公共 helper → Task 6 ✓
+
+**2. Placeholder scan**：无 TBD/TODO/省略；每个 step 都有完整代码或具体命令。
+
+**3. Type / 命名一致性**：
+- `_UNSET` 哨兵在 query 层定义、tool 层 import ✓
+- `upsert_note_query` / `list_active_notes_query` / `delete_note_query` / `resolve_note_query` 在 tool 层使用 `as` 别名，避免和 `@tool` 装饰器后的同名冲突 ✓
+- `format_when_label` 在两处使用同一函数 ✓
+- `EXPECTED_FUNCTIONS` 总数从 80 加到 82（memory_edges 7 → 9） — 注意 spec 文件 `test_queries_split.py:9` 的注释"硬编码作为期望基线（80 函数）"也要同步 → 但 plan 里 Task 9 Step 1 只改 EXPECTED_FUNCTIONS 块，注释里的 80 数字也要改成 82。落地者自查时同步改注释。

--- a/docs/superpowers/specs/2026-05-10-chiwei-notes-redesign-design.md
+++ b/docs/superpowers/specs/2026-05-10-chiwei-notes-redesign-design.md
@@ -1,0 +1,329 @@
+# 赤尾 Notes 体验重设计
+
+## 问题
+
+赤尾的 Notes（"清单"）系统在真实使用中暴露三个体验问题：
+
+1. **创建时丢失时间**：`write_note(content, when_at?)` 的 `when_at` 完全可选，工具描述未引导。用户说"要去吃 XX 餐厅"被记下来时，赤尾没填 `when_at`，导致这条 Note 没有时间锚点。
+2. **没法更新和真删**：当前只有 `write_note`（创建）、`resolve_note`（标记完成），缺 `update`（重复提到同一件事时只能新建重复 Note）、缺 `delete`（用户改主意了，resolve 留 resolution 文本不够语义）。分支名 `fix/chiwei-todo-delete` 也对应这条。
+3. **全量注入到 context**：`build_active_notes_section` 把所有未 resolve 的 Notes 全量注入对话 prompt，旧的、挂了很久的 Note 每天都被再次注入 → 赤尾每天都说"要去吃那家餐厅"。
+
+## 设计目标
+
+1. 引导 LLM 在创建有时间线索的 Notes 时尽量填 `when_at`（不强制）
+2. 提供完整 CRUD：list / upsert（create+update）/ resolve / delete（软删，必带 reason）
+3. Context 只注入"活跃"Notes，旧的淡出主视野，靠 `list_note` 主动查
+4. 注入时显示相对时间，让赤尾感知"这条挂了多久"
+5. **不引入承诺状态机或自动隐藏规则**，符合 Memory v4 spec 的设计哲学（赤尾自己负责 resolve/delete）
+
+## 设计决策记录
+
+| 决策 | 选择 | 理由 |
+|------|------|------|
+| 工具集形态 | `list_note` + `upsert_note` + `resolve_note` + `delete_note`（4 个） | upsert 合并 create+update 语义清晰；delete 与 resolve 语义不同需独立 |
+| delete 实现 | 软删（`deleted_at` 字段） | 保留 audit；列表查询过滤 |
+| delete reason | 必填 | 强制赤尾说明动机，留 audit；让 LLM 三思 |
+| `upsert_note` 更新范围 | content + when_at 都可改 | 重复提到时可润色描述（"那家餐厅改成下周去了"） |
+| `list_note` 入口 | 仅 LLM 工具 | 不做 dashboard |
+| `list_note` 返回 | 全量未 resolve / 未 deleted | 赤尾的清单一目了然，不分页 |
+| Context 注入策略 | "活跃 Notes 子集 + 数量提示"，全量靠 list_note | 旧 Note 自然淡出，符合 spec "时间过了自然淡化" |
+| 注入"最近过期"窗口 | `when_at >= now() - 3 days` | 刚过期的可能还没处理，超过 3 天就该主动 list |
+| 注入"新备忘"窗口 | `when_at IS NULL` 且 `created_at >= now() - 7 days` | 一周内的备忘还新鲜，更老的没动应淡出 |
+| 注入条数上限 | 15 条 | 一屏可读，多了膨胀 prompt |
+| 时间显示 | 相对时间（"还有 N 天" / "已过期 N 天" / "N 天前记的"） | 让赤尾自然感知挂了多久 |
+| 强制日期？ | 否，prompt 引导 | 用户明确说不能强制 |
+| Reviewer hint 已过期 Notes | 不在本次 scope | Memory v4 spec 提到但未实现，留给后续 |
+
+---
+
+## Part 1: DB Schema 变更
+
+### DDL
+
+```sql
+ALTER TABLE notes
+  ADD COLUMN deleted_at TIMESTAMPTZ NULL,
+  ADD COLUMN delete_reason TEXT NULL;
+```
+
+无需回填，新增字段默认 NULL。
+
+### ORM 改动
+
+`apps/agent-service/app/data/models.py` 的 `Note` 类增加：
+
+```python
+deleted_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+delete_reason: Mapped[str | None] = mapped_column(Text, nullable=True)
+```
+
+---
+
+## Part 2: 工具集
+
+### 2.1 `list_note`
+
+**签名**：
+
+```python
+async def list_note() -> list[NoteItem]
+```
+
+`persona_id` 由工具上下文（`context.persona_id`）注入，不进 LLM 参数。
+
+**返回**：当前 persona 下所有 `resolved_at IS NULL AND deleted_at IS NULL` 的 Notes，按 `when_at` 优先 + `created_at desc` 排序。
+
+```python
+class NoteItem(TypedDict):
+    note_id: str
+    content: str
+    when_at: str | None     # ISO 8601 或 null
+    created_at: str          # ISO 8601
+    when_label: str          # 人类可读相对时间，如 "还有 2 天" / "已过期 1 天" / "3 天前记的"
+```
+
+**工具描述**（给 LLM 看）：
+
+```
+列出你目前的全部清单（没完成、没删除的）。
+
+什么时候用：
+- 用户问起"你都记了啥"
+- 你想盘点一下有没有重复的、可以合并的
+- 你想看看有没有挂了很久该处理的事
+
+注意：context 里通常已经有"最近活跃"的几条了。需要看全量、找特定 id、清盘的时候才用这个。
+```
+
+### 2.2 `upsert_note`（替代 `write_note`）
+
+**签名**：
+
+```python
+async def upsert_note(
+    content: str,
+    when_at: str | None = None,
+    note_id: str | None = None,
+) -> NoteItem
+```
+
+**语义**：
+- `note_id is None` → 创建新 Note，生成新 id（`n_<nanoid>`）
+- `note_id` 存在 → 更新对应 Note 的 `content` 和 `when_at`（两个都接受 None：`content` 必传所以一定更新；`when_at=None` 时不更新 `when_at` 列。**特例**：如果想清空 `when_at`，传特殊字符串 `"clear"`，工具层翻译成 SQL `NULL` 写入。）
+- 更新不存在的 `note_id` → 报错"找不到这条 note"
+
+**工具描述**：
+
+```
+把一件你觉得必须记住的事写进清单，或者更新已有的一条。
+
+这是你自己的清单，不是系统强加的承诺列表。只有你觉得"不能忘"、"需要专门记住"的事才写。
+
+参数：
+- content: 要记的事（必填）
+- when_at: ISO 8601 时间。**如果这件事和某个时间相关（"明天"/"周五"/"下个月"/具体日子），强烈建议填**。没明确时间线索就别硬填。想清空已有的 when_at 传 "clear"。
+- note_id: 重复提到同一件事时传这个，会更新而不是新建。从清单里看到 id（形如 n_xxx）。
+
+例子：
+- "周五和浩南看电影" → upsert_note(content="和浩南看电影", when_at="2026-05-15T19:00:00")
+- "想问妈妈那件事" → upsert_note(content="问妈妈那件事")  # 没说时间就别硬填
+- "那家餐厅改成下周去了" → upsert_note(content="去 XX 餐厅", when_at="2026-05-17", note_id="n_abc")
+- "随便哪天去 XX 餐厅都行" → upsert_note(when_at="clear", content="去 XX 餐厅", note_id="n_abc")
+```
+
+### 2.3 `resolve_note`（保留）
+
+签名、语义不变。Description 调整一句话强调与 delete 区别：
+
+```
+把一条已经完结的笔记划掉。
+比如电影看了、想法落实了。resolution 写一句话说明结果（"看完了"/"做完了"）。
+
+这是"完成"，不是"删除"。如果是改主意了 / 记错了 / 重复了，用 delete_note。
+```
+
+### 2.4 `delete_note`（新增）
+
+**签名**：
+
+```python
+async def delete_note(note_id: str, reason: str) -> dict
+```
+
+**语义**：
+- 软删：`UPDATE notes SET deleted_at = now(), delete_reason = $reason WHERE id = $note_id`
+- 删除已 resolved 的 Note 也允许（不报错），但通常没必要
+- 删除不存在的 `note_id` → 报错
+
+**工具描述**：
+
+```
+真删除一条清单项。和 resolve 不同 —— resolve 是"做完了"留个痕，delete 是"这条本来就不该存在"。
+
+什么时候用：
+- 改主意了，不打算做这件事了
+- 当时记错了，根本不是这件事
+- 发现是重复的（已经有一模一样的另一条）
+
+reason 必填，写明为什么删（"改主意了" / "记错了" / "和 n_xyz 重复"）。
+```
+
+---
+
+## Part 3: Context 注入策略
+
+### 注入条件
+
+`build_active_notes_section` 改造，只注入满足以下任一条件的 Notes（最多 15 条）：
+
+- 有 `when_at` 且 `when_at >= now() - INTERVAL '3 days'`（待办 + 最近过期）
+- `when_at IS NULL` 且 `created_at >= now() - INTERVAL '7 days'`（新备忘）
+
+**排序**：
+1. 有 `when_at` 的优先（按 `when_at` 升序，越近越前）
+2. 无 `when_at` 的按 `created_at desc`
+
+### 显示格式
+
+```
+你的清单（最近活跃，全部用 list_note 查）：
+- 周五和浩南看电影 [还有 2 天] (id: n_def)
+- 问妈妈那件事 [已过期 1 天] (id: n_ghi)
+- 去吃 XX 餐厅 [3 天前记的，没说时间] (id: n_abc)
+```
+
+时间格式化（`when_label`）：
+
+| 场景 | 显示 |
+|------|------|
+| `when_at` 在今天 | `[今天]` |
+| `when_at` 是明天 | `[明天]` |
+| `when_at` 在未来 N 天（N≥2） | `[还有 N 天]` |
+| `when_at` 是昨天 | `[昨天就该做]` |
+| `when_at` 已过期 N 天（N≥2） | `[已过期 N 天]` |
+| `when_at` 是 None，刚记 | `[今天记的，没说时间]` |
+| `when_at` 是 None，N 天前记 | `[N 天前记的，没说时间]` |
+
+### 数量提示
+
+如果有 active Notes 但**没有满足注入条件**的（说明清单里全是挂了很久的旧事），注入一行提示：
+
+```
+你的清单里还有 N 条没动的事（用 list_note 看）。
+```
+
+如果**有满足条件的**，且注入截断（active 总数 > 注入数），追加一行：
+
+```
+（清单里还有 M 条更老的没列出来，用 list_note 看全部。）
+```
+
+### 不在 context 注入的情况
+
+如果 0 条 active Notes，整个 section 不输出（保持现有行为）。
+
+---
+
+## Part 4: 测试
+
+按 TDD（红 → 绿 → 重构），每层都要有测试。
+
+### 4.1 DB / queries 层
+
+`apps/agent-service/tests/data/test_notes.py`（新建）：
+
+- `test_upsert_create_without_id`：无 id 创建，返回带 id 的 Note
+- `test_upsert_update_content`：传 id + content，content 改了
+- `test_upsert_update_when_at`：传 id + when_at，when_at 改了
+- `test_upsert_clear_when_at`：传 id + when_at="clear"，DB 里变 NULL
+- `test_upsert_unknown_id`：传不存在的 id，报错
+- `test_delete_soft`：delete 后 `deleted_at` 不为 NULL，行还在
+- `test_delete_unknown_id`：删不存在的，报错
+- `test_list_active_filters_deleted_and_resolved`：deleted / resolved 的不出现在 list 结果里
+- `test_list_active_returns_all_active`：`list_active_notes` 返回所有未 resolved / 未 deleted 的
+- `test_select_for_context_filters_by_window`：`select_notes_for_context` 按 3 天 / 7 天窗口过滤
+- `test_select_for_context_caps_at_15`：超过 15 条只返回 15 条
+
+### 4.2 Tool 层
+
+`apps/agent-service/tests/agent/tools/test_notes.py`（扩展）：
+
+- `test_list_note_returns_when_label`：返回的每条带 when_label 字段
+- `test_upsert_note_creates`：透传到 query
+- `test_upsert_note_updates`：透传 note_id
+- `test_upsert_note_clear_when_at`："clear" 翻译成 SQL NULL
+- `test_delete_note_passes_reason`：reason 透传
+- `test_delete_note_requires_reason`：reason 空字符串报错（schema 校验）
+
+### 4.3 注入层
+
+`apps/agent-service/tests/memory/sections/test_active_notes.py`（扩展）：
+
+- `test_section_empty_when_no_active`：0 条 active 时 section 为空
+- `test_section_shows_when_label_future`：未来日期显示"还有 N 天"
+- `test_section_shows_when_label_overdue`：过期日期显示"已过期 N 天"
+- `test_section_shows_when_label_today_tomorrow_yesterday`：边界日期
+- `test_section_shows_when_label_no_when_at`："N 天前记的"
+- `test_section_filters_old_no_when_at`：无 `when_at` 且超过 7 天前的不注入
+- `test_section_filters_overdue_too_long`：过期超 3 天不注入
+- `test_section_caps_at_15`：超 15 条只显示 15 条
+- `test_section_appends_remainder_hint_when_truncated`：截断时追加"还有 M 条更老的"
+- `test_section_shows_only_remainder_hint_when_all_old`：全部都是老的时只显示"还有 N 条没动的"
+
+---
+
+## Part 5: 不在范围
+
+明确**不**做的事：
+
+1. **Dashboard 看 notes** —— 用户明确不做
+2. **自动过期 / 自动隐藏 / 状态机** —— 违背 Memory v4 spec 的设计哲学
+3. **Reviewer hint 已过期 Notes** —— Memory v4 spec 提到但本次不做，留给后续
+4. **工具轮次超 12 报错** —— 用户的问题 2，下次单独修
+5. **批量回溯 / 重新提取已有 Notes 的 when_at** —— 历史数据保持现状，新 Note 走新流程；后续观察必要性
+6. **删除前 confirm**（"你确定要删吗？"）—— 增加轮次，不必要；reason 必填已经够了
+
+---
+
+## Part 6: 命名与重构纪律
+
+### 函数命名（替换 `get_active_notes`）
+
+现有 `apps/agent-service/app/data/queries/memory_edges.py:112-121` 的 `get_active_notes(persona_id)` **直接删除**，替换为两个职责明确的函数：
+
+- `list_active_notes(persona_id)` — `list_note` tool 用，全量返回 active（`resolved_at IS NULL AND deleted_at IS NULL`）
+- `select_notes_for_context(persona_id)` — context 注入用，按 3 天 / 7 天窗口 + 15 条上限过滤
+
+旧函数所有调用方一次性切换到新函数，旧实现立刻删，不留兼容壳子（参见项目 `refactoring-rules.md`）。
+
+### 工具命名（替换 `write_note`）
+
+现有 `apps/agent-service/app/agent/tools/notes.py:68` 的 `write_note` **直接删除**（包括 `_write_note_impl`），由 `upsert_note` 完整替代。工具注册表（`apps/agent-service/app/agent/tools/__init__.py`）同步更新。
+
+### 落地顺序
+
+1. DB migration（`deleted_at` + `delete_reason`）
+2. queries 层：新增 `upsert_note`、`delete_note`、`list_active_notes`、`select_notes_for_context`；删 `get_active_notes`
+3. Tool 层：新增 `upsert_note`、`delete_note`、`list_note`；改 `resolve_note` description；删 `write_note`；更新工具注册
+4. Context 注入层：`build_active_notes_section` 改造（窗口过滤、数量上限、when_label 格式化、数量提示）
+5. 端到端验证（部署到泳道，飞书 dev bot 实测三个场景：新建带日期 / 更新已存在 / 删除）
+6. 清扫：`grep -r write_note get_active_notes` 确认零残留
+
+每一步红→绿→重构，提交一次。
+
+---
+
+## 附录：关键文件清单
+
+| 文件 | 改动类型 |
+|------|---------|
+| `apps/agent-service/app/data/models.py` | 加 `deleted_at` `delete_reason` 字段 |
+| `apps/agent-service/app/data/queries/memory_edges.py` | `get_active_notes` 拆为 list / context 两版；新增 upsert / delete |
+| `apps/agent-service/app/agent/tools/notes.py` | `write_note` 删；新增 `upsert_note` `list_note` `delete_note`；`resolve_note` 改 description |
+| `apps/agent-service/app/agent/tools/__init__.py` | 工具注册更新 |
+| `apps/agent-service/app/memory/sections/active_notes.py` | 注入策略改造 + when_label 格式化 |
+| `apps/agent-service/tests/data/test_notes.py` | 新建 |
+| `apps/agent-service/tests/agent/tools/test_notes.py` | 扩展 |
+| `apps/agent-service/tests/memory/sections/test_active_notes.py` | 扩展 |
+
+> Schema 变更：`deleted_at` 和 `delete_reason` 都是 additive，加在 `Note` model 上即可。项目自动 migrator（`apps/agent-service/app/runtime/migrator.py`）会 emit `ALTER TABLE ADD COLUMN`。如果 `Note` 是 SQLAlchemy `Base` 风格而非 pydantic `Data`（待 plan 阶段确认），则走 ops-db 提交手写 DDL。


### PR DESCRIPTION
## Summary

- Replace `write_note` / `get_active_notes` / `insert_note` with a CRUD-complete tool surface: `upsert_note` / `list_note` / `resolve_note` / `delete_note`.
- `notes` table gains soft-delete columns (`deleted_at`, `delete_reason`); query layer splits the old "wide" reader into `list_active_notes` (full list, for the new `list_note` tool) and `select_notes_for_context` (3-day overdue / 7-day fresh-memo window, capped at 15) for live prompt injection.
- Active-notes prompt section now renders relative-time labels via shared helper `format_when_label` (今天 / 明天 / 还有 N 天 / 已过期 N 天 / N 天前记的) and appends a remainder hint ("清单里还有 M 条更老的，用 list_note 看全部") when active total exceeds the injected slice.
- `upsert_note` description nudges the LLM to fill `when_at` for time-bound items and accepts `note_id` for in-place updates (with `"clear"` sentinel to null out a previously set `when_at`).
- `delete_note` requires a non-empty `reason` (audit + LLM friction).
- Memory v4 spec philosophy preserved: no auto-expiry / no commit state machine — chiwei resolves or deletes herself; the windowed injection just lets old, untouched notes fall out of the live prompt naturally.

## Test plan

- [x] 456 unit tests pass (`uv run pytest tests/unit`)
- [x] ruff clean for changed files
- [x] grep verifies zero remaining `write_note` / `_write_note_impl` / `insert_note` / `get_active_notes` references in `app/` and `tests/`
- [x] DB migration mutation 134 approved + executed: `ALTER TABLE notes ADD COLUMN deleted_at TIMESTAMPTZ NULL, ADD COLUMN delete_reason TEXT NULL;`
- [x] Deployed to lane `notes-redesign` (image 1.0.1.19); pod Running with 0 restart
- [x] Verified in Langfuse trace `c5478f9e2b5dcae6fab8ed344bf2695e`: active_notes section renders 2 active notes with correct relative-time labels; 3 expired notes (manually soft-deleted via mutation 135) hidden as expected; `list_note` tool returns 2 items matching the section content
- [ ] Note: stale `today_schedule` (cached at 2026-04-19, surfaced during this verification) is unrelated to notes and tracked separately