### PR TITLE
feat(agent-service): govern framework source loops

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,9 @@
+# Framework/runtime changes should always get an explicit owner review.
+/apps/agent-service/app/runtime/ @bezhai
+/apps/agent-service/app/wiring/ @bezhai
+/apps/agent-service/app/deployment.py @bezhai
+/apps/agent-service/app/main.py @bezhai
+/apps/agent-service/app/workers/runtime_entry.py @bezhai
+/docs/governance/ @bezhai
+/docs/guides/dataflow-* @bezhai
+/.github/workflows/ @bezhai

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,15 @@
+## Summary
+
+
+## Validation
+
+
+## Framework Layer
+
+Framework-Layer-Spec:
+
+- [ ] This PR does not change the agent-service framework layer.
+- [ ] This PR changes the framework layer and cites the spec above.
+
+Framework layer means `apps/agent-service/app/runtime/**`, wiring,
+deployment bindings, runtime entrypoints, framework docs, or CI gates.

--- a/.github/workflows/framework-governance.yml
+++ b/.github/workflows/framework-governance.yml
@@ -1,0 +1,42 @@
+name: framework governance gate
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  require-framework-spec:
+    name: Require spec for framework-layer changes
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Check PR body
+        shell: bash
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          set -euo pipefail
+
+          changed="$(git diff --name-only "$BASE_SHA" "$HEAD_SHA")"
+          framework_changed="$(printf '%s\n' "$changed" | grep -E '^(apps/agent-service/app/runtime/|apps/agent-service/app/wiring/|apps/agent-service/app/deployment\.py|apps/agent-service/app/main\.py|apps/agent-service/app/workers/runtime_entry\.py|docs/governance/|docs/guides/dataflow-|\.github/workflows/)' || true)"
+
+          if [ -z "$framework_changed" ]; then
+            echo "No framework-layer files changed."
+            exit 0
+          fi
+
+          echo "Framework-layer files changed:"
+          printf '%s\n' "$framework_changed"
+
+          if printf '%s\n' "$PR_BODY" | grep -Eq 'Framework-Layer-Spec:[[:space:]]+docs/[^[:space:]]+\.md'; then
+            echo "Framework-Layer-Spec found."
+            exit 0
+          fi
+
+          echo "Framework-layer changes require a PR body line like:"
+          echo "Framework-Layer-Spec: docs/plan/example.md"
+          exit 1

--- a/.github/workflows/grep-gate.yml
+++ b/.github/workflows/grep-gate.yml
@@ -54,7 +54,7 @@ jobs:
           c=$(grep -rn 'headers\["trace_id"\]\|headers\["lane"\]' apps/agent-service/app/ \
               2>/dev/null | grep -v "runtime/propagation.py\|__pycache__\|/test_" | wc -l)
           [ "$c" -eq 0 ] || { echo "Gap 11 violation: $c raw header reads"; exit 1; }
-      - name: Gap 8 — business `await emit(` count == 14 (12 category-B + 2 docstring)
+      - name: Gap 8 — business `await emit(` count == 10 reviewed call sites
         shell: bash
         run: |
           set -e
@@ -67,7 +67,7 @@ jobs:
               apps/agent-service/app/chat/ apps/agent-service/app/life/ \
               apps/agent-service/app/memory/ \
               --include='*.py' 2>/dev/null | wc -l)
-          [ "$c" -eq 14 ] || { echo "Gap 8 violation: business await emit count=$c, expected 14"; exit 1; }
+          [ "$c" -eq 10 ] || { echo "Gap 8 violation: business await emit count=$c, expected 10"; exit 1; }
       - name: Gap 15 — no arq imports, no arq dependency
         shell: bash
         run: |

--- a/apps/agent-service/app/memory/vectorize_memory.py
+++ b/apps/agent-service/app/memory/vectorize_memory.py
@@ -5,11 +5,10 @@ The dataflow ``vectorize_memory_fragment`` / ``vectorize_memory_abstract``
 runtime decodes an incoming MQ frame from
 ``Source.mq("memory_fragment_vectorize")`` / ``Source.mq("memory_abstract_vectorize")``.
 
