### PR TITLE
revert(channels): IdentityResolver back to raw SQL ON CONFLICT idiom

### DIFF
--- a/apps/channel-server/src/infrastructure/dal/repositories/identity-store.race.test.ts
+++ b/apps/channel-server/src/infrastructure/dal/repositories/identity-store.race.test.ts
@@ -1,243 +1,149 @@
 import { describe, it, expect, mock, beforeEach } from 'bun:test';
 
-// 钉死 TypeOrmIdentityStore.upsertMapping 的 race-safe 语义 + 实现禁令：
-// 必须用 TypeORM Repository 标准 ORM 接口（findOne / save），禁止裸 SQL
-// (AppDataSource.query 调用) 出现在该文件。
+// 钉死 TypeOrmIdentityStore.upsertMapping 的 SQL 形态与 race 安全语义。
 //
 // 真实 prod bug（已在丢消息）：
-//   旧实现用手写 SQL "INSERT ... ON CONFLICT DO NOTHING + UNION ALL SELECT"
-//   并发 race 时 UNION ALL 看不到 conflicting row，返回 0 行 fail-loud。
-//   之后改成 raw SQL "ON CONFLICT DO UPDATE RETURNING" 修了 race，但 raw SQL
-//   是 critical concurrency primitive 上的硬骨头，不该在业务层手写。
-//   本次彻底改用 ORM repository.findOne + repository.save（unique violation
-//   → catch + 重读）—— PG 内部 visibility 语义交给 TypeORM 处理。
+//   旧实现 SQL =
+//     WITH ins AS (
+//       INSERT ... ON CONFLICT ON CONSTRAINT uq_* DO NOTHING
+//       RETURNING <internal_col> AS internal_id
+//     )
+//     SELECT internal_id FROM ins
+//     UNION ALL
+//     SELECT <internal_col> AS internal_id FROM <table>
+//     WHERE channel=$2 AND <channel_id_col>=$3
+//     LIMIT 1
+//   并发同 (channel, channel_id) 第二次进来：INSERT 走 ON CONFLICT DO NOTHING
+//   → ins 0 行；PG read committed 下同一 CTE 的 UNION ALL SELECT 看不到那条
+//   conflicting row（snapshot 边界） → SELECT 0 行 → 整体 0 行 → store 抛
+//   "returned no internal id; store is inconsistent" → fail-loud 链路中断 →
+//   prod 丢消息。
 //
-// 不连真实 PG —— mock @ormconfig 让我们能验证 ORM 接口的调用形态 + 模拟
-// 并发场景下 forward-key 已被别人占用的情况。
+// 修复方向：改成 ON CONFLICT ... DO UPDATE SET <indexed_col>=EXCLUDED.<...>
+// RETURNING <internal_col>。DO UPDATE 即使 SET no-op 也"涉及行"，永远把那行
+// 通过 RETURNING 拉回，不再依赖 CTE UNION ALL 兜底。三张表 (identity_user /
+// identity_chat / identity_message) 同款 SQL 全部统一。
+//
+// 不连真实 PG —— mock @ormconfig 让我们能捕获实际下发的 SQL 文本，并按需
+// 模拟 query 返回行。
 
-interface FakeRow {
-    channel: string;
-    [key: string]: string;
-}
+let capturedSqls: string[] = [];
+let nextRows: Array<Array<{ internal_id: string }>> = [];
 
