### PR TITLE
feat(gateway): phase2 P0 traffic scheduling — weighted split, explain, kill-switch

### DIFF
--- a/.claude/skills/ops/SKILL.md
+++ b/.claude/skills/ops/SKILL.md
@@ -70,6 +70,54 @@ $HTTP POST "$BASE/ops/lane-bindings" \
 $HTTP DELETE "$BASE/ops/lane-bindings?type=<TYPE>&key=<KEY>" "$AUTH"
 ```
 
+### `gateway` — api-gateway 路由规则调度
+
+调度 api-gateway 的流量路由规则：预览命中、止血启停、调整权重。所有动作经 Dashboard 中转写审计，再转发到 paas-engine 的 gateway-rules 管理 API。
+
+> ⚠️ **依赖 Dashboard 中转端点（当前为 gap，见文末「Dashboard 待补能力」）。** 在 Dashboard 落地 `/ops/gateway-rules*` 中转 + 审计前，下列命令会 404，不可用于线上调度。
+
+#### `gateway explain PATH [LANE]` — 预览一个请求会命中哪条规则
+
+```bash
+# LANE 可空（代表请求不带 x-lane）
+$HTTP POST "$BASE/ops/gateway-rules:explain" \
+  '{"path":"<PATH>","x_lane":"<LANE>"}' \
+  "$AUTH"
+```
+
+返回：是否命中、命中规则名 + 原因、would_forward / would_redirect、候选 targets（含 effective_lane）、其余规则未命中原因（disabled / request_lane 不匹配 / path 不匹配 / 被更高优先级 shadowed）。**上线权重分流前必须先 explain 确认命中符合预期。**
+
+#### `gateway disable NAME REASON` — 停用一条规则（止血）
+
+```bash
+$HTTP POST "$BASE/ops/gateway-rules/<NAME>:disable" \
+  '{"reason":"<REASON>"}' \
+  "$AUTH"
+```
+
+返回 before/after 的 enabled 值。⚠️ 不要把入口的全部规则都 disable——api-gateway 会拒绝「无任何 enabled 规则」的快照并保留 last-good，导致 disable 不生效。
+
+#### `gateway enable NAME REASON` — 重新启用一条规则
+
+```bash
+$HTTP POST "$BASE/ops/gateway-rules/<NAME>:enable" \
+  '{"reason":"<REASON>"}' \
+  "$AUTH"
+```
+
+#### `gateway set-weights NAME REASON` — 整体替换一条规则的 target 权重（止血/灰度）
+
+整体替换该规则**全部** target 的权重，按 `service`+`lane` 标识每个 target。请求体字段名是 `weights`（数组，每项 `{service, lane, weight}`）。权重总和必须 = 100，单个可为 0（把某 target 改 0 即把流量切走），不可缺失或多出 target。
+
+```bash
+# 示例：把 agent-canary 规则切回 prod（prod=100, ppe-new=0）
+$HTTP POST "$BASE/ops/gateway-rules/<NAME>:set-weights" \
+  '{"reason":"<REASON>","weights":[{"service":"agent-service","lane":"prod","weight":100},{"service":"agent-service","lane":"ppe-new","weight":0}]}' \
+  "$AUTH"
+```
+
+返回 before/after 的 targets 权重。target 集合必须与规则现有 target 完全一致（缺失/多余/重复都会被拒绝）。
+
 ### `audit [caller=xxx] [action=xxx]` — 审计日志查询
 
 ```bash
@@ -149,5 +197,20 @@ $HTTP DELETE "$BASE/skills/<NAME>" "$AUTH"
 
 ## 注意事项
 
-- 写操作（bind/unbind/skill-create/skill-edit/skill-delete）影响线上，执行前先告知用户
+- 写操作（bind/unbind/gateway disable/enable/set-weights/skill-create/skill-edit/skill-delete）影响线上，执行前先告知用户
 - 不涵盖 deploy/undeploy/release/self-deploy/logs，这些仍走 `make` 命令
+
+## Dashboard 待补能力（gateway 调度的跨 repo gap）
+
+`gateway` 子命令依赖 Dashboard（不在本 repo）新增以下中转端点，本 repo 只完成了 paas-engine 引擎侧 API（`/api/paas/gateway-rules:explain`、`/{name}:disable`、`:enable`、`:set-weights`）。**在 Dashboard 落地前 gateway 命令不可用。**
+
+Dashboard 需新增并把请求转发到 paas-engine 对应端点：
+
+| Dashboard 中转端点 | 转发到 paas-engine | 审计 |
+|---|---|---|
+| `POST /dashboard/api/ops/gateway-rules:explain` | `POST /api/paas/gateway-rules:explain` | 只读，可不审计 |
+| `POST /dashboard/api/ops/gateway-rules/{name}:disable` | 同名 | 必须审计 |
+| `POST /dashboard/api/ops/gateway-rules/{name}:enable` | 同名 | 必须审计 |
+| `POST /dashboard/api/ops/gateway-rules/{name}:set-weights` | 同名 | 必须审计 |
+
+止血动作（disable/enable/set-weights）的审计必须记录：操作者、规则名、before→after 值、reason、生效时间、当前快照版本。paas-engine 端点已在响应里返回 before/after 供 Dashboard 落审计。**在审计中转就绪前，止血端点不应投入 ops 日常使用**（否则出现「能改但未被审计」的空窗）。

--- a/apps/api-gateway/internal/gateway/gateway.go
+++ b/apps/api-gateway/internal/gateway/gateway.go
@@ -3,6 +3,7 @@ package gateway
 import (
 	"fmt"
 	"log/slog"
+	"math/rand"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
@@ -25,6 +26,9 @@ type Gateway struct {
 	snapshots SnapshotProvider
 	timeout   time.Duration
 	transport *http.Transport
+	// rng returns a value in [0,1) used for weighted-random target selection.
+	// Injectable so tests can drive deterministic target choices.
+	rng func() float64
 }
 
 // New creates a Gateway.
@@ -38,6 +42,7 @@ func New(snapshots SnapshotProvider, timeout time.Duration) *Gateway {
 		snapshots: snapshots,
 		timeout:   timeout,
 		transport: t,
+		rng:       rand.Float64,
 	}
 }
 