-Publisher-side enqueue is now uniform: callers do
-``await emit(MemoryFragmentRequest(fragment_id=fid))`` /
-``await emit(MemoryAbstractRequest(abstract_id=aid))`` — runtime emit()
-auto-publishes to the right queue when the consumer is in another process
-(see app/runtime/emit.py:_mq_publish_for_source).
+Publisher-side enqueue is now uniform: callers emit MemoryFragmentRequest /
+MemoryAbstractRequest Data; runtime emit auto-publishes to the right queue
+when the consumer is in another process (see
+app/runtime/emit.py:_mq_publish_for_source).
 
 Qdrant point ids must be uint or UUID, so we use a deterministic ``uuid5``
 derived from the prefixed DB id (``f_xxx`` / ``a_xxx``) and stash the original

--- a/apps/agent-service/app/nodes/life_dataflow.py
+++ b/apps/agent-service/app/nodes/life_dataflow.py
@@ -73,14 +73,14 @@ async def _persona_dicts() -> list[dict]:
 
 
 @node
-async def fan_out_life_tick(t: MinuteTick) -> None:
+async def fan_out_life_tick(t: MinuteTick) -> LifeTickRequest | None:
     if not _is_prod():
         return
-    await emit(LifeTickRequest(ts=t.ts))
+    return LifeTickRequest(ts=t.ts)
 
 
 @node
-async def fan_out_voice(t: MinuteTick) -> None:
+async def fan_out_voice(t: MinuteTick) -> VoiceRequest | None:
     if not _is_prod():
         return
     cst_ts = datetime.fromisoformat(t.ts).astimezone(CST)
@@ -88,28 +88,28 @@ async def fan_out_voice(t: MinuteTick) -> None:
         return
     if cst_ts.minute != 0:
         return  # voice 整点触发
-    await emit(VoiceRequest(ts=t.ts))
+    return VoiceRequest(ts=t.ts)
 
 
 @node
-async def fan_out_light_day(t: LightDayTick) -> None:
+async def fan_out_light_day(t: LightDayTick) -> LightReviewRequest | None:
     if not _is_prod():
         return
-    await emit(LightReviewRequest(ts=t.ts, window_minutes=30))
+    return LightReviewRequest(ts=t.ts, window_minutes=30)
 
 
 @node
-async def fan_out_light_night(t: LightNightTick) -> None:
+async def fan_out_light_night(t: LightNightTick) -> LightReviewRequest | None:
     if not _is_prod():
         return
-    await emit(LightReviewRequest(ts=t.ts, window_minutes=60))
+    return LightReviewRequest(ts=t.ts, window_minutes=60)
 
 
 @node
-async def fan_out_heavy(t: HeavyReviewTick) -> None:
+async def fan_out_heavy(t: HeavyReviewTick) -> HeavyReviewRequest | None:
     if not _is_prod():
         return
-    await emit(HeavyReviewRequest(ts=t.ts))
+    return HeavyReviewRequest(ts=t.ts)
 
 
 # ---------------------------------------------------------------------------
@@ -133,13 +133,13 @@ async def run_shared_daily_pipeline_node(t: DailyPlanTick) -> SharedDailyContext
 
 
 @node