-// 模拟 TypeORM Repository：保留 (channel, channelIdCol) 复合唯一约束 +
-// internal_id 主键唯一约束的行为。
-class FakeRepo {
-    rows: FakeRow[] = [];
-    findOneCalls = 0;
-    saveCalls = 0;
-    upsertCalls = 0;
-    queryCalls = 0;
-
-    constructor(
-        private readonly internalCol: string,
-        private readonly channelIdCol: string,
-        private readonly forwardConstraint: string,
-    ) {}
-
-    async findOne(opts: { where: Record<string, string> }): Promise<FakeRow | null> {
-        this.findOneCalls += 1;
-        const where = opts.where;
-        const hit = this.rows.find((r) =>
-            Object.keys(where).every((k) => r[k] === where[k]),
-        );
-        return hit ?? null;
-    }
-
-    async save(row: FakeRow): Promise<FakeRow> {
-        this.saveCalls += 1;
-        // 模拟 PG forward-key 唯一约束：(channel, channelIdCol) 已存在 → 抛 23505
-        const fwdHit = this.rows.find(
-            (r) =>
-                r.channel === row.channel &&
-                r[this.channelIdCol] === row[this.channelIdCol],
-        );
-        if (fwdHit) {
-            const e: Error & { code?: string; constraint?: string } = new Error(
-                'duplicate key value violates unique constraint',
-            );
-            e.code = '23505';
-            e.constraint = this.forwardConstraint;
-            (e as unknown as { driverError: { code: string; constraint: string } }).driverError = {
-                code: '23505',
-                constraint: this.forwardConstraint,
-            };
-            throw e;
-        }
-        // 模拟 PG 主键唯一约束：internal_id 已存在 → 抛 23505 但 constraint 是主键
-        const pkHit = this.rows.find(
-            (r) => r[this.internalCol] === row[this.internalCol],
-        );
-        if (pkHit) {
-            const e: Error & { code?: string; constraint?: string } = new Error(
-                'duplicate key value violates unique constraint',
-            );
-            e.code = '23505';
-            e.constraint = `identity_pkey`;
-            (e as unknown as { driverError: { code: string; constraint: string } }).driverError = {
-                code: '23505',
-                constraint: `identity_pkey`,
-            };
-            throw e;
-        }
-        this.rows.push({ ...row });
-        return row;
-    }
-}
-
-// 注入这些 fake repo 给 TypeOrmIdentityStore 通过 AppDataSource.getRepository
-const repos = {
-    user: new FakeRepo('internal_user_id', 'channel_user_id', 'uq_identity_user_channel'),
-    chat: new FakeRepo('internal_chat_id', 'channel_chat_id', 'uq_identity_chat_channel'),
-    message: new FakeRepo('internal_message_id', 'channel_message_id', 'uq_identity_message_channel'),
-};
-
-// query() 调用计数 —— 这是禁令：实现里不应该再调用 AppDataSource.query()
-let rawQueryCalls = 0;
-
-const getRepositoryMock = mock((entity: { name?: string }) => {
-    const name = entity?.name ?? '';
-    if (name.includes('User')) return repos.user;
-    if (name.includes('Chat')) return repos.chat;
-    if (name.includes('Message')) return repos.message;
-    throw new Error(`unknown entity: ${name}`);
-});
-
-const queryMock = mock(async (_sql: string, _params?: unknown[]) => {
-    rawQueryCalls += 1;
-    return [];
+const queryMock = mock(async (sql: string, _params: unknown[]) => {
+    capturedSqls.push(sql);
+    // 顺序消费下一个预设的返回值；没预设则返回单行（默认 happy path）。
+    const next = nextRows.shift();
+    if (next !== undefined) return next;
+    return [{ internal_id: 'DEFAULT_ULID_______________' }];
 });
 
 mock.module('@ormconfig', () => ({
     default: {
-        getRepository: getRepositoryMock,
         query: queryMock,
     },
 }));
 
+// 让 identity-store.ts 顶层 import 的 entities 不实际走 TypeORM 解析（解析
+// 流程在测试环境下没意义；TypeOrmIdentityStore 真正用到 KIND_TABLE.entity
+// 的只在 findInternalId/findChannelRef，本测试只覆盖 upsertMapping 路径）。
 mock.module('@entities/identity-mapping', () => ({
-    IdentityUser: class { static name = 'IdentityUser'; },
-    IdentityChat: class { static name = 'IdentityChat'; },
-    IdentityMessage: class { static name = 'IdentityMessage'; },
+    IdentityUser: class {},
+    IdentityChat: class {},
+    IdentityMessage: class {},
 }));
 
 const { TypeOrmIdentityStore } = await import('./identity-store');
-const { PrimaryKeyConflictError } = await import('@core/channels/db-identity-resolver');
 
-describe('TypeOrmIdentityStore.upsertMapping race-safe via TypeORM ORM 接口', () => {
+const KIND_CASES = [
+    {
+        kind: 'user' as const,
+        table: 'identity_user',
+        internalCol: 'internal_user_id',
+        channelIdCol: 'channel_user_id',
+        constraint: 'uq_identity_user_channel',
+    },
+    {
+        kind: 'chat' as const,
+        table: 'identity_chat',
+        internalCol: 'internal_chat_id',
+        channelIdCol: 'channel_chat_id',
+        constraint: 'uq_identity_chat_channel',
+    },
+    {
+        kind: 'message' as const,
+        table: 'identity_message',
+        internalCol: 'internal_message_id',
+        channelIdCol: 'channel_message_id',
+        constraint: 'uq_identity_message_channel',
+    },
+];
+
+describe('TypeOrmIdentityStore.upsertMapping race-safe SQL 形态契约', () => {
     beforeEach(() => {
-        repos.user.rows = [];
-        repos.chat.rows = [];
-        repos.message.rows = [];
-        repos.user.findOneCalls = 0;
-        repos.user.saveCalls = 0;
-        repos.chat.findOneCalls = 0;
-        repos.chat.saveCalls = 0;
-        repos.message.findOneCalls = 0;
-        repos.message.saveCalls = 0;
-        rawQueryCalls = 0;
+        capturedSqls = [];
+        nextRows = [];
+        queryMock.mockClear();
     });
 
-    it('禁用 raw SQL：上层 ORM 接口收敛后，AppDataSource.query 不应被调用', async () => {
-        const store = new TypeOrmIdentityStore();
-        await store.upsertMapping({
-            kind: 'message',
-            channel: 'lark',
-            channelId: 'om_first',
-            internalId: 'ULID_FRESH________________',
+    for (const c of KIND_CASES) {
+        it(`${c.kind}: SQL 必须用 DO UPDATE + RETURNING，不得用 DO NOTHING + UNION ALL SELECT 兜底`, async () => {
+            // 预设 RETURNING 返回单行（DO UPDATE 永远 RETURNING）
+            nextRows.push([{ internal_id: 'ULID_FROM_RETURNING_______' }]);
+
+            const store = new TypeOrmIdentityStore();
+            const got = await store.upsertMapping({
+                kind: c.kind,
+                channel: 'lark',
+                channelId: 'om_xxx',
+                internalId: 'ULID_FRESH_______________0',
+            });
+            expect(got).toBe('ULID_FROM_RETURNING_______');
+
+            expect(capturedSqls).toHaveLength(1);
+            const sql = capturedSqls[0]!;
+
+            // 必须含目标表/约束/列名
+            expect(sql).toContain(c.table);
+            expect(sql).toContain(c.constraint);
+            expect(sql).toContain(c.internalCol);
+            expect(sql).toContain(c.channelIdCol);
+
+            // 必须是 DO UPDATE，不再 DO NOTHING
+            expect(sql).toMatch(/ON\s+CONFLICT\s+ON\s+CONSTRAINT\s+\w+\s+DO\s+UPDATE/i);
+            expect(sql).not.toMatch(/DO\s+NOTHING/i);
+
+            // 不应再有 CTE/UNION ALL 兜底（DO UPDATE 永远 RETURNING）
+            expect(sql).not.toMatch(/UNION\s+ALL/i);
+            expect(sql).not.toMatch(/\bWITH\s+ins\b/i);
+
+            // 必须 RETURNING internalCol
+            expect(sql).toMatch(
+                new RegExp(`RETURNING\\s+${c.internalCol}`, 'i'),
+            );
+
+            // EXCLUDED.* 引用（DO UPDATE SET 用到 EXCLUDED 才是规范写法）
+            expect(sql).toMatch(/EXCLUDED\./);
         });
-        // 实现必须只用 ORM repository.findOne / repository.save / repository.upsert
-        // 等标准接口；query() 不应被调用。
-        expect(rawQueryCalls).toBe(0);
-    });
+    }
 
-    it('forward-key 不存在 -> save 成功返回 internalId', async () => {
+    it('race 复现：旧 SQL pattern 下 conflict 路径若返回 0 行会 fail-loud；新 SQL DO UPDATE 永远返回单行，store 不再抛 inconsistent', async () => {
+        // 这条直接对着 race 行为：模拟"DB 在 conflict 路径仍然 RETURNING 一行"
+        // —— 这是 DO UPDATE 的承诺，PG 引擎保证。
+        // 旧实现下当 conflict 触发 DO NOTHING 时 query 返回 []，store 抛
+        // inconsistent。新实现下 DB 永远不会返回 []，所以 store 永远拿到 id。
+        nextRows.push([{ internal_id: 'EXISTING_ULID_______________' }]);
+
         const store = new TypeOrmIdentityStore();
         const id = await store.upsertMapping({
-            kind: 'user',
-            channel: 'lark',
-            channelId: 'uid_1',
-            internalId: 'ULID_FRESH_USER___________',
-        });
-        expect(id).toBe('ULID_FRESH_USER___________');
-        expect(repos.user.rows).toHaveLength(1);
-        expect(repos.user.rows[0]!.channel_user_id).toBe('uid_1');
-        expect(repos.user.rows[0]!.internal_user_id).toBe(
-            'ULID_FRESH_USER___________',
-        );
-    });
-
-    it('forward-key 已存在（race 复现）：upsertMapping 收敛回已有 internalId、不抛错', async () => {
-        // 预置已有行（并发竞争场景：别人已经写过同 (channel, channelId)）
-        repos.message.rows.push({
-            channel: 'lark',
-            channel_message_id: 'om_exist',
-            internal_message_id: 'EXISTING_ULID_______________',
-        });
-
-        const store = new TypeOrmIdentityStore();
-        const id = await store.upsertMapping({
             kind: 'message',
             channel: 'lark',
-            channelId: 'om_exist',
+            channelId: 'om_existing',
             internalId: 'CANDIDATE_ULID_NOT_USED____',
         });
-        // 必须返回已有的 internalId（不是 candidate）—— ON CONFLICT 收敛语义
+
         expect(id).toBe('EXISTING_ULID_______________');
-        // 仍然只有一行（candidate 没有被新插入）
-        expect(repos.message.rows).toHaveLength(1);
-    });
-
-    it('forward-key save race（同时写）：第一次 race 抛 23505 forward 约束后，重新读到现有行并返回其 internalId', async () => {
-        // 模拟"我先 findOne 看没人，然后 save 时 race 输了"的并发：findOne
-        // 阶段为空，但 save 时另一个并发已写入。实现应捕获 23505 + 重读，
-        // 拿到现有行的 internalId 返回。
-        const store = new TypeOrmIdentityStore();
-
-        // 在 save 之前篡改 rows：第一次 findOne 返回 null，save 触发 23505，
-        // 实现再重新 findOne 拿到这条 race-winner 的 internalId
-        let saveAttempt = 0;
-        const origSave = repos.chat.save.bind(repos.chat);
-        repos.chat.save = (async (row: FakeRow) => {
-            saveAttempt += 1;
-            if (saveAttempt === 1) {
-                // 模拟 race winner 抢先写入
-                repos.chat.rows.push({
-                    channel: row.channel,
-                    channel_chat_id: row.channel_chat_id!,
-                    internal_chat_id: 'WINNER_ULID________________',
-                });
-            }
-            return origSave(row);
-        }) as typeof repos.chat.save;
-
-        const id = await store.upsertMapping({
-            kind: 'chat',
-            channel: 'lark',
-            channelId: 'oc_race',
-            internalId: 'LOSER_CANDIDATE_ULID_______',
-        });
-        // 实现必须返回 race winner 的 internalId（不是 candidate 也不抛错）
-        expect(id).toBe('WINNER_ULID________________');
-    });
-
-    it('internal_id 主键(ULID)冲突：抛 PrimaryKeyConflictError 让 resolver 重新生成', async () => {
-        // 预置一行占用某个 ULID（不同 forward-key），下次 upsert 用同一 ULID
-        // 但新 forward-key —— 必须抛 PrimaryKeyConflictError，不能静默收敛
-        repos.user.rows.push({
-            channel: 'qq',
-            channel_user_id: 'qq_uid_1',
-            internal_user_id: 'TAKEN_ULID________________',
-        });
-
-        const store = new TypeOrmIdentityStore();
-        await expect(
-            store.upsertMapping({
-                kind: 'user',
-                channel: 'lark',
-                channelId: 'different_uid',
-                internalId: 'TAKEN_ULID________________',
-            }),
-        ).rejects.toBeInstanceOf(PrimaryKeyConflictError);
+        // 不抛 "returned no internal id" / "store is inconsistent"
+        // —— 通过 await 不抛 就证明了。
     });
 });

--- a/apps/channel-server/src/infrastructure/dal/repositories/identity-store.ts
+++ b/apps/channel-server/src/infrastructure/dal/repositories/identity-store.ts
@@ -1,24 +1,17 @@
-// 生产运行时的 IdentityStore 实现：用 TypeORM Repository 标准 ORM 接口
-// （findOne / save）读写 identity_user / identity_chat / identity_message
-// 三张映射表。
+// 生产运行时的 IdentityStore 实现：用 TypeORM 读写 identity_user /
+// identity_chat / identity_message 三张映射表。写路径用真实的
+// INSERT ... ON CONFLICT (channel, channel_*_id) DO UPDATE ... RETURNING，
+// 把 forward-key 冲突交给 PG 引擎在单条语句内收敛（事务安全、不依赖隔离
+// 级别——DO UPDATE 永远 RETURNING，不需要 CTE/UNION ALL 兜底；之前用 DO
+// NOTHING + UNION ALL SELECT 在 read committed 下 race 时 SELECT 看不到
+// conflicting row，会返回 0 行让上游 fail-loud）。只把 internal_*_id 主键
+// (ULID) 冲突翻译成 PrimaryKeyConflictError 让 DbIdentityResolver 换 ULID
+// 重试。
 //
-// 设计：findOne -> 命中即返回；未命中走 save；save 撞 forward-key 唯一约束
-// (23505 on uq_identity_*_channel) → race winner 已抢先写入 → 重新 findOne 拿
-// 现有行返回。撞主键 (23505 on identity_*_pkey) → 抛 PrimaryKeyConflictError
-// 让 DbIdentityResolver 换 ULID 重试。
-//
-// 为什么不用 raw SQL ON CONFLICT DO UPDATE RETURNING？之前那版工作，但 raw
-// SQL 是 critical concurrency primitive 上的硬骨头：表名/列名/约束名靠字符串
-// 拼，迁移容易漏；ON CONFLICT 的 visibility 细节难维护。改用 ORM 标准接口
-// 后，PG-internal visibility 语义交给 TypeORM；race 安全靠 try-save +
-// catch-unique-violation + 重读这种与 ORM 同构的模式，业务代码不再碰 SQL 字
-// 符串。
-//
-// 单测不 import 本文件实际接 TypeORM 数据源——它通过 mock @ormconfig 的
-// getRepository 注入 fake repo 验证调用形态。DbIdentityResolver 的单测走
-// 内存版 FakeIdentityStore（不经过本文件）。
+// 单测不 import 本文件（它静态依赖 TypeORM 数据源）；DbIdentityResolver 的
+// 单测走内存版 FakeIdentityStore。本文件只在运行时接线时使用。
 
-import { QueryFailedError, type Repository } from 'typeorm';
+import { QueryFailedError } from 'typeorm';
 import AppDataSource from '@ormconfig';
 import {
     IdentityUser,
@@ -32,24 +25,27 @@ import {
     PrimaryKeyConflictError,
 } from '@core/channels/db-identity-resolver';
 
-// 每个 kind 对应哪张实体、哪两列名、forward-key 约束名（与 DDL 一致，用于
-// 区分 23505 是 forward-key 冲突还是主键冲突）。三张表结构相同，只是列名/
-// 约束名带各自前缀。
+// 每个 kind 对应哪张表、哪两个列、表名、约束名。三张表结构相同，
+// 只是列名/约束名带各自前缀。约束名必须与 DDL（multi-channel-T5-
+// identity-mapping-tables.sql）一致，ON CONFLICT 按约束名引用。
 const KIND_TABLE = {
     user: {
         entity: IdentityUser,
+        table: 'identity_user',
         internalCol: 'internal_user_id',
         channelIdCol: 'channel_user_id',
         forwardConstraint: 'uq_identity_user_channel',
     },
     chat: {
         entity: IdentityChat,
+        table: 'identity_chat',
         internalCol: 'internal_chat_id',
         channelIdCol: 'channel_chat_id',
         forwardConstraint: 'uq_identity_chat_channel',
     },
     message: {
         entity: IdentityMessage,
+        table: 'identity_message',
         internalCol: 'internal_message_id',
         channelIdCol: 'channel_message_id',
         forwardConstraint: 'uq_identity_message_channel',
@@ -60,56 +56,33 @@ const KIND_TABLE = {
 const PG_UNIQUE_VIOLATION = '23505';
 
 // 把 driverError 拆出来：PG 在 23505 时附带 constraint（违反的约束名），
-// 用它区分 forward-key 冲突 vs 主键 (ULID) 冲突。
+// 用它区分 forward-key 冲突 vs 主键(ULID)冲突。
 function pgError(
     err: unknown,
 ): { code?: string; constraint?: string } | null {
-    if (err instanceof QueryFailedError) {
-        const d = (
-            err as unknown as {
-                driverError?: { code?: string; constraint?: string };
-            }
-        ).driverError;
-        return d ?? null;
-    }
-    // 测试 / 部分 driver 直接把 code/constraint 挂在 Error 上；同样支持。
-    if (err && typeof err === 'object') {
-        const e = err as { code?: string; constraint?: string; driverError?: { code?: string; constraint?: string } };
-        if (e.driverError) return e.driverError;
-        if (e.code) return { code: e.code, constraint: e.constraint };
-    }
-    return null;
+    if (!(err instanceof QueryFailedError)) return null;
+    const d = (
+        err as unknown as {
+            driverError?: { code?: string; constraint?: string };
+        }
+    ).driverError;
+    return d ?? null;
 }
 
 export class TypeOrmIdentityStore implements IdentityStore {
-    private repoFor<K extends IdentityKind>(
-        kind: K,
-    ): {
-        repo: Repository<object>;
-        internalCol: string;
-        channelIdCol: string;
-        forwardConstraint: string;
-    } {
-        const t = KIND_TABLE[kind];
-        return {
-            repo: AppDataSource.getRepository(t.entity) as unknown as Repository<object>,
-            internalCol: t.internalCol,
-            channelIdCol: t.channelIdCol,
-            forwardConstraint: t.forwardConstraint,
-        };
-    }
-
     async findInternalId(
         kind: IdentityKind,
         channel: string,
         channelId: string,
     ): Promise<string | null> {
-        const { repo, internalCol, channelIdCol } = this.repoFor(kind);
+        const t = KIND_TABLE[kind];
+        const repo = AppDataSource.getRepository(t.entity);
         const row = await repo.findOne({
-            where: { channel, [channelIdCol]: channelId } as object,
+            where: { channel, [t.channelIdCol]: channelId } as object,
         });
         return row
-            ? ((row as unknown as Record<string, string>)[internalCol] ?? null)
+            ? ((row as unknown as Record<string, string>)[t.internalCol] ??
+                  null)
             : null;
     }
 
@@ -117,64 +90,65 @@ export class TypeOrmIdentityStore implements IdentityStore {
         kind: IdentityKind,
         internalId: string,
     ): Promise<{ channel: string; channelId: string } | null> {
-        const { repo, internalCol, channelIdCol } = this.repoFor(kind);
+        const t = KIND_TABLE[kind];
+        const repo = AppDataSource.getRepository(t.entity);
         const row = await repo.findOne({
-            where: { [internalCol]: internalId } as object,
+            where: { [t.internalCol]: internalId } as object,
         });
         if (!row) return null;
         const r = row as unknown as Record<string, string>;
-        return { channel: r.channel!, channelId: r[channelIdCol]! };
+        return { channel: r.channel!, channelId: r[t.channelIdCol]! };
     }
 
     async upsertMapping(row: IdentityRow): Promise<string> {
-        const { repo, internalCol, channelIdCol, forwardConstraint } =
-            this.repoFor(row.kind);
-
-        // 快路径：先 findOne 看 forward-key 是否已存在。命中即幂等返回（最常见
-        // 的并发场景：第一个 resolve 把行写进去，后续都从这里返回）。
-        const existing = await repo.findOne({
-            where: { channel: row.channel, [channelIdCol]: row.channelId } as object,
-        });
-        if (existing) {
-            return (existing as unknown as Record<string, string>)[internalCol]!;
-        }
-
-        // 未命中：尝试 save。race 输给并发竞争者会撞 23505：
-        //   - 撞 forward-key 唯一约束 -> race winner 已写入 -> 重读返回 winner
-        //     的 internalId（绝不抛错，绝不写入 candidate 的 ULID）
-        //   - 撞主键 (internal_*_id) 唯一约束 -> 极罕见 ULID 撞 -> 抛
-        //     PrimaryKeyConflictError 让 resolver 换 ULID 重试
-        const entity = {
-            [internalCol]: row.internalId,
-            channel: row.channel,
-            [channelIdCol]: row.channelId,
-        };
+        const t = KIND_TABLE[row.kind];
+        // 单 SQL upsert：对 forward-key 复合唯一约束 ON CONFLICT DO UPDATE。
+        // 之前用 DO NOTHING + 同 CTE UNION ALL SELECT 回取，PG read committed
+        // 下当 DO NOTHING 触发时同语句的 SELECT 看不到 conflicting row（快照
+        // 边界），并发同 (channel, channel_*_id) 第二次进来 SELECT 0 行 → 整体
+        // 0 行 → 调用方 fail-loud → prod 丢消息。
+        //
+        // DO UPDATE 即使 SET 为 no-op（把 channel_*_id 设回 EXCLUDED.* 同值）
+        // 仍会"涉及行"，把那条行通过 RETURNING 拉回来，永远拿到 internal_id；
+        // forward-key 在 PG 引擎单语句内收敛，不依赖外层事务/隔离级别。
+        // 注意：永远不要 SET internal_*_id —— 那是全局主键，DO UPDATE 时
+        // 已存在行的 internal_id 不能被来访 candidate ULID 覆盖。
+        const sql = `
+            INSERT INTO ${t.table} (${t.internalCol}, channel, ${t.channelIdCol})
+            VALUES ($1, $2, $3)
+            ON CONFLICT ON CONSTRAINT ${t.forwardConstraint}
+            DO UPDATE SET ${t.channelIdCol} = EXCLUDED.${t.channelIdCol}
+            RETURNING ${t.internalCol} AS internal_id
+        `;
         try {
-            const saved = (await repo.save(entity as object)) as unknown as Record<string, string>;
-            return saved[internalCol]!;
+            const rows = (await AppDataSource.query(sql, [
+                row.internalId,
+                row.channel,
+                row.channelId,
+            ])) as Array<{ internal_id: string }>;
+            const internalId = rows[0]?.internal_id;
+            if (internalId == null) {
+                // 理论不可达：要么 INSERT 成功 RETURNING，要么 DO NOTHING
+                // 后 SELECT 命中已存在行。读不到说明 store 状态不一致。
+                throw new Error(
+                    `identity ${row.kind} upsert (${row.channel}, ${row.channelId}) ` +
+                        `returned no internal id; store is inconsistent`,
+                );
+            }
+            return internalId;
         } catch (err) {
             const d = pgError(err);
             if (d?.code === PG_UNIQUE_VIOLATION) {
-                if (d.constraint === forwardConstraint) {
-                    // race 输了：另一个并发已经写入同 (channel, channelId)。
-                    // 重读拿现有 internalId 返回——收敛到 race winner，不抛错。
-                    const winner = await repo.findOne({
-                        where: { channel: row.channel, [channelIdCol]: row.channelId } as object,
-                    });
-                    if (winner) {
-                        return (winner as unknown as Record<string, string>)[internalCol]!;
-                    }
-                    // 理论不可达：23505 forward 约束触发但回读不到说明 store 不
-                    // 一致（PG 出了别的问题）。明确抛错而不是吞掉。
-                    throw new Error(
-                        `identity ${row.kind} forward-key conflict on (${row.channel}, ` +
-                            `${row.channelId}) but re-read returned no row; store is inconsistent`,
+                // 23505 但不是 forward-key 约束 -> 是 internal_*_id 主键(ULID)
+                // 冲突。区分二者：forward-key 冲突已被 ON CONFLICT DO NOTHING
+                // 吸收不会冒到这里；冒到这里的 23505 即主键冲突，翻译成
+                // PrimaryKeyConflictError 让 resolver 换 ULID 重试。
+                if (d.constraint !== t.forwardConstraint) {
+                    throw new PrimaryKeyConflictError(
+                        row.kind,
+                        row.internalId,
                     );
                 }
-                // 23505 但不是 forward-key 约束 -> 是 internal_*_id 主键 (ULID)
-                // 冲突。抛 PrimaryKeyConflictError 让 resolver 换 ULID 重试，
-                // 绝不当 forward-key 冲突静默收敛到别人的映射。
-                throw new PrimaryKeyConflictError(row.kind, row.internalId);
             }
             throw err;
         }


### PR DESCRIPTION
Hotfix #232 commit b66e8aa rewrote IdentityResolver from raw SQL
ON CONFLICT DO UPDATE to TypeORM findOne+save+catch unique. In prod
under real concurrent traffic (multiple bots, webhook retries), the
catch path failed: pgError() reads err.driverError.code but TypeORM
QueryFailedError exposes the PG code on err.code directly when
driverError is undefined. Unique violations leaked out instead of
being caught and re-read, dropping inbound messages.

PG's ON CONFLICT (channel, key) DO UPDATE SET <indexed>=EXCLUDED.<indexed>
RETURNING internal_id resolves the race inside the engine - never
throws, always returns the conflicting row's id. That's the right
primitive for this concurrency pattern; the ORM detour was a regression.

Reverts only identity-store.ts and its race test back to the pre-#232
state. Keeps the proactive _is_lark_raw_id guard and chat-response-worker
field-mapping test from #232, which are unrelated to the SQL/ORM choice.