@@ -110,7 +115,7 @@ func (g *Gateway) serveEmergency(w http.ResponseWriter, r *http.Request, request
 // resolution is delegated to the lane-sidecar via the X-Ctx-Lane header; the
 // gateway never resolves "service-lane" itself.
 func (g *Gateway) forward(w http.ResponseWriter, r *http.Request, rt route.Rule, requestLane string) {
-	target := rt.Targets[0]
+	target := selectTarget(rt.Targets, g.rng())
 	effLane := effectiveLane(target, requestLane)
 
 	targetPath := route.RewritePath(r.URL.Path, target)

--- a/apps/api-gateway/internal/gateway/gateway_test.go
+++ b/apps/api-gateway/internal/gateway/gateway_test.go
@@ -21,14 +21,16 @@ type snapProvider struct {
 func (p *snapProvider) Current() *route.Snapshot { return p.snap.Load() }
 func (p *snapProvider) set(s *route.Snapshot)    { p.snap.Store(s) }
 
-func rule(name, prefix, reqLane string, t route.Target, fb string) route.Rule {
+func rule(name, prefix, reqLane string, t route.Target) route.Rule {
+	if t.Weight == 0 {
+		t.Weight = 100
+	}
 	return route.Rule{
 		Name:     name,
 		Enabled:  true,
 		Priority: 100,
 		Match:    route.Match{PathPrefix: prefix, RequestLane: reqLane},
 		Targets:  []route.Target{t},
-		Fallback: route.Fallback{Mode: fb},
 	}
 }
 
@@ -62,7 +64,7 @@ func TestGatewayColdStartEmergencyRoutes(t *testing.T) {
 func TestGatewayNoMatch404(t *testing.T) {
 	p := &snapProvider{}
 	p.set(route.NewSnapshot(1, []route.Rule{
-		rule("paas", "/api/paas/", "", route.Target{Service: "paas-engine", Port: 8080}, "prod"),
+		rule("paas", "/api/paas/", "", route.Target{Service: "paas-engine", Port: 8080}),
 	}))
 	gw := New(p, 5*time.Second)
 
@@ -105,16 +107,15 @@ func TestForwardEffectiveLane(t *testing.T) {
 		name        string
 		requestLane string
 		targetLane  string
-		fallback    string
 		wantCtxLane string
 		wantCtxSet  bool
 	}{
-		{"default prod omits header", "", "", "prod", "", false},
-		{"passthrough request lane", "ppe-a", "", "prod", "ppe-a", true},
-		{"force target lane", "", "ppe-a", "prod", "ppe-a", true},
-		{"target lane overrides request", "ppe-a", "ppe-b", "prod", "ppe-b", true},
-		{"force prod", "ppe-a", "prod", "prod", "prod", true},
-		{"absent lane with reject does not 503", "", "ppe-missing", route.FallbackReject, "ppe-missing", true},
+		{"default prod omits header", "", "", "", false},
+		{"passthrough request lane", "ppe-a", "", "ppe-a", true},
+		{"force target lane", "", "ppe-a", "ppe-a", true},
+		{"target lane overrides request", "ppe-a", "ppe-b", "ppe-b", true},
+		{"force prod", "ppe-a", "prod", "prod", true},
+		{"absent target lane passes through missing request lane", "", "ppe-missing", "ppe-missing", true},
 	}
 
 	for _, tc := range cases {
@@ -123,7 +124,7 @@ func TestForwardEffectiveLane(t *testing.T) {
 
 			p := &snapProvider{}
 			p.set(route.NewSnapshot(1, []route.Rule{
-				rule("agent", "/api/agent/", "", route.Target{Service: "agent-service", Lane: tc.targetLane, Port: 8000}, tc.fallback),
+				rule("agent", "/api/agent/", "", route.Target{Service: "agent-service", Lane: tc.targetLane, Port: 8000}),
 			}))
 			gw := New(p, 5*time.Second)
 			gw.transport = transport
@@ -195,7 +196,7 @@ func TestColdStartForwardEffectiveLane(t *testing.T) {
 func TestGatewayRedirectTrailingSlash(t *testing.T) {
 	p := &snapProvider{}
 	p.set(route.NewSnapshot(1, []route.Rule{
-		rule("webhook", "/webhook/", "", route.Target{Service: "channel-proxy", Port: 3003}, "prod"),
+		rule("webhook", "/webhook/", "", route.Target{Service: "channel-proxy", Port: 3003}),
 	}))
 	gw := New(p, 5*time.Second)
 
@@ -227,7 +228,7 @@ func TestGatewayInjectsCtxLane(t *testing.T) {
 
 	p := &snapProvider{}
 	p.set(route.NewSnapshot(1, []route.Rule{
-		rule("paas", "/api/paas/", "", route.Target{Service: "paas-engine", Port: 8080}, "prod"),
+		rule("paas", "/api/paas/", "", route.Target{Service: "paas-engine", Port: 8080}),
 	}))
 	gw := New(p, 5*time.Second)
 	gw.transport = transport
@@ -241,6 +242,77 @@ func TestGatewayInjectsCtxLane(t *testing.T) {
 	}
 	if gotCtxLane != "ppe-x" {
 		t.Errorf("X-Ctx-Lane: got %q want ppe-x", gotCtxLane)
+	}
+}
+
+// TestForwardWeightedRandomPicksTarget locks the end-to-end forwarding for a
+// multi-target rule: with the random source injected to a fixed draw, the
+// gateway dials the chosen target's service and writes its lane into
+// X-Ctx-Lane. draw=0.0 -> 90-weight target A (lane prod), draw=0.95 -> 10-weight
+// target B (lane ppe-new). Deterministic, not flaky.
+func TestForwardWeightedRandomPicksTarget(t *testing.T) {
+	var gotCtxLane string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotCtxLane = r.Header.Get("X-Ctx-Lane")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+	upstreamURL, _ := url.Parse(upstream.URL)
+
+	var dialedAddr string
+	transport := &http.Transport{
+		DisableKeepAlives: true,
+		DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+			dialedAddr = addr
+			return net.Dial(network, upstreamURL.Host)
+		},
+	}
+
+	multiRule := route.Rule{
+		Name:     "agent",
+		Enabled:  true,
+		Priority: 100,
+		Match:    route.Match{PathPrefix: "/api/agent/"},
+		Targets: []route.Target{
+			{Service: "agent-a", Lane: "prod", Port: 8000, Weight: 90},
+			{Service: "agent-b", Lane: "ppe-new", Port: 8000, Weight: 10},
+		},
+	}
+
+	cases := []struct {
+		name        string
+		draw        float64
+		wantService string
+		wantCtxLane string
+	}{
+		{"draw below boundary picks A", 0.0, "agent-a", "prod"},
+		{"draw at boundary picks B", 0.90, "agent-b", "ppe-new"},
+		{"draw in B range picks B", 0.95, "agent-b", "ppe-new"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dialedAddr, gotCtxLane = "", ""
+			p := &snapProvider{}
+			p.set(route.NewSnapshot(1, []route.Rule{multiRule}))
+			gw := New(p, 5*time.Second)
+			gw.transport = transport
+			gw.rng = func() float64 { return tc.draw }
+
+			req := httptest.NewRequest("GET", "/api/agent/health", nil)
+			w := httptest.NewRecorder()
+			gw.ServeHTTP(w, req)
+
+			if w.Code != http.StatusOK {
+				t.Fatalf("expected 200, got %d", w.Code)
+			}
+			wantAddr := tc.wantService + ":8000"
+			if dialedAddr != wantAddr {
+				t.Errorf("dialed: got %q want %q", dialedAddr, wantAddr)
+			}
+			if gotCtxLane != tc.wantCtxLane {
+				t.Errorf("X-Ctx-Lane: got %q want %q", gotCtxLane, tc.wantCtxLane)
+			}
+		})
 	}
 }
 
@@ -261,7 +333,7 @@ func TestGatewayStripPrefixForwarded(t *testing.T) {
 
 	p := &snapProvider{}
 	p.set(route.NewSnapshot(1, []route.Rule{
-		rule("agent", "/api/agent/", "", route.Target{Service: "agent-service", Port: 8000, StripPrefix: "/api/agent"}, "prod"),
+		rule("agent", "/api/agent/", "", route.Target{Service: "agent-service", Port: 8000, StripPrefix: "/api/agent"}),
 	}))
 	gw := New(p, 5*time.Second)
 	gw.transport = transport

--- a/apps/api-gateway/internal/gateway/select.go
+++ b/apps/api-gateway/internal/gateway/select.go
@@ -1,0 +1,35 @@
+package gateway
+
+import "github.com/chiwei-platform/api-gateway/internal/route"
+
+// selectTarget picks one target by weighted random. draw is a value in [0,1)
+// (typically from the injected random source); it is scaled across the total
+// weight and the cumulative-threshold walk picks the matching target. A single
+// target always wins. A target with weight 0 is never selected. Targets are
+// validated upstream (weights sum to 100, at least one target), so this only
+// needs a sane fallback for the degenerate all-zero case.
+func selectTarget(targets []route.Target, draw float64) route.Target {
+	if len(targets) == 1 {
+		return targets[0]
+	}
+	total := 0
+	for _, t := range targets {
+		total += t.Weight
+	}
+	if total <= 0 {
+		// Degenerate (all weights zero): fall back to the first target rather
+		// than divide by zero or return nothing.
+		return targets[0]
+	}
+	point := draw * float64(total)
+	cumulative := 0
+	for _, t := range targets {
+		cumulative += t.Weight
+		if point < float64(cumulative) {
+			return t
+		}
+	}
+	// draw is in [0,1) so point < total; the loop returns above. This is an
+	// unreachable safety net for floating-point edge cases.
+	return targets[len(targets)-1]
+}

--- a/apps/api-gateway/internal/gateway/select_test.go
+++ b/apps/api-gateway/internal/gateway/select_test.go
@@ -1,0 +1,94 @@
+package gateway
+
+import (
+	"testing"
+
+	"github.com/chiwei-platform/api-gateway/internal/route"
+)
+
+// TestSelectTargetSingle: a single target (weight 100) is always chosen,
+// regardless of the random draw.
+func TestSelectTargetSingle(t *testing.T) {
+	targets := []route.Target{
+		{Service: "agent-service", Port: 8000, Weight: 100},
+	}
+	for _, draw := range []float64{0.0, 0.5, 0.999} {
+		got := selectTarget(targets, draw)
+		if got.Service != "agent-service" {
+			t.Errorf("draw=%v: got %q want agent-service", draw, got.Service)
+		}
+	}
+}
+
+// TestSelectTargetWeightedBoundary: a 90/10 split. The draw is a value in
+// [0,1) scaled across the total weight (100). Draws in [0,0.90) pick the
+// 90-weight target A; draws in [0.90,1.0) pick the 10-weight target B. We
+// assert the exact boundary deterministically (no statistical wobble).
+func TestSelectTargetWeightedBoundary(t *testing.T) {
+	targets := []route.Target{
+		{Service: "svc-a", Lane: "prod", Port: 8000, Weight: 90},
+		{Service: "svc-b", Lane: "ppe-new", Port: 8000, Weight: 10},
+	}
+	cases := []struct {
+		draw float64
+		want string
+	}{
+		{0.0, "svc-a"},     // bottom of A's range
+		{0.5, "svc-a"},     // middle of A's range
+		{0.8999, "svc-a"},  // just below the A/B boundary
+		{0.90, "svc-b"},    // exactly at the boundary -> B
+		{0.95, "svc-b"},    // middle of B's range
+		{0.9999, "svc-b"},  // top of B's range
+	}
+	for _, c := range cases {
+		got := selectTarget(targets, c.draw)
+		if got.Service != c.want {
+			t.Errorf("draw=%v: got %q want %q", c.draw, got.Service, c.want)
+		}
+	}
+}
+
+// TestSelectTargetZeroWeight: a target with weight 0 is never selected; the
+// other target (weight 100) absorbs the whole range. Mirrors the "set weight
+// to 0 to drain a target" hemostasis flow.
+func TestSelectTargetZeroWeight(t *testing.T) {
+	targets := []route.Target{
+		{Service: "drained", Port: 8000, Weight: 0},
+		{Service: "live", Port: 8000, Weight: 100},
+	}
+	for _, draw := range []float64{0.0, 0.001, 0.5, 0.9999} {
+		got := selectTarget(targets, draw)
+		if got.Service != "live" {
+			t.Errorf("draw=%v: got %q want live (weight-0 target must never win)", draw, got.Service)
+		}
+	}
+}
+
+// TestSelectTargetDistribution: a large-sample distribution check using a
+// deterministic stepping source (not real randomness, so it is not flaky).
+// Feeding evenly-spaced draws across [0,1) must split ~90:10 for a 90/10
+// rule. We assert exact counts because the source is deterministic.
+func TestSelectTargetDistribution(t *testing.T) {
+	targets := []route.Target{
+		{Service: "svc-a", Port: 8000, Weight: 90},
+		{Service: "svc-b", Port: 8000, Weight: 10},
+	}
+	const n = 10000
+	countA, countB := 0, 0
+	for i := 0; i < n; i++ {
+		draw := float64(i) / float64(n) // evenly spaced over [0,1)
+		got := selectTarget(targets, draw)
+		switch got.Service {
+		case "svc-a":
+			countA++
+		case "svc-b":
+			countB++
+		default:
+			t.Fatalf("unexpected service %q", got.Service)
+		}
+	}
+	// With evenly-spaced deterministic draws the split is exact: 9000/1000.
+	if countA != 9000 || countB != 1000 {
+		t.Errorf("distribution: A=%d B=%d want A=9000 B=1000", countA, countB)
+	}
+}

--- a/apps/api-gateway/internal/loader/loader_test.go
+++ b/apps/api-gateway/internal/loader/loader_test.go
@@ -4,8 +4,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
-
-	"github.com/chiwei-platform/api-gateway/internal/route"
 )
 
 // onePayload is in the EXACT wire format paas-engine emits from
@@ -224,6 +222,9 @@ func TestValidationRejectsNilFields(t *testing.T) {
 }
 
 func TestValidPayloadParsesAllFields(t *testing.T) {
+	// The "fallback" field is still present in this payload on purpose: during
+	// cutover paas-engine may keep emitting it. The loader must tolerate the
+	// now-unknown field (json ignores it) and parse everything else.
 	body := `{"version":9,"rules":[
 	  {"name":"agent","enabled":true,"priority":100,
 	   "match":{"path_prefix":"/api/agent/","request_lane":"ppe-x"},
@@ -240,10 +241,7 @@ func TestValidPayloadParsesAllFields(t *testing.T) {
 		t.Errorf("match parse wrong: %+v", r)
 	}
 	tg := r.Targets[0]
-	if tg.Service != "agent-service" || tg.Lane != "prod" || tg.Port != 8000 || tg.StripPrefix != "/api/agent" {
+	if tg.Service != "agent-service" || tg.Lane != "prod" || tg.Port != 8000 || tg.StripPrefix != "/api/agent" || tg.Weight != 100 {
 		t.Errorf("target parse wrong: %+v", tg)
-	}
-	if r.Fallback.Mode != route.FallbackReject {
-		t.Errorf("fallback parse wrong: %q", r.Fallback.Mode)
 	}
 }

--- a/apps/api-gateway/internal/route/matcher.go
+++ b/apps/api-gateway/internal/route/matcher.go
@@ -63,16 +63,13 @@ func RewritePath(path string, t Target) string {
 func EmergencyRules() []Rule {
 	return []Rule{
 		{Name: "emergency-paas", Enabled: true, Priority: 100,
-			Match:    Match{PathPrefix: "/api/paas/"},
-			Targets:  []Target{{Service: "paas-engine", Port: 8080}},
-			Fallback: Fallback{Mode: FallbackProd}},
+			Match:   Match{PathPrefix: "/api/paas/"},
+			Targets: []Target{{Service: "paas-engine", Port: 8080, Weight: 100}}},
 		{Name: "emergency-dashboard-api", Enabled: true, Priority: 100,
-			Match:    Match{PathPrefix: "/dashboard/api/"},
-			Targets:  []Target{{Service: "monitor-dashboard", Port: 3002}},
-			Fallback: Fallback{Mode: FallbackProd}},
+			Match:   Match{PathPrefix: "/dashboard/api/"},
+			Targets: []Target{{Service: "monitor-dashboard", Port: 3002, Weight: 100}}},
 		{Name: "emergency-dashboard-web", Enabled: true, Priority: 100,
-			Match:    Match{PathPrefix: "/dashboard/"},
-			Targets:  []Target{{Service: "monitor-dashboard-web", Port: 80}},
-			Fallback: Fallback{Mode: FallbackProd}},
+			Match:   Match{PathPrefix: "/dashboard/"},
+			Targets: []Target{{Service: "monitor-dashboard-web", Port: 80, Weight: 100}}},
 	}
 }

--- a/apps/api-gateway/internal/route/matcher_test.go
+++ b/apps/api-gateway/internal/route/matcher_test.go
@@ -3,23 +3,22 @@ package route
 import "testing"
 
 // helper to build a rule with a single target
-func rule(name, prefix, reqLane string, priority int, enabled bool, t Target, fbMode string) Rule {
+func rule(name, prefix, reqLane string, priority int, enabled bool, t Target) Rule {
 	return Rule{
 		Name:     name,
 		Enabled:  enabled,
 		Priority: priority,
 		Match:    Match{PathPrefix: prefix, RequestLane: reqLane},
 		Targets:  []Target{t},
-		Fallback: Fallback{Mode: fbMode},
 	}
 }
 
 func TestMatchLongestPrefixAndPriority(t *testing.T) {
 	rules := []Rule{
-		rule("dash-api", "/dashboard/api/", "", 100, true, Target{Service: "monitor-dashboard", Port: 3002}, "prod"),
-		rule("dash-web", "/dashboard/", "", 100, true, Target{Service: "monitor-dashboard-web", Port: 80}, "prod"),
-		rule("paas", "/api/paas/", "", 100, true, Target{Service: "paas-engine", Port: 8080}, "prod"),
-		rule("webhook", "/webhook/", "", 100, true, Target{Service: "channel-proxy", Port: 3003}, "prod"),
+		rule("dash-api", "/dashboard/api/", "", 100, true, Target{Service: "monitor-dashboard", Port: 3002}),
+		rule("dash-web", "/dashboard/", "", 100, true, Target{Service: "monitor-dashboard-web", Port: 80}),
+		rule("paas", "/api/paas/", "", 100, true, Target{Service: "paas-engine", Port: 8080}),
+		rule("webhook", "/webhook/", "", 100, true, Target{Service: "channel-proxy", Port: 3003}),
 	}
 	m := NewMatcher(NewSnapshot(1, rules))
 
@@ -49,8 +48,8 @@ func TestMatchLongestPrefixAndPriority(t *testing.T) {
 func TestMatchPriorityWins(t *testing.T) {
 	// Two rules same path_prefix, different priority: higher priority wins.
 	rules := []Rule{
-		rule("low", "/api/paas/", "", 100, true, Target{Service: "old-svc", Port: 1}, "prod"),
-		rule("high", "/api/paas/", "", 200, true, Target{Service: "new-svc", Port: 2}, "prod"),
+		rule("low", "/api/paas/", "", 100, true, Target{Service: "old-svc", Port: 1}),
+		rule("high", "/api/paas/", "", 200, true, Target{Service: "new-svc", Port: 2}),
 	}
 	m := NewMatcher(NewSnapshot(1, rules))
 	res, ok := m.Match("/api/paas/x", "")
@@ -64,8 +63,8 @@ func TestMatchPriorityWins(t *testing.T) {
 
 func TestMatchSamePriorityLongerPrefixWins(t *testing.T) {
 	rules := []Rule{
-		rule("short", "/dashboard/", "", 100, true, Target{Service: "web", Port: 80}, "prod"),
-		rule("long", "/dashboard/api/", "", 100, true, Target{Service: "api", Port: 3002}, "prod"),
+		rule("short", "/dashboard/", "", 100, true, Target{Service: "web", Port: 80}),
+		rule("long", "/dashboard/api/", "", 100, true, Target{Service: "api", Port: 3002}),
 	}
 	m := NewMatcher(NewSnapshot(1, rules))
 	res, ok := m.Match("/dashboard/api/metrics", "")
@@ -79,8 +78,8 @@ func TestMatchSamePriorityLongerPrefixWins(t *testing.T) {
 
 func TestMatchDisabledSkipped(t *testing.T) {
 	rules := []Rule{
-		rule("disabled", "/api/paas/", "", 200, false, Target{Service: "disabled-svc", Port: 1}, "prod"),
-		rule("enabled", "/api/paas/", "", 100, true, Target{Service: "enabled-svc", Port: 8080}, "prod"),
+		rule("disabled", "/api/paas/", "", 200, false, Target{Service: "disabled-svc", Port: 1}),
+		rule("enabled", "/api/paas/", "", 100, true, Target{Service: "enabled-svc", Port: 8080}),
 	}
 	m := NewMatcher(NewSnapshot(1, rules))
 	res, ok := m.Match("/api/paas/x", "")
@@ -95,9 +94,9 @@ func TestMatchDisabledSkipped(t *testing.T) {
 func TestMatchRequestLaneFilter(t *testing.T) {
 	rules := []Rule{
 		// rule requires request_lane == ppe-x
-		rule("laned", "/api/paas/", "ppe-x", 200, true, Target{Service: "laned-svc", Port: 1}, "prod"),
+		rule("laned", "/api/paas/", "ppe-x", 200, true, Target{Service: "laned-svc", Port: 1}),
 		// generic rule, no lane constraint
-		rule("generic", "/api/paas/", "", 100, true, Target{Service: "generic-svc", Port: 8080}, "prod"),
+		rule("generic", "/api/paas/", "", 100, true, Target{Service: "generic-svc", Port: 8080}),
 	}
 	m := NewMatcher(NewSnapshot(1, rules))
 

--- a/apps/api-gateway/internal/route/model.go
+++ b/apps/api-gateway/internal/route/model.go
@@ -1,11 +1,5 @@
 package route
 
-// Fallback modes.
-const (
-	FallbackProd   = "prod"
-	FallbackReject = "reject"
-)
-
 // Match holds the conditions a request must satisfy to select a rule.
 // Only PathPrefix and RequestLane are honored in this version; the other
 // fields are accepted in the wire schema but rejected by paas-engine's
@@ -27,15 +21,6 @@ type Target struct {
 	RewritePrefix string `json:"rewrite_prefix,omitempty"`
 }
 
-// Fallback is part of the wire schema (set by paas-engine) describing what
-// should happen when the target lane has no instance: "prod" falls back to the
-// service's prod instance, "reject" fails closed. The api-gateway no longer
-// acts on this — lane resolution and fail-closed are delegated to the
-// lane-sidecar — so the field is currently advisory only.
-type Fallback struct {
-	Mode string `json:"mode"`
-}
-
 // Rule is one routing rule.
 type Rule struct {
 	Name     string   `json:"name"`
@@ -43,5 +28,4 @@ type Rule struct {
 	Priority int      `json:"priority"`
 	Match    Match    `json:"match"`
 	Targets  []Target `json:"targets"`
-	Fallback Fallback `json:"fallback"`
 }

--- a/apps/paas-engine/internal/adapter/http/gateway_rule_emergency_test.go
+++ b/apps/paas-engine/internal/adapter/http/gateway_rule_emergency_test.go
@@ -1,0 +1,161 @@
+package http
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/chiwei-platform/paas-engine/internal/domain"
+	"github.com/chiwei-platform/paas-engine/internal/service"
+	"github.com/go-chi/chi/v5"
+)
+
+// newEmergencyTestRouter wires the full gateway-rules sub-router (including the
+// explain / disable / enable / set-weights action endpoints) over a stub repo,
+// matching how router.go registers them.
+func newEmergencyTestRouter() (*chi.Mux, *gwStubRepo) {
+	repo := newGwStubRepo()
+	svc := service.NewGatewayRuleService(repo)
+	h := NewGatewayRuleHandler(svc)
+	r := chi.NewRouter()
+	r.Route("/api/paas", func(r chi.Router) {
+		r.Post("/gateway-rules:explain", h.Explain)
+		r.Route("/gateway-rules", func(r chi.Router) {
+			r.Get("/", h.List)
+			r.Get("/{name}", h.Get)
+			r.Put("/{name}", h.Upsert)
+			r.Delete("/{name}", h.Delete)
+			r.Post("/{name}:disable", h.Disable)
+			r.Post("/{name}:enable", h.Enable)
+			r.Post("/{name}:set-weights", h.SetWeights)
+		})
+	})
+	return r, repo
+}
+
+func seedTwoTargetRule(repo *gwStubRepo) {
+	repo.rules["agent"] = &domain.GatewayRule{
+		Name:       "agent",
+		Enabled:    true,
+		Priority:   100,
+		PathPrefix: "/api/agent/",
+		Match:      domain.GatewayMatch{PathPrefix: "/api/agent/"},
+		Targets: []domain.GatewayTarget{
+			{Service: "agent-service", Lane: "prod", Port: 8000, Weight: 90},
+			{Service: "agent-service", Lane: "ppe-new", Port: 8000, Weight: 10},
+		},
+		Version: 1,
+	}
+}
+
+func TestExplainEndpointReturnsTrace(t *testing.T) {
+	r, repo := newEmergencyTestRouter()
+	seedTwoTargetRule(repo)
+
+	rec := doReq(t, r, http.MethodPost, "/api/paas/gateway-rules:explain",
+		`{"path":"/api/agent/health","x_lane":""}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("explain expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var env struct {
+		Data domain.GatewayExplainResult `json:"data"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &env); err != nil {
+		t.Fatalf("decode explain: %v", err)
+	}
+	if !env.Data.Matched || env.Data.WinningRule != "agent" {
+		t.Errorf("explain matched=%v winner=%q", env.Data.Matched, env.Data.WinningRule)
+	}
+	if len(env.Data.CandidateTargets) != 2 {
+		t.Errorf("expected 2 candidate targets, got %d", len(env.Data.CandidateTargets))
+	}
+}
+
+func TestDisableEndpoint(t *testing.T) {
+	r, repo := newEmergencyTestRouter()
+	seedTwoTargetRule(repo)
+
+	rec := doReq(t, r, http.MethodPost, "/api/paas/gateway-rules/agent:disable",
+		`{"reason":"incident-1"}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("disable expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var env struct {
+		Data service.EnableChange `json:"data"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &env); err != nil {
+		t.Fatalf("decode disable: %v", err)
+	}
+	if env.Data.BeforeEnabled != true || env.Data.AfterEnabled != false {
+		t.Errorf("before/after = %v/%v want true/false", env.Data.BeforeEnabled, env.Data.AfterEnabled)
+	}
+	if env.Data.Reason != "incident-1" {
+		t.Errorf("reason=%q", env.Data.Reason)
+	}
+	if repo.rules["agent"].Enabled {
+		t.Error("rule still enabled in repo")
+	}
+}
+
+func TestEnableEndpoint(t *testing.T) {
+	r, repo := newEmergencyTestRouter()
+	seedTwoTargetRule(repo)
+	repo.rules["agent"].Enabled = false
+
+	rec := doReq(t, r, http.MethodPost, "/api/paas/gateway-rules/agent:enable",
+		`{"reason":"recovered"}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("enable expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if !repo.rules["agent"].Enabled {
+		t.Error("rule not enabled after enable endpoint")
+	}
+}
+
+func TestSetWeightsEndpoint(t *testing.T) {
+	r, repo := newEmergencyTestRouter()
+	seedTwoTargetRule(repo)
+
+	body := `{"reason":"drain ppe-new","weights":[
+		{"service":"agent-service","lane":"prod","weight":100},
+		{"service":"agent-service","lane":"ppe-new","weight":0}]}`
+	rec := doReq(t, r, http.MethodPost, "/api/paas/gateway-rules/agent:set-weights", body)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("set-weights expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var env struct {
+		Data service.WeightsChange `json:"data"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &env); err != nil {
+		t.Fatalf("decode set-weights: %v", err)
+	}
+	if len(env.Data.BeforeTargets) != 2 || len(env.Data.AfterTargets) != 2 {
+		t.Fatalf("before/after target count wrong")
+	}
+	for _, tg := range repo.rules["agent"].Targets {
+		if tg.Lane == "ppe-new" && tg.Weight != 0 {
+			t.Errorf("ppe-new weight=%d want 0", tg.Weight)
+		}
+	}
+}
+
+func TestSetWeightsEndpointRejectsBadSum(t *testing.T) {
+	r, repo := newEmergencyTestRouter()
+	seedTwoTargetRule(repo)
+
+	body := `{"reason":"x","weights":[
+		{"service":"agent-service","lane":"prod","weight":50},
+		{"service":"agent-service","lane":"ppe-new","weight":40}]}`
+	rec := doReq(t, r, http.MethodPost, "/api/paas/gateway-rules/agent:set-weights", body)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for bad sum, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestDisableEndpointMissingRule404(t *testing.T) {
+	r, _ := newEmergencyTestRouter()
+	rec := doReq(t, r, http.MethodPost, "/api/paas/gateway-rules/nope:disable", `{"reason":"x"}`)
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", rec.Code)
+	}
+}

--- a/apps/paas-engine/internal/adapter/http/gateway_rule_handler.go
+++ b/apps/paas-engine/internal/adapter/http/gateway_rule_handler.go
@@ -2,6 +2,7 @@ package http
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 
 	"github.com/chiwei-platform/paas-engine/internal/domain"
@@ -66,6 +67,84 @@ func (h *GatewayRuleHandler) Delete(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	writeJSON(w, http.StatusOK, map[string]string{"deleted": name})
+}
+
+// explainRequest 是 POST /api/paas/gateway-rules:explain 的请求体。
+type explainRequest struct {
+	Path  string `json:"path"`
+	XLane string `json:"x_lane"`
+}
+
+// Explain 预览一个请求会命中哪条规则、为何命中、其余规则为何没命中。
+func (h *GatewayRuleHandler) Explain(w http.ResponseWriter, r *http.Request) {
+	var req explainRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, domain.ErrInvalidInput)
+		return
+	}
+	if req.Path == "" {
+		writeError(w, fmt.Errorf("%w: path is required", domain.ErrInvalidInput))
+		return
+	}
+	res, err := h.svc.Explain(r.Context(), req.Path, req.XLane)
+	if err != nil {
+		writeError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, res)
+}
+
+// reasonRequest 是 disable/enable 端点的请求体（仅含 reason，供审计）。
+type reasonRequest struct {
+	Reason string `json:"reason"`
+}
+
+// Disable 把规则 enabled 置 false，返回 before/after 供审计。
+func (h *GatewayRuleHandler) Disable(w http.ResponseWriter, r *http.Request) {
+	name := chi.URLParam(r, "name")
+	var req reasonRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, domain.ErrInvalidInput)
+		return
+	}
+	res, err := h.svc.Disable(r.Context(), name, req.Reason)
+	if err != nil {
+		writeError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, res)
+}
+
+// Enable 把规则 enabled 置 true，返回 before/after 供审计。
+func (h *GatewayRuleHandler) Enable(w http.ResponseWriter, r *http.Request) {
+	name := chi.URLParam(r, "name")
+	var req reasonRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, domain.ErrInvalidInput)
+		return
+	}
+	res, err := h.svc.Enable(r.Context(), name, req.Reason)
+	if err != nil {
+		writeError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, res)
+}
+
+// SetWeights 整体替换规则全部 target 权重，返回 before/after 供审计。
+func (h *GatewayRuleHandler) SetWeights(w http.ResponseWriter, r *http.Request) {
+	name := chi.URLParam(r, "name")
+	var req service.SetWeightsRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, domain.ErrInvalidInput)
+		return
+	}
+	res, err := h.svc.SetWeights(r.Context(), name, req)
+	if err != nil {
+		writeError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, res)
 }
 
 // Snapshot 返回完整快照（内部端点，不鉴权，不走信封）。

--- a/apps/paas-engine/internal/adapter/http/gateway_rule_handler_test.go
+++ b/apps/paas-engine/internal/adapter/http/gateway_rule_handler_test.go
@@ -79,8 +79,7 @@ func validRuleBody() string {
 		"priority": 100,
 		"path_prefix": "/api/agent/",
 		"match": {"path_prefix": "/api/agent/"},
-		"targets": [{"service": "agent-service", "lane": "prod", "port": 8000, "weight": 100, "strip_prefix": "/api/agent"}],
-		"fallback": {"mode": "prod"}
+		"targets": [{"service": "agent-service", "lane": "prod", "port": 8000, "weight": 100, "strip_prefix": "/api/agent"}]
 	}`
 }
 
@@ -163,8 +162,7 @@ func bodyWithoutEnabled() string {
 		"priority": 100,
 		"path_prefix": "/api/agent/",
 		"match": {"path_prefix": "/api/agent/"},
-		"targets": [{"service": "agent-service", "lane": "prod", "port": 8000, "weight": 100}],
-		"fallback": {"mode": "prod"}
+		"targets": [{"service": "agent-service", "lane": "prod", "port": 8000, "weight": 100}]
 	}`
 }
 
@@ -174,8 +172,7 @@ func bodyEnabledFalse() string {
 		"priority": 100,
 		"path_prefix": "/api/agent/",
 		"match": {"path_prefix": "/api/agent/"},
-		"targets": [{"service": "agent-service", "lane": "prod", "port": 8000, "weight": 100}],
-		"fallback": {"mode": "prod"}
+		"targets": [{"service": "agent-service", "lane": "prod", "port": 8000, "weight": 100}]
 	}`
 }
 
@@ -219,7 +216,7 @@ func TestGatewayHandler_PutExplicitEnabledTrueStaysTrue(t *testing.T) {
 
 func TestGatewayHandler_PutInvalidReturns400(t *testing.T) {
 	r, _ := newGatewayTestRouter()
-	body := `{"enabled":true,"priority":100,"path_prefix":"no-slash/","match":{"path_prefix":"no-slash/"},"targets":[{"service":"x","lane":"prod","port":80,"weight":100}],"fallback":{"mode":"prod"}}`
+	body := `{"enabled":true,"priority":100,"path_prefix":"no-slash/","match":{"path_prefix":"no-slash/"},"targets":[{"service":"x","lane":"prod","port":80,"weight":100}]}`
 	rec := doReq(t, r, http.MethodPut, "/api/paas/gateway-rules/bad", body)
 	if rec.Code != http.StatusBadRequest {
 		t.Fatalf("expected 400 for invalid rule, got %d: %s", rec.Code, rec.Body.String())

--- a/apps/paas-engine/internal/adapter/http/router.go
+++ b/apps/paas-engine/internal/adapter/http/router.go
@@ -151,11 +151,19 @@ func NewRouter(
 		})
 
 		// Gateway Rules (management)
+		// explain 是 collection 级 custom method，注册为 "gateway-rules:explain"（冒号紧跟
+		// collection，无斜杠）；带 name 的 action 用 "{name}:action"。两者都走 chi 的段内
+		// 字面后缀。explain 必须在 /gateway-rules 子路由之外注册，否则会变成
+		// "gateway-rules/:explain"（多一段斜杠），与对外契约不符。
+		r.Post("/gateway-rules:explain", gatewayRuleH.Explain)
 		r.Route("/gateway-rules", func(r chi.Router) {
 			r.Get("/", gatewayRuleH.List)
 			r.Get("/{name}", gatewayRuleH.Get)
 			r.Put("/{name}", gatewayRuleH.Upsert)
 			r.Delete("/{name}", gatewayRuleH.Delete)
+			r.Post("/{name}:disable", gatewayRuleH.Disable)
+			r.Post("/{name}:enable", gatewayRuleH.Enable)
+			r.Post("/{name}:set-weights", gatewayRuleH.SetWeights)
 		})
 	})
 

--- a/apps/paas-engine/internal/adapter/repository/gateway_rule_repo.go
+++ b/apps/paas-engine/internal/adapter/repository/gateway_rule_repo.go
@@ -32,7 +32,7 @@ func (r *GatewayRuleRepo) Upsert(ctx context.Context, rule *domain.GatewayRule) 
 		Columns: []clause.Column{{Name: "name"}},
 		DoUpdates: clause.AssignmentColumns([]string{
 			"enabled", "priority", "path_prefix", "request_lane",
-			"match", "targets", "fallback", "version", "updated_at",
+			"match", "targets", "version", "updated_at",
 		}),
 	}).Create(m).Error
 }
@@ -99,10 +99,6 @@ func gatewayRuleToModel(rule *domain.GatewayRule) (*GatewayRuleModel, error) {
 	if err != nil {
 		return nil, fmt.Errorf("marshal targets: %w", err)
 	}
-	fallbackJSON, err := json.Marshal(rule.Fallback)
-	if err != nil {
-		return nil, fmt.Errorf("marshal fallback: %w", err)
-	}
 	return &GatewayRuleModel{
 		Name:        rule.Name,
 		Enabled:     rule.Enabled,
@@ -111,7 +107,6 @@ func gatewayRuleToModel(rule *domain.GatewayRule) (*GatewayRuleModel, error) {
 		RequestLane: rule.RequestLane,
 		Match:       string(matchJSON),
 		Targets:     string(targetsJSON),
-		Fallback:    string(fallbackJSON),
 		Version:     rule.Version,
 		CreatedAt:   rule.CreatedAt,
 		UpdatedAt:   rule.UpdatedAt,
@@ -131,12 +126,6 @@ func modelToGatewayRule(m *GatewayRuleModel) (*domain.GatewayRule, error) {
 			return nil, fmt.Errorf("unmarshal targets for rule %q: %w", m.Name, err)
 		}
 	}
-	var fallback domain.GatewayFallback
-	if m.Fallback != "" {
-		if err := json.Unmarshal([]byte(m.Fallback), &fallback); err != nil {
-			return nil, fmt.Errorf("unmarshal fallback for rule %q: %w", m.Name, err)
-		}
-	}
 	return &domain.GatewayRule{
 		Name:        m.Name,
 		Enabled:     m.Enabled,
@@ -145,7 +134,6 @@ func modelToGatewayRule(m *GatewayRuleModel) (*domain.GatewayRule, error) {
 		RequestLane: m.RequestLane,
 		Match:       match,
 		Targets:     targets,
-		Fallback:    fallback,
 		Version:     m.Version,
 		CreatedAt:   m.CreatedAt,
 		UpdatedAt:   m.UpdatedAt,

--- a/apps/paas-engine/internal/adapter/repository/gateway_rule_repo_test.go
+++ b/apps/paas-engine/internal/adapter/repository/gateway_rule_repo_test.go
@@ -21,7 +21,6 @@ func sampleGatewayRule() *domain.GatewayRule {
 		Targets: []domain.GatewayTarget{
 			{Service: "agent-service", Lane: "prod", Port: 8000, Weight: 100, StripPrefix: "/api/agent"},
 		},
-		Fallback:  domain.GatewayFallback{Mode: "prod"},
 		CreatedAt: time.Now(),
 		UpdatedAt: time.Now(),
 		Version:   3,
@@ -58,14 +57,6 @@ func TestGatewayRuleToModel_SerializesJSON(t *testing.T) {
 	}
 	if len(targets) != 1 || targets[0].StripPrefix != "/api/agent" {
 		t.Errorf("targets not preserved: %+v", targets)
-	}
-
-	var fb domain.GatewayFallback
-	if err := json.Unmarshal([]byte(m.Fallback), &fb); err != nil {
-		t.Fatalf("fallback not valid JSON: %v", err)
-	}
-	if fb.Mode != "prod" {
-		t.Errorf("fallback.mode mismatch: %q", fb.Mode)
 	}
 }
 
@@ -107,9 +98,6 @@ func TestGatewayRuleRoundTrip(t *testing.T) {
 	if got.Targets[0].StripPrefix != "/api/agent" {
 		t.Errorf("strip_prefix not preserved: %q", got.Targets[0].StripPrefix)
 	}
-	if got.Fallback.Mode != "prod" {
-		t.Errorf("fallback.mode mismatch: %q", got.Fallback.Mode)
-	}
 }
 
 func TestModelToGatewayRule_TargetsNeverNil(t *testing.T) {
@@ -118,7 +106,6 @@ func TestModelToGatewayRule_TargetsNeverNil(t *testing.T) {
 		PathPrefix: "/x/",
 		Match:      `{"path_prefix":"/x/"}`,
 		Targets:    "",
-		Fallback:   `{"mode":"prod"}`,
 	}
 	got, err := modelToGatewayRule(m)
 	if err != nil {

--- a/apps/paas-engine/internal/adapter/repository/model.go
+++ b/apps/paas-engine/internal/adapter/repository/model.go
@@ -174,7 +174,7 @@ type DynamicConfigModel struct {
 func (DynamicConfigModel) TableName() string { return "dynamic_configs" }
 
 // GatewayRuleModel 是 GatewayRule 的数据库持久化模型。
-// match / targets / fallback 用 jsonb 列存（写入 JSON 序列化字符串）；
+// match / targets 用 jsonb 列存（写入 JSON 序列化字符串）；
 // path_prefix / request_lane 提到顶层列做索引与反查。
 type GatewayRuleModel struct {
 	Name        string    `gorm:"primaryKey"`
@@ -184,7 +184,6 @@ type GatewayRuleModel struct {
 	RequestLane string    `gorm:""`
 	Match       string    `gorm:"type:jsonb;not null"`
 	Targets     string    `gorm:"type:jsonb;not null"`
-	Fallback    string    `gorm:"type:jsonb;not null"`
 	Version     int64     `gorm:"not null;default:1"`
 	CreatedAt   time.Time `gorm:"not null"`
 	UpdatedAt   time.Time `gorm:"not null"`

--- a/apps/paas-engine/internal/domain/gateway_explain.go
+++ b/apps/paas-engine/internal/domain/gateway_explain.go
@@ -1,0 +1,208 @@
+package domain
+
+import (
+	"sort"
+	"strings"
+)
+
+// Explain status values for each rule in an explain trace.
+const (
+	// ExplainStatusWinner: this rule is the one api-gateway would select.
+	ExplainStatusWinner = "winner"
+	// ExplainStatusShadowed: this rule would have matched the request, but a
+	// higher-priority rule (earlier in sort order) won first.
+	ExplainStatusShadowed = "shadowed"
+	// ExplainStatusDisabled: rule is disabled, matcher skips it entirely.
+	ExplainStatusDisabled = "disabled"
+	// ExplainStatusLaneMismatch: rule constrains request_lane and it differs
+	// from the request's x-lane.
+	ExplainStatusLaneMismatch = "request_lane_mismatch"
+	// ExplainStatusPathMismatch: the request path is not under this rule's
+	// path_prefix (and is not the trailing-slash redirect case).
+	ExplainStatusPathMismatch = "path_prefix_mismatch"
+)
+
+// GatewayExplainTarget describes one candidate target of the winning rule plus
+// the effective lane that would apply to a request routed through it.
+type GatewayExplainTarget struct {
+	Service string `json:"service"`
+	Lane    string `json:"lane"`
+	Port    int    `json:"port"`
+	Weight  int    `json:"weight"`
+	// EffectiveLane is the lane api-gateway would stamp into X-Ctx-Lane:
+	// target.lane if non-empty (override), else the request's x-lane (follow).
+	EffectiveLane string `json:"effective_lane"`
+}
+
+// GatewayRuleExplain is the per-rule verdict in an explain trace.
+type GatewayRuleExplain struct {
+	Name        string `json:"name"`
+	Priority    int    `json:"priority"`
+	PathPrefix  string `json:"path_prefix"`
+	RequestLane string `json:"request_lane,omitempty"`
+	Enabled     bool   `json:"enabled"`
+	// Status is one of the ExplainStatus* constants.
+	Status string `json:"status"`
+	// Reason is a human-readable sentence explaining the status.
+	Reason string `json:"reason"`
+}
+
+// GatewayExplainResult is the full trace for one (path, request_lane) probe.
+type GatewayExplainResult struct {
+	Path        string `json:"path"`
+	RequestLane string `json:"request_lane,omitempty"`
+	Matched     bool   `json:"matched"`
+	// WinningRule is the name of the selected rule, empty when Matched is false.
+	WinningRule string `json:"winning_rule,omitempty"`
+	// WinningReason explains why the winning rule was selected.
+	WinningReason string `json:"winning_reason,omitempty"`
+	// WouldForward / WouldRedirect are mutually exclusive and only meaningful
+	// when Matched. WouldRedirect mirrors the matcher's trailing-slash 301.
+	WouldForward  bool `json:"would_forward"`
+	WouldRedirect bool `json:"would_redirect"`
+	// CandidateTargets are the winning rule's targets with effective lanes.
+	CandidateTargets []GatewayExplainTarget `json:"candidate_targets,omitempty"`
+	// EffectiveLaneNote explains how effective lane is derived.
+	EffectiveLaneNote string `json:"effective_lane_note,omitempty"`
+	// Rules is every rule's verdict, in matcher sort order.
+	Rules []GatewayRuleExplain `json:"rules"`
+}
+
+// ExplainGatewayMatch replicates api-gateway's matcher (matcher.go Match over a
+// Snapshot built by snapshot.go NewSnapshot) as a pure function that, instead of
+// returning only the first hit, annotates every rule with why it did or did not
+// win. The winning rule / redirect verdict is byte-for-byte aligned with the
+// matcher; see gateway_explain_test.go golden cases.
+//
+// Sort order (matches NewSnapshot + List): priority desc, then Match.PathPrefix
+// length desc, then name asc for stability. matcher.go matches on the Match
+// fields (Match.PathPrefix / Match.RequestLane), so this does too.
+func ExplainGatewayMatch(rules []*GatewayRule, path, requestLane string) GatewayExplainResult {
+	sorted := make([]*GatewayRule, len(rules))
+	copy(sorted, rules)
+	sort.SliceStable(sorted, func(i, j int) bool {
+		if sorted[i].Priority != sorted[j].Priority {
+			return sorted[i].Priority > sorted[j].Priority
+		}
+		li, lj := len(sorted[i].Match.PathPrefix), len(sorted[j].Match.PathPrefix)
+		if li != lj {
+			return li > lj
+		}
+		return sorted[i].Name < sorted[j].Name
+	})
+
+	result := GatewayExplainResult{
+		Path:        path,
+		RequestLane: requestLane,
+		Rules:       make([]GatewayRuleExplain, 0, len(sorted)),
+	}
+
+	winnerFound := false
+	for _, r := range sorted {
+		entry := GatewayRuleExplain{
+			Name:        r.Name,
+			Priority:    r.Priority,
+			PathPrefix:  r.Match.PathPrefix,
+			RequestLane: r.Match.RequestLane,
+			Enabled:     r.Enabled,
+		}
+
+		hit, redirect := ruleHits(r, path, requestLane)
+
+		switch {
+		case !r.Enabled:
+			// matcher.go L32: disabled rules are skipped before any other check.
+			entry.Status = ExplainStatusDisabled
+			entry.Reason = "rule is disabled, matcher skips it"
+		case r.Match.RequestLane != "" && r.Match.RequestLane != requestLane:
+			// matcher.go L35: request_lane constraint not satisfied.
+			entry.Status = ExplainStatusLaneMismatch
+			entry.Reason = "rule requires request_lane=" + quote(r.Match.RequestLane) +
+				" but request x-lane=" + quote(requestLane)
+		case !hit:
+			// matcher.go L39/L43: path is not under the prefix (nor the
+			// trailing-slash redirect of it).
+			entry.Status = ExplainStatusPathMismatch
+			entry.Reason = "path " + quote(path) + " is not under path_prefix " + quote(r.Match.PathPrefix)
+		case !winnerFound:
+			// First enabled, lane-ok, path-matching rule in sort order wins.
+			winnerFound = true
+			entry.Status = ExplainStatusWinner
+			if redirect {
+				entry.Reason = "path equals path_prefix without trailing slash; matcher issues a 301 redirect"
+				result.WouldRedirect = true
+			} else {
+				entry.Reason = "highest-priority enabled rule whose path_prefix prefixes the request path"
+				result.WouldForward = true
+			}
+			result.Matched = true
+			result.WinningRule = r.Name
+			result.WinningReason = entry.Reason
+			result.CandidateTargets = buildCandidates(r, requestLane)
+			result.EffectiveLaneNote = effectiveLaneNote(r, requestLane)
+		default:
+			// Would have matched, but a higher-priority rule already won.
+			entry.Status = ExplainStatusShadowed
+			entry.Reason = "would have matched, but higher-priority rule " +
+				quote(result.WinningRule) + " was selected first"
+		}
+
+		result.Rules = append(result.Rules, entry)
+	}
+
+	return result
+}
+
+// ruleHits reports whether a rule matches the path (ignoring enabled/lane, which
+// the caller checks separately) and whether the hit is the trailing-slash
+// redirect case. Mirrors matcher.go L38-45.
+func ruleHits(r *GatewayRule, path, _ string) (hit, redirect bool) {
+	prefix := r.Match.PathPrefix
+	if strings.HasPrefix(path, prefix) {
+		return true, false
+	}
+	if strings.HasSuffix(prefix, "/") && path == strings.TrimSuffix(prefix, "/") {
+		return true, true
+	}
+	return false, false
+}
+
+func buildCandidates(r *GatewayRule, requestLane string) []GatewayExplainTarget {
+	out := make([]GatewayExplainTarget, 0, len(r.Targets))
+	for _, t := range r.Targets {
+		eff := t.Lane
+		if eff == "" {
+			eff = requestLane
+		}
+		out = append(out, GatewayExplainTarget{
+			Service:       t.Service,
+			Lane:          t.Lane,
+			Port:          t.Port,
+			Weight:        t.Weight,
+			EffectiveLane: eff,
+		})
+	}
+	return out
+}
+
+func effectiveLaneNote(r *GatewayRule, requestLane string) string {
+	hasForced := false
+	for _, t := range r.Targets {
+		if t.Lane != "" {
+			hasForced = true
+			break
+		}
+	}
+	if hasForced {
+		return "targets with a non-empty lane override the request x-lane; " +
+			"targets with empty lane follow the request x-lane=" + quote(requestLane)
+	}
+	return "all targets have empty lane, so effective lane follows the request x-lane=" + quote(requestLane)
+}
+
+func quote(s string) string {
+	if s == "" {
+		return `""`
+	}
+	return `"` + s + `"`
+}

--- a/apps/paas-engine/internal/domain/gateway_explain_test.go
+++ b/apps/paas-engine/internal/domain/gateway_explain_test.go
@@ -1,0 +1,232 @@
+package domain
+
+import "testing"
+
+// gwRule builds a single-target GatewayRule for explain tests. It mirrors the
+// shape api-gateway consumes: top-level PathPrefix/RequestLane are kept equal to
+// Match.PathPrefix/Match.RequestLane (paas-engine validation enforces this), and
+// the matcher (apps/api-gateway/internal/route/matcher.go) matches on the Match
+// fields, so explain must too.
+func gwRule(name, prefix, reqLane string, priority int, enabled bool, targets ...GatewayTarget) *GatewayRule {
+	return &GatewayRule{
+		Name:        name,
+		Enabled:     enabled,
+		Priority:    priority,
+		PathPrefix:  prefix,
+		RequestLane: reqLane,
+		Match:       GatewayMatch{PathPrefix: prefix, RequestLane: reqLane},
+		Targets:     targets,
+	}
+}
+
+func tgt(service, lane string, port, weight int) GatewayTarget {
+	return GatewayTarget{Service: service, Lane: lane, Port: port, Weight: weight}
+}
+
+// TestExplainGoldenCases anchors explain's "which rule wins / is it a redirect"
+// conclusion against the api-gateway matcher (matcher.go Match). Each expected
+// value below was derived by hand-tracing matcher.go and is annotated with the
+// matcher line it exercises. matcher.go scans snapshot rules pre-sorted by
+// (priority desc, Match.PathPrefix len desc) [snapshot.go NewSnapshot] and
+// returns the FIRST rule that is (a) Enabled, (b) Match.RequestLane=="" or
+// ==requestLane, (c) strings.HasPrefix(path, prefix) -> hit, or
+// (d) prefix ends "/" && path==TrimSuffix(prefix,"/") -> hit+Redirect.
+func TestExplainGoldenCases(t *testing.T) {
+	cases := []struct {
+		name        string
+		rules       []*GatewayRule
+		path        string
+		lane        string
+		wantMatched bool
+		wantWinner  string
+		wantRedir   bool
+	}{
+		{
+			// matcher.go L39 strings.HasPrefix: "/api/agent/health" has prefix
+			// "/api/agent/" -> hit, not redirect.
+			name: "plain-prefix-hit",
+			rules: []*GatewayRule{
+				gwRule("agent", "/api/agent/", "", 100, true, tgt("agent-service", "", 8000, 100)),
+			},
+			path: "/api/agent/health", lane: "",
+			wantMatched: true, wantWinner: "agent", wantRedir: false,
+		},
+		{
+			// matcher.go L43 trailing-slash redirect: prefix "/dashboard/" ends
+			// in "/" and path "/dashboard" == TrimSuffix("/dashboard/","/")
+			// -> hit with Redirect=true.
+			name: "trailing-slash-redirect",
+			rules: []*GatewayRule{
+				gwRule("dash", "/dashboard/", "", 100, true, tgt("monitor-dashboard-web", "", 80, 100)),
+			},
+			path: "/dashboard", lane: "",
+			wantMatched: true, wantWinner: "dash", wantRedir: true,
+		},
+		{
+			// matcher.go L32 !r.Enabled continue: higher-priority rule is
+			// disabled and skipped; the enabled lower-priority rule wins.
+			name: "disabled-skipped",
+			rules: []*GatewayRule{
+				gwRule("disabled", "/api/paas/", "", 200, false, tgt("old", "", 1, 100)),
+				gwRule("enabled", "/api/paas/", "", 100, true, tgt("paas-engine", "", 8080, 100)),
+			},
+			path: "/api/paas/apps", lane: "",
+			wantMatched: true, wantWinner: "enabled", wantRedir: false,
+		},
+		{
+			// matcher.go L35 request_lane filter: laned rule requires ppe-x and
+			// request lane is ppe-x -> laned (priority 200) wins.
+			name: "request-lane-match",
+			rules: []*GatewayRule{
+				gwRule("laned", "/api/paas/", "ppe-x", 200, true, tgt("laned-svc", "ppe-x", 8080, 100)),
+				gwRule("generic", "/api/paas/", "", 100, true, tgt("paas-engine", "", 8080, 100)),
+			},
+			path: "/api/paas/x", lane: "ppe-x",
+			wantMatched: true, wantWinner: "laned", wantRedir: false,
+		},
+		{
+			// matcher.go L35 request_lane filter: laned rule requires ppe-x but
+			// request lane is ppe-other -> laned skipped, generic wins.
+			name: "request-lane-mismatch-falls-through",
+			rules: []*GatewayRule{
+				gwRule("laned", "/api/paas/", "ppe-x", 200, true, tgt("laned-svc", "ppe-x", 8080, 100)),
+				gwRule("generic", "/api/paas/", "", 100, true, tgt("paas-engine", "", 8080, 100)),
+			},
+			path: "/api/paas/x", lane: "ppe-other",
+			wantMatched: true, wantWinner: "generic", wantRedir: false,
+		},
+		{
+			// snapshot.go NewSnapshot sort: same priority, longer Match prefix
+			// sorts first -> "/dashboard/api/" (len 15) wins over "/dashboard/"
+			// (len 11) for path under /dashboard/api/.
+			name: "same-priority-longer-prefix-wins",
+			rules: []*GatewayRule{
+				gwRule("short", "/dashboard/", "", 100, true, tgt("web", "", 80, 100)),
+				gwRule("long", "/dashboard/api/", "", 100, true, tgt("monitor-dashboard", "", 3002, 100)),
+			},
+			path: "/dashboard/api/metrics", lane: "",
+			wantMatched: true, wantWinner: "long", wantRedir: false,
+		},
+		{
+			// matcher.go L31-47 no rule prefixes the path -> no match.
+			name: "no-match",
+			rules: []*GatewayRule{
+				gwRule("agent", "/api/agent/", "", 100, true, tgt("agent-service", "", 8000, 100)),
+			},
+			path: "/totally/unknown", lane: "",
+			wantMatched: false, wantWinner: "", wantRedir: false,
+		},
+		{
+			// priority desc: higher priority rule with same prefix wins
+			// (matcher.go relies on snapshot.go sort, priority before length).
+			name: "higher-priority-wins",
+			rules: []*GatewayRule{
+				gwRule("low", "/api/paas/", "", 100, true, tgt("old-svc", "", 1, 100)),
+				gwRule("high", "/api/paas/", "", 200, true, tgt("new-svc", "", 2, 100)),
+			},
+			path: "/api/paas/x", lane: "",
+			wantMatched: true, wantWinner: "high", wantRedir: false,
+		},
+		{
+			// snapshot.go NewSnapshot sort tiebreak: when priority AND
+			// Match.PathPrefix length are equal, fall back to name asc. Input
+			// order is [bbb, aaa] on purpose — the winner must be decided by the
+			// sort (name asc -> "aaa"), not by input order. This pins the
+			// tiebreak api-gateway inherits via paas-engine snapshot ordering;
+			// if List/Snapshot sorting drifts, this case catches it.
+			name: "same-priority-same-length-name-asc-wins",
+			rules: []*GatewayRule{
+				gwRule("bbb", "/api/paas/", "", 100, true, tgt("svc-b", "", 8080, 100)),
+				gwRule("aaa", "/api/paas/", "", 100, true, tgt("svc-a", "", 8080, 100)),
+			},
+			path: "/api/paas/x", lane: "",
+			wantMatched: true, wantWinner: "aaa", wantRedir: false,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			res := ExplainGatewayMatch(c.rules, c.path, c.lane)
+			if res.Matched != c.wantMatched {
+				t.Fatalf("matched=%v want %v", res.Matched, c.wantMatched)
+			}
+			if c.wantMatched {
+				if res.WinningRule != c.wantWinner {
+					t.Errorf("winner=%q want %q", res.WinningRule, c.wantWinner)
+				}
+				if res.WouldRedirect != c.wantRedir {
+					t.Errorf("would_redirect=%v want %v", res.WouldRedirect, c.wantRedir)
+				}
+			}
+		})
+	}
+}
+
+// TestExplainNonMatchReasons covers the per-rule non-match classification:
+// disabled, request_lane mismatch, path prefix mismatch, and shadowed (the rule
+// itself would have matched but a higher-priority rule won first).
+func TestExplainNonMatchReasons(t *testing.T) {
+	rules := []*GatewayRule{
+		gwRule("winner", "/api/", "", 200, true, tgt("svc-a", "", 80, 100)),
+		gwRule("shadowed", "/api/", "", 100, true, tgt("svc-b", "", 80, 100)),
+		gwRule("disabled", "/api/", "", 300, false, tgt("svc-c", "", 80, 100)),
+		gwRule("wrong-lane", "/api/", "ppe-x", 250, true, tgt("svc-d", "ppe-x", 80, 100)),
+		gwRule("wrong-path", "/other/", "", 150, true, tgt("svc-e", "", 80, 100)),
+	}
+	res := ExplainGatewayMatch(rules, "/api/thing", "")
+
+	if res.WinningRule != "winner" {
+		t.Fatalf("winner=%q want winner", res.WinningRule)
+	}
+
+	byName := map[string]GatewayRuleExplain{}
+	for _, e := range res.Rules {
+		byName[e.Name] = e
+	}
+
+	checks := []struct {
+		rule       string
+		wantStatus string
+	}{
+		{"winner", ExplainStatusWinner},
+		{"shadowed", ExplainStatusShadowed},
+		{"disabled", ExplainStatusDisabled},
+		{"wrong-lane", ExplainStatusLaneMismatch},
+		{"wrong-path", ExplainStatusPathMismatch},
+	}
+	for _, c := range checks {
+		e, ok := byName[c.rule]
+		if !ok {
+			t.Fatalf("rule %q missing from explain", c.rule)
+		}
+		if e.Status != c.wantStatus {
+			t.Errorf("rule %q status=%q want %q (reason=%q)", c.rule, e.Status, c.wantStatus, e.Reason)
+		}
+	}
+}
+
+// TestExplainEffectiveLane verifies effective-lane resolution: a target with a
+// non-empty lane overrides the request x-lane; an empty target lane follows the
+// request x-lane.
+func TestExplainEffectiveLane(t *testing.T) {
+	// target lane set -> overrides request lane
+	rules := []*GatewayRule{
+		gwRule("forced", "/api/", "", 100, true, tgt("svc", "ppe-new", 80, 100)),
+	}
+	res := ExplainGatewayMatch(rules, "/api/x", "prod")
+	if len(res.CandidateTargets) != 1 {
+		t.Fatalf("expected 1 candidate, got %d", len(res.CandidateTargets))
+	}
+	if res.CandidateTargets[0].EffectiveLane != "ppe-new" {
+		t.Errorf("forced lane: effective=%q want ppe-new", res.CandidateTargets[0].EffectiveLane)
+	}
+
+	// empty target lane -> follows request lane
+	rules = []*GatewayRule{
+		gwRule("follow", "/api/", "", 100, true, tgt("svc", "", 80, 100)),
+	}
+	res = ExplainGatewayMatch(rules, "/api/x", "prod")
+	if res.CandidateTargets[0].EffectiveLane != "prod" {
+		t.Errorf("follow lane: effective=%q want prod", res.CandidateTargets[0].EffectiveLane)
+	}
+}

--- a/apps/paas-engine/internal/domain/gateway_rule.go
+++ b/apps/paas-engine/internal/domain/gateway_rule.go
@@ -3,7 +3,7 @@ package domain
 import "time"
 
 // GatewayRule 表示一条 api-gateway 动态路由规则。
-// Name 是业务主键 + 幂等 key；match / targets / fallback 在 DB 用 jsonb 列存。
+// Name 是业务主键 + 幂等 key；match / targets 在 DB 用 jsonb 列存。
 type GatewayRule struct {
 	Name        string          `json:"name"`
 	Enabled     bool            `json:"enabled"`
@@ -12,7 +12,6 @@ type GatewayRule struct {
 	RequestLane string          `json:"request_lane,omitempty"`
 	Match       GatewayMatch    `json:"match"`
 	Targets     []GatewayTarget `json:"targets"`
-	Fallback    GatewayFallback `json:"fallback"`
 	CreatedAt   time.Time       `json:"created_at"`
 	UpdatedAt   time.Time       `json:"updated_at"`
 	Version     int64           `json:"version"`
@@ -30,7 +29,7 @@ type GatewayMatch struct {
 	Cookies     map[string]string `json:"cookies,omitempty"`
 }
 
-// GatewayTarget 是规则的转发目标。MVP 强制单 target、weight==100。
+// GatewayTarget 是规则的转发目标。支持多 target 加权分流，weight 总和须为 100。
 type GatewayTarget struct {
 	Service       string `json:"service"`
 	Lane          string `json:"lane"`
@@ -38,11 +37,6 @@ type GatewayTarget struct {
 	Weight        int    `json:"weight"`
 	StripPrefix   string `json:"strip_prefix,omitempty"`
 	RewritePrefix string `json:"rewrite_prefix,omitempty"`
-}
-
-// GatewayFallback 决定 target lane 在 registry 找不到时的兜底行为。
-type GatewayFallback struct {
-	Mode string `json:"mode"`
 }
 
 // GatewaySnapshot 是 /internal/gateway-rules 返回的完整快照。

--- a/apps/paas-engine/internal/domain/gateway_rule_validate.go
+++ b/apps/paas-engine/internal/domain/gateway_rule_validate.go
@@ -39,9 +39,6 @@ func ValidateGatewayRule(rule GatewayRule) error {
 	if err := validateGatewayTargets(rule.Targets); err != nil {
 		return err
 	}
-	if err := validateGatewayFallback(rule.Fallback); err != nil {
-		return err
-	}
 	return nil
 }
 
@@ -114,34 +111,48 @@ func validateGatewayMatchExtensions(m GatewayMatch) error {
 	return nil
 }
 
+// validateGatewayTargets 放开多 target 加权分流：至少 1 个 target，
+// 每个 target 校验 service / lane / port，且全部 weight 之和必须等于 100。
+// 单个 target 权重 0 合法（用于把流量从某 target 撤走），负数拒绝。
 func validateGatewayTargets(targets []GatewayTarget) error {
-	if len(targets) != 1 {
-		return fmt.Errorf("%w: targets must contain exactly 1 entry (MVP 不支持多 target), got %d", ErrInvalidInput, len(targets))
+	if len(targets) == 0 {
+		return fmt.Errorf("%w: targets must contain at least 1 entry, got 0", ErrInvalidInput)
 	}
-	t := targets[0]
-	if t.Service == "" {
-		return fmt.Errorf("%w: target.service is required", ErrInvalidInput)
+	weightSum := 0
+	type targetIdentity struct{ service, lane string }
+	seen := make(map[targetIdentity]struct{}, len(targets))
+	for i := range targets {
+		t := targets[i]
+		if t.Service == "" {
+			return fmt.Errorf("%w: target[%d].service is required", ErrInvalidInput, i)
+		}
+		// service+lane 是 target 身份（set-weights 据此定位 target），规则内必须唯一。
+		id := targetIdentity{t.Service, t.Lane}
+		if _, dup := seen[id]; dup {
+			return fmt.Errorf(
+				"%w: target[%d] has duplicate identity service=%q lane=%q (service+lane must be unique within a rule)",
+				ErrInvalidInput, i, t.Service, t.Lane,
+			)
+		}
+		seen[id] = struct{}{}
+		// target.lane 可空：空 = "跟随请求 x-lane 透传"（api-gateway 运行时行为），
+		// paas-engine 视为合法、跳过 lane 命名校验；非空时才校验 prod / ppe-* / coe-*（拒 blue）。
+		if t.Lane != "" && !isGatewayLane(t.Lane) {
+			return fmt.Errorf(
+				"%w: target[%d].lane %q is not allowed (only prod / ppe-* / coe-*, not blue)",
+				ErrInvalidInput, i, t.Lane,
+			)
+		}
+		if t.Port < 1 || t.Port > 65535 {
+			return fmt.Errorf("%w: target[%d].port %d must be in [1, 65535]", ErrInvalidInput, i, t.Port)
+		}
+		if t.Weight < 0 {
+			return fmt.Errorf("%w: target[%d].weight %d must not be negative", ErrInvalidInput, i, t.Weight)
+		}
+		weightSum += t.Weight
 	}
-	// target.lane 可空：空 = "跟随请求 x-lane 透传"（api-gateway 运行时行为），
-	// paas-engine 视为合法、跳过 lane 命名校验；非空时才校验 prod / ppe-* / coe-*（拒 blue）。
-	if t.Lane != "" && !isGatewayLane(t.Lane) {
-		return fmt.Errorf(
-			"%w: target.lane %q is not allowed (only prod / ppe-* / coe-*, not blue)",
-			ErrInvalidInput, t.Lane,
-		)
-	}
-	if t.Port < 1 || t.Port > 65535 {
-		return fmt.Errorf("%w: target.port %d must be in [1, 65535]", ErrInvalidInput, t.Port)
-	}
-	if t.Weight != 100 {
-		return fmt.Errorf("%w: target.weight must be 100 in MVP (单 target), got %d", ErrInvalidInput, t.Weight)
-	}
-	return nil
-}
-
-func validateGatewayFallback(f GatewayFallback) error {
-	if f.Mode != "prod" && f.Mode != "reject" {
-		return fmt.Errorf("%w: fallback.mode %q must be one of {prod, reject}", ErrInvalidInput, f.Mode)
+	if weightSum != 100 {
+		return fmt.Errorf("%w: target weight sum must be 100, got %d", ErrInvalidInput, weightSum)
 	}
 	return nil
 }

--- a/apps/paas-engine/internal/domain/gateway_rule_validate_test.go
+++ b/apps/paas-engine/internal/domain/gateway_rule_validate_test.go
@@ -26,7 +26,6 @@ func validRule() GatewayRule {
 				Weight:  100,
 			},
 		},
-		Fallback: GatewayFallback{Mode: "prod"},
 	}
 }
 
@@ -170,16 +169,63 @@ func TestValidateGatewayRule_TargetsEmpty(t *testing.T) {
 	assertReject(t, r, "targets")
 }
 
-func TestValidateGatewayRule_TargetsMultiple(t *testing.T) {
+func TestValidateGatewayRule_TargetsMultipleSumming100OK(t *testing.T) {
+	// 二期放开多 target：权重总和=100 必须通过。
 	r := validRule()
-	r.Targets = append(r.Targets, GatewayTarget{Service: "x", Lane: "prod", Port: 80, Weight: 100})
-	assertReject(t, r, "targets")
+	r.Targets[0].Weight = 90
+	r.Targets = append(r.Targets, GatewayTarget{Service: "agent-service", Lane: "ppe-new", Port: 8000, Weight: 10})
+	if err := ValidateGatewayRule(r); err != nil {
+		t.Fatalf("expected 90/10 dual target to pass, got: %v", err)
+	}
 }
 
-func TestValidateGatewayRule_TargetWeightNot100(t *testing.T) {
+func TestValidateGatewayRule_TargetsMultipleSumNot100Rejected(t *testing.T) {
+	r := validRule()
+	r.Targets[0].Weight = 90
+	r.Targets = append(r.Targets, GatewayTarget{Service: "agent-service", Lane: "ppe-new", Port: 8000, Weight: 5})
+	assertReject(t, r, "weight")
+}
+
+func TestValidateGatewayRule_TargetsMultipleWithZeroWeightOK(t *testing.T) {
+	// 单 target 权重 0 合法（验收：把某 target 权重改 0 让流量回 prod），总和仍=100。
+	r := validRule()
+	r.Targets[0].Weight = 100
+	r.Targets = append(r.Targets, GatewayTarget{Service: "agent-service", Lane: "ppe-new", Port: 8000, Weight: 0})
+	if err := ValidateGatewayRule(r); err != nil {
+		t.Fatalf("expected 100/0 dual target to pass, got: %v", err)
+	}
+}
+
+func TestValidateGatewayRule_SingleTargetWeight100OK(t *testing.T) {
+	// 现网 6 条单 target weight=100 规则在新校验下必须仍合法。
+	r := validRule()
+	r.Targets[0].Weight = 100
+	if err := ValidateGatewayRule(r); err != nil {
+		t.Fatalf("expected single target weight=100 to pass, got: %v", err)
+	}
+}
+
+func TestValidateGatewayRule_SingleTargetWeightNot100Rejected(t *testing.T) {
 	r := validRule()
 	r.Targets[0].Weight = 50
 	assertReject(t, r, "weight")
+}
+
+func TestValidateGatewayRule_NegativeWeightRejected(t *testing.T) {
+	r := validRule()
+	r.Targets[0].Weight = 110
+	r.Targets = append(r.Targets, GatewayTarget{Service: "agent-service", Lane: "ppe-new", Port: 8000, Weight: -10})
+	assertReject(t, r, "weight")
+}
+
+func TestValidateGatewayRule_DuplicateTargetIdentityRejected(t *testing.T) {
+	// set-weights 用 service+lane 标识 target，要求规则内 service+lane 唯一；
+	// 否则会出现「能创建却无法 set-weights」的规则。两个 service+lane 相同的
+	// target（仅权重不同）必须被拒。
+	r := validRule()
+	r.Targets[0].Weight = 60
+	r.Targets = append(r.Targets, GatewayTarget{Service: "agent-service", Lane: "prod", Port: 8000, Weight: 40})
+	assertReject(t, r, "duplicate")
 }
 
 func TestValidateGatewayRule_TargetServiceEmpty(t *testing.T) {
@@ -210,6 +256,28 @@ func TestValidateGatewayRule_TargetLaneInvalid(t *testing.T) {
 	assertReject(t, r, "lane")
 }
 
+func TestValidateGatewayRule_SecondTargetLaneBlue(t *testing.T) {
+	// 校验必须遍历所有 target，不只校验第 0 个：第二个 target lane=blue 也要拒。
+	r := validRule()
+	r.Targets[0].Weight = 90
+	r.Targets = append(r.Targets, GatewayTarget{Service: "agent-service", Lane: "blue", Port: 8000, Weight: 10})
+	assertReject(t, r, "lane")
+}
+
+func TestValidateGatewayRule_SecondTargetPortOutOfRange(t *testing.T) {
+	r := validRule()
+	r.Targets[0].Weight = 90
+	r.Targets = append(r.Targets, GatewayTarget{Service: "agent-service", Lane: "ppe-new", Port: 70000, Weight: 10})
+	assertReject(t, r, "port")
+}
+
+func TestValidateGatewayRule_SecondTargetServiceEmpty(t *testing.T) {
+	r := validRule()
+	r.Targets[0].Weight = 90
+	r.Targets = append(r.Targets, GatewayTarget{Service: "", Lane: "prod", Port: 8000, Weight: 10})
+	assertReject(t, r, "service")
+}
+
 func TestValidateGatewayRule_TargetPortZero(t *testing.T) {
 	r := validRule()
 	r.Targets[0].Port = 0
@@ -229,20 +297,6 @@ func TestValidateGatewayRule_TargetPortBoundaries(t *testing.T) {
 		if err := ValidateGatewayRule(r); err != nil {
 			t.Fatalf("expected port %d to pass, got: %v", p, err)
 		}
-	}
-}
-
-func TestValidateGatewayRule_FallbackModeInvalid(t *testing.T) {
-	r := validRule()
-	r.Fallback.Mode = "target"
-	assertReject(t, r, "fallback")
-}
-
-func TestValidateGatewayRule_FallbackModeReject(t *testing.T) {
-	r := validRule()
-	r.Fallback.Mode = "reject"
-	if err := ValidateGatewayRule(r); err != nil {
-		t.Fatalf("expected fallback=reject to pass, got: %v", err)
 	}
 }
 

--- a/apps/paas-engine/internal/service/gateway_rule_emergency.go
+++ b/apps/paas-engine/internal/service/gateway_rule_emergency.go
@@ -1,0 +1,159 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/chiwei-platform/paas-engine/internal/domain"
+)
+
+// EnableChange is the before/after audit payload for disable/enable.
+type EnableChange struct {
+	Name          string `json:"name"`
+	BeforeEnabled bool   `json:"before_enabled"`
+	AfterEnabled  bool   `json:"after_enabled"`
+	Reason        string `json:"reason"`
+	Version       int64  `json:"version"`
+}
+
+// TargetWeight identifies a target by service+lane and gives its new weight.
+// The (service, lane) pair is the target identity used by set-weights.
+type TargetWeight struct {
+	Service string `json:"service"`
+	Lane    string `json:"lane"`
+	Weight  int    `json:"weight"`
+}
+
+// SetWeightsRequest is the body for the set-weights emergency op. It must list
+// every target of the rule exactly once (matched by service+lane); the weights
+// wholesale replace the rule's current weights.
+type SetWeightsRequest struct {
+	Reason  string         `json:"reason"`
+	Weights []TargetWeight `json:"weights"`
+}
+
+// WeightsChange is the before/after audit payload for set-weights.
+type WeightsChange struct {
+	Name          string                 `json:"name"`
+	BeforeTargets []domain.GatewayTarget `json:"before_targets"`
+	AfterTargets  []domain.GatewayTarget `json:"after_targets"`
+	Reason        string                 `json:"reason"`
+	Version       int64                  `json:"version"`
+}
+
+// Disable flips a rule's enabled flag to false, bumps its version, and returns
+// the before/after enabled values for auditing. It does NOT re-validate the
+// whole rule (止血动作要原子、不重跑整条校验).
+func (s *GatewayRuleService) Disable(ctx context.Context, name, reason string) (*EnableChange, error) {
+	return s.setEnabled(ctx, name, false, reason)
+}
+
+// Enable flips a rule's enabled flag to true.
+func (s *GatewayRuleService) Enable(ctx context.Context, name, reason string) (*EnableChange, error) {
+	return s.setEnabled(ctx, name, true, reason)
+}
+
+func (s *GatewayRuleService) setEnabled(ctx context.Context, name string, enabled bool, reason string) (*EnableChange, error) {
+	rule, err := s.repo.FindByName(ctx, name)
+	if err != nil {
+		return nil, err
+	}
+	before := rule.Enabled
+	rule.Enabled = enabled
+	rule.Version++
+	rule.UpdatedAt = time.Now()
+	if err := s.repo.Upsert(ctx, rule); err != nil {
+		return nil, err
+	}
+	return &EnableChange{
+		Name:          name,
+		BeforeEnabled: before,
+		AfterEnabled:  enabled,
+		Reason:        reason,
+		Version:       rule.Version,
+	}, nil
+}
+
+// SetWeights wholesale-replaces the weights of all targets in a rule. The
+// request must contain exactly the rule's current target set (matched by
+// service+lane): a missing or extra target is rejected. Individual weight 0 is
+// allowed (to drain a target), negatives are rejected, and the sum must be 100.
+// The new weights are validated through the existing multi-target validator.
+func (s *GatewayRuleService) SetWeights(ctx context.Context, name string, req SetWeightsRequest) (*WeightsChange, error) {
+	rule, err := s.repo.FindByName(ctx, name)
+	if err != nil {
+		return nil, err
+	}
+
+	before := make([]domain.GatewayTarget, len(rule.Targets))
+	copy(before, rule.Targets)
+
+	if len(req.Weights) != len(rule.Targets) {
+		return nil, fmt.Errorf(
+			"%w: weights must list exactly the rule's %d target(s), got %d",
+			domain.ErrInvalidInput, len(rule.Targets), len(req.Weights),
+		)
+	}
+
+	// Index incoming weights by service+lane; reject duplicate identities.
+	type key struct{ service, lane string }
+	incoming := make(map[key]int, len(req.Weights))
+	for _, w := range req.Weights {
+		k := key{w.Service, w.Lane}
+		if _, dup := incoming[k]; dup {
+			return nil, fmt.Errorf(
+				"%w: duplicate target identity service=%q lane=%q in weights",
+				domain.ErrInvalidInput, w.Service, w.Lane,
+			)
+		}
+		incoming[k] = w.Weight
+	}
+
+	// Apply by matching each existing target to an incoming weight. A missing
+	// match means the request omitted a target; a leftover incoming entry means
+	// the request had an extra one.
+	after := make([]domain.GatewayTarget, len(rule.Targets))
+	copy(after, rule.Targets)
+	for i := range after {
+		k := key{after[i].Service, after[i].Lane}
+		w, ok := incoming[k]
+		if !ok {
+			return nil, fmt.Errorf(
+				"%w: weights missing target service=%q lane=%q present in rule",
+				domain.ErrInvalidInput, after[i].Service, after[i].Lane,
+			)
+		}
+		after[i].Weight = w
+		delete(incoming, k)
+	}
+	if len(incoming) > 0 {
+		for k := range incoming {
+			return nil, fmt.Errorf(
+				"%w: weights contains target service=%q lane=%q not present in rule",
+				domain.ErrInvalidInput, k.service, k.lane,
+			)
+		}
+	}
+
+	// Reuse the multi-target validator: enforces weight>=0 and sum==100 (plus
+	// service/lane/port, which are unchanged here and already valid).
+	rule.Targets = after
+	if err := domain.ValidateGatewayRule(*rule); err != nil {
+		return nil, err
+	}
+
+	rule.Version++
+	rule.UpdatedAt = time.Now()
+	if err := s.repo.Upsert(ctx, rule); err != nil {
+		return nil, err
+	}
+
+	return &WeightsChange{
+		Name:          name,
+		BeforeTargets: before,
+		AfterTargets:  after,
+		Reason:        req.Reason,
+		Version:       rule.Version,
+	}, nil
+}

--- a/apps/paas-engine/internal/service/gateway_rule_emergency_test.go
+++ b/apps/paas-engine/internal/service/gateway_rule_emergency_test.go
@@ -1,0 +1,212 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/chiwei-platform/paas-engine/internal/domain"
+)
+
+// seedRule writes a rule directly into the stub repo for emergency-op tests.
+func seedRule(repo *stubGatewayRuleRepo, rule *domain.GatewayRule) {
+	cp := *rule
+	repo.rules[rule.Name] = &cp
+}
+
+func twoTargetRule() *domain.GatewayRule {
+	return &domain.GatewayRule{
+		Name:        "agent",
+		Enabled:     true,
+		Priority:    100,
+		PathPrefix:  "/api/agent/",
+		RequestLane: "",
+		Match:       domain.GatewayMatch{PathPrefix: "/api/agent/"},
+		Targets: []domain.GatewayTarget{
+			{Service: "agent-service", Lane: "prod", Port: 8000, Weight: 90},
+			{Service: "agent-service", Lane: "ppe-new", Port: 8000, Weight: 10},
+		},
+		Version: 3,
+	}
+}
+
+func TestDisableSetsEnabledFalseAndReportsBeforeAfter(t *testing.T) {
+	repo := newStubGatewayRuleRepo()
+	seedRule(repo, twoTargetRule())
+	svc := NewGatewayRuleService(repo)
+
+	res, err := svc.Disable(context.Background(), "agent", "incident-1234")
+	if err != nil {
+		t.Fatalf("Disable error: %v", err)
+	}
+	if res.BeforeEnabled != true || res.AfterEnabled != false {
+		t.Errorf("before/after enabled = %v/%v, want true/false", res.BeforeEnabled, res.AfterEnabled)
+	}
+	if res.Reason != "incident-1234" {
+		t.Errorf("reason=%q want incident-1234", res.Reason)
+	}
+	got, _ := repo.FindByName(context.Background(), "agent")
+	if got.Enabled {
+		t.Error("rule still enabled after Disable")
+	}
+	if got.Version != 4 {
+		t.Errorf("version=%d want 4 (bumped)", got.Version)
+	}
+}
+
+func TestEnableSetsEnabledTrue(t *testing.T) {
+	repo := newStubGatewayRuleRepo()
+	r := twoTargetRule()
+	r.Enabled = false
+	seedRule(repo, r)
+	svc := NewGatewayRuleService(repo)
+
+	res, err := svc.Enable(context.Background(), "agent", "recovered")
+	if err != nil {
+		t.Fatalf("Enable error: %v", err)
+	}
+	if res.BeforeEnabled != false || res.AfterEnabled != true {
+		t.Errorf("before/after = %v/%v want false/true", res.BeforeEnabled, res.AfterEnabled)
+	}
+	got, _ := repo.FindByName(context.Background(), "agent")
+	if !got.Enabled {
+		t.Error("rule not enabled after Enable")
+	}
+}
+
+func TestDisableMissingRuleReturnsNotFound(t *testing.T) {
+	svc := NewGatewayRuleService(newStubGatewayRuleRepo())
+	_, err := svc.Disable(context.Background(), "nope", "x")
+	if !errors.Is(err, domain.ErrGatewayRuleNotFound) {
+		t.Fatalf("expected ErrGatewayRuleNotFound, got %v", err)
+	}
+}
+
+func TestSetWeightsDrainsTargetToZero(t *testing.T) {
+	repo := newStubGatewayRuleRepo()
+	seedRule(repo, twoTargetRule())
+	svc := NewGatewayRuleService(repo)
+
+	req := SetWeightsRequest{
+		Reason: "drain ppe-new",
+		Weights: []TargetWeight{
+			{Service: "agent-service", Lane: "prod", Weight: 100},
+			{Service: "agent-service", Lane: "ppe-new", Weight: 0},
+		},
+	}
+	res, err := svc.SetWeights(context.Background(), "agent", req)
+	if err != nil {
+		t.Fatalf("SetWeights error: %v", err)
+	}
+	// before: 90/10, after: 100/0
+	if findWeight(res.BeforeTargets, "agent-service", "prod") != 90 ||
+		findWeight(res.BeforeTargets, "agent-service", "ppe-new") != 10 {
+		t.Errorf("before weights wrong: %+v", res.BeforeTargets)
+	}
+	if findWeight(res.AfterTargets, "agent-service", "prod") != 100 ||
+		findWeight(res.AfterTargets, "agent-service", "ppe-new") != 0 {
+		t.Errorf("after weights wrong: %+v", res.AfterTargets)
+	}
+	got, _ := repo.FindByName(context.Background(), "agent")
+	for _, tg := range got.Targets {
+		if tg.Lane == "ppe-new" && tg.Weight != 0 {
+			t.Errorf("ppe-new weight=%d want 0", tg.Weight)
+		}
+		if tg.Lane == "prod" && tg.Weight != 100 {
+			t.Errorf("prod weight=%d want 100", tg.Weight)
+		}
+	}
+}
+
+func TestSetWeightsRejectsSumNot100(t *testing.T) {
+	repo := newStubGatewayRuleRepo()
+	seedRule(repo, twoTargetRule())
+	svc := NewGatewayRuleService(repo)
+
+	req := SetWeightsRequest{
+		Reason: "bad",
+		Weights: []TargetWeight{
+			{Service: "agent-service", Lane: "prod", Weight: 50},
+			{Service: "agent-service", Lane: "ppe-new", Weight: 40},
+		},
+	}
+	_, err := svc.SetWeights(context.Background(), "agent", req)
+	if !errors.Is(err, domain.ErrInvalidInput) {
+		t.Fatalf("expected ErrInvalidInput for sum!=100, got %v", err)
+	}
+}
+
+func TestSetWeightsRejectsNegative(t *testing.T) {
+	repo := newStubGatewayRuleRepo()
+	seedRule(repo, twoTargetRule())
+	svc := NewGatewayRuleService(repo)
+
+	req := SetWeightsRequest{
+		Reason: "bad",
+		Weights: []TargetWeight{
+			{Service: "agent-service", Lane: "prod", Weight: 110},
+			{Service: "agent-service", Lane: "ppe-new", Weight: -10},
+		},
+	}
+	_, err := svc.SetWeights(context.Background(), "agent", req)
+	if !errors.Is(err, domain.ErrInvalidInput) {
+		t.Fatalf("expected ErrInvalidInput for negative weight, got %v", err)
+	}
+}
+
+func TestSetWeightsRejectsMissingTarget(t *testing.T) {
+	repo := newStubGatewayRuleRepo()
+	seedRule(repo, twoTargetRule())
+	svc := NewGatewayRuleService(repo)
+
+	// only one target supplied, rule has two -> missing target rejected
+	req := SetWeightsRequest{
+		Reason: "bad",
+		Weights: []TargetWeight{
+			{Service: "agent-service", Lane: "prod", Weight: 100},
+		},
+	}
+	_, err := svc.SetWeights(context.Background(), "agent", req)
+	if !errors.Is(err, domain.ErrInvalidInput) {
+		t.Fatalf("expected ErrInvalidInput for missing target, got %v", err)
+	}
+}
+
+func TestSetWeightsRejectsExtraTarget(t *testing.T) {
+	repo := newStubGatewayRuleRepo()
+	seedRule(repo, twoTargetRule())
+	svc := NewGatewayRuleService(repo)
+
+	// an extra target not present in the rule -> rejected
+	req := SetWeightsRequest{
+		Reason: "bad",
+		Weights: []TargetWeight{
+			{Service: "agent-service", Lane: "prod", Weight: 50},
+			{Service: "agent-service", Lane: "ppe-new", Weight: 30},
+			{Service: "agent-service", Lane: "ppe-other", Weight: 20},
+		},
+	}
+	_, err := svc.SetWeights(context.Background(), "agent", req)
+	if !errors.Is(err, domain.ErrInvalidInput) {
+		t.Fatalf("expected ErrInvalidInput for extra target, got %v", err)
+	}
+}
+
+func TestSetWeightsMissingRuleReturnsNotFound(t *testing.T) {
+	svc := NewGatewayRuleService(newStubGatewayRuleRepo())
+	_, err := svc.SetWeights(context.Background(), "nope", SetWeightsRequest{
+		Weights: []TargetWeight{{Service: "x", Lane: "prod", Weight: 100}},
+	})
+	if !errors.Is(err, domain.ErrGatewayRuleNotFound) {
+		t.Fatalf("expected ErrGatewayRuleNotFound, got %v", err)
+	}
+}
+
+func findWeight(targets []domain.GatewayTarget, service, lane string) int {
+	for _, t := range targets {
+		if t.Service == service && t.Lane == lane {
+			return t.Weight
+		}
+	}
+	return -999
+}

--- a/apps/paas-engine/internal/service/gateway_rule_seed.go
+++ b/apps/paas-engine/internal/service/gateway_rule_seed.go
@@ -21,7 +21,6 @@ type BaselineGatewayRule struct {
 //
 // 关键约定：所有 target.lane 全部留空——空表示"跟随请求 x-lane 透传"，
 // 跟当前 routes.yaml 的泳道路由行为完全一致，绝不写死 prod。
-// fallback.mode 统一 prod，平迁现状的 silent fallback 行为。
 func BaselineGatewayRules() []BaselineGatewayRule {
 	enabled := true
 	rule := func(name, prefix, service string, port int, stripPrefix string) BaselineGatewayRule {
@@ -46,7 +45,6 @@ func BaselineGatewayRules() []BaselineGatewayRule {
 						StripPrefix: stripPrefix,
 					},
 				},
-				Fallback: domain.GatewayFallback{Mode: "prod"},
 			},
 		}
 	}

--- a/apps/paas-engine/internal/service/gateway_rule_seed_test.go
+++ b/apps/paas-engine/internal/service/gateway_rule_seed_test.go
@@ -94,9 +94,6 @@ func TestBaselineGatewayRules_MatchRoutesYaml(t *testing.T) {
 		if tg.StripPrefix != want.stripPrefix {
 			t.Errorf("%s: target.strip_prefix got %q want %q", want.name, tg.StripPrefix, want.stripPrefix)
 		}
-		if req.Fallback.Mode != "prod" {
-			t.Errorf("%s: fallback.mode got %q want prod", want.name, req.Fallback.Mode)
-		}
 	}
 }
 
@@ -111,7 +108,6 @@ func TestBaselineGatewayRules_PassValidation(t *testing.T) {
 			RequestLane: s.Request.RequestLane,
 			Match:       s.Request.Match,
 			Targets:     s.Request.Targets,
-			Fallback:    s.Request.Fallback,
 		}
 		if err := domain.ValidateGatewayRule(rule); err != nil {
 			t.Errorf("baseline rule %q failed validation: %v", s.Name, err)

--- a/apps/paas-engine/internal/service/gateway_rule_service.go
+++ b/apps/paas-engine/internal/service/gateway_rule_service.go
@@ -32,7 +32,6 @@ type UpsertGatewayRuleRequest struct {
 	RequestLane string                 `json:"request_lane"`
 	Match       domain.GatewayMatch    `json:"match"`
 	Targets     []domain.GatewayTarget `json:"targets"`
-	Fallback    domain.GatewayFallback `json:"fallback"`
 }
 
 // enabledOrDefault 解析 Enabled 三态：nil（未提供）-> true（规则默认启用）；
@@ -56,7 +55,6 @@ func (s *GatewayRuleService) Upsert(ctx context.Context, name string, req Upsert
 		RequestLane: req.RequestLane,
 		Match:       req.Match,
 		Targets:     req.Targets,
-		Fallback:    req.Fallback,
 		UpdatedAt:   now,
 	}
 
@@ -91,7 +89,6 @@ func (s *GatewayRuleService) ensureRule(ctx context.Context, name string, req Up
 		RequestLane: req.RequestLane,
 		Match:       req.Match,
 		Targets:     req.Targets,
-		Fallback:    req.Fallback,
 		Version:     1,
 		CreatedAt:   now,
 		UpdatedAt:   now,
@@ -123,6 +120,17 @@ func (s *GatewayRuleService) List(ctx context.Context) ([]*domain.GatewayRule, e
 // Delete 删除一条规则。
 func (s *GatewayRuleService) Delete(ctx context.Context, name string) error {
 	return s.repo.Delete(ctx, name)
+}
+
+// Explain 预览一个请求会命中哪条规则、为何命中、其余规则为何没命中。
+// 取全部规则交给 domain.ExplainGatewayMatch（与 api-gateway matcher 对齐的纯逻辑）。
+func (s *GatewayRuleService) Explain(ctx context.Context, path, requestLane string) (*domain.GatewayExplainResult, error) {
+	rules, err := s.repo.FindAll(ctx)
+	if err != nil {
+		return nil, err
+	}
+	res := domain.ExplainGatewayMatch(rules, path, requestLane)
+	return &res, nil
 }
 
 // Snapshot 组装 /internal/gateway-rules 返回的快照。

--- a/apps/paas-engine/internal/service/gateway_rule_service_test.go
+++ b/apps/paas-engine/internal/service/gateway_rule_service_test.go
@@ -78,7 +78,6 @@ func validUpsertReq() service_UpsertReq {
 		Targets: []domain.GatewayTarget{
 			{Service: "agent-service", Lane: "prod", Port: 8000, Weight: 100},
 		},
-		Fallback: domain.GatewayFallback{Mode: "prod"},
 	}
 }
 


### PR DESCRIPTION
## Summary
- Multi-target weighted random split (no stickiness) for gateway rules; api-gateway picks a target by weight using an injectable rng source.
- Rule explain/preview endpoint on paas-engine, kept matcher-aligned via a golden-case suite (forward / redirect / disabled / shadowed classification).
- Kill-switch endpoints: disable / enable / set-weights, each taking a reason and returning before/after for Dashboard audit.
- Removed the dangling Fallback field from both services (the sidecar already performs the uniform prod fallback); DB column drop is staged for the deploy cutover.

## Test plan
- paas-engine + api-gateway: go build / go vet / go test all green; explain golden cases, weighted-selection determinism, multi-target validation, and kill-switch boundaries covered by unit tests.
- ppe-gw2 lane (real prod DB after DROP NOT NULL): GET shows no fallback field, multi-target PUT / set-weights / disable all work, explain returns correct trace.
- api-gateway weighted split confirmed on real instance via NodePort: paas-engine 23 / channel-proxy 18 over 41 requests (~50:50).

## Follow-ups
- After prod is stable, submit `ALTER TABLE gateway_routing_rules DROP COLUMN fallback` (irreversible, separate step).
- Dashboard transit endpoints + audit for the ops gateway commands (cross-repo gap).