-async def fan_out_daily_plan(c: SharedDailyContext) -> None:
-    await emit(DailyPlanRequest(
+async def fan_out_daily_plan(c: SharedDailyContext) -> DailyPlanRequest:
+    return DailyPlanRequest(
         target_date=c.target_date,
         wild_materials=c.wild_materials,
         search_anchors=c.search_anchors,
         theater=c.theater,
-    ))
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -218,12 +218,12 @@ def _new_glimpse_request(persona_id: str, chat_id: str, ts: str, kind: str) -> G
 
 
 @node
-async def fan_out_glimpse(t: GlimpseTick) -> None:
+async def fan_out_glimpse(t: GlimpseTick) -> GlimpseTickRequest | None:
     """5min cron → emit GlimpseTickRequest template; the wire's
     ``.fan_out_per(_persona_dicts)`` fans it into per-persona copies."""
     if not _is_prod():
         return
-    await emit(GlimpseTickRequest(ts=t.ts))
+    return GlimpseTickRequest(ts=t.ts)
 
 
 @node

--- a/apps/agent-service/app/nodes/memory_pipelines.py
+++ b/apps/agent-service/app/nodes/memory_pipelines.py
@@ -33,7 +33,6 @@ from app.domain.memory_request import MemoryAbstractRequest, MemoryFragmentReque
 from app.domain.memory_triggers import AfterthoughtTrigger, DriftTrigger
 from app.memory._persona import load_persona
 from app.memory._timeline import format_timeline
-from app.runtime import emit
 from app.runtime.db import emit_tx, tx
 from app.runtime.debounce import DebounceReschedule
 from app.runtime.node import node
@@ -260,13 +259,13 @@ async def afterthought_check(trigger: AfterthoughtTrigger) -> None:
 
 
 @node
-async def on_abstract_committed(e: AbstractMemoryCommitted) -> None:
+async def on_abstract_committed(e: AbstractMemoryCommitted) -> MemoryAbstractRequest:
     """Translate a tool-event into a vectorize request.
 
     commit_abstract emits AbstractMemoryCommitted after DB commit; this
-    in-process node re-emits MemoryAbstractRequest so vectorize-worker
+    in-process node returns MemoryAbstractRequest so vectorize-worker
     picks it up via Source.mq. Future subscribers (reviewer notification,
     dirty cache invalidation, etc.) attach via wire(AbstractMemoryCommitted)
     instead of patching the tool body.
     """
-    await emit(MemoryAbstractRequest(abstract_id=e.abstract_id))
+    return MemoryAbstractRequest(abstract_id=e.abstract_id)

--- a/apps/agent-service/app/runtime/engine.py
+++ b/apps/agent-service/app/runtime/engine.py
@@ -30,6 +30,10 @@ from pydantic import ValidationError
 from app.runtime.data import DATA_REGISTRY
 from app.runtime.durable import start_consumers, stop_consumers
 from app.runtime.graph import compile_graph
+from app.runtime.lane_policy import (
+    current_deployment_lane,
+    time_sources_enabled_by_default,
+)
 from app.runtime.migrator import plan_migration
 from app.runtime.outbox_dispatcher import dispatcher_loop
 from app.runtime.placement import DEFAULT_APP, known_apps, nodes_for_app
@@ -59,9 +63,15 @@ class Runtime:
         app_name: str | None = None,
         *,
         migrate_schema_on_run: bool = True,
+        time_sources_enabled: bool | None = None,
     ) -> None:
         self.app_name = app_name or os.getenv("APP_NAME") or DEFAULT_APP
         self._migrate_schema_on_run = migrate_schema_on_run
+        self._time_sources_enabled = (
+            time_sources_enabled_by_default()
+            if time_sources_enabled is None
+            else time_sources_enabled
+        )
         self._source_tasks: list[asyncio.Task] = []
         self._stop_event: asyncio.Event | None = None
         # First fatal error a source loop hit (so ``run()`` can re-raise
@@ -259,6 +269,7 @@ class Runtime:
         allowed_nodes = nodes_for_app(self.app_name)
         loop = asyncio.get_running_loop()
         self._stop_event = asyncio.Event()
+        skipped_time_sources = 0
 
         for w in graph.wires:
             if not w.consumers:
@@ -267,6 +278,9 @@ class Runtime:
                 continue
             for src in w.sources:
                 if src.kind == "cron":
+                    if not self._time_sources_enabled:
+                        skipped_time_sources += 1
+                        continue
                     self._source_tasks.append(
                         loop.create_task(
                             self._source_loop_cron(w, src),
@@ -274,6 +288,9 @@ class Runtime:
                         )
                     )
                 elif src.kind == "interval":
+                    if not self._time_sources_enabled:
+                        skipped_time_sources += 1
+                        continue
                     self._source_tasks.append(
                         loop.create_task(
                             self._source_loop_interval(w, src),
@@ -287,6 +304,16 @@ class Runtime:
                             name=f"mq[{w.data_type.__name__}]",
                         )
                     )
