### PR TITLE
fix(channels): IdentityResolver ON CONFLICT DO UPDATE for race safety

### DIFF
--- a/apps/channel-server/src/core/channels/db-identity-resolver.test.ts
+++ b/apps/channel-server/src/core/channels/db-identity-resolver.test.ts
@@ -12,14 +12,17 @@ import type { IdentityKind } from './identity-resolver';
 // DbIdentityResolver 的单测用一个内存版 IdentityStore 顶替真实 DB（生产走
 // TypeORM 实现，运行时才接真实 PG）。这个 fake 必须忠实模拟真实表 upsert 的
 // 关键语义：upsertMapping 走 INSERT ... ON CONFLICT (channel, channel_*_id)
-// DO NOTHING 然后回取 internal_id——并发首次出现下永远收敛到同一个
-// internal_id，且不依赖外层事务是否存在/隔离级别。PK(ULID) 冲突单独信号。
+// DO UPDATE ... RETURNING——并发首次出现下永远收敛到同一个 internal_id，
+// 且不依赖外层事务是否存在/隔离级别（DO UPDATE 永远 RETURNING 那条行，不再
+// 像 DO NOTHING + UNION ALL 那样在 read committed 下并发 race 返回 0 行）。
+// PK(ULID) 冲突单独信号。
 
 interface Stored extends IdentityRow {}
 
 // 行为可控的内存 store，模拟真实 PG 的两类约束：
