### PR TITLE
chore(hooks): relax main-agent bash for fd-copy and stdout filters

### DIFF
--- a/.claude/hooks/enforce-routing.sh
+++ b/.claude/hooks/enforce-routing.sh
@@ -210,6 +210,16 @@ seg_is_allowed() {
   if echo "$first" | grep -qPi '^codex\b'; then
     return 0
   fi
+  # stdout filter argv0 allowlist (spec 2026-05-20): read-from-stdin,
+  # write-to-stdout, no file write, no command construction, not interactive.
+  # Intentionally EXCLUDES `tee` (writes files), `less`/`more` (interactive),
+  # `xargs` (constructs arbitrary commands), `cat`/`find` (file readers).
+  # A-plan trade-off: argv is NOT inspected here, so `tail CLAUDE.md` slips
+  # past the hook; rationale is spec-side (read-only, small output, not code
+  # exploration). Argv-path-aware filtering is explicitly out of scope.
+  if echo "$first" | grep -qPi '^(tail|head|grep|awk|sed|cut|sort|uniq|wc|jq|column)\b'; then
+    return 0
+  fi
 
   return 1
 }
@@ -247,9 +257,37 @@ seg_is_allowed() {
 # hole. (This is distinct from the bad-JSON path above, which stays fail-open
 # and is intentionally NOT changed here.)
 SEGMENTS="$(printf '%s' "$COMMAND" | python3 -c '
-import sys
+import sys, re
 
 s = sys.stdin.read()
+
+# RELAX (spec 2026-05-20): fd-to-fd copy `[n]>&[m]` / `[n]<&[m]` (m MUST be a
+# digit) is just kernel fd-table duplication — no file open, no repo touch.
+# Pre-scan and mark these byte ranges as "safe": the smuggling guard below
+# skips > / < that fall inside one of them. Strictness on the right side is
+# load-bearing: `>&out` / `&>file` / `&>>log` MUST NOT match (right side is a
+# non-digit word or the left side starts with `&`), so they keep hitting the
+# normal > / < guard and continue to block.
+#
+# Regex breakdown:
+#   (?<![\w&])  — left boundary: previous char is NOT a word char or `&` (so
+#                 `&>` and `&>>` do not match; `1>&2` does because left of `1`
+#                 is space/start).
+#   ([0-9]+)?   — optional source fd number.
+#   ([><])&     — direction + literal `&`.
+#   ([0-9]+)    — destination fd number (REQUIRED, must be digits — this is
+#                 what excludes `>&file`).
+#   (?!\w)      — right boundary: next char is NOT a word char (so `>&12foo`
+#                 does not match, but `>&1` followed by space/end/| does).
+FD_COPY_RE = re.compile(r"(?<![\w&])([0-9]+)?([><])&([0-9]+)(?!\w)")
+fd_copy_spans = [(m.start(), m.end()) for m in FD_COPY_RE.finditer(s)]
+
+def in_fd_copy(idx):
+    for a, b in fd_copy_spans:
+        if a <= idx < b:
+            return True
+    return False
+
 segs = []          # list of independent commands (each: list of pipeline stages)
 cur = ""           # current pipeline-stage buffer
 stages = []        # pipeline stages of the current independent command
@@ -290,7 +328,9 @@ while i < n:
     # < << <( by matching the single chars $( ` > < .
     if c == "$" and i + 1 < n and s[i + 1] == "(":
         sys.exit(4)
-    if c == "`" or c == ">" or c == "<":
+    if c == "`":
+        sys.exit(4)
+    if (c == ">" or c == "<") and not in_fd_copy(i):
         sys.exit(4)
     if c == ";" or c == "\n":
         # A real newline OUTSIDE quotes is a command separator just like `;`

--- a/.claude/hooks/enforce-routing.sh
+++ b/.claude/hooks/enforce-routing.sh
@@ -270,16 +270,20 @@ s = sys.stdin.read()
 # normal > / < guard and continue to block.
 #
 # Regex breakdown:
-#   (?<![\w&])  — left boundary: previous char is NOT a word char or `&` (so
-#                 `&>` and `&>>` do not match; `1>&2` does because left of `1`
-#                 is space/start).
+#   (?<!&)      — left boundary: previous char is NOT `&` (so `&>` and `&>>`
+#                 do not match — bash treats those as the file-write sugar
+#                 `&>file`/`&>>file`). Word chars ARE allowed left (`var1>&2`
+#                 / adjacent fd-copies `2>&1>&2` both legitimately match the
+#                 trailing `>&2`). Codex T3 follow-up: the prior `\w` exclusion
+#                 caused `2>&1>&2` (two fd-copies, no space) to wrongly block
+#                 because the trailing match had a digit `1` to the left.
 #   ([0-9]+)?   — optional source fd number.
 #   ([><])&     — direction + literal `&`.
 #   ([0-9]+)    — destination fd number (REQUIRED, must be digits — this is
 #                 what excludes `>&file`).
 #   (?!\w)      — right boundary: next char is NOT a word char (so `>&12foo`
 #                 does not match, but `>&1` followed by space/end/| does).
-FD_COPY_RE = re.compile(r"(?<![\w&])([0-9]+)?([><])&([0-9]+)(?!\w)")
+FD_COPY_RE = re.compile(r"(?<!&)([0-9]+)?([><])&([0-9]+)(?!\w)")
 fd_copy_spans = [(m.start(), m.end()) for m in FD_COPY_RE.finditer(s)]
 
 def in_fd_copy(idx):

--- a/.claude/hooks/test-enforce-routing.sh
+++ b/.claude/hooks/test-enforce-routing.sh
@@ -241,6 +241,63 @@ run_case "main pipe less -> block"  2 "$(main_tool Bash "$(bash_in 'git diff | l
 run_case "main pipe xargs rm -> block" 2 "$(main_tool Bash "$(bash_in 'git status | xargs rm')")"
 run_case "main pipe more -> block"  2 "$(main_tool Bash "$(bash_in 'git log | more')")"
 
+# ---------- Codex T3 review follow-up: FD_COPY_RE boundary probes (17 cases) ----------
+# Codex T3 pointed at the FD_COPY_RE right boundary `(?!\w)`; running 17 probes
+# uncovered an unrelated LEFT-boundary bug: `2>&1>&2` (two fd-copies adjacent,
+# no space) blocked because the second `>&2` couldn't match (prev char `1` is
+# a word char). Fix: drop `\w` from left lookbehind, keep `&` exclusion. Probes
+# below pin every edge the audit covered so regressions surface fast.
+#
+# Probe 1: `2>&1>file` — fd-copy then file write -> smuggling guard MUST fire.
+run_case "probe1 main 2>&1>file -> block"   2 "$(main_tool Bash "$(bash_in 'make logs APP=foo 2>&1>out')")"
+# Probe 2: `2>&1<file` — fd-copy then file read -> smuggling guard MUST fire.
+run_case "probe2 main 2>&1<file -> block"   2 "$(main_tool Bash "$(bash_in 'make logs APP=foo 2>&1<in')")"
+# Probe 3: `2>&1>&2` — TWO fd-copies adjacent, NO space. Pre-fix: blocked
+# because left lookbehind disallowed `1` (word char). Post-fix: allow.
+run_case "probe3 main 2>&1>&2 adjacent -> allow" 0 "$(main_tool Bash "$(bash_in 'make logs APP=foo 2>&1>&2')")"
+# Probe 4: `2>&1&>foo` — fd-copy then `&>foo` (file write sugar). Block.
+run_case "probe4 main 2>&1&>foo -> block"   2 "$(main_tool Bash "$(bash_in 'make logs APP=foo 2>&1&>out')")"
+# Probe 5: `2>&1$(date)` — fd-copy then command substitution. Block.
+run_case "probe5 main 2>&1\$(date) -> block" 2 "$(main_tool Bash "$(bash_in 'make logs APP=foo 2>&1$(date)')")"
+# Probe 6: `2>&12` — fd 12 (two-digit destination). Allow as fd-copy.
+run_case "probe6 main 2>&12 fd-12 -> allow" 0 "$(main_tool Bash "$(bash_in 'make logs APP=foo 2>&12')")"
+# Probe 7: `2>&12 file` — fd 12 then a separate arg word. Allow.
+run_case "probe7 main 2>&12 + arg -> allow" 0 "$(main_tool Bash "$(bash_in 'make logs APP=foo 2>&12 file')")"
+# Probe 8: `2>&1foo` — destination is `1foo` (digits+letters). Right boundary
+# `(?!\w)` rejects -> no fd-copy match -> smuggling guard fires. Bash itself
+# rejects this as ambiguous redirect, so blocking is conservative-safe.
+run_case "probe8 main 2>&1foo ambiguous -> block" 2 "$(main_tool Bash "$(bash_in 'make logs APP=foo 2>&1foo')")"
+# Probe 9: `>&12word` — same as probe 8 with two-digit + letter tail. Block.
+run_case "probe9 main >&12word -> block" 2 "$(main_tool Bash "$(bash_in 'make logs APP=foo >&12word')")"
+# Probe 10: `"2>&1 leak"` — entirely inside double quotes -> literal. Allow.
+run_case "probe10 main dq fd literal -> allow" 0 "$(main_tool Bash "$(bash_in 'git status "2>&1 leak"')")"
+# Probe 11: `'2>&1 leak'` — single-quote literal. Allow.
+run_case "probe11 main sq fd literal -> allow" 0 "$(main_tool Bash "$(bash_in "git status '2>&1 leak'")")"
+# Probe 12: `> &1` — `>` with space before `&1` is NOT fd-copy syntax. Block.
+run_case "probe12 main > &1 not fd-copy -> block" 2 "$(main_tool Bash "$(bash_in 'make logs APP=foo > &1')")"
+# Probe 13: `2>&1 cmd` — fd-copy at start of command. The smuggling guard
+# passes (fd-copy is marked safe), but the segment's argv0 becomes `2>&1`
+# which is not allowlisted -> block at allowlist layer. Documents the
+# bash-uncommon-but-valid leading-redirect form.
+run_case "probe13 main leading fd-copy -> block (allowlist)" 2 "$(main_tool Bash "$(bash_in '2>&1 echo hi')")"
+# Probe 14: `2>& 1` — space between `&` and `1` is not valid fd-copy. Block.
+run_case "probe14 main 2>& 1 not fd-copy -> block" 2 "$(main_tool Bash "$(bash_in 'make logs APP=foo 2>& 1')")"
+# Probe 15: `>&-` — bash fd-close syntax (`-` is not a digit). Block (regex
+# doesn't match `>&-`; smuggling guard fires on `>`). Conservative-safe.
+run_case "probe15 main >&- fd-close -> block" 2 "$(main_tool Bash "$(bash_in 'make logs APP=foo >&-')")"
+# Probe 16: `2>&1; echo hi` — fd-copy then segment separator. First segment
+# allows (`make logs ... 2>&1`); second segment `echo hi` not allowlisted ->
+# block. Use git status as second segment to assert "; after fd-copy splits"
+# without dragging in unrelated allowlist failure.
+run_case "probe16 main 2>&1; allowlisted -> allow" 0 "$(main_tool Bash "$(bash_in 'make logs APP=foo 2>&1; git status')")"
+# Probe 17: `2>&1 | tail` — the user's real pain point. Allow.
+run_case "probe17 main 2>&1 | tail -> allow" 0 "$(main_tool Bash "$(bash_in 'make logs APP=foo 2>&1 | tail')")"
+# Bonus: probe-3 variant WITHOUT allowlisted argv0 — confirms the smuggling
+# guard alone (independent of allowlist) accepts adjacent fd-copies after fix.
+# We assert exit 2 (allowlist still blocks `cmd`) but the FAILURE REASON must
+# be allowlist, not smuggling. Bash echo on stderr would assert that but the
+# test harness drops stderr; this case is documented in the report instead.
+
 # ---------- Codex T1 review combo cases: safe-prefix + dangerous tail ----------
 # 2>&1 alone is safe, but stapling `> out` (file write) or `&& cat <repo>` after
 # it must still trip the existing guards. Hook can't short-circuit on a benign

--- a/.claude/hooks/test-enforce-routing.sh
+++ b/.claude/hooks/test-enforce-routing.sh
@@ -83,8 +83,13 @@ run_case "main http.sh -> allow"    0 "$(main_tool Bash "$(bash_in 'bash .claude
 run_case "main git show file -> block" 2 "$(main_tool Bash "$(bash_in 'git show HEAD:apps/lark-proxy/main.ts')")"
 run_case "main git cat-file -> block"  2 "$(main_tool Bash "$(bash_in 'git cat-file -p HEAD:foo.go')")"
 run_case "main cat file -> block"      2 "$(main_tool Bash "$(bash_in 'cat apps/lark-proxy/main.ts')")"
-run_case "main sed file -> block"      2 "$(main_tool Bash "$(bash_in 'sed -n 1,20p foo.go')")"
-run_case "main grep cmd -> block"      2 "$(main_tool Bash "$(bash_in 'grep -r foo apps/')")"
+# Spec 2026-05-20 trade-off: sed/grep are now stdout filter argv0 (read-only
+# integers). Hook does NOT inspect argv for repo paths — so `sed foo.go` /
+# `grep -r foo apps/` slip past the hook. Documented in spec "扩展放行" section
+# (the three reasons: read-only, small output, not code exploration). Tests
+# pinned to that contract: these now ALLOW.
+run_case "main sed file -> allow (spec trade-off)" 0 "$(main_tool Bash "$(bash_in 'sed -n 1,20p foo.go')")"
+run_case "main grep cmd -> allow (spec trade-off)" 0 "$(main_tool Bash "$(bash_in 'grep -r foo apps/')")"
 
 # ---------- Security layer: kubectl write / curl POST -> BLOCK (main AND sub) ----------
 run_case "main kubectl apply -> block"  2 "$(main_tool Bash "$(bash_in 'kubectl apply -f x.yaml')")"
@@ -103,13 +108,13 @@ run_case "main dispatch Task -> allow"  0 "$(main_tool Task '{"description":"x"}
 run_case "main cd . && git status -> allow"   0 "$(main_tool Bash "$(bash_in 'cd . && git status')")"
 run_case "main cd /tmp && git log -> allow"   0 "$(main_tool Bash "$(bash_in 'cd /tmp && git log')")"
 run_case "main git add && git commit -> allow" 0 "$(main_tool Bash "$(bash_in 'git add x && git commit -m y')")"
-# T3 HARDENING: every pipeline stage's argv0 must be allowlisted now. The old
-# "pipeline only vets first stage" carve-out was a real downstream-bypass hole
-# (codex T3). `grep`/`head` argv0 are NOT on the allowlist -> these now BLOCK.
-# This is the INTENDED tightening, not a regression. Want fewer git lines: use
-# `git log -n`. Want to filter: dispatch a subagent.
-run_case "main git status | grep -> block (T3)"  2 "$(main_tool Bash "$(bash_in 'git status | grep foo')")"
-run_case "main git log | head -> block (T3)"     2 "$(main_tool Bash "$(bash_in 'git log --oneline | head -20')")"
+# T3 HARDENING + spec 2026-05-20 RELAX: every pipeline stage's argv0 is still
+# vetted (downstream-bypass hole stays closed), but stdout filter argv0
+# (tail/head/grep/awk/sed/cut/sort/uniq/wc/jq/column) are now on the allowlist.
+# So `git status | grep foo` and `git log | head -20` now ALLOW. `cat`, `tee`,
+# `xargs`, `less` are deliberately NOT on the filter allowlist and still BLOCK.
+run_case "main git status | grep -> allow (spec relax)" 0 "$(main_tool Bash "$(bash_in 'git status | grep foo')")"
+run_case "main git log | head -> allow (spec relax)"    0 "$(main_tool Bash "$(bash_in 'git log --oneline | head -20')")"
 
 # Bug 2 (false allow / security hole): allowlisted leading token let trailing
 # repo-touching segments through unchecked.
@@ -195,6 +200,66 @@ run_case "sub curl -dfoo -> block"            2 "$(sub_tool Bash "$(bash_in64 'Y
 # Main context too (defense-in-depth: blocked either way).
 run_case "main curl --request=POST -> block"  2 "$(main_tool Bash "$(bash_in64 'Y3VybCAtLXJlcXVlc3Q9UE9TVCBodHRwOi8veA==')")"
 run_case "main curl -dfoo -> block"           2 "$(main_tool Bash "$(bash_in64 'Y3VybCAtZGZvbyBodHRwOi8veA==')")"
+
+# ---------- RELAX: fd-to-fd copy [n]>&[m] / [n]<&[m] (m must be a digit) ----------
+# Pure fd table duplication, no file I/O — main session can do it directly.
+run_case "main fd 2>&1 -> allow"  0 "$(main_tool Bash "$(bash_in 'git status 2>&1')")"
+run_case "main fd 1>&2 -> allow"  0 "$(main_tool Bash "$(bash_in 'make logs 1>&2')")"
+run_case "main fd 3<&0 -> allow"  0 "$(main_tool Bash "$(bash_in 'git status 3<&0')")"
+run_case "main fd 2>&3 -> allow"  0 "$(main_tool Bash "$(bash_in 'git diff 2>&3')")"
+# fd-copy tokens inside double quotes are literal anyway — must still allow.
+run_case "main fd dq literal 2>&1 -> allow" 0 "$(main_tool Bash "$(bash_in 'git status "x 2>&1"')")"
+
+# ---------- BLOCK: fd boundary cases that look like fd ops but actually touch files ----------
+# &> / &>> are `cmd > out 2>&1` sugar with a file target on the right.
+run_case "main &> file -> block"      2 "$(main_tool Bash "$(bash_in 'git status &> out')")"
+run_case "main &>> file -> block"     2 "$(main_tool Bash "$(bash_in 'git log &>> log')")"
+# >&file (right side is a non-digit token) is normal file redirection sugar.
+run_case "main >&file -> block"       2 "$(main_tool Bash "$(bash_in 'git status >&out')")"
+# 2>file with no & is just normal file redirection.
+run_case "main 2>file -> block"       2 "$(main_tool Bash "$(bash_in 'git status 2>err.log')")"
+# Process substitution opens a Trojan command channel.
+run_case "main >(proc-subst) -> block" 2 "$(main_tool Bash "$(bash_in 'git status > >(tee log)')")"
+run_case "main <(proc-subst) -> block" 2 "$(main_tool Bash "$(bash_in 'git diff <(cat CLAUDE.md)')")"
+
+# ---------- RELAX: stdout filter argv0 allowlist (pipe segments) ----------
+# Read-from-stdin, write-to-stdout, no file write, no command construction.
+run_case "main pipe tail -> allow"  0 "$(main_tool Bash "$(bash_in 'make logs APP=foo | tail -150')")"
+run_case "main pipe head -> allow"  0 "$(main_tool Bash "$(bash_in 'make logs APP=foo | head -100')")"
+run_case "main pipe grep filter -> allow" 0 "$(main_tool Bash "$(bash_in 'make logs APP=foo | grep ERROR')")"
+run_case "main pipe awk -> allow"   0 "$(main_tool Bash "$(bash_in "make logs APP=foo | awk '{print \$1}'")")"
+run_case "main pipe sed -> allow"   0 "$(main_tool Bash "$(bash_in 'make logs APP=foo | sed s/x/y/')")"
+run_case "main pipe jq -> allow"    0 "$(main_tool Bash "$(bash_in 'make logs APP=foo | jq .')")"
+run_case "main pipe cut -> allow"   0 "$(main_tool Bash "$(bash_in 'make logs APP=foo | cut -d: -f1')")"
+run_case "main pipe sort uniq wc -> allow" 0 "$(main_tool Bash "$(bash_in 'make logs APP=foo | sort | uniq | wc -l')")"
+run_case "main git diff | wc -> allow" 0 "$(main_tool Bash "$(bash_in 'git diff | wc -l')")"
+
+# ---------- BLOCK: dangerous argv0 still not allowed as pipe segments ----------
+# tee writes files; less/more are interactive; xargs constructs new commands.
+run_case "main pipe tee -> block"   2 "$(main_tool Bash "$(bash_in 'git status | tee /tmp/x')")"
+run_case "main pipe less -> block"  2 "$(main_tool Bash "$(bash_in 'git diff | less foo')")"
+run_case "main pipe xargs rm -> block" 2 "$(main_tool Bash "$(bash_in 'git status | xargs rm')")"
+run_case "main pipe more -> block"  2 "$(main_tool Bash "$(bash_in 'git log | more')")"
+
+# ---------- Codex T1 review combo cases: safe-prefix + dangerous tail ----------
+# 2>&1 alone is safe, but stapling `> out` (file write) or `&& cat <repo>` after
+# it must still trip the existing guards. Hook can't short-circuit on a benign
+# prefix.
+run_case "main 2>&1 > out -> block"   2 "$(main_tool Bash "$(bash_in 'make logs APP=foo 2>&1 > out')")"
+run_case "main 2>&1 && cat repo -> block" 2 "$(main_tool Bash "$(bash_in 'make logs APP=foo 2>&1 && cat CLAUDE.md')")"
+# The user's real pain point: must allow end-to-end.
+run_case "main 2>&1 | tail -> allow"  0 "$(main_tool Bash "$(bash_in 'make logs APP=foo 2>&1 | tail -150')")"
+run_case "main 2>&1 | grep -> allow"  0 "$(main_tool Bash "$(bash_in 'make logs APP=foo 2>&1 | grep ERROR')")"
+
+# ---------- Smuggling regression guard: existing blocks must still block ----------
+# These should have been blocked already by the existing $( ` > < guard; restate
+# explicitly to pin the contract under the new fd-copy relaxation.
+run_case "main smuggling > CLAUDE.md regress -> block" 2 "$(main_tool Bash "$(bash_in 'git status > CLAUDE.md')")"
+run_case "main smuggling >> ./foo regress -> block"    2 "$(main_tool Bash "$(bash_in 'git status >> ./foo')")"
+run_case "main smuggling \$(cat) regress -> block"     2 "$(main_tool Bash "$(bash_in 'git status $(cat CLAUDE.md)')")"
+run_case "main smuggling backtick regress -> block"    2 "$(main_tool Bash "$(bash_in 'cat \`whoami\`')")"
+run_case "main smuggling < file regress -> block"      2 "$(main_tool Bash "$(bash_in 'grep foo < src/x.py')")"
+run_case "main smuggling <<< herestring regress -> block" 2 "$(main_tool Bash "$(bash_in 'git status <<<$(date)')")"
 
 # ---------- Misc ----------
 run_case "empty stdin -> allow" 0 "$EMPTY"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -131,7 +131,7 @@ ConfigBundle 通过 `class_overrides[coe]` + `required_keys[coe]` 自动把 coe-
 - **general-purpose 子 agent（并行）**：所有仓库文件修改**必须**经它，主会话不亲手改。**先 map 再 parallel**：并行前**必须**先派一个 Explore 子 agent 按"各 task 方法实际能触达哪些文件"摸出真实分区图（不是按声明产出算），无文件冲突的 task **鼓励并行**派多个子 agent；有冲突 / 有依赖的串行委派。每个 agent 拿一条 task 自己想细节、自己走 TDD 红-绿-重构（先写测试再写实现）、自己跑验证、自己报产出。主会话只接产出 + 证据，不参与中间过程。
 - **应用 reviewer 反馈本身是子 agent 任务**：采纳 codex 反馈去改 spec 或代码，这个落地动作**必须**委派子 agent 执行，不论目标文件在不在仓库内，主会话不亲手改。
 - **跨需求并行**：用 worktree + 多会话，不在一个会话里塞多个独立 feature。
-- **编排豁免边界**：主会话仍可直接跑 git 版本控制 / make / 部署 / `ghc`，以及 skill 驱动的脚本（codex-worker / api-test / ops 等）——这些是编排，不是排查。但 `git show <path>` / `git cat-file` 这类借 git 读逐文件内容的形态**算排查、不算编排**，**必须**委派子 agent。Bash 元字符 / argv0 的边界也按同一思路划：判定标准是这条命令**是否触发对仓库内容的实际读写**，不是是否含某个字符。fd-to-fd 复制 `[n]>&[m]` 和 `[n]<&[m]`（m 必须是数字，典型如 `2>&1` `1>&2` `3<&0`）只是复制 fd 表项，不打开文件，主会话直接做；管道 `|` 接 stdout filter argv0（`tail` / `head` / `grep` / `awk` / `sed` / `cut` / `sort` / `uniq` / `wc` / `jq` / `column`）是输出整形不构造命令，主会话直接做；串联 `;` / `&&` / `||` 每段独立走 argv allowlist 校验，主会话直接做。反过来，文件重定向 `>` `>>` `<` 和写文件的语法糖 `&>` `&>>` `>&file`（右侧是文件名 token，非纯数字 fd 编号）、命令替换 `$(...)` 和反引号、输入重定向 `<<<` 和 heredoc `<<` `<<-`、进程替换 `<(...)` `>(...)`，以及 `tee`（写文件）/ `less` `more`（交互）/ `xargs`（任意命令构造）/ `cat` `find` 等读 repo 文件的 argv0——任何一条命中都可能 leak 或污染仓库内容，**必须**委派子 agent。
+- **编排豁免边界**：主会话仍可直接跑 git 版本控制 / make / 部署 / `ghc`，以及 skill 驱动的脚本（codex-worker / api-test / ops 等）——这些是编排，不是排查。但 `git show <path>` / `git cat-file` 这类借 git 读逐文件内容的形态**算排查、不算编排**，**必须**委派子 agent。
 - **codex**：外部 reviewer，不是 worker。T1（spec 写完）/ T2（plan 写完，本项目 plan 合并进 spec 不单独触发）/ T3（一批含设计变动的代码 commit 前）/ T4（debug 死循环，需用户先同意），详见 `~/.claude/rules/codex-collaboration.md`。
 
 ### 上线前必须完成的检查（TODO）

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -131,7 +131,7 @@ ConfigBundle 通过 `class_overrides[coe]` + `required_keys[coe]` 自动把 coe-
 - **general-purpose 子 agent（并行）**：所有仓库文件修改**必须**经它，主会话不亲手改。**先 map 再 parallel**：并行前**必须**先派一个 Explore 子 agent 按"各 task 方法实际能触达哪些文件"摸出真实分区图（不是按声明产出算），无文件冲突的 task **鼓励并行**派多个子 agent；有冲突 / 有依赖的串行委派。每个 agent 拿一条 task 自己想细节、自己走 TDD 红-绿-重构（先写测试再写实现）、自己跑验证、自己报产出。主会话只接产出 + 证据，不参与中间过程。
 - **应用 reviewer 反馈本身是子 agent 任务**：采纳 codex 反馈去改 spec 或代码，这个落地动作**必须**委派子 agent 执行，不论目标文件在不在仓库内，主会话不亲手改。
 - **跨需求并行**：用 worktree + 多会话，不在一个会话里塞多个独立 feature。
-- **编排豁免边界**：主会话仍可直接跑 git 版本控制 / make / 部署 / `ghc`，以及 skill 驱动的脚本（codex-worker / api-test / ops 等）——这些是编排，不是排查。但 `git show <path>` / `git cat-file` 这类借 git 读逐文件内容的形态**算排查、不算编排**，**必须**委派子 agent。
+- **编排豁免边界**：主会话仍可直接跑 git 版本控制 / make / 部署 / `ghc`，以及 skill 驱动的脚本（codex-worker / api-test / ops 等）——这些是编排，不是排查。但 `git show <path>` / `git cat-file` 这类借 git 读逐文件内容的形态**算排查、不算编排**，**必须**委派子 agent。Bash 元字符 / argv0 的边界也按同一思路划：判定标准是这条命令**是否触发对仓库内容的实际读写**，不是是否含某个字符。fd-to-fd 复制 `[n]>&[m]` 和 `[n]<&[m]`（m 必须是数字，典型如 `2>&1` `1>&2` `3<&0`）只是复制 fd 表项，不打开文件，主会话直接做；管道 `|` 接 stdout filter argv0（`tail` / `head` / `grep` / `awk` / `sed` / `cut` / `sort` / `uniq` / `wc` / `jq` / `column`）是输出整形不构造命令，主会话直接做；串联 `;` / `&&` / `||` 每段独立走 argv allowlist 校验，主会话直接做。反过来，文件重定向 `>` `>>` `<` 和写文件的语法糖 `&>` `&>>` `>&file`（右侧是文件名 token，非纯数字 fd 编号）、命令替换 `$(...)` 和反引号、输入重定向 `<<<` 和 heredoc `<<` `<<-`、进程替换 `<(...)` `>(...)`，以及 `tee`（写文件）/ `less` `more`（交互）/ `xargs`（任意命令构造）/ `cat` `find` 等读 repo 文件的 argv0——任何一条命中都可能 leak 或污染仓库内容，**必须**委派子 agent。
 - **codex**：外部 reviewer，不是 worker。T1（spec 写完）/ T2（plan 写完，本项目 plan 合并进 spec 不单独触发）/ T3（一批含设计变动的代码 commit 前）/ T4（debug 死循环，需用户先同意），详见 `~/.claude/rules/codex-collaboration.md`。
 
 ### 上线前必须完成的检查（TODO）

--- a/docs/specs/2026-05-20-relax-main-agent-bash-restrictions.md
+++ b/docs/specs/2026-05-20-relax-main-agent-bash-restrictions.md
@@ -15,23 +15,46 @@
 - 不动文件工具铁律：Read / Edit / Write / Grep / Glob / MultiEdit / NotebookEdit / LSP 主会话仍全拦。
 - 不动安全层：`kubectl` 写、`curl` 写、直连 `.svc.cluster.local` / `localhost:*` / 内网 IP、`psql` `mysql` `mongosh` `redis-cli` 等数据库客户端，主子均拦。
 - 不放行 `>` `>>` 文件重定向（哪怕目标在 `/tmp/`）——一旦引入路径白名单就要解析引号、变量展开、相对路径，复杂度和误判风险陡增，收益小到可以用 `| tee /tmp/x` 或 `| tail -N` 全替代。
-- 不放行 `$( ... )`、反引号、`<`、`<<<`、`<( ... )`——这几种是 Trojan 风险源（命令替换可能把 repo 内容当参数 leak，输入重定向可能从 repo 读文件），主会话继续禁用。
+- 不放行 `&>` 和 `&>>`——这两个不是 fd 操作，是 `cmd > out 2>&1` 的语法糖，右侧跟文件路径，会真的写文件。
+- 不放行 `>&file` 这类右侧是文件名 token（非纯数字）的形式，等价于普通文件重定向。
+- 不放行 `>(cmd)`、`<(cmd)` 进程替换——bash 会先把内部命令跑起来，等于给了任意命令构造通道。
+- 不放行 `$(...)`、反引号、`<`、`<<<`——这几种是 Trojan 风险源（命令替换可能把 repo 内容当参数 leak，输入重定向可能从 repo 读文件），主会话继续禁用。
+- 不放行 `tee`（写文件）、`less` / `more`（交互式终端工具）、`xargs`（任意命令构造），这些不进 stdout filter allowlist。
+- 不对 stdout filter 的 argv 做"是否含 repo 路径"的精确判定。`tail CLAUDE.md`、`grep -r foo .` 不会被 hook 拦，这是 A 方案刻意承担的 surface，理由见关键设计决策段。
 - 不动子 agent 行为：子 agent 除安全层外全部放行的现状保持。
 - 不引入 spec 流程 / TDD discipline / 任何工作流层面的改动，本 spec 只动一条 hook 规则 + 一处 CLAUDE.md 表述。
 
 ## 关键设计决策
 
-判定标准从"是否含某个元字符"重写成"**是否触发对仓库内容的实际读写**"。按这个标准重新分类：
+判定标准从"是否含某个元字符"重写成"**是否触发对仓库内容的实际读写**"。按这个标准重新分类。
 
-`2>&1`、`&>`、`>&2`、`>&N`、`<&N`、`&>>`（这里的 N 是数字 fd）这类纯 fd 描述符重定向不写任何文件，只是把一个 fd 复制 / 重定向到另一个 fd，理论上不可能 leak repo 内容也不可能写 repo 文件，应该放行。判定上有一个简单的语法特征：`>` `<` 后面紧跟 `&数字` 或前面是 `数字>&`，整体没有出现文件路径 token。
+放行的形式只有一种：**fd-to-fd 复制**，语法是 `[n]>&[m]` 或 `[n]<&[m]`，其中 m 必须是数字（也就是另一个 fd 编号），左侧 n 可以省略也可以是数字。典型例子有 `2>&1`、`1>&2`、`2>&3`、`3<&0` 等。这种形式只是把内核里的 fd 表项复制一份，不打开任何文件，不可能 leak repo 内容也不可能写 repo 文件。
 
-`>` `>>` 后跟一个路径 token（无论是 `/tmp/x`、`./foo`、`$HOME/y` 还是带引号的形式）继续拦——保守起见全拦，不引入路径白名单。如果用户真需要把输出写到 `/tmp`，可以 `| tee /tmp/x` 或派子 agent。
+必须明确剔除几类容易被错误归到"fd 重定向"里的形式：
 
-`$( ... )`、反引号、`<`、`<<<`、`<(` 继续拦，理由同"不做什么"。
+`&>` 和 `&>>` 看起来像 fd 操作，实际是 `cmd > out 2>&1` 的语法糖，右侧跟的是文件路径，会真的写文件，**不放行**。
 
-管道（`|`）和串联（`;` `&&` `||`）按当前 hook 实现其实已经放行——每段独立走 argv0 allowlist 校验。本 spec 不修改这部分，只补测试覆盖确认行为。
+`>&file` `>&out` 这种右侧是文件名 token（不是纯数字）的形式，是 bash 的另一类语法糖，等价于普通文件重定向，**不放行**。判定标记是 `>&` 后面跟的不是纯数字 token。
 
-CLAUDE.md "编排豁免边界"段（行 134 附近）的措辞需要同步更新一句，澄清"fd 重定向 + 管道整形 + 串联可主会话直接做，文件重定向 / 命令替换 / 输入重定向必须子 agent"，避免读者只看 CLAUDE.md 时误以为含元字符就一定要派子 agent。
+`>(cmd)` 和 `<(cmd)` 是进程替换，bash 会展开成 `/dev/fd/N` 并先把内部命令跑起来——内部命令可以是任意东西，等于给了一条 Trojan 通道，**不放行**。
+
+`>` `>>` 后跟任何路径 token（`/tmp/x`、`./foo`、`$HOME/y`、带引号的形式都算）继续拦，保守起见全拦，不引入路径白名单。如果用户真需要把输出写到 `/tmp`，可以 `| tee /tmp/x` 或派子 agent。
+
+`$(...)`、反引号、`<`、`<<<` 继续拦，理由同"不做什么"。
+
+管道（`|`）和串联（`;` `&&` `||`）按当前 hook 实现其实已经放行——每段独立走 argv0 allowlist 校验。本 spec 不修改这部分判定结构，只补测试覆盖确认行为。
+
+CLAUDE.md "编排豁免边界"段（行 134 附近）的措辞需要同步更新，澄清"fd-to-fd 复制 + stdout filter argv0 可主会话直接做，文件重定向 / 命令替换 / 输入重定向 / 进程替换必须子 agent"，避免读者只看 CLAUDE.md 时误以为含元字符就一定要派子 agent。
+
+## 扩展放行：stdout filter argv0 allowlist
+
+光放 fd-to-fd 复制还不够。用户的真实痛点完整长这样：`make logs APP=channel-proxy LANE=coe-t5-id SINCE=10m 2>&1 | tail -150`。前半段 `2>&1` 的语义问题靠上面的 fd 放行解决；后半段 `| tail -150` 是另一个问题——`tail` 当前根本不在 argv0 allowlist 里，hook 拦的不是 `>` 而是"未审计 argv0"。所以解决用户痛点必须把常见的 stdout filter argv0 一起放进 allowlist，否则 fd 放行单独做了等于没做。
+
+加进 argv0 allowlist 的 stdout filter：`tail`、`head`、`grep`、`awk`、`sed`、`cut`、`sort`、`uniq`、`wc`、`jq`、`column`。这一组的共同特征是从 stdin 读、向 stdout 写、不交互、不写文件、不构造新命令，纯输出整形工具。
+
+明确不放进 allowlist 的几个工具：`tee` 会写文件，落到"文件重定向"语义里，不放；`less` 和 `more` 是交互式终端工具，在 Claude 子进程里跑会卡住或行为诡异，不放；`xargs` 把 stdin 切成 argv 拼成新命令执行，等于任意命令构造，是典型 Trojan 通道，不放。
+
+A 方案承担的 surface 必须明示：放完 `tail/head/grep/awk/sed/...` 之后，主会话用 `tail CLAUDE.md` 或 `grep -r foo .` 不再被 hook 拦，因为 hook 不做"argv 是否含 repo 路径"的精确判定（要做就要解析引号、变量展开、相对路径，工程量和误判面都不划算）。这是 A 方案刻意接受的 trade-off，理由有三条。一是这组 filter 是 read-only，看一眼输出不会污染仓库，没有副作用残留。二是输出量级远小于 Read 工具，`tail -150 CLAUDE.md` 进上下文的最多 150 行，远小于 Read 整文件，对"上下文隔离"铁律的本意冲击有限。三是铁律本意是防代码探索污染主会话上下文（feedback_file_ops_must_use_subagent 里说的就是 Explore / 多文件浏览这种场景），临时整形日志输出不构成代码探索。剩下的风险靠 CLAUDE.md 规范文字约束——如果用户故意 `tail CLAUDE.md` 看仓库代码，那是手贱不是攻击面，不靠 hook 拦。
 
 ## 调用方全覆盖
 
@@ -45,17 +68,32 @@ Hook 的唯一调用方是 Claude Code harness 的 PreToolUse 事件钩子，每
 
 ## 粗颗粒 Task
 
-**T1 — 放行 fd 描述符重定向**
-目标：让 `2>&1`、`&>`、`>&2`、`>&N`、`<&N` 等纯 fd 形式不再触发走私拦截，同时 `> /path`、`< /path`、`$(...)`、反引号继续拦。
-产出：`.claude/hooks/enforce-routing.sh` 走私检测段（约行 249-342）的判定逻辑改动。
-验收：原痛点命令 `make logs APP=channel-proxy LANE=coe-t5-id SINCE=10m 2>&1 | tail -150` 在主会话路径下不被 hook 拦；`git status > CLAUDE.md`、`git status >> ./foo`、`git status $(cat CLAUDE.md)`、` cat \`whoami\` `、`grep foo < src/bar.py` 在主会话路径下仍被拦。
+**T1 — 放行 fd 描述符复制 + 扩展 stdout filter argv0 allowlist**
+目标：让 fd-to-fd 复制（`[n]>&[m]`，m 是数字）不再触发走私拦截；同时把 `tail / head / grep / awk / sed / cut / sort / uniq / wc / jq / column` 这一组 stdout filter argv0 加进 allowlist；其他形式继续拦。
+产出：`.claude/hooks/enforce-routing.sh` 走私检测段（约行 249-342）的判定逻辑改动 + argv0 allowlist 扩展。
+验收清单：
+- 原痛点命令 `make logs APP=channel-proxy LANE=coe-t5-id SINCE=10m 2>&1 | tail -150` 在主会话路径下完整放行。
+- fd-to-fd 复制 `2>&1`、`1>&2`、`2>&3`、`3<&0` 在主会话路径下放行。
+- `&>` / `&>>` / `>&out`（右侧非数字）/ `2>file` / `> /path` / `>> ./foo` / `>(cmd)` / `<(cmd)` 在主会话路径下继续拦。
+- `tail -150`、`head -100`、`grep pattern`、`awk '{print $1}'`、`sed s/x/y/`、`jq .` 这一组作为 pipe segment 的 argv0 在主会话路径下放行。
+- `tee /tmp/x`、`less foo`、`more bar`、`xargs rm` 作为 pipe segment 在主会话路径下继续拦。
+- 走私通道 `git status > CLAUDE.md`、`grep -r foo < src/x.py`、`git status $(cat CLAUDE.md)`、` cat \`whoami\` ` 在主会话路径下继续拦。
 
 **T2 — 补单元测试**
-目标：把"哪些放 / 哪些拦"的边界用测试钉死，防止后续回归。
-产出：`.claude/hooks/test-enforce-routing.sh` 新增 case，至少覆盖：fd 合并 `2>&1` 放行、`&>` 放行、`>&2` 放行、双引号内 `2>&1` 放行；`> /tmp/x` 仍拦、`>> ./foo` 仍拦、`$(...)` 仍拦、反引号仍拦、`< file` 仍拦、`<(...)` 仍拦；以及完整真实痛点 `make logs ... 2>&1 | tail -150` 放行。
-验收：跑 `bash .claude/hooks/test-enforce-routing.sh` 全部 pass，case 数量较改前增加且新 case 与上述场景一一对应。
+目标：把"哪些放 / 哪些拦"的边界用测试钉死，防止后续回归。特别要覆盖 codex T1 review 指出的"安全 fd 后接危险尾巴"组合形态——单看 `2>&1` 是放行的，但拼上 `> out` 或 `&& cat <repo 文件>` 就必须拦，hook 不能因为前缀安全就放过整串。
+产出：`.claude/hooks/test-enforce-routing.sh` 新增 case，必须覆盖以下分组：
+
+组合形态（codex 建议）：`make logs 2>&1 > out` 拦（结尾 `> out` 写文件）、`make logs 2>&1 && cat CLAUDE.md` 拦（`cat` 读 repo 路径，argv0 / 路径都不在允许范围）、`make logs 2>&1 | tail -150` 放。
+
+fd 边界：`2>&1` 放、`1>&2` 放、`3<&0` 放、`&>` 拦、`&>>` 拦、`>&out` 拦（右侧非数字 token）、`2>file` 拦、`>(cmd)` 拦、`<(cmd)` 拦。
+
+stdout filter argv0：`tail -150` 放、`head -100` 放、`grep pattern` 放、`awk '{print $1}'` 放（注意 awk pattern 含 `$1`，spec 测试中要单引号包裹避免 shell 展开）、`sed s/x/y/` 放、`jq .` 放。
+
+危险 argv0：`tee /tmp/x` 拦、`less foo` 拦、`more bar` 拦、`xargs rm` 拦。
+
+验收：跑 `bash .claude/hooks/test-enforce-routing.sh` 全部 pass，case 数量较改前显著增加且新 case 与上述四组场景一一对应。
 
 **T3 — 同步 CLAUDE.md 表述**
 目标：澄清新边界，避免文档和 hook 行为脱节。
-产出：CLAUDE.md "编排豁免边界"段（行 134 附近）补一句话，说明 fd 重定向 / 管道整形 / 串联在主会话可直接做，文件重定向 / 命令替换 / 输入重定向必须子 agent。
-验收：用户人工 review 这一句表述清晰、与 hook 行为一致。
+产出：CLAUDE.md "编排豁免边界"段（行 134 附近）补一句话，要点是 fd-to-fd 复制（`[n]>&[m]`，m=数字）以及 stdout filter argv0（`tail` / `head` / `grep` / `awk` / `sed` / `cut` / `sort` / `uniq` / `wc` / `jq` / `column`）在主会话可直接做；文件重定向（`>` / `>>` / `&>` / `&>>` / `>&file`）、命令替换（`$(...)` / 反引号）、输入重定向（`<` / `<<<` / `<(`）、进程替换（`>(cmd)`）、`tee` / `xargs` / `less` 这些必须子 agent。
+验收：用户人工 review 这一段表述清晰、与 hook 行为一致。

--- a/docs/specs/2026-05-20-relax-main-agent-bash-restrictions.md
+++ b/docs/specs/2026-05-20-relax-main-agent-bash-restrictions.md
@@ -1,0 +1,61 @@
+# Spec: 放松主 agent Bash 元字符限制
+
+## 背景
+
+当前 `.claude/hooks/enforce-routing.sh` 在主会话上跑 Bash 时，命令里只要在引号外出现 `$(` / 反引号 / `>` / `<`（含 `>>` `<<` `>(` `<(`）就一刀切拦截，视为 allowlist argv0 夹带未审计 repo touch 的 Trojan。这条规则把日志查看的高频组合也砸到了：`make logs APP=xxx LANE=xxx SINCE=10m 2>&1 | tail -150`——`2>&1` 里的那个 `>` 是 fd 描述符合并，根本不触发文件 I/O，但规则不区分语义，命中即拦，导致主会话连看日志都要派子 agent。
+
+铁律"主会话对仓库文件零直接接触"的本质动机是上下文隔离（feedback_file_ops_must_use_subagent），适用于 Read/Edit/Write/Grep/Glob 这类文件工具和真正会读写仓库内容的 Bash。fd 描述符重定向不属于这类——它纯粹是输出整形，没有任何 repo touch 的可能性。规则应该按"是否触发对仓库内容的实际读写"来分，而不是"是否含某个字符"。
+
+## 目标
+
+让主会话能直接跑常见运维查询 + 看日志命令（含 fd 合并、管道整形、命令串联），同时保持"主会话对仓库文件零直接接触"的铁律不变；走私规则（`$( ` 反引号、文件重定向、输入重定向）继续硬拦。
+
+## 不做什么
+
+- 不动文件工具铁律：Read / Edit / Write / Grep / Glob / MultiEdit / NotebookEdit / LSP 主会话仍全拦。
+- 不动安全层：`kubectl` 写、`curl` 写、直连 `.svc.cluster.local` / `localhost:*` / 内网 IP、`psql` `mysql` `mongosh` `redis-cli` 等数据库客户端，主子均拦。
+- 不放行 `>` `>>` 文件重定向（哪怕目标在 `/tmp/`）——一旦引入路径白名单就要解析引号、变量展开、相对路径，复杂度和误判风险陡增，收益小到可以用 `| tee /tmp/x` 或 `| tail -N` 全替代。
+- 不放行 `$( ... )`、反引号、`<`、`<<<`、`<( ... )`——这几种是 Trojan 风险源（命令替换可能把 repo 内容当参数 leak，输入重定向可能从 repo 读文件），主会话继续禁用。
+- 不动子 agent 行为：子 agent 除安全层外全部放行的现状保持。
+- 不引入 spec 流程 / TDD discipline / 任何工作流层面的改动，本 spec 只动一条 hook 规则 + 一处 CLAUDE.md 表述。
+
+## 关键设计决策
+
+判定标准从"是否含某个元字符"重写成"**是否触发对仓库内容的实际读写**"。按这个标准重新分类：
+
+`2>&1`、`&>`、`>&2`、`>&N`、`<&N`、`&>>`（这里的 N 是数字 fd）这类纯 fd 描述符重定向不写任何文件，只是把一个 fd 复制 / 重定向到另一个 fd，理论上不可能 leak repo 内容也不可能写 repo 文件，应该放行。判定上有一个简单的语法特征：`>` `<` 后面紧跟 `&数字` 或前面是 `数字>&`，整体没有出现文件路径 token。
+
+`>` `>>` 后跟一个路径 token（无论是 `/tmp/x`、`./foo`、`$HOME/y` 还是带引号的形式）继续拦——保守起见全拦，不引入路径白名单。如果用户真需要把输出写到 `/tmp`，可以 `| tee /tmp/x` 或派子 agent。
+
+`$( ... )`、反引号、`<`、`<<<`、`<(` 继续拦，理由同"不做什么"。
+
+管道（`|`）和串联（`;` `&&` `||`）按当前 hook 实现其实已经放行——每段独立走 argv0 allowlist 校验。本 spec 不修改这部分，只补测试覆盖确认行为。
+
+CLAUDE.md "编排豁免边界"段（行 134 附近）的措辞需要同步更新一句，澄清"fd 重定向 + 管道整形 + 串联可主会话直接做，文件重定向 / 命令替换 / 输入重定向必须子 agent"，避免读者只看 CLAUDE.md 时误以为含元字符就一定要派子 agent。
+
+## 调用方全覆盖
+
+Hook 的唯一调用方是 Claude Code harness 的 PreToolUse 事件钩子，每次主会话或子 agent 发起 Bash / Read / Edit / Write 等工具调用前都会执行一次。直接消费者只有主会话和子 agent 两类。测试调用方只有 `.claude/hooks/test-enforce-routing.sh` 一个。CLAUDE.md "编排豁免边界"段是文档层面的语义来源，需要同步。
+
+不存在间接消费者（hook 不被任何 CI、任何业务代码、任何 skill 脚本调用）。改动只影响主会话发起的 Bash 命令在元字符判定上的行为，子 agent 路径完全不动，安全层完全不动，文件工具铁律完全不动。
+
+## 数据 & 部署影响
+
+零 DB / Redis / MQ / 服务部署改动。影响范围只在本仓库三个文件：`.claude/hooks/enforce-routing.sh`、`.claude/hooks/test-enforce-routing.sh`、`CLAUDE.md`。hook 是 PreToolUse 每次执行 bash 脚本，改完下次主会话调用 Bash 时立即生效，不需要重启 Claude Code、不需要重启会话、不需要部署任何服务。
+
+## 粗颗粒 Task
+
+**T1 — 放行 fd 描述符重定向**
+目标：让 `2>&1`、`&>`、`>&2`、`>&N`、`<&N` 等纯 fd 形式不再触发走私拦截，同时 `> /path`、`< /path`、`$(...)`、反引号继续拦。
+产出：`.claude/hooks/enforce-routing.sh` 走私检测段（约行 249-342）的判定逻辑改动。
+验收：原痛点命令 `make logs APP=channel-proxy LANE=coe-t5-id SINCE=10m 2>&1 | tail -150` 在主会话路径下不被 hook 拦；`git status > CLAUDE.md`、`git status >> ./foo`、`git status $(cat CLAUDE.md)`、` cat \`whoami\` `、`grep foo < src/bar.py` 在主会话路径下仍被拦。
+
+**T2 — 补单元测试**
+目标：把"哪些放 / 哪些拦"的边界用测试钉死，防止后续回归。
+产出：`.claude/hooks/test-enforce-routing.sh` 新增 case，至少覆盖：fd 合并 `2>&1` 放行、`&>` 放行、`>&2` 放行、双引号内 `2>&1` 放行；`> /tmp/x` 仍拦、`>> ./foo` 仍拦、`$(...)` 仍拦、反引号仍拦、`< file` 仍拦、`<(...)` 仍拦；以及完整真实痛点 `make logs ... 2>&1 | tail -150` 放行。
+验收：跑 `bash .claude/hooks/test-enforce-routing.sh` 全部 pass，case 数量较改前增加且新 case 与上述场景一一对应。
+
+**T3 — 同步 CLAUDE.md 表述**
+目标：澄清新边界，避免文档和 hook 行为脱节。
+产出：CLAUDE.md "编排豁免边界"段（行 134 附近）补一句话，说明 fd 重定向 / 管道整形 / 串联在主会话可直接做，文件重定向 / 命令替换 / 输入重定向必须子 agent。
+验收：用户人工 review 这一句表述清晰、与 hook 行为一致。


### PR DESCRIPTION
## Why

The main-agent bash hook was rejecting common log-viewing commands like `make logs APP=foo LANE=foo SINCE=10m 2>&1 | tail -150`. Root cause: the smuggling guard tripped on the `>` inside `2>&1` (an fd-to-fd duplication that touches no file) and on the `| tail` segment (because `tail` was not in the argv0 allowlist). Every "look at the logs" call had to be dispatched to a sub-agent, which was the wrong tax for an operation that has no repo-touch surface.

The rule of thumb is restated: the criterion is **whether the command actually reads or writes repo content**, not whether some character appears. fd-to-fd duplication and stdout filtering pass; file redirection, command substitution, input redirection, and dangerous argv0s do not.

## What changes

`.claude/hooks/enforce-routing.sh`
- New `FD_COPY_RE` pre-scan marks `[n]>&[m]` and `[n]<&[m]` byte spans as safe before the smuggling scan runs, so `2>&1`, `1>&2`, `3<&0`, and adjacent fd-copy forms (`2>&1>&2`) no longer trip the `> < $( \``-in-unquoted guard.
- Left boundary is `(?<!&)` only — excluding `\w` would have wrongly rejected adjacent fd-copy pairs; `&>` and `&>>` are still caught because they are stdout+stderr file-write syntactic sugar, not fd duplication.
- Right boundary requires `[0-9]+(?!\w)` so `>&file`, `>&out`, etc., remain blocked.
- `seg_is_allowed` now permits `tail / head / grep / awk / sed / cut / sort / uniq / wc / jq / column` as argv0. `tee` (writes files), `less / more` (interactive), `xargs` (arbitrary command construction), `cat / find` (read repo paths) are deliberately not added.

`.claude/hooks/test-enforce-routing.sh`
- 78 → 128 cases. New groups: fd-to-fd allow, fd boundary block, stdout-filter allow, dangerous-argv0 block, adjacency edge cases (17 probes covering `2>&1>file`, `2>&1<file`, `2>&1>&2`, `2>&1&>foo`, `2>&12`, quote-internal `>` literals, etc.), and combined forms suggested by codex T1 (`2>&1 > out` blocked, `2>&1 && cat CLAUDE.md` blocked, `2>&1 | tail -150` allowed).

`CLAUDE.md`
- One paragraph appended to the "编排豁免边界" item codifying the new boundary in plain prose: which metacharacters / argv0s the main session may run directly, which must be dispatched to a sub-agent, and the single rule that decides — does this command touch repo content?

`docs/specs/2026-05-20-relax-main-agent-bash-restrictions.md`
- New spec capturing background, design decisions, what is intentionally not done (no path whitelist for `>`, no `tee`/`less`/`xargs` allowance), and the acknowledged surface of allowing `tail CLAUDE.md` / `grep -r foo .` directly from the main session (rationale: read-only, output volume far smaller than the Read tool, the iron rule's real intent is preventing context pollution from code exploration).

## What does NOT change

- File tools (Read / Edit / Write / Grep / Glob / MultiEdit / NotebookEdit / LSP) remain fully blocked in the main session.
- Security layer (kubectl writes, curl writes, direct connections to `*.svc.cluster.local` / internal IPs, db clients like psql/mysql/redis-cli/mongosh) blocked in both main and sub-agent.
- Sub-agent behavior is untouched.
- Trojan vectors stay blocked: `$( ... )`, backticks, `< file`, `<<<`, heredocs, `<(...)`, `>(...)`, file redirection `>` `>>`.

## Verification

- 128 / 128 unit tests pass.
- The original pain command `make logs APP=channel-proxy LANE=coe-t5-id SINCE=10m 2>&1 | tail -150` resolves to exit 0 (allow) when piped to the hook as main-session input.
- Representative regression block cases still return exit 2: `git status > CLAUDE.md`, `git status $(cat CLAUDE.md)`, `` cat `whoami` ``, `grep foo < src/x.py`, `cmd | tee /tmp/x`.

## Test plan

- [ ] Open a new Claude Code session in this repo and run `make logs APP=lark-server LANE=prod SINCE=5m 2>&1 | tail -50` from the main agent; confirm no hook block.
- [ ] Try `git status > CLAUDE.md` and `git diff $(date)` from the main agent; confirm both still blocked.
- [ ] Sub-agent path remains permissive (try the same commands in an Explore/general-purpose agent — all should pass).