+
+        if skipped_time_sources:
+            lane = current_deployment_lane()
+            logger.warning(
+                "runtime: app=%s skipped %d cron/interval source(s) in lane=%s; "
+                "set DATAFLOW_ENABLE_TIME_SOURCES=1 to run them intentionally",
+                self.app_name,
+                skipped_time_sources,
+                lane or "prod",
+            )
 
         self._watchdog_task = loop.create_task(
             self._watch_source_error(),

--- a/apps/agent-service/app/runtime/lane_policy.py
+++ b/apps/agent-service/app/runtime/lane_policy.py
@@ -1,0 +1,65 @@
+"""Runtime lane policy.
+
+PaaS owns lane naming, but agent-service still needs one local decision:
+time-based sources (cron / interval) must not run by default in test lanes.
+Those lanes may share prod data, so a second cron runner can create real
+business side effects.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Literal, TypeAlias
+
+LaneClass: TypeAlias = Literal["prod", "coe", "ppe", "unknown"]
+
+_UNSET = object()
+
+
+def normalize_deployment_lane(lane: str | None) -> str | None:
+    """Normalize deployment lane; None means prod."""
+    if not lane or lane == "prod":
+        return None
+    return lane
+
+
+def current_deployment_lane() -> str | None:
+    """Read the process deployment lane from env.
+
+    This intentionally ignores request context. Source loops are process-level
+    background work, so the only relevant lane is the Deployment's ``LANE``.
+    """
+    return normalize_deployment_lane(os.getenv("LANE"))
+
+
+def classify_deployment_lane(lane: str | None) -> LaneClass:
+    """Mirror the PaaS lane contract for runtime safety decisions."""
+    normalized = normalize_deployment_lane(lane)
+    if normalized is None or normalized == "blue":
+        return "prod"
+    if normalized.startswith("coe-"):
+        return "coe"
+    if normalized.startswith("ppe-"):
+        return "ppe"
+    return "unknown"
+
+
+def time_sources_enabled_by_default(
+    lane: str | None | object = _UNSET,
+    *,
+    enable_override: str | None | object = _UNSET,
+) -> bool:
+    """Return whether cron / interval sources should run by default.
+
+    ``DATAFLOW_ENABLE_TIME_SOURCES=1`` is the explicit escape hatch for a
+    coe/ppe verification that is intentionally testing cron behavior.
+    """
+    actual_lane = current_deployment_lane() if lane is _UNSET else lane
+    override = (
+        os.getenv("DATAFLOW_ENABLE_TIME_SOURCES")
+        if enable_override is _UNSET
+        else enable_override
+    )
+    if override == "1":
+        return True
+    return classify_deployment_lane(actual_lane) == "prod"

--- a/apps/agent-service/tests/nodes/test_memory_pipelines_helpers.py
+++ b/apps/agent-service/tests/nodes/test_memory_pipelines_helpers.py
@@ -92,7 +92,7 @@ async def test_generate_fragment_skip_when_no_messages():
     ), patch(
         "app.nodes.memory_pipelines.insert_fragment", new=AsyncMock()
     ) as mock_ins, patch(
-        "app.nodes.memory_pipelines.emit", new=AsyncMock()
+        "app.nodes.memory_pipelines.emit_tx", new=AsyncMock()
     ) as mock_enq:
         await _generate_fragment("chat_1", "ayana")
 
@@ -124,7 +124,7 @@ async def test_generate_fragment_skip_when_empty_content():
     ), patch(
         "app.nodes.memory_pipelines.insert_fragment", new=AsyncMock()
     ) as mock_ins, patch(
-        "app.nodes.memory_pipelines.emit",
+        "app.nodes.memory_pipelines.emit_tx",
         new=AsyncMock(),
     ) as mock_enq:
         MockAgent.return_value.run = AsyncMock(

--- a/apps/agent-service/tests/runtime/test_engine_phase4.py
+++ b/apps/agent-service/tests/runtime/test_engine_phase4.py
@@ -76,8 +76,10 @@ async def test_cron_source_uses_declared_tz(monkeypatch):
     ))
     await asyncio.sleep(0.05)
     task.cancel()
-    try: await task
-    except asyncio.CancelledError: pass
+    try:
+        await task
+    except asyncio.CancelledError:
+        pass
 
     assert captured["base"].tzinfo == ZoneInfo("Asia/Shanghai")
 
@@ -86,12 +88,21 @@ class _StartTick(Data):
     ts: Annotated[str, Key]
 
 
+class _MqTick(Data):
+    message_id: Annotated[str, Key]
+
+
 _start_seen: list[_StartTick] = []
 
 
 @node
 async def _record_start(t: _StartTick) -> None:
     _start_seen.append(t)
+
+
+@node
+async def _record_mq_tick(t: _MqTick) -> None:  # pragma: no cover - never reached
+    raise AssertionError("_record_mq_tick should be stubbed before execution")
 
 
 @pytest.mark.asyncio
@@ -108,6 +119,70 @@ async def test_start_source_loops_starts_only_sources():
     try:
         await asyncio.sleep(0.2)
         assert len(_start_seen) >= 2
+    finally:
+        await rt.stop_source_loops()
+
+
+@pytest.mark.asyncio
+async def test_start_source_loops_skips_time_sources_in_ppe(monkeypatch, caplog):
+    clear_wiring()
+    clear_bindings()
+    reset_emit_runtime()
+    _start_seen.clear()
+    monkeypatch.setenv("LANE", "ppe-refactor")
+    monkeypatch.delenv("DATAFLOW_ENABLE_TIME_SOURCES", raising=False)
+
+    wire(_StartTick).from_(Source.interval(seconds=0.05)).to(_record_start)
+
+    rt = Runtime(app_name="agent-service", migrate_schema_on_run=False)
+    await rt.start_source_loops()
+    try:
+        await asyncio.sleep(0.2)
+        assert _start_seen == []
+        assert "skipped 1 cron/interval source(s)" in caplog.text
+    finally:
+        await rt.stop_source_loops()
+
+
+@pytest.mark.asyncio
+async def test_start_source_loops_override_allows_time_sources_in_ppe(monkeypatch):
+    clear_wiring()
+    clear_bindings()
+    reset_emit_runtime()
+    _start_seen.clear()
+    monkeypatch.setenv("LANE", "ppe-refactor")
+    monkeypatch.setenv("DATAFLOW_ENABLE_TIME_SOURCES", "1")
+
+    wire(_StartTick).from_(Source.interval(seconds=0.05)).to(_record_start)
+
+    rt = Runtime(app_name="agent-service", migrate_schema_on_run=False)
+    await rt.start_source_loops()
+    try:
+        await asyncio.sleep(0.2)
+        assert len(_start_seen) >= 1
+    finally:
+        await rt.stop_source_loops()
+
+
+@pytest.mark.asyncio
+async def test_start_source_loops_keeps_mq_sources_in_ppe(monkeypatch):
+    clear_wiring()
+    clear_bindings()
+    reset_emit_runtime()
+    monkeypatch.setenv("LANE", "ppe-refactor")
+    monkeypatch.delenv("DATAFLOW_ENABLE_TIME_SOURCES", raising=False)
+
+    async def _fake_source_loop_mq(self, w, src):
+        await asyncio.Event().wait()
+
+    monkeypatch.setattr(Runtime, "_source_loop_mq", _fake_source_loop_mq)
+
+    wire(_MqTick).from_(Source.mq("runtime_test_mq")).to(_record_mq_tick)
+
+    rt = Runtime(app_name="agent-service", migrate_schema_on_run=False)
+    await rt.start_source_loops()
+    try:
+        assert [t.get_name() for t in rt._source_tasks] == ["mq[_MqTick]"]
     finally:
         await rt.stop_source_loops()
 

--- a/apps/agent-service/tests/runtime/test_lane_policy.py
+++ b/apps/agent-service/tests/runtime/test_lane_policy.py
@@ -1,0 +1,41 @@
+"""Runtime lane policy tests."""
+
+from __future__ import annotations
+
+from app.runtime.lane_policy import (
+    classify_deployment_lane,
+    normalize_deployment_lane,
+    time_sources_enabled_by_default,
+)
+
+
+def test_normalize_deployment_lane_treats_missing_and_prod_as_prod() -> None:
+    assert normalize_deployment_lane(None) is None
+    assert normalize_deployment_lane("") is None
+    assert normalize_deployment_lane("prod") is None
+    assert normalize_deployment_lane("ppe-refactor") == "ppe-refactor"
+
+
+def test_classify_deployment_lane_matches_paas_lane_contract() -> None:
+    assert classify_deployment_lane(None) == "prod"
+    assert classify_deployment_lane("prod") == "prod"
+    assert classify_deployment_lane("blue") == "prod"
+    assert classify_deployment_lane("coe-agent") == "coe"
+    assert classify_deployment_lane("ppe-refactor") == "ppe"
+    assert classify_deployment_lane("dev") == "unknown"
+
+
+def test_time_sources_default_only_prod_class_runs() -> None:
+    assert time_sources_enabled_by_default(None)
+    assert time_sources_enabled_by_default("prod")
+    assert time_sources_enabled_by_default("blue")
+    assert not time_sources_enabled_by_default("coe-agent")
+    assert not time_sources_enabled_by_default("ppe-refactor")
+    assert not time_sources_enabled_by_default("dev")
+
+
+def test_time_sources_explicit_override_enables_test_lane() -> None:
+    assert time_sources_enabled_by_default(
+        "ppe-refactor",
+        enable_override="1",
+    )

--- a/docs/governance/framework-layer.md
+++ b/docs/governance/framework-layer.md
@@ -1,0 +1,90 @@
+# Agent-Service Framework Layer Governance
+
+This document defines the boundary that keeps dataflow/runtime work from
+leaking into business code.
+
+## Layers
+
+### [A] Framework Layer
+
+Owns runtime semantics and must be changed only with a spec reference.
+
+- `apps/agent-service/app/runtime/**`
+- `apps/agent-service/app/wiring/**`
+- `apps/agent-service/app/deployment.py`
+- runtime entrypoints: `apps/agent-service/app/main.py`,
+  `apps/agent-service/app/workers/runtime_entry.py`
+- framework contracts, governance docs, and CI gates under `docs/guides/`,
+  `docs/governance/`, and `.github/workflows/`
+
+Framework changes define what nodes, wires, sources, durable routing,
+startup, retries, error routing, and cross-process emit mean. They must not
+be hidden inside a business node as a local workaround.
+
+### [B] Capability Layer
+
+Owns typed access to external systems and shared primitives.
+
+- `apps/agent-service/app/capabilities/**`
+- stable public facades around infra/runtime internals
+
+Capabilities expose typed errors and domain-shaped methods. Business code can
+call capabilities, but should not reach through them to raw Redis, HTTP,
+RabbitMQ, DB sessions, or runtime-private modules.
+
+### [C] Business Layer
+
+Owns product behavior.
+
+- `apps/agent-service/app/nodes/**`
+- `apps/agent-service/app/agent/**`
+- `apps/agent-service/app/chat/**`
+- `apps/agent-service/app/life/**`
+- `apps/agent-service/app/memory/**`
+- `apps/agent-service/app/skills/**`
+
+Business code declares Data, nodes, and calls capabilities. If it needs a
+new runtime behavior, extend [A] first instead of bypassing the framework.
+
+## Change Rules
+
+- Any PR touching [A] must cite a markdown spec in the PR body with:
+  `Framework-Layer-Spec: docs/.../*.md`.
+- [A] changes must cover both FastAPI lifespan and worker `Runtime.run()` when
+  the behavior affects startup, source loops, consumers, or emit semantics.
+- Single-output `@node` functions return `Data` and let the wrapper auto-emit.
+- Per-key fan-out uses `wire(Data).fan_out_per(extractor)`, not hand-written
+  persona loops.
+- DB mutation followed by emit uses `emit_tx` / outbox semantics, not
+  commit-then-emit in business code.
+- Manual `await emit(...)` in business code is allowed only for non-node code,
+  genuinely multiple dynamic outputs, streaming segments, or deliberate
+  fire-and-forget side effects with local error handling.
+
+## Time Source Policy
+
+Cron and interval sources are production side effects. In deployment lanes:
+
+- `prod` / `blue`: cron and interval sources run by default.
+- `coe-*` / `ppe-*` / unknown: cron and interval sources are skipped by
+  default.
+- To intentionally test time sources in a lane, set
+  `DATAFLOW_ENABLE_TIME_SOURCES=1`.
+
+MQ sources are not disabled by this policy; workers still need lane-scoped
+queue consumption for normal verification.
+
+## Current Manual Emit Roster
+
+The reviewed business baseline is 10 real `await emit(...)` call sites:
+
+- `chat/context.py`: non-node image-content sync side effect.
+- `chat/post_actions.py`: post safety and memory trigger fire-and-forget
+  emits with local exception handling.
+- `nodes/chat_node.py`: router-driven persona fan-out and streaming response
+  segment emission.
+- `nodes/life_dataflow.py`: glimpse emits per target chat with per-chat
+  request ids and per-chat error isolation.
+
+New business `await emit(...)` sites should be treated as framework debt until
+the PR explains why one of the allowed cases applies.


### PR DESCRIPTION
## Summary

- Add framework-layer governance docs, CODEOWNERS, PR template, and CI gate.
- Disable cron/interval source loops by default in non-prod lanes while keeping MQ sources running.
- Convert single-output business nodes from manual emit to return Data for runtime auto-emit.

## Validation

- uv run pytest tests/runtime/test_lane_policy.py tests/runtime/test_engine_phase4.py -q: 13 passed
- PPE deploy: agent-service/vectorize-worker 1.2.0.2 Running and ready in ppe-framework-govern
- Health check: GET $PAAS_API/api/agent/health with x-lane ppe-framework-govern returned 200
- PPE log confirmed skipped 6 cron/interval source(s)
- Feishu dev bot E2E passed through ppe-framework-govern and returned reply

## Framework Layer

Framework-Layer-Spec: docs/governance/framework-layer.md

- [ ] This PR does not change the agent-service framework layer.
- [x] This PR changes the framework layer and cites the spec above.
