### PR TITLE
fix(hooks): resolve enforce-routing.sh via $CLAUDE_PROJECT_DIR

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -126,7 +126,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash .claude/hooks/enforce-routing.sh"
+            "command": "bash \"$CLAUDE_PROJECT_DIR\"/.claude/hooks/enforce-routing.sh"
           }
         ]
       }


### PR DESCRIPTION
The PreToolUse hook used a relative path that broke when the tool's
working directory was not the worktree root (e.g. TaskUpdate), causing
'no such file or directory'. Use the injected project-dir env var so the
path resolves regardless of CWD.
