### PR TITLE
feat(ops-db): support chiwei-test database

### DIFF
--- a/.claude/skills/ops-db/SKILL.md
+++ b/.claude/skills/ops-db/SKILL.md
@@ -14,6 +14,7 @@ user_invocable: true
 
 ```
 /ops-db @chiwei <SQL>            # 查询 chiwei（业务数据）
+/ops-db @chiwei-test <SQL>       # 查询 chiwei-test（COE 隔离离线库）
 /ops-db @paas_engine <SQL>       # 查询 paas_engine（PaaS 元数据）
 /ops-db @chiwei schema           # 查看 chiwei 的表结构
 /ops-db @paas_engine schema      # 查看 paas_engine 的表结构
@@ -47,6 +48,7 @@ user_invocable: true
 |------|------|---------|
 | `paas_engine` | PaaS 元数据：apps、builds、releases、config_bundles 等表 | 操作 PaaS 管理数据 |
 | `chiwei` | 业务数据：messages、chats、users、memory 等表 | 操作赤尾业务数据 |
+| `chiwei-test` | COE 隔离的独立离线 PG 容器集（chiwei_test 库） | 操作 coe-* 泳道测试数据，与线上隔离 |
 
 **提交前**先用 `@数据库 schema` 确认目标库和表结构正确。
 

--- a/.claude/skills/ops-db/query.py
+++ b/.claude/skills/ops-db/query.py
@@ -21,6 +21,8 @@ DB_ALIASES = {
     "paas-engine": "paas_engine",
     "paas_engine": "paas_engine",
     "chiwei": "chiwei",
+    "chiwei-test": "chiwei_test",
+    "chiwei_test": "chiwei_test",
 }
 DEFAULT_DB = "paas_engine"
 

--- a/.claude/skills/ops-db/test_query.py
+++ b/.claude/skills/ops-db/test_query.py
@@ -1,0 +1,64 @@
+"""Tests for ops-db skill query runner db-alias normalization.
+
+Focus: the canonical db string sent to the server must be byte-identical to
+what paas-engine registers in its opsDbs/writeDbs maps. Server does a bare
+map lookup with no normalization, so client normalization is load-bearing.
+"""
+
+import importlib.util
+import os
+import sys
+
+import pytest
+
+_SPEC = importlib.util.spec_from_file_location(
+    "ops_db_query", os.path.join(os.path.dirname(__file__), "query.py")
+)
+query = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(query)
+
+
+@pytest.fixture
+def captured(monkeypatch):
+    """Capture the payload that would be POSTed, skip real HTTP."""
+    box = {}
+
+    def fake_curl_post(url, payload, token):
+        box["url"] = url
+        box["payload"] = payload
+        return {"columns": [], "rows": []}
+
+    monkeypatch.setattr(query, "curl_post", fake_curl_post)
+    monkeypatch.setattr(query, "get_env", lambda: ("http://fake", "tok"))
+    return box
+
+
+@pytest.mark.parametrize("user_input", ["chiwei-test", "chiwei_test"])
+def test_query_normalizes_chiwei_test_to_canonical(captured, user_input):
+    query.cmd_query([f"@{user_input}", "SELECT", "1"])
+    assert captured["payload"]["db"] == "chiwei_test"
+
+
+@pytest.mark.parametrize("user_input", ["chiwei-test", "chiwei_test"])
+def test_submit_normalizes_chiwei_test_to_canonical(captured, user_input):
+    query.cmd_submit([f"@{user_input}", "ALTER", "TABLE", "t", "ADD", "c", "INT;"])
+    assert captured["payload"]["db"] == "chiwei_test"
+
+
+def test_existing_aliases_unchanged(captured):
+    query.cmd_query(["@chiwei", "SELECT", "1"])
+    assert captured["payload"]["db"] == "chiwei"
+    query.cmd_query(["@paas-engine", "SELECT", "1"])
+    assert captured["payload"]["db"] == "paas_engine"
+
+
+def test_unknown_db_still_rejected(captured):
+    with pytest.raises(SystemExit):
+        query.cmd_query(["@chiwei-prod", "SELECT", "1"])
+
+
+def test_available_list_includes_chiwei_test(capsys):
+    with pytest.raises(SystemExit):
+        query.cmd_query(["@nope", "SELECT", "1"])
+    err = capsys.readouterr().err
+    assert "chiwei_test" in err

--- a/apps/paas-engine/cmd/paas-engine/main.go
+++ b/apps/paas-engine/cmd/paas-engine/main.go
@@ -125,6 +125,14 @@ func main() {
 			opsDbs["chiwei"] = chiweiDB
 		}
 	}
+	if cfg.ChiweiTestDatabaseURL != "" {
+		chiweiTestDB, err := repository.OpenReadOnlyDB(cfg.ChiweiTestDatabaseURL)
+		if err != nil {
+			slog.Warn("chiwei_test database unavailable for ops queries", "error", err)
+		} else {
+			opsDbs["chiwei_test"] = chiweiTestDB
+		}
+	}
 
 	// Ops 写连接池（用于执行审批通过的 DDL/DML）
 	writeDbs := map[string]*gorm.DB{"paas_engine": db}
@@ -134,6 +142,14 @@ func main() {
 			slog.Warn("chiwei write database unavailable for mutations", "error", err)
 		} else {
 			writeDbs["chiwei"] = chiweiWriteDB
+		}
+	}
+	if cfg.ChiweiTestDatabaseURL != "" {
+		chiweiTestWriteDB, err := repository.OpenWriteDB(cfg.ChiweiTestDatabaseURL)
+		if err != nil {
+			slog.Warn("chiwei_test write database unavailable for mutations", "error", err)
+		} else {
+			writeDbs["chiwei_test"] = chiweiTestWriteDB
 		}
 	}
 

--- a/apps/paas-engine/internal/adapter/http/mutation_handler_test.go
+++ b/apps/paas-engine/internal/adapter/http/mutation_handler_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/chiwei-platform/paas-engine/internal/adapter/repository"
 	"github.com/go-chi/chi/v5"
+	"gorm.io/gorm"
 )
 
 // fakeMutationStore 是 MutationStore 的内存实现，用于单元测试。
@@ -80,6 +81,53 @@ func TestSubmitMutation_MissingSQL(t *testing.T) {
 
 	if rec.Code != http.StatusBadRequest {
 		t.Errorf("want 400, got %d", rec.Code)
+	}
+}
+
+func TestSubmitMutation_UnknownDB(t *testing.T) {
+	// db 必须按 writeDbs 白名单校验：未知库 fail fast，否则会创建
+	// 审批时才失败的 pending 记录（canonical 权威在服务端 map）。
+	store := newFakeMutationStore()
+	h := NewOpsHandler(nil, map[string]*gorm.DB{"chiwei_test": nil}, store)
+	r := chi.NewRouter()
+	r.Post("/mutations", h.SubmitMutation)
+
+	body, _ := json.Marshal(map[string]string{"db": "chiwei-test", "sql": "ALTER TABLE t ADD c INT"})
+	req := httptest.NewRequest(http.MethodPost, "/mutations", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("want 400 for unknown db, got %d (body: %s)", rec.Code, rec.Body.String())
+	}
+	// 核心副作用：未知 db 绝不能落成 pending 记录（否则审批时才炸）。
+	if got, _ := store.List(context.Background(), ""); len(got) != 0 {
+		t.Errorf("unknown db must not create a pending record, got %d", len(got))
+	}
+}
+
+func TestSubmitMutation_KnownDB_OK(t *testing.T) {
+	store := newFakeMutationStore()
+	h := NewOpsHandler(nil, map[string]*gorm.DB{"chiwei_test": nil}, store)
+	r := chi.NewRouter()
+	r.Post("/mutations", h.SubmitMutation)
+
+	body, _ := json.Marshal(map[string]string{"db": "chiwei_test", "sql": "ALTER TABLE t ADD c INT"})
+	req := httptest.NewRequest(http.MethodPost, "/mutations", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusCreated {
+		t.Errorf("want 201 for known db, got %d (body: %s)", rec.Code, rec.Body.String())
+	}
+	got, _ := store.List(context.Background(), "")
+	if len(got) != 1 {
+		t.Fatalf("want 1 persisted mutation, got %d", len(got))
+	}
+	if got[0].DB != "chiwei_test" {
+		t.Errorf("want persisted db=chiwei_test, got %q", got[0].DB)
 	}
 }
 

--- a/apps/paas-engine/internal/adapter/http/ops_handler.go
+++ b/apps/paas-engine/internal/adapter/http/ops_handler.go
@@ -153,6 +153,16 @@ func (h *OpsHandler) SubmitMutation(w http.ResponseWriter, r *http.Request) {
 	if req.DB == "" {
 		req.DB = "paas_engine"
 	}
+	if _, ok := h.writeDbs[req.DB]; !ok {
+		available := make([]string, 0, len(h.writeDbs))
+		for k := range h.writeDbs {
+			available = append(available, k)
+		}
+		writeJSON(w, http.StatusBadRequest, map[string]string{
+			"error": fmt.Sprintf("unknown database %q, available: %s", req.DB, strings.Join(available, ", ")),
+		})
+		return
+	}
 	if req.SubmittedBy == "" {
 		req.SubmittedBy = "unknown"
 	}

--- a/apps/paas-engine/internal/config/config.go
+++ b/apps/paas-engine/internal/config/config.go
@@ -22,8 +22,9 @@ type Config struct {
 	BuildNoProxy      string
 	APIToken          string
 	LokiURL           string
-	ChiweiDatabaseURL string
-	SidecarImage      string
+	ChiweiDatabaseURL     string
+	ChiweiTestDatabaseURL string
+	SidecarImage          string
 
 	// CI Pipeline
 	CINamespace     string        // K8s namespace for CI test jobs
@@ -53,7 +54,8 @@ func Load() *Config {
 		BuildNoProxy:      os.Getenv("BUILD_NO_PROXY"),
 		APIToken:          os.Getenv("API_TOKEN"),
 		LokiURL:           getEnv("LOKI_URL", "http://loki-gateway.monitoring.svc.cluster.local"),
-		ChiweiDatabaseURL: os.Getenv("CHIWEI_DATABASE_URL"),
+		ChiweiDatabaseURL:     os.Getenv("CHIWEI_DATABASE_URL"),
+		ChiweiTestDatabaseURL: os.Getenv("CHIWEI_TEST_DATABASE_URL"),
 		SidecarImage:      os.Getenv("SIDECAR_IMAGE"),
 
 		CINamespace:     getEnv("CI_NAMESPACE", "paas-builds"),

--- a/docs/plan/ops-db-chiwei-test.md
+++ b/docs/plan/ops-db-chiwei-test.md
@@ -1,0 +1,41 @@
+# ops-db 支持 chiwei-test 库
+
+## 目标
+
+让 `/ops-db` skill 能对 chiwei-test（COE 隔离的独立离线 PG 容器集）做只读查询和 submit 变更申请，跟现有 `@chiwei` / `@paas_engine` 体验一致。
+
+## 不做什么
+
+- 不改 ops-db 的审批流程、不改 db-query/db-mutations 端点的协议。
+- 不引入"从 ConfigBundle 动态解析连接串"的新机制（已决策走静态 env，复刻 chiwei 模式）。
+- 不动其他 COE 基础设施（Redis/MQ/Qdrant/Mongo）。
+
+## 关键设计决策
+
+复刻现有 chiwei 走 `CHIWEI_DATABASE_URL` 环境变量的模式，新增一条独立链路：
+
+1. **客户端 skill（query.py + SKILL.md）**：`DB_ALIASES` 新增 `chiwei-test` 和 `chiwei_test` 两个别名，都映射到 canonical 字符串 `chiwei_test`；SKILL.md 用法文档同步声明 `@chiwei-test`（否则 agent-facing 文档与实际能力不一致）。
+2. **服务端 paas-engine**：
+   - `config.go` 新增 `ChiweiTestDatabaseURL: os.Getenv("CHIWEI_TEST_DATABASE_URL")`。
+   - `main.go` 复刻 chiwei 的两段 block，`cfg.ChiweiTestDatabaseURL != ""` 时往 `opsDbs` / `writeDbs` 注册 key `chiwei_test`（OpenReadOnlyDB / OpenWriteDB）。
+   - `SubmitMutation` 增加 db 白名单校验（按 `writeDbs` map 精确校验，未知库 fail fast 返回 400，复刻 Query 的报错逻辑）。canonical 权威在服务端 map，一致性约束必须落在服务端而非只靠客户端归一化——否则任何绕过 skill 的调用或未来 UI 输入会创建审批时才失败的 pending 记录。
+3. **部署**：通过 PaaS API 给 paas-engine 注入生产环境变量 `CHIWEI_TEST_DATABASE_URL`，值由 paas_engine 的 `pg-main` config bundle `class_overrides[coe]` 拼出（host/port/db/user/password）；然后 `make self-deploy`。注入位置需明确：查清 paas-engine 现有 `CHIWEI_DATABASE_URL` 来自哪个 config bundle / 哪个 key，把 `CHIWEI_TEST_DATABASE_URL` 放在同一处，避免 secret 加错位置或下次 release 丢失。
+
+## 坑（重点）
+
+1. **客户端 / 服务端 canonical 名字必须逐字节一致。** 服务端是 `h.dbs[dbAlias]` 裸 map 查找，无任何归一化。客户端发什么字符串，服务端就拿什么去查 map。统一定为 `chiwei_test`（下划线）。客户端接受用户输入 `chiwei-test`（连字符，符合泳道命名直觉）和 `chiwei_test`，但发出去的 canonical 一律 `chiwei_test`。一致性约束服务端兜底（见设计决策 2 的 SubmitMutation 校验），不只靠客户端。
+2. **`make self-deploy` 先发 prod 再发 blue，没有 blue 预验证闸口。** 不能"blue 先验再 swap prod"。这个改动靠 **fail-safe 设计** 兜底而非预验证：DSN 配错/网络不通时 `OpenReadOnlyDB` 报错，main.go 走 `slog.Warn` 分支跳过注册，paas-engine 本身和现有 `paas_engine`/`chiwei` 链路完全不受影响——最坏情况只是"chiwei-test 仍不可用"，等于现状，不会炸 prod。代价：DSN 配错需改 env + 再 self-deploy（env 在启动时读，必须重启进程才生效），每次迭代都再 hit 一次 prod，但每次都 fail-safe。所以 **尽量一次把 DSN 配对**：从 pg-main coe override 精确拼，部署后立刻查日志确认是否走了 Warn 分支。
+3. **网络可达性是最大未知。** chiwei-test PG 在 `10.37.6.235:5433`，COE 业务应用以 coe 泳道 Pod 连它（ConfigBundle 注入）。paas-engine 跑 prod ns，能否直连该地址无法在部署前验证。靠坑 2 的 fail-safe 兜底：连不上只是 Warn 跳过，不破坏 prod。部署后必须查 paas-engine 日志确认 alias 真注册成功（无 `chiwei_test ... unavailable` 的 Warn），不能只看部署成功。
+4. **DSN 含内网 IP + 密码,绝不入 git。** spec / 代码 / 测试里只能用假 DSN。真实值只通过 PaaS API env 注入。
+5. **部署即杀 Pod。** self-deploy 前确认没有正在跑的 build/rebuild（paas-engine 自身在跑构建时尤其注意，self-deploy 会中断）。
+6. **gorm.Open 行为**：复刻 chiwei 即可,连不上不 panic、只 Warn 跳过,降级行为跟 chiwei 一致,无需额外处理。
+
+## 接受的风险（继承自现有 chiwei 模型，本次不扩大）
+
+- **"只读查询"的写保护靠客户端 SQL 正则，不靠 DB 权限。** `OpenReadOnlyDB` 只是普通 gorm 连接、不 AutoMigrate；`CHIWEI_TEST_DATABASE_URL` 用的是 pg-main coe 的 `chiwei_test` 账号（写权限）。只读边界由 query.py 的 `WRITE_KEYWORDS` 正则在客户端拦截，与现有 `@chiwei` 完全同模型。本次复刻不新增风险，也不在本次引入独立只读账号（chiwei 也没有，属另一个独立议题）。
+
+## 任务（粗颗粒）
+
+- **T1 客户端别名 + 文档（TDD）**：query.py `DB_ALIASES` 加 `chiwei-test`/`chiwei_test` → canonical `chiwei_test`；SKILL.md 用法文档同步加 `@chiwei-test`。先写 pytest 覆盖：两种输入都解析到 canonical `chiwei_test`、未知库仍报错、可用库列表含 `chiwei_test`。产出：测试先红后绿 + query.py + SKILL.md 改动。验收：`pytest` 通过（断言归一化后的 db 值为 `chiwei_test`，不依赖真机 curl——`curl -sfS` 的 `-f` 会吞掉 400 body，真机错误文本验证放 T3）。
+- **T2 服务端接线 + submit 校验**：config.go 加 `ChiweiTestDatabaseURL`;main.go 复刻 chiwei 两段 block 注册 `chiwei_test` 到 opsDbs/writeDbs;SubmitMutation 加按 writeDbs 的 db 白名单校验（未知库 400 fail fast，复刻 Query 报错逻辑）。产出：Go 改动 + `go build ./...` 通过 + SubmitMutation 校验的 Go 测试（先红后绿）。验收：编译通过 + 测试通过 + code review 确认 map key 与 T1 canonical 逐字节一致。
+- **T3 部署 + 真机验证**：先查清 paas-engine 现有 `CHIWEI_DATABASE_URL` 来自哪个 config bundle/key，把 `CHIWEI_TEST_DATABASE_URL`（从 pg-main coe override 精确拼 DSN）放同一处 → PaaS API 注入 → 确认无正在跑的 build → `make self-deploy`。产出：paas-engine 日志确认 chiwei_test alias 注册成功（无 `chiwei_test ... unavailable` Warn）。验收：`/ops-db @chiwei-test SELECT 1` 返回结果;`/ops-db submit @chiwei-test <无害 DDL>` 能提交并审批执行成功。fail-safe 兜底：若日志显示 Warn（DSN/网络问题），prod 不受影响，修正 env 后重新 self-deploy。


### PR DESCRIPTION
ops-db skill could only target chiwei/paas_engine; chiwei-test (the COE
isolated offline PG) was unreachable for both queries and submit. Wire a
dedicated CHIWEI_TEST_DATABASE_URL path mirroring the existing chiwei env
pattern, and harden SubmitMutation to validate db against writeDbs up
front so an unknown db fails fast at submit instead of creating a pending
record that only fails at approve time.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