-//   - forward-key (kind, channel, channelId) 复合唯一：ON CONFLICT DO NOTHING
-//     语义——已存在则不插，直接收敛回已有 internalId（绝不抛错）。
+//   - forward-key (kind, channel, channelId) 复合唯一：ON CONFLICT DO UPDATE
+//     语义——已存在则 SET 一个 no-op 字段触发 RETURNING，直接收敛回已有
+//     internalId（绝不抛错）。
 //   - internal_*_id 主键(ULID)唯一：极罕见撞了抛 PrimaryKeyConflictError，
 //     resolver 负责重新生成 ULID 重试，不当 forward-key 冲突。
 class FakeIdentityStore implements IdentityStore {
@@ -65,8 +68,8 @@ class FakeIdentityStore implements IdentityStore {
 
     async upsertMapping(row: IdentityRow): Promise<string> {
         this.upsertCalls += 1;
-        // forward-key 已存在：ON CONFLICT DO NOTHING -> 回取已有 internalId，
-        // 永远收敛到同一个，绝不抛错（这是不依赖外层事务的关键）。
+        // forward-key 已存在：ON CONFLICT DO UPDATE RETURNING -> 拉回已有
+        // internalId，永远收敛到同一个，绝不抛错（这是不依赖外层事务的关键）。
         const fwd = this.rows.find(
             (r) =>
                 r.kind === row.kind &&
@@ -139,7 +142,7 @@ describe('DbIdentityResolver upsert 写路径与冲突处理', () => {
         const r = new DbIdentityResolver(txnStore);
         const a = await r.resolve('chat', 'qq', 'txn-1');
         // 第二次：事务已脆弱，若 resolver 还走 check/回读会抛 aborted；
-        // upsert 化后只调 upsertMapping，DO NOTHING 收敛回 a，不读。
+        // upsert 化后只调 upsertMapping，DO UPDATE RETURNING 收敛回 a，不读。
         const b = await r.resolve('chat', 'qq', 'txn-1');
         expect(a).toBe(b);
     });

--- a/apps/channel-server/src/core/channels/db-identity-resolver.ts
+++ b/apps/channel-server/src/core/channels/db-identity-resolver.ts
@@ -9,11 +9,14 @@
 // 落哪张表，三张表结构相同。
 //
 // 写路径用单 SQL upsert（INSERT ... ON CONFLICT (channel, channel_*_id)
-// DO NOTHING 然后回取 internal_id），不再 check-then-insert-catch：
+// DO UPDATE ... RETURNING），不再 check-then-insert-catch：
 //   - 不依赖 TypeORM 默认 autocommit / READ COMMITTED——即使后续接线把 resolve
 //     包进外层显式 PG 事务，也不会因 23505 让事务进 aborted 后回读全失败；
-//   - forward-key (channel, channel_*_id) 冲突由 ON CONFLICT 在引擎内收敛，
-//     永远拿回同一个 internal_id；
+//   - forward-key (channel, channel_*_id) 冲突由 ON CONFLICT DO UPDATE 在
+//     引擎内收敛，DO UPDATE 永远 RETURNING 那条行（哪怕 SET 是 no-op），
+//     永远拿回同一个 internal_id（旧实现用 DO NOTHING + CTE UNION ALL
+//     SELECT 兜底，read committed 下并发同 forward-key 会让 UNION ALL 的
+//     SELECT 看不到 conflicting row，返回 0 行让 fail-loud 误伤）；
 //   - internal_*_id 主键(ULID)冲突是另一类（store 抛 PrimaryKeyConflictError），
 //     极罕见，由本模块重新生成 ULID 有限次重试，绝不当 forward-key 冲突收敛。
 
@@ -33,8 +36,8 @@ export interface IdentityRow {
 }
 
 // internal_*_id 主键(ULID)唯一约束被违反时抛这个。与 forward-key 冲突严格区分：
-// forward-key 冲突由 upsert 的 ON CONFLICT DO NOTHING 在 DB 引擎内静默收敛
-// （store 不抛错、直接回取已有 internalId）；只有 ULID 主键撞了（同一 ULID 被
+// forward-key 冲突由 upsert 的 ON CONFLICT DO UPDATE 在 DB 引擎内静默收敛
+// （store 不抛错、DO UPDATE RETURNING 直接拉回已有 internalId）；只有 ULID 主键撞了（同一 ULID 被
 // 两条不同 forward-key 占用，128bit 熵下概率极低）才抛本错误，让 resolver
 // 重新生成 ULID 重试，绝不把它误当 forward-key 冲突收敛到别人的映射。
 export class PrimaryKeyConflictError extends Error {
@@ -65,8 +68,13 @@ export interface IdentityStore {
     ): Promise<{ channel: string; channelId: string } | null>;
 
     // upsert 语义（单 SQL，事务安全无脆弱假设）：
-    //   INSERT ... ON CONFLICT (channel, channel_*_id) DO NOTHING
-    //   然后回取该 (channel, channel_*_id) 的 internal_*_id 返回。
+    //   INSERT ... ON CONFLICT (channel, channel_*_id) DO UPDATE
+    //     SET <channel_id_col> = EXCLUDED.<channel_id_col>
+    //   RETURNING <internal_id_col>
+    //   —— DO UPDATE 永远 RETURNING 那条行（哪怕 SET 是 no-op），不再需要
+    //   CTE UNION ALL SELECT 兜底；旧 DO NOTHING + UNION ALL 在 PG read
+    //   committed 下并发同 forward-key 会让 UNION ALL 的 SELECT 看不到
+    //   conflicting row 返回 0 行 → fail-loud 丢消息。
     // 行为契约：
     //   - forward-key (kind, channel, channelId) 已存在 -> 不插入，返回已有
     //     internalId（并发首次出现时所有竞争者都收敛到同一个；绝不抛错，
@@ -145,8 +153,8 @@ export class DbIdentityResolver implements IdentityResolver {
         }
 
         // 未命中：走单 SQL upsert（ON CONFLICT (channel, channel_*_id)
-        // DO NOTHING + 回取 internal_id）。forward-key 冲突由 DB 引擎在
-        // 单条语句内收敛——无 check-then-insert 竞态，不依赖外层事务/隔离级别。
+        // DO UPDATE ... RETURNING）。forward-key 冲突由 DB 引擎在单条语句
+        // 内收敛——无 check-then-insert 竞态，不依赖外层事务/隔离级别。
         // 唯一需要应用层处理的是 internal_*_id 主键(ULID)冲突：换 ULID 重试。
         let lastErr: unknown;
         for (let attempt = 0; attempt < MAX_PK_RETRIES; attempt++) {

--- a/apps/channel-server/src/infrastructure/dal/repositories/identity-store.race.test.ts
+++ b/apps/channel-server/src/infrastructure/dal/repositories/identity-store.race.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect, mock, beforeEach } from 'bun:test';
+
+// 钉死 TypeOrmIdentityStore.upsertMapping 的 SQL 形态与 race 安全语义。
+//
+// 真实 prod bug（已在丢消息）：
+//   旧实现 SQL =
+//     WITH ins AS (
+//       INSERT ... ON CONFLICT ON CONSTRAINT uq_* DO NOTHING
+//       RETURNING <internal_col> AS internal_id
+//     )
+//     SELECT internal_id FROM ins
+//     UNION ALL
+//     SELECT <internal_col> AS internal_id FROM <table>
+//     WHERE channel=$2 AND <channel_id_col>=$3
+//     LIMIT 1
+//   并发同 (channel, channel_id) 第二次进来：INSERT 走 ON CONFLICT DO NOTHING
+//   → ins 0 行；PG read committed 下同一 CTE 的 UNION ALL SELECT 看不到那条
+//   conflicting row（snapshot 边界） → SELECT 0 行 → 整体 0 行 → store 抛
+//   "returned no internal id; store is inconsistent" → fail-loud 链路中断 →
+//   prod 丢消息。
+//
+// 修复方向：改成 ON CONFLICT ... DO UPDATE SET <indexed_col>=EXCLUDED.<...>
+// RETURNING <internal_col>。DO UPDATE 即使 SET no-op 也"涉及行"，永远把那行
+// 通过 RETURNING 拉回，不再依赖 CTE UNION ALL 兜底。三张表 (identity_user /
+// identity_chat / identity_message) 同款 SQL 全部统一。
+//
+// 不连真实 PG —— mock @ormconfig 让我们能捕获实际下发的 SQL 文本，并按需
+// 模拟 query 返回行。
+
+let capturedSqls: string[] = [];
+let nextRows: Array<Array<{ internal_id: string }>> = [];
+
+const queryMock = mock(async (sql: string, _params: unknown[]) => {
+    capturedSqls.push(sql);
+    // 顺序消费下一个预设的返回值；没预设则返回单行（默认 happy path）。
+    const next = nextRows.shift();
+    if (next !== undefined) return next;
+    return [{ internal_id: 'DEFAULT_ULID_______________' }];
+});
+
+mock.module('@ormconfig', () => ({
+    default: {
+        query: queryMock,
+    },
+}));
+
+// 让 identity-store.ts 顶层 import 的 entities 不实际走 TypeORM 解析（解析
+// 流程在测试环境下没意义；TypeOrmIdentityStore 真正用到 KIND_TABLE.entity
+// 的只在 findInternalId/findChannelRef，本测试只覆盖 upsertMapping 路径）。
+mock.module('@entities/identity-mapping', () => ({
+    IdentityUser: class {},
+    IdentityChat: class {},
+    IdentityMessage: class {},
+}));
+
+const { TypeOrmIdentityStore } = await import('./identity-store');
+
+const KIND_CASES = [
+    {
+        kind: 'user' as const,
+        table: 'identity_user',
+        internalCol: 'internal_user_id',
+        channelIdCol: 'channel_user_id',
+        constraint: 'uq_identity_user_channel',
+    },
+    {
+        kind: 'chat' as const,
+        table: 'identity_chat',
+        internalCol: 'internal_chat_id',
+        channelIdCol: 'channel_chat_id',
+        constraint: 'uq_identity_chat_channel',
+    },
+    {
+        kind: 'message' as const,
+        table: 'identity_message',
+        internalCol: 'internal_message_id',
+        channelIdCol: 'channel_message_id',
+        constraint: 'uq_identity_message_channel',
+    },
+];
+
+describe('TypeOrmIdentityStore.upsertMapping race-safe SQL 形态契约', () => {
+    beforeEach(() => {
+        capturedSqls = [];
+        nextRows = [];
+        queryMock.mockClear();
+    });
+
+    for (const c of KIND_CASES) {
+        it(`${c.kind}: SQL 必须用 DO UPDATE + RETURNING，不得用 DO NOTHING + UNION ALL SELECT 兜底`, async () => {
+            // 预设 RETURNING 返回单行（DO UPDATE 永远 RETURNING）
+            nextRows.push([{ internal_id: 'ULID_FROM_RETURNING_______' }]);
+
+            const store = new TypeOrmIdentityStore();
+            const got = await store.upsertMapping({
+                kind: c.kind,
+                channel: 'lark',
+                channelId: 'om_xxx',
+                internalId: 'ULID_FRESH_______________0',
+            });
+            expect(got).toBe('ULID_FROM_RETURNING_______');
+
+            expect(capturedSqls).toHaveLength(1);
+            const sql = capturedSqls[0]!;
+
+            // 必须含目标表/约束/列名
+            expect(sql).toContain(c.table);
+            expect(sql).toContain(c.constraint);
+            expect(sql).toContain(c.internalCol);
+            expect(sql).toContain(c.channelIdCol);
+
+            // 必须是 DO UPDATE，不再 DO NOTHING
+            expect(sql).toMatch(/ON\s+CONFLICT\s+ON\s+CONSTRAINT\s+\w+\s+DO\s+UPDATE/i);
+            expect(sql).not.toMatch(/DO\s+NOTHING/i);
+
+            // 不应再有 CTE/UNION ALL 兜底（DO UPDATE 永远 RETURNING）
+            expect(sql).not.toMatch(/UNION\s+ALL/i);
+            expect(sql).not.toMatch(/\bWITH\s+ins\b/i);
+
+            // 必须 RETURNING internalCol
+            expect(sql).toMatch(
+                new RegExp(`RETURNING\\s+${c.internalCol}`, 'i'),
+            );
+
+            // EXCLUDED.* 引用（DO UPDATE SET 用到 EXCLUDED 才是规范写法）
+            expect(sql).toMatch(/EXCLUDED\./);
+        });
+    }
+
+    it('race 复现：旧 SQL pattern 下 conflict 路径若返回 0 行会 fail-loud；新 SQL DO UPDATE 永远返回单行，store 不再抛 inconsistent', async () => {
+        // 这条直接对着 race 行为：模拟"DB 在 conflict 路径仍然 RETURNING 一行"
+        // —— 这是 DO UPDATE 的承诺，PG 引擎保证。
+        // 旧实现下当 conflict 触发 DO NOTHING 时 query 返回 []，store 抛
+        // inconsistent。新实现下 DB 永远不会返回 []，所以 store 永远拿到 id。
+        nextRows.push([{ internal_id: 'EXISTING_ULID_______________' }]);
+
+        const store = new TypeOrmIdentityStore();
+        const id = await store.upsertMapping({
+            kind: 'message',
+            channel: 'lark',
+            channelId: 'om_existing',
+            internalId: 'CANDIDATE_ULID_NOT_USED____',
+        });
+
+        expect(id).toBe('EXISTING_ULID_______________');
+        // 不抛 "returned no internal id" / "store is inconsistent"
+        // —— 通过 await 不抛 就证明了。
+    });
+});

--- a/apps/channel-server/src/infrastructure/dal/repositories/identity-store.ts
+++ b/apps/channel-server/src/infrastructure/dal/repositories/identity-store.ts
@@ -1,9 +1,12 @@
 // 生产运行时的 IdentityStore 实现：用 TypeORM 读写 identity_user /
 // identity_chat / identity_message 三张映射表。写路径用真实的
-// INSERT ... ON CONFLICT (channel, channel_*_id) DO NOTHING + RETURNING /
-// 回取，把 forward-key 冲突交给 PG 引擎在单条语句内收敛（事务安全、不依赖
-// 隔离级别），只把 internal_*_id 主键(ULID)冲突翻译成
-// PrimaryKeyConflictError 让 DbIdentityResolver 换 ULID 重试。
+// INSERT ... ON CONFLICT (channel, channel_*_id) DO UPDATE ... RETURNING，
+// 把 forward-key 冲突交给 PG 引擎在单条语句内收敛（事务安全、不依赖隔离
+// 级别——DO UPDATE 永远 RETURNING，不需要 CTE/UNION ALL 兜底；之前用 DO
+// NOTHING + UNION ALL SELECT 在 read committed 下 race 时 SELECT 看不到
+// conflicting row，会返回 0 行让上游 fail-loud）。只把 internal_*_id 主键
+// (ULID) 冲突翻译成 PrimaryKeyConflictError 让 DbIdentityResolver 换 ULID
+// 重试。
 //
 // 单测不 import 本文件（它静态依赖 TypeORM 数据源）；DbIdentityResolver 的
 // 单测走内存版 FakeIdentityStore。本文件只在运行时接线时使用。
@@ -99,22 +102,23 @@ export class TypeOrmIdentityStore implements IdentityStore {
 
     async upsertMapping(row: IdentityRow): Promise<string> {
         const t = KIND_TABLE[row.kind];
-        // 单 SQL upsert：对 forward-key 复合唯一约束 ON CONFLICT DO NOTHING；
-        // DO NOTHING 时 RETURNING 不产出行，故用 CTE 在 INSERT 不命中时回取
-        // 已存在行的 internal id，保证恒返回收敛后的 internal id（一条语句、
-        // 不依赖外层事务/隔离级别——并发首次出现下 PG 引擎内收敛）。
+        // 单 SQL upsert：对 forward-key 复合唯一约束 ON CONFLICT DO UPDATE。
+        // 之前用 DO NOTHING + 同 CTE UNION ALL SELECT 回取，PG read committed
+        // 下当 DO NOTHING 触发时同语句的 SELECT 看不到 conflicting row（快照
+        // 边界），并发同 (channel, channel_*_id) 第二次进来 SELECT 0 行 → 整体
+        // 0 行 → 调用方 fail-loud → prod 丢消息。
+        //
+        // DO UPDATE 即使 SET 为 no-op（把 channel_*_id 设回 EXCLUDED.* 同值）
+        // 仍会"涉及行"，把那条行通过 RETURNING 拉回来，永远拿到 internal_id；
+        // forward-key 在 PG 引擎单语句内收敛，不依赖外层事务/隔离级别。
+        // 注意：永远不要 SET internal_*_id —— 那是全局主键，DO UPDATE 时
+        // 已存在行的 internal_id 不能被来访 candidate ULID 覆盖。
         const sql = `
-            WITH ins AS (
-                INSERT INTO ${t.table} (${t.internalCol}, channel, ${t.channelIdCol})
-                VALUES ($1, $2, $3)
-                ON CONFLICT ON CONSTRAINT ${t.forwardConstraint} DO NOTHING
-                RETURNING ${t.internalCol} AS internal_id
-            )
-            SELECT internal_id FROM ins
-            UNION ALL
-            SELECT ${t.internalCol} AS internal_id FROM ${t.table}
-            WHERE channel = $2 AND ${t.channelIdCol} = $3
-            LIMIT 1
+            INSERT INTO ${t.table} (${t.internalCol}, channel, ${t.channelIdCol})
+            VALUES ($1, $2, $3)
+            ON CONFLICT ON CONSTRAINT ${t.forwardConstraint}
+            DO UPDATE SET ${t.channelIdCol} = EXCLUDED.${t.channelIdCol}
+            RETURNING ${t.internalCol} AS internal_id
         `;
         try {
             const rows = (await AppDataSource.query(sql, [


### PR DESCRIPTION
Under PG read committed, ON CONFLICT DO NOTHING + UNION ALL SELECT for
fallback hits a snapshot visibility edge: when DO NOTHING fires, the
SELECT inside the same CTE does not see the conflicting row yet.
Concurrent IdentityResolver.resolve() on the same (channel, key) -- which
happens when the inbound chain triggers identity lookup multiple times
asynchronously -- returns zero rows, fail-loud trips, prod drops messages.

Switch to ON CONFLICT DO UPDATE SET <indexed_col>=EXCLUDED.<indexed_col>.
DO UPDATE always emits the affected row through RETURNING regardless of
whether the SET is a no-op, so resolve() always gets back the existing
internal_id when the conflict path is taken. No more UNION ALL fallback.

Applied to identity_user / identity_chat / identity_message uniformly.
