### PR TITLE
feat(gateway): phase3 — Dashboard ops 中转+审计、稳定分流、快照回滚

### DIFF
--- a/.claude/skills/ops/SKILL.md
+++ b/.claude/skills/ops/SKILL.md
@@ -72,9 +72,35 @@ $HTTP DELETE "$BASE/ops/lane-bindings?type=<TYPE>&key=<KEY>" "$AUTH"
 
 ### `gateway` — api-gateway 路由规则调度
 
-调度 api-gateway 的流量路由规则：预览命中、止血启停、调整权重。所有动作经 Dashboard 中转写审计，再转发到 paas-engine 的 gateway-rules 管理 API。
+调度 api-gateway 的流量路由规则：查看配置、预览命中、增删改、止血启停、调权、回滚。所有写动作经 Dashboard 中转写审计（caller/规则名/before→after/reason/快照版本），再转发到 paas-engine 的 gateway-rules 管理 API。
 
-> ⚠️ **依赖 Dashboard 中转端点（当前为 gap，见文末「Dashboard 待补能力」）。** 在 Dashboard 落地 `/ops/gateway-rules*` 中转 + 审计前，下列命令会 404，不可用于线上调度。
+#### `gateway list` — 列出全部规则（只读）
+
+```bash
+$HTTP GET "$BASE/ops/gateway-rules" "$AUTH"
+```
+
+#### `gateway get NAME` — 看单条规则（只读）
+
+```bash
+$HTTP GET "$BASE/ops/gateway-rules/<NAME>" "$AUTH"
+```
+
+#### `gateway snapshot` — 看 paas-engine 当前下发的期望配置（version + 规则，只读）
+
+```bash
+$HTTP GET "$BASE/ops/gateway-rules/snapshot" "$AUTH"
+```
+
+这是「流量调度配置长什么样」的权威来源——paas-engine 的当前快照，即 api-gateway 应当执行的规则。看调度现状用这个。
+
+#### `gateway snapshots [LIMIT]` — 列出最近 N 条规则快照历史（只读）
+
+```bash
+$HTTP GET "$BASE/ops/gateway-rules/snapshots?limit=<LIMIT>" "$AUTH"
+```
+
+每条快照含 snapshot_version / created_by / reason / created_at / 规则全量。用于回滚前定位目标版本。
 
 #### `gateway explain PATH [LANE]` — 预览一个请求会命中哪条规则
 
@@ -85,7 +111,7 @@ $HTTP POST "$BASE/ops/gateway-rules:explain" \
   "$AUTH"
 ```
 
-返回：是否命中、命中规则名 + 原因、would_forward / would_redirect、候选 targets（含 effective_lane）、其余规则未命中原因（disabled / request_lane 不匹配 / path 不匹配 / 被更高优先级 shadowed）。**上线权重分流前必须先 explain 确认命中符合预期。**
+返回：是否命中、命中规则名 + 原因、would_forward / would_redirect、候选 targets（含 effective_lane）、是否启用稳定分流（stable_split + split_key_headers）、其余规则未命中原因（disabled / request_lane 不匹配 / path 不匹配 / 被更高优先级 shadowed）。**上线权重分流前必须先 explain 确认命中符合预期。**
 
 #### `gateway disable NAME REASON` — 停用一条规则（止血）
 
@@ -117,6 +143,34 @@ $HTTP POST "$BASE/ops/gateway-rules/<NAME>:set-weights" \
 ```
 
 返回 before/after 的 targets 权重。target 集合必须与规则现有 target 完全一致（缺失/多余/重复都会被拒绝）。
+
+#### `gateway upsert NAME REASON` — 创建或更新一条规则（写）
+
+按 NAME 整体创建/覆盖一条规则。请求体字段：`path_prefix`（路径前缀，必须 `/` 开头）、`match.path_prefix`（匹配条件，与顶层 path_prefix 一致）、`targets`（每项含 `service`/`lane`/`port`/`weight`，weight 总和=100，lane 留空表示跟随请求 x-lane 透传）、`priority`、`enabled`、可选 `split_key_headers`。`split_key_headers` 非空时启用稳定分流：按请求里第一个命中的 header 值做 hash 分桶，同一来源稳定落同一 target；为空则退化为加权随机。
+
+```bash
+$HTTP PUT "$BASE/ops/gateway-rules/<NAME>" \
+  '{"reason":"<REASON>","priority":10,"enabled":true,"path_prefix":"/api/agent/","match":{"path_prefix":"/api/agent/"},"targets":[{"service":"agent-service","lane":"","port":8000,"weight":100}],"split_key_headers":["x-user-id"]}' \
+  "$AUTH"
+```
+
+#### `gateway delete NAME REASON` — 删除一条规则（写）
+
+```bash
+$HTTP DELETE "$BASE/ops/gateway-rules/<NAME>" \
+  '{"reason":"<REASON>"}' \
+  "$AUTH"
+```
+
+#### `gateway rollback VERSION REASON` — 回滚到历史某快照版本（写）
+
+把整套规则回滚到 `gateway snapshots` 列出的某个 `snapshot_version`，会分配一个新的、更高的快照版本（不是原地复活旧版本号）。回滚前先用 `gateway snapshots` 确认目标版本内容。
+
+```bash
+$HTTP POST "$BASE/ops/gateway-rules:rollback" \
+  '{"reason":"<REASON>","snapshot_version":<VERSION>}' \
+  "$AUTH"
+```
 
 ### `audit [caller=xxx] [action=xxx]` — 审计日志查询
 
@@ -197,20 +251,5 @@ $HTTP DELETE "$BASE/skills/<NAME>" "$AUTH"
 
 ## 注意事项
 
-- 写操作（bind/unbind/gateway disable/enable/set-weights/skill-create/skill-edit/skill-delete）影响线上，执行前先告知用户
+- 写操作（bind/unbind/gateway upsert/delete/disable/enable/set-weights/rollback/skill-create/skill-edit/skill-delete）影响线上，执行前先告知用户
 - 不涵盖 deploy/undeploy/release/self-deploy/logs，这些仍走 `make` 命令
-
-## Dashboard 待补能力（gateway 调度的跨 repo gap）
-
-`gateway` 子命令依赖 Dashboard（不在本 repo）新增以下中转端点，本 repo 只完成了 paas-engine 引擎侧 API（`/api/paas/gateway-rules:explain`、`/{name}:disable`、`:enable`、`:set-weights`）。**在 Dashboard 落地前 gateway 命令不可用。**
-
-Dashboard 需新增并把请求转发到 paas-engine 对应端点：
-
-| Dashboard 中转端点 | 转发到 paas-engine | 审计 |
-|---|---|---|
-| `POST /dashboard/api/ops/gateway-rules:explain` | `POST /api/paas/gateway-rules:explain` | 只读，可不审计 |
-| `POST /dashboard/api/ops/gateway-rules/{name}:disable` | 同名 | 必须审计 |
-| `POST /dashboard/api/ops/gateway-rules/{name}:enable` | 同名 | 必须审计 |
-| `POST /dashboard/api/ops/gateway-rules/{name}:set-weights` | 同名 | 必须审计 |
-
-止血动作（disable/enable/set-weights）的审计必须记录：操作者、规则名、before→after 值、reason、生效时间、当前快照版本。paas-engine 端点已在响应里返回 before/after 供 Dashboard 落审计。**在审计中转就绪前，止血端点不应投入 ops 日常使用**（否则出现「能改但未被审计」的空窗）。

--- a/apps/api-gateway/go.mod
+++ b/apps/api-gateway/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/kr/text v0.1.0 // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.66.1 // indirect

--- a/apps/api-gateway/internal/gateway/gateway.go
+++ b/apps/api-gateway/internal/gateway/gateway.go
@@ -2,6 +2,7 @@ package gateway
 
 import (
 	"fmt"
+	"hash/fnv"
 	"log/slog"
 	"math/rand"
 	"net/http"
@@ -29,6 +30,9 @@ type Gateway struct {
 	// rng returns a value in [0,1) used for weighted-random target selection.
 	// Injectable so tests can drive deterministic target choices.
 	rng func() float64
+	// hash maps the (rule_name + split key) string to a uint64 for stable
+	// (sticky) target selection. Injectable so tests can pin a bucket.
+	hash hashFunc
 }
 
 // New creates a Gateway.
@@ -43,7 +47,15 @@ func New(snapshots SnapshotProvider, timeout time.Duration) *Gateway {
 		timeout:   timeout,
 		transport: t,
 		rng:       rand.Float64,
+		hash:      fnvHash,
 	}
+}
+
+// fnvHash is the production stable-split hash: FNV-1a over the input bytes.
+func fnvHash(s string) uint64 {
+	h := fnv.New64a()
+	_, _ = h.Write([]byte(s))
+	return h.Sum64()
 }
 
 func (g *Gateway) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -114,8 +126,24 @@ func (g *Gateway) serveEmergency(w http.ResponseWriter, r *http.Request, request
 // forward proxies the request to the matched target's logical service. Lane
 // resolution is delegated to the lane-sidecar via the X-Ctx-Lane header; the
 // gateway never resolves "service-lane" itself.
+// chooseTarget selects the upstream target for a matched rule. When the rule
+// configures split_key_headers and a key resolves from the request, selection
+// is stable (hash(rule+key) -> fixed bucket). Otherwise it falls back to
+// weighted random; if the rule was configured for stable split but no key
+// resolved, the fallback metric is bumped for the rule.
+func (g *Gateway) chooseTarget(rt route.Rule, r *http.Request) route.Target {
+	if len(rt.SplitKeyHeaders) > 0 {
+		if key, ok := resolveSplitKey(rt.SplitKeyHeaders, r.Header); ok {
+			bucket := stableBucket(g.hash, rt.Name, key)
+			return selectTargetStable(rt.Targets, bucket)
+		}
+		middleware.GatewaySplitFallbackTotal.WithLabelValues(rt.Name).Inc()
+	}
+	return selectTarget(rt.Targets, g.rng())
+}
+
 func (g *Gateway) forward(w http.ResponseWriter, r *http.Request, rt route.Rule, requestLane string) {
-	target := selectTarget(rt.Targets, g.rng())
+	target := g.chooseTarget(rt, r)
 	effLane := effectiveLane(target, requestLane)
 
 	targetPath := route.RewritePath(r.URL.Path, target)

--- a/apps/api-gateway/internal/gateway/stable_forward_test.go
+++ b/apps/api-gateway/internal/gateway/stable_forward_test.go
@@ -1,0 +1,170 @@
+package gateway
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/chiwei-platform/api-gateway/internal/middleware"
+	"github.com/chiwei-platform/api-gateway/internal/route"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+)
+
+// dialRecordingTransport returns a transport that records the dialed address
+// and routes every connection to the given test upstream.
+func dialRecordingTransport(upstreamHost string, dialed *string) *http.Transport {
+	return &http.Transport{
+		DisableKeepAlives: true,
+		DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+			*dialed = addr
+			return net.Dial(network, upstreamHost)
+		},
+	}
+}
+
+func splitRule(headers []string) route.Rule {
+	return route.Rule{
+		Name:            "agent",
+		Enabled:         true,
+		Priority:        100,
+		Match:           route.Match{PathPrefix: "/api/agent/"},
+		SplitKeyHeaders: headers,
+		Targets: []route.Target{
+			{Service: "agent-a", Lane: "prod", Port: 8000, Weight: 90},
+			{Service: "agent-b", Lane: "ppe-new", Port: 8000, Weight: 10},
+		},
+	}
+}
+
+// TestForwardStableSticky: with split_key_headers configured and a key present,
+// the same key always reaches the same target regardless of the random source.
+// We pin a hash that we know lands the key in B's bucket, and assert the choice
+// is independent of g.rng (which would have picked A).
+func TestForwardStableSticky(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+	upstreamURL, _ := url.Parse(upstream.URL)
+
+	var dialed string
+	p := &snapProvider{}
+	p.set(route.NewSnapshot(1, []route.Rule{splitRule([]string{"X-User-Id"})}))
+	gw := New(p, 5*time.Second)
+	gw.transport = dialRecordingTransport(upstreamURL.Host, &dialed)
+	// rng would pick A (draw 0.0), but a stable key must override it.
+	gw.rng = func() float64 { return 0.0 }
+	// Hash forces bucket 95 -> within B's [90,100) range.
+	gw.hash = func(string) uint64 { return 95 }
+
+	for i := 0; i < 5; i++ {
+		dialed = ""
+		req := httptest.NewRequest("GET", "/api/agent/health", nil)
+		req.Header.Set("X-User-Id", "stable-user")
+		w := httptest.NewRecorder()
+		gw.ServeHTTP(w, req)
+		if w.Code != http.StatusOK {
+			t.Fatalf("iter %d: expected 200, got %d", i, w.Code)
+		}
+		if dialed != "agent-b:8000" {
+			t.Errorf("iter %d: stable key must always pick agent-b, dialed %q", i, dialed)
+		}
+	}
+}
+
+// TestForwardStableUsesHashNotRng: the bucket comes from hash(rule+key), not
+// from g.rng. With hash forcing bucket 10 (-> A) the target is A even though
+// rng=0.99 (which random selection would map to B).
+func TestForwardStableUsesHashNotRng(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+	upstreamURL, _ := url.Parse(upstream.URL)
+
+	var dialed string
+	p := &snapProvider{}
+	p.set(route.NewSnapshot(1, []route.Rule{splitRule([]string{"X-User-Id"})}))
+	gw := New(p, 5*time.Second)
+	gw.transport = dialRecordingTransport(upstreamURL.Host, &dialed)
+	gw.rng = func() float64 { return 0.99 } // random would pick B
+	gw.hash = func(string) uint64 { return 10 } // stable bucket 10 -> A
+
+	req := httptest.NewRequest("GET", "/api/agent/health", nil)
+	req.Header.Set("X-User-Id", "u")
+	w := httptest.NewRecorder()
+	gw.ServeHTTP(w, req)
+	if dialed != "agent-a:8000" {
+		t.Errorf("hash bucket 10 must pick agent-a, dialed %q", dialed)
+	}
+}
+
+// TestForwardFallbackNoKeyRecordsMetric: split_key_headers configured but the
+// header is absent -> fall back to weighted random (driven by rng) AND bump the
+// fallback metric for this rule.
+func TestForwardFallbackNoKeyRecordsMetric(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+	upstreamURL, _ := url.Parse(upstream.URL)
+
+	var dialed string
+	p := &snapProvider{}
+	p.set(route.NewSnapshot(1, []route.Rule{splitRule([]string{"X-User-Id"})}))
+	gw := New(p, 5*time.Second)
+	gw.transport = dialRecordingTransport(upstreamURL.Host, &dialed)
+	gw.rng = func() float64 { return 0.0 } // random picks A
+	gw.hash = func(string) uint64 { return 95 } // would pick B if key existed
+
+	before := testutil.ToFloat64(middleware.GatewaySplitFallbackTotal.WithLabelValues("agent"))
+
+	req := httptest.NewRequest("GET", "/api/agent/health", nil) // no X-User-Id
+	w := httptest.NewRecorder()
+	gw.ServeHTTP(w, req)
+
+	if dialed != "agent-a:8000" {
+		t.Errorf("no key must fall back to weighted random (rng=0 -> A), dialed %q", dialed)
+	}
+	after := testutil.ToFloat64(middleware.GatewaySplitFallbackTotal.WithLabelValues("agent"))
+	if after-before != 1 {
+		t.Errorf("fallback metric for rule agent: delta=%v want 1", after-before)
+	}
+}
+
+// TestForwardNoSplitHeadersNoFallbackMetric: a rule WITHOUT split_key_headers
+// uses weighted random and does NOT bump the fallback metric (fallback metric
+// only fires when a rule is configured for stable split but cannot resolve a
+// key — not for plain unconfigured rules).
+func TestForwardNoSplitHeadersNoFallbackMetric(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+	upstreamURL, _ := url.Parse(upstream.URL)
+
+	var dialed string
+	p := &snapProvider{}
+	p.set(route.NewSnapshot(1, []route.Rule{splitRule(nil)})) // no split headers
+	gw := New(p, 5*time.Second)
+	gw.transport = dialRecordingTransport(upstreamURL.Host, &dialed)
+	gw.rng = func() float64 { return 0.99 } // picks B
+
+	before := testutil.ToFloat64(middleware.GatewaySplitFallbackTotal.WithLabelValues("agent"))
+
+	req := httptest.NewRequest("GET", "/api/agent/health", nil)
+	w := httptest.NewRecorder()
+	gw.ServeHTTP(w, req)
+
+	if dialed != "agent-b:8000" {
+		t.Errorf("unconfigured rule uses weighted random (rng=0.99 -> B), dialed %q", dialed)
+	}
+	after := testutil.ToFloat64(middleware.GatewaySplitFallbackTotal.WithLabelValues("agent"))
+	if after != before {
+		t.Errorf("unconfigured rule must not bump fallback metric: delta=%v", after-before)
+	}
+}

--- a/apps/api-gateway/internal/gateway/stable_select.go
+++ b/apps/api-gateway/internal/gateway/stable_select.go
@@ -1,0 +1,80 @@
+package gateway
+
+import (
+	"net/http"
+
+	"github.com/chiwei-platform/api-gateway/internal/route"
+)
+
+// hashFunc maps a string to a uint64. Injectable so tests can drive
+// deterministic bucket placement; production uses fnv (see New / forward).
+type hashFunc func(string) uint64
+
+// headerGetter resolves a header name to its values, case-insensitively, the
+// same way net/http does. It is a thin adapter so resolveSplitKey can be unit
+// tested against a plain map without constructing a full *http.Request.
+type headerGetter map[string][]string
+
+// Values returns all values for the given header name (canonicalized), or nil.
+func (h headerGetter) Values(name string) []string {
+	return http.Header(h).Values(name)
+}
+
+// keyValuer is the minimal header surface stable splitting needs: ordered
+// values for a (canonicalized) header name. *http.Header and headerGetter both
+// satisfy it.
+type keyValuer interface {
+	Values(name string) []string
+}
+
+// resolveSplitKey walks splitKeyHeaders in order and returns the first
+// non-empty value found. Header lookup is case-insensitive (net/http
+// canonicalization); a multi-value header yields its first value; an empty
+// string value counts as absent and the walk continues. Returns ("", false)
+// when no usable key is found (caller falls back to weighted random).
+func resolveSplitKey(splitKeyHeaders []string, h keyValuer) (string, bool) {
+	for _, name := range splitKeyHeaders {
+		vals := h.Values(name)
+		if len(vals) == 0 {
+			continue
+		}
+		if v := vals[0]; v != "" {
+			return v, true
+		}
+	}
+	return "", false
+}
+
+// stableBucket maps (ruleName, key) to a deterministic bucket in [0,99] via the
+// injected hash. ruleName is mixed in with a separator so two different rules
+// never share a sticky bucket for the same key by accident.
+func stableBucket(hash hashFunc, ruleName, key string) int {
+	return int(hash(ruleName+"\x00"+key) % 100)
+}
+
+// selectTargetStable picks a target by walking cumulative weights against a
+// fixed bucket in [0,99]. Same contract as selectTarget but deterministic: a
+// single target always wins, a weight-0 target is never selected, and the
+// all-zero degenerate case falls back to the first target.
+func selectTargetStable(targets []route.Target, bucket int) route.Target {
+	if len(targets) == 1 {
+		return targets[0]
+	}
+	total := 0
+	for _, t := range targets {
+		total += t.Weight
+	}
+	if total <= 0 {
+		return targets[0]
+	}
+	// Scale the 0-99 bucket onto the total weight so non-100 sums still work.
+	point := bucket * total / 100
+	cumulative := 0
+	for _, t := range targets {
+		cumulative += t.Weight
+		if point < cumulative {
+			return t
+		}
+	}
+	return targets[len(targets)-1]
+}

--- a/apps/api-gateway/internal/gateway/stable_select_test.go
+++ b/apps/api-gateway/internal/gateway/stable_select_test.go
@@ -1,0 +1,186 @@
+package gateway
+
+import (
+	"testing"
+
+	"github.com/chiwei-platform/api-gateway/internal/route"
+)
+
+// TestSelectTargetStableBoundary: stable selection maps a 0-99 bucket onto the
+// cumulative weight ranges. For a 90/10 split, buckets [0,90) pick A and
+// [90,100) pick B. We assert exact boundaries deterministically.
+func TestSelectTargetStableBoundary(t *testing.T) {
+	targets := []route.Target{
+		{Service: "svc-a", Lane: "prod", Port: 8000, Weight: 90},
+		{Service: "svc-b", Lane: "ppe-new", Port: 8000, Weight: 10},
+	}
+	cases := []struct {
+		bucket int
+		want   string
+	}{
+		{0, "svc-a"},
+		{50, "svc-a"},
+		{89, "svc-a"},
+		{90, "svc-b"},
+		{95, "svc-b"},
+		{99, "svc-b"},
+	}
+	for _, c := range cases {
+		got := selectTargetStable(targets, c.bucket)
+		if got.Service != c.want {
+			t.Errorf("bucket=%d: got %q want %q", c.bucket, got.Service, c.want)
+		}
+	}
+}
+
+// TestSelectTargetStableSingle: a single target always wins regardless of bucket.
+func TestSelectTargetStableSingle(t *testing.T) {
+	targets := []route.Target{{Service: "only", Port: 8000, Weight: 100}}
+	for _, b := range []int{0, 33, 99} {
+		if got := selectTargetStable(targets, b); got.Service != "only" {
+			t.Errorf("bucket=%d: got %q want only", b, got.Service)
+		}
+	}
+}
+
+// TestSelectTargetStableZeroWeight: a weight-0 target is never selected.
+func TestSelectTargetStableZeroWeight(t *testing.T) {
+	targets := []route.Target{
+		{Service: "drained", Port: 8000, Weight: 0},
+		{Service: "live", Port: 8000, Weight: 100},
+	}
+	for _, b := range []int{0, 1, 50, 99} {
+		if got := selectTargetStable(targets, b); got.Service != "live" {
+			t.Errorf("bucket=%d: got %q want live (weight-0 must never win)", b, got.Service)
+		}
+	}
+}
+
+// TestSelectTargetStableFullSwitch: weights 100/0 send every bucket to A;
+// flipping to 0/100 sends every bucket to B (调权后立即全切).
+func TestSelectTargetStableFullSwitch(t *testing.T) {
+	allA := []route.Target{
+		{Service: "a", Port: 8000, Weight: 100},
+		{Service: "b", Port: 8000, Weight: 0},
+	}
+	allB := []route.Target{
+		{Service: "a", Port: 8000, Weight: 0},
+		{Service: "b", Port: 8000, Weight: 100},
+	}
+	for b := 0; b < 100; b++ {
+		if got := selectTargetStable(allA, b); got.Service != "a" {
+			t.Errorf("100/0 bucket=%d: got %q want a", b, got.Service)
+		}
+		if got := selectTargetStable(allB, b); got.Service != "b" {
+			t.Errorf("0/100 bucket=%d: got %q want b", b, got.Service)
+		}
+	}
+}
+
+// TestStableBucket: the bucket is hash(rule_name + key) % 100; the same
+// (rule, key) pair always lands in the same bucket, and changing either input
+// changes the input fed to the hash. We use an injectable hash so the test is
+// deterministic and independent of the production hash algorithm.
+func TestStableBucket(t *testing.T) {
+	// Identity hash over the byte sum keeps the math obvious and deterministic.
+	h := func(s string) uint64 {
+		var sum uint64
+		for _, c := range []byte(s) {
+			sum += uint64(c)
+		}
+		return sum
+	}
+	b1 := stableBucket(h, "rule-x", "user-1")
+	b2 := stableBucket(h, "rule-x", "user-1")
+	if b1 != b2 {
+		t.Errorf("same (rule,key) must be stable: %d vs %d", b1, b2)
+	}
+	if b1 < 0 || b1 > 99 {
+		t.Errorf("bucket %d out of [0,99]", b1)
+	}
+	// Different rule name with same key must feed a different string to the
+	// hash (so two rules don't share a sticky bucket by accident).
+	if stableBucket(h, "rule-x", "k") == stableBucket(h, "rule-y", "k") {
+		// With the identity hash this would only collide if "rule-x"+key and
+		// "rule-y"+key sum equal; they don't, so this asserts the name is mixed in.
+		t.Errorf("rule name must be part of the hashed string")
+	}
+}
+
+// TestResolveSplitKey covers the key-resolution boundaries the spec mandates:
+// case-insensitive header lookup, first-present-in-order wins, empty value
+// counts as absent, multi-value header takes the first value, and no headers /
+// no match returns absent.
+func TestResolveSplitKey(t *testing.T) {
+	cases := []struct {
+		name       string
+		headerKeys []string
+		headers    map[string][]string
+		wantKey    string
+		wantOK     bool
+	}{
+		{
+			name:       "no split headers configured",
+			headerKeys: nil,
+			headers:    map[string][]string{"X-User-Id": {"u1"}},
+			wantKey:    "", wantOK: false,
+		},
+		{
+			name:       "case-insensitive lookup",
+			headerKeys: []string{"x-user-id"},
+			headers:    map[string][]string{"X-User-Id": {"u1"}},
+			wantKey:    "u1", wantOK: true,
+		},
+		{
+			name:       "first present in order wins",
+			headerKeys: []string{"X-Trace-Id", "X-User-Id"},
+			headers:    map[string][]string{"X-User-Id": {"u1"}},
+			wantKey:    "u1", wantOK: true,
+		},
+		{
+			name:       "earlier header preferred when both present",
+			headerKeys: []string{"X-Trace-Id", "X-User-Id"},
+			headers:    map[string][]string{"X-Trace-Id": {"t1"}, "X-User-Id": {"u1"}},
+			wantKey:    "t1", wantOK: true,
+		},
+		{
+			name:       "empty value counts as absent, falls to next header",
+			headerKeys: []string{"X-Trace-Id", "X-User-Id"},
+			headers:    map[string][]string{"X-Trace-Id": {""}, "X-User-Id": {"u1"}},
+			wantKey:    "u1", wantOK: true,
+		},
+		{
+			name:       "all empty -> absent",
+			headerKeys: []string{"X-Trace-Id"},
+			headers:    map[string][]string{"X-Trace-Id": {""}},
+			wantKey:    "", wantOK: false,
+		},
+		{
+			name:       "multi-value header takes first value",
+			headerKeys: []string{"X-User-Id"},
+			headers:    map[string][]string{"X-User-Id": {"first", "second"}},
+			wantKey:    "first", wantOK: true,
+		},
+		{
+			name:       "no matching header -> absent",
+			headerKeys: []string{"X-User-Id"},
+			headers:    map[string][]string{"X-Other": {"x"}},
+			wantKey:    "", wantOK: false,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			h := make(map[string][]string)
+			for k, v := range c.headers {
+				h[k] = v
+			}
+			gotKey, gotOK := resolveSplitKey(c.headerKeys, headerGetter(h))
+			if gotOK != c.wantOK {
+				t.Fatalf("ok=%v want %v (key=%q)", gotOK, c.wantOK, gotKey)
+			}
+			if gotKey != c.wantKey {
+				t.Errorf("key=%q want %q", gotKey, c.wantKey)
+			}
+		})
+	}
+}

--- a/apps/api-gateway/internal/middleware/metrics.go
+++ b/apps/api-gateway/internal/middleware/metrics.go
@@ -36,6 +36,14 @@ var (
 		Help:    "Proxy request duration in seconds.",
 		Buckets: prometheus.DefBuckets,
 	}, []string{"service"})
+
+	// GatewaySplitFallbackTotal counts requests where a rule configured for
+	// stable split could not resolve a split key and fell back to weighted
+	// random target selection, labeled by rule name.
+	GatewaySplitFallbackTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "gateway_split_fallback_total",
+		Help: "Requests that fell back to weighted random because a stable-split rule could not resolve a key.",
+	}, []string{"rule"})
 )
 
 // Metrics is an HTTP middleware that records request metrics.

--- a/apps/api-gateway/internal/route/model.go
+++ b/apps/api-gateway/internal/route/model.go
@@ -28,4 +28,9 @@ type Rule struct {
 	Priority int      `json:"priority"`
 	Match    Match    `json:"match"`
 	Targets  []Target `json:"targets"`
+	// SplitKeyHeaders is an ordered list of header names used for stable
+	// (sticky) target selection: the first present, non-empty header value is
+	// hashed with the rule name to pick a target deterministically. Empty means
+	// no stable split (weighted-random selection).
+	SplitKeyHeaders []string `json:"split_key_headers,omitempty"`
 }

--- a/apps/monitor-dashboard/src/middleware/audit.gateway.test.ts
+++ b/apps/monitor-dashboard/src/middleware/audit.gateway.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, mock } from 'bun:test';
+
+// mock DB：捕获 auditMiddleware 落库的对象，验合并逻辑真把 gatewayAudit 提到 params 顶层。
+const savedRows: Array<Record<string, unknown>> = [];
+mock.module('../db', () => ({
+  AppDataSource: {
+    getRepository: () => ({
+      save: async (row: Record<string, unknown>) => {
+        savedRows.push(row);
+        return row;
+      },
+    }),
+  },
+}));
+
+import { deriveAction, auditMiddleware } from './audit';
+
+// 钉死 gateway-rules 各路径的 action 映射（list/get/explain/create-update/delete/
+// disable/enable/set-weights），审计要能按 action 检索到这些操作。
+
+describe('deriveAction：gateway-rules 路径映射', () => {
+  const cases: Array<[string, string, string]> = [
+    ['GET', '/dashboard/api/ops/gateway-rules', 'ops.gateway-rules.list'],
+    ['GET', '/dashboard/api/ops/gateway-rules/snapshot', 'ops.gateway-rules.snapshot'],
+    ['GET', '/dashboard/api/ops/gateway-rules/r1', 'ops.gateway-rules.get'],
+    ['POST', '/dashboard/api/ops/gateway-rules:explain', 'ops.gateway-rules.explain'],
+    ['PUT', '/dashboard/api/ops/gateway-rules/r1', 'ops.gateway-rules.update'],
+    ['DELETE', '/dashboard/api/ops/gateway-rules/r1', 'ops.gateway-rules.delete'],
+    ['POST', '/dashboard/api/ops/gateway-rules/r1:disable', 'ops.gateway-rules.disable'],
+    ['POST', '/dashboard/api/ops/gateway-rules/r1:enable', 'ops.gateway-rules.enable'],
+    ['POST', '/dashboard/api/ops/gateway-rules/r1:set-weights', 'ops.gateway-rules.set-weights'],
+    ['GET', '/dashboard/api/ops/gateway-rules/snapshots', 'ops.gateway-rules.snapshots'],
+    ['POST', '/dashboard/api/ops/gateway-rules:rollback', 'ops.gateway-rules.rollback'],
+  ];
+
+  for (const [method, path, expected] of cases) {
+    it(`${method} ${path} → ${expected}`, () => {
+      expect(deriveAction(method, path)).toBe(expected);
+    });
+  }
+
+  it('snapshot 不被误判成 get（{name} 不能吃掉 snapshot）', () => {
+    expect(deriveAction('GET', '/dashboard/api/ops/gateway-rules/snapshot')).not.toBe('ops.gateway-rules.get');
+  });
+
+  it('snapshots（历史列表）不被误判成 get', () => {
+    expect(deriveAction('GET', '/dashboard/api/ops/gateway-rules/snapshots')).not.toBe('ops.gateway-rules.get');
+  });
+});
+
+// 钉死：handler 通过 c.set('gatewayAudit') stash 的固定五键，必须被 auditMiddleware
+// 提升到落库 params 的顶层（不是嵌在 params.gatewayAudit 里），否则 audit_logs.params
+// 没法按 rule_name / snapshot_version 做 JSONB 检索。
+describe('auditMiddleware：gatewayAudit 五键提升到落库 params 顶层', () => {
+  it('disable 写操作的 before/after/snapshot_version 进 params 顶层', async () => {
+    savedRows.length = 0;
+    const { Hono } = await import('hono');
+    const app = new Hono();
+    app.use('*', auditMiddleware);
+    app.post('/dashboard/api/ops/gateway-rules/r1:disable', (c) => {
+      c.set('caller' as never, 'tester' as never);
+      c.set('gatewayAudit' as never, {
+        rule_name: 'r1',
+        reason: 'stop',
+        before: { enabled: true },
+        after: { enabled: false },
+        snapshot_version: 12,
+      } as never);
+      return c.json({ ok: true });
+    });
+
+    const res = await app.request('/dashboard/api/ops/gateway-rules/r1:disable', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ reason: 'stop' }),
+    });
+    expect(res.status).toBe(200);
+
+    expect(savedRows.length).toBe(1);
+    const row = savedRows[0];
+    expect(row.action).toBe('ops.gateway-rules.disable');
+    const params = row.params as Record<string, unknown>;
+    expect(params.rule_name).toBe('r1');
+    expect(params.snapshot_version).toBe(12);
+    expect(params.before).toEqual({ enabled: true });
+    expect(params.after).toEqual({ enabled: false });
+  });
+});

--- a/apps/monitor-dashboard/src/middleware/audit.ts
+++ b/apps/monitor-dashboard/src/middleware/audit.ts
@@ -4,11 +4,23 @@ import { AppDataSource } from '../db';
 import { AuditLog } from '../entities/audit-log';
 
 /** Map route path to a human-readable action name */
-function deriveAction(method: string, path: string): string {
+export function deriveAction(method: string, path: string): string {
   // Strip /dashboard prefix for matching
   const p = path.replace(/^\/dashboard/, '');
 
   const patterns: [RegExp, string][] = [
+    // gateway-rules：custom method（:explain / :disable / ...）匹配必须排在
+    // /{name} 之前，否则带冒号的整段会被 {name} 误吃；snapshot 同理要先于 {name}。
+    [/^\/api\/ops\/gateway-rules:explain$/, 'ops.gateway-rules.explain'],
+    [/^\/api\/ops\/gateway-rules:rollback$/, 'ops.gateway-rules.rollback'],
+    [/^\/api\/ops\/gateway-rules\/[^/]+:disable$/, 'ops.gateway-rules.disable'],
+    [/^\/api\/ops\/gateway-rules\/[^/]+:enable$/, 'ops.gateway-rules.enable'],
+    [/^\/api\/ops\/gateway-rules\/[^/]+:set-weights$/, 'ops.gateway-rules.set-weights'],
+    // snapshots（历史列表）与 snapshot（当前期望配置）都必须排在 /{name} 之前。
+    [/^\/api\/ops\/gateway-rules\/snapshots$/, 'ops.gateway-rules.snapshots'],
+    [/^\/api\/ops\/gateway-rules\/snapshot$/, 'ops.gateway-rules.snapshot'],
+    [/^\/api\/ops\/gateway-rules$/, 'ops.gateway-rules.list'],
+    [/^\/api\/ops\/gateway-rules\/[^/]+$/, method === 'PUT' ? 'ops.gateway-rules.update' : method === 'DELETE' ? 'ops.gateway-rules.delete' : 'ops.gateway-rules.get'],
     [/^\/api\/ops\/services\/[^/]+\/pods$/, 'ops.pods.read'],
     [/^\/api\/ops\/services$/, 'ops.services.read'],
     [/^\/api\/ops\/builds\/[^/]+\/latest$/, 'ops.builds.read'],
@@ -92,6 +104,15 @@ export const auditMiddleware: MiddlewareHandler<AppEnv> = async (c, next) => {
       delete body.password;
       delete body.api_key;
       params.body = body;
+    }
+
+    // Structured audit payload stashed by a handler (e.g. gateway-rules write ops).
+    // Lifted to top-level params keys (rule_name/reason/before/after/snapshot_version)
+    // so audit_logs.params is JSONB-queryable by rule_name or snapshot_version.
+    // before/after/snapshot_version 的真值取自 paas-engine 写操作响应、不是中转层编的。
+    const stashed = c.get('gatewayAudit');
+    if (stashed && typeof stashed === 'object') {
+      Object.assign(params, stashed);
     }
 
     // Fire-and-forget audit write

--- a/apps/monitor-dashboard/src/paas-client.ts
+++ b/apps/monitor-dashboard/src/paas-client.ts
@@ -52,9 +52,14 @@ function createClient(configFn: () => { baseURL: string; headers: Record<string,
       return unwrap(res.data);
     },
 
-    async del(path: string, params?: Record<string, string>, extraHeaders?: Record<string, string>) {
+    async del(path: string, params?: Record<string, string>, extraHeaders?: Record<string, string>, body?: unknown) {
       const { baseURL, headers } = configFn();
-      const config: AxiosRequestConfig = { headers: { ...headers, ...extraHeaders }, timeout: TIMEOUT, params };
+      const config: AxiosRequestConfig = {
+        headers: { ...headers, 'Content-Type': 'application/json', ...extraHeaders },
+        timeout: TIMEOUT,
+        params,
+        data: body,
+      };
       const res = await axios.delete(`${baseURL}${path}`, config);
       return unwrap(res.data);
     },

--- a/apps/monitor-dashboard/src/routes/operations.gateway.test.ts
+++ b/apps/monitor-dashboard/src/routes/operations.gateway.test.ts
@@ -1,0 +1,364 @@
+import { describe, it, expect, mock, beforeEach } from 'bun:test';
+
+// ---------------------------------------------------------------------------
+// 钉死 Task1：Dashboard ops 中转 gateway-rules + reason 强制 + 审计 before/after。
+//
+// 这一层是"安全入口"：人和 AI 通过 Dashboard 操作 gateway 规则，写操作必须带
+// reason、否则拒绝；before/after/snapshot_version 的真值取自 paas-engine 写操作
+// 的响应体（disable/enable 的 EnableChange、set-weights 的 WeightsChange），不是
+// 中转层自己编。审计 best-effort，handler 把结构化 payload 塞进 c.set('gatewayAudit')，
+// 由 audit 中间件合并进 params 顶层固定键。
+// ---------------------------------------------------------------------------
+
+// mock paas-client，记录每次转发的 path/body，并返回可控的下游响应
+const calls: Array<{ method: string; path: string; body?: unknown; delBody?: unknown }> = [];
+let nextResponse: unknown = {};
+
+mock.module('../paas-client', () => {
+  const record = (method: string) => async (path: string, bodyOrParams?: unknown) => {
+    calls.push({ method, path, body: bodyOrParams });
+    return nextResponse;
+  };
+  // del 的 body 是第 4 个位置参（前 3 个是 path/params/extraHeaders），
+  // 单独记录 delBody 以钉死 reason 确实被转发到下游 body 而不是丢在 query。
+  const recordDel = async (
+    path: string,
+    _params?: unknown,
+    _extraHeaders?: unknown,
+    body?: unknown,
+  ) => {
+    calls.push({ method: 'DELETE', path, delBody: body });
+    return nextResponse;
+  };
+  return {
+    paasClient: {
+      get: record('GET'),
+      post: record('POST'),
+      put: record('PUT'),
+      del: recordDel,
+    },
+    larkClient: {
+      get: record('GET'),
+      post: record('POST'),
+      put: record('PUT'),
+      del: recordDel,
+    },
+  };
+});
+
+// 在 mock 之后 import 被测模块
+const operationsModule = await import('./operations');
+const operationsApp = operationsModule.default;
+const { buildGatewayAuditParams } = operationsModule as unknown as {
+  buildGatewayAuditParams: (
+    action: string,
+    ruleName: string | null,
+    reason: string | null,
+    downstream: unknown,
+  ) => Record<string, unknown>;
+};
+
+beforeEach(() => {
+  calls.length = 0;
+  nextResponse = {};
+});
+
+describe('gateway-rules 中转：下游路径映射', () => {
+  it('GET list → /api/paas/gateway-rules/', async () => {
+    nextResponse = [{ name: 'r1' }];
+    const res = await operationsApp.request('/api/ops/gateway-rules');
+    expect(res.status).toBe(200);
+    expect(calls[0]).toMatchObject({ method: 'GET', path: '/api/paas/gateway-rules/' });
+  });
+
+  it('GET snapshot → /internal/gateway-rules（version + 规则）', async () => {
+    nextResponse = { version: 7, rules: [{ name: 'r1' }] };
+    const res = await operationsApp.request('/api/ops/gateway-rules/snapshot');
+    expect(res.status).toBe(200);
+    expect(calls[0]).toMatchObject({ method: 'GET', path: '/internal/gateway-rules' });
+    expect(await res.json()).toMatchObject({ version: 7 });
+  });
+
+  it('GET single rule → /api/paas/gateway-rules/{name}', async () => {
+    nextResponse = { name: 'r1' };
+    await operationsApp.request('/api/ops/gateway-rules/r1');
+    expect(calls[0]).toMatchObject({ method: 'GET', path: '/api/paas/gateway-rules/r1' });
+  });
+
+  it('POST explain → /api/paas/gateway-rules:explain，只读不要求 reason', async () => {
+    nextResponse = { matched: 'r1' };
+    const res = await operationsApp.request('/api/ops/gateway-rules:explain', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ path: '/foo', x_lane: 'prod' }),
+    });
+    expect(res.status).toBe(200);
+    expect(calls[0]).toMatchObject({ method: 'POST', path: '/api/paas/gateway-rules:explain' });
+  });
+
+  it('PUT upsert → /api/paas/gateway-rules/{name}', async () => {
+    nextResponse = { name: 'r1', version: 3 };
+    const res = await operationsApp.request('/api/ops/gateway-rules/r1', {
+      method: 'PUT',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ reason: 'add canary', path_prefix: '/x' }),
+    });
+    expect(res.status).toBe(200);
+    expect(calls[0]).toMatchObject({ method: 'PUT', path: '/api/paas/gateway-rules/r1' });
+  });
+
+  it('DELETE → /api/paas/gateway-rules/{name}', async () => {
+    nextResponse = { deleted: 'r1' };
+    const res = await operationsApp.request('/api/ops/gateway-rules/r1', {
+      method: 'DELETE',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ reason: 'cleanup' }),
+    });
+    expect(res.status).toBe(200);
+    expect(calls[0]).toMatchObject({ method: 'DELETE', path: '/api/paas/gateway-rules/r1' });
+  });
+
+  it('DELETE 把 reason 转发到下游 body（不是丢在 query）', async () => {
+    nextResponse = { deleted: 'r1' };
+    await operationsApp.request('/api/ops/gateway-rules/r1', {
+      method: 'DELETE',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ reason: 'cleanup' }),
+    });
+    expect(calls[0].delBody).toEqual({ reason: 'cleanup' });
+  });
+
+  it('disable → /api/paas/gateway-rules/{name}:disable', async () => {
+    nextResponse = { name: 'r1', before_enabled: true, after_enabled: false, version: 9 };
+    const res = await operationsApp.request('/api/ops/gateway-rules/r1:disable', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ reason: 'stop bleeding' }),
+    });
+    expect(res.status).toBe(200);
+    expect(calls[0]).toMatchObject({ method: 'POST', path: '/api/paas/gateway-rules/r1:disable' });
+  });
+
+  it('enable → /api/paas/gateway-rules/{name}:enable', async () => {
+    nextResponse = { name: 'r1', before_enabled: false, after_enabled: true, version: 10 };
+    const res = await operationsApp.request('/api/ops/gateway-rules/r1:enable', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ reason: 'recovered' }),
+    });
+    expect(res.status).toBe(200);
+    expect(calls[0]).toMatchObject({ method: 'POST', path: '/api/paas/gateway-rules/r1:enable' });
+  });
+
+  it('set-weights → /api/paas/gateway-rules/{name}:set-weights', async () => {
+    nextResponse = { name: 'r1', before_targets: [], after_targets: [], version: 11 };
+    const res = await operationsApp.request('/api/ops/gateway-rules/r1:set-weights', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ reason: 'shift', weights: [{ service: 's', lane: 'prod', weight: 100 }] }),
+    });
+    expect(res.status).toBe(200);
+    expect(calls[0]).toMatchObject({ method: 'POST', path: '/api/paas/gateway-rules/r1:set-weights' });
+  });
+});
+
+describe('gateway-rules 中转：写操作强制 reason', () => {
+  const writeCases: Array<{ name: string; method: string; path: string; body: object }> = [
+    { name: 'PUT', method: 'PUT', path: '/api/ops/gateway-rules/r1', body: { path_prefix: '/x' } },
+    { name: 'DELETE', method: 'DELETE', path: '/api/ops/gateway-rules/r1', body: {} },
+    { name: 'disable', method: 'POST', path: '/api/ops/gateway-rules/r1:disable', body: {} },
+    { name: 'enable', method: 'POST', path: '/api/ops/gateway-rules/r1:enable', body: {} },
+    { name: 'set-weights', method: 'POST', path: '/api/ops/gateway-rules/r1:set-weights', body: { weights: [] } },
+  ];
+
+  for (const tc of writeCases) {
+    it(`${tc.name} 缺 reason 直接拒绝 400 且不转发下游`, async () => {
+      const res = await operationsApp.request(tc.path, {
+        method: tc.method,
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify(tc.body),
+      });
+      expect(res.status).toBe(400);
+      expect(calls.length).toBe(0);
+    });
+
+    it(`${tc.name} reason 为空字符串也拒绝`, async () => {
+      const res = await operationsApp.request(tc.path, {
+        method: tc.method,
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ ...tc.body, reason: '   ' }),
+      });
+      expect(res.status).toBe(400);
+      expect(calls.length).toBe(0);
+    });
+  }
+
+  it('只读 explain 不要求 reason', async () => {
+    nextResponse = { matched: 'r1' };
+    const res = await operationsApp.request('/api/ops/gateway-rules:explain', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ path: '/foo' }),
+    });
+    expect(res.status).toBe(200);
+  });
+});
+
+describe('buildGatewayAuditParams：before/after/snapshot_version 取自下游响应', () => {
+  it('disable：从 EnableChange 提取 before/after = enabled 翻转 + version', () => {
+    const params = buildGatewayAuditParams('disable', 'r1', 'stop bleeding', {
+      name: 'r1',
+      before_enabled: true,
+      after_enabled: false,
+      version: 9,
+    });
+    expect(params).toEqual({
+      rule_name: 'r1',
+      reason: 'stop bleeding',
+      before: { enabled: true },
+      after: { enabled: false },
+      snapshot_version: 9,
+    });
+  });
+
+  it('set-weights：从 WeightsChange 提取 before/after = targets + version', () => {
+    const before = [{ service: 's', lane: 'prod', weight: 90 }];
+    const after = [{ service: 's', lane: 'prod', weight: 0 }];
+    const params = buildGatewayAuditParams('set-weights', 'r1', 'shift', {
+      name: 'r1',
+      before_targets: before,
+      after_targets: after,
+      version: 11,
+    });
+    expect(params).toEqual({
+      rule_name: 'r1',
+      reason: 'shift',
+      before: { targets: before },
+      after: { targets: after },
+      snapshot_version: 11,
+    });
+  });
+
+  it('upsert：snapshot_version 取下游的快照版本，不是规则自己的 version', () => {
+    // 下游响应平铺规则字段（含 rule version=3）+ 事务分配的 snapshot_version=42。
+    // 审计游标必须是 snapshot_version，绝不能误取 rule version。
+    const downstream = { name: 'r1', version: 3, path_prefix: '/x', snapshot_version: 42 };
+    const params = buildGatewayAuditParams('update', 'r1', 'add canary', downstream);
+    expect(params.rule_name).toBe('r1');
+    expect(params.reason).toBe('add canary');
+    expect(params.snapshot_version).toBe(42);
+    expect(params.after).toEqual(downstream);
+  });
+
+  it('delete：snapshot_version 取下游事务分配的快照版本（不再恒为 null）', () => {
+    const params = buildGatewayAuditParams('delete', 'r1', 'cleanup', {
+      deleted: 'r1',
+      snapshot_version: 43,
+    });
+    expect(params.rule_name).toBe('r1');
+    expect(params.snapshot_version).toBe(43);
+  });
+
+  it('固定顶层键：永远含 rule_name/reason/before/after/snapshot_version 五键', () => {
+    const params = buildGatewayAuditParams('delete', 'r1', 'cleanup', { deleted: 'r1' });
+    expect(Object.keys(params).sort()).toEqual(
+      ['after', 'before', 'reason', 'rule_name', 'snapshot_version'].sort(),
+    );
+  });
+});
+
+describe('Task3：快照历史列表 + 一键回滚中转', () => {
+  it('GET snapshots → /api/paas/gateway-rules/snapshots（只读，不要求 reason，透传 limit）', async () => {
+    nextResponse = [{ snapshot_version: 9, rules: [] }];
+    const res = await operationsApp.request('/api/ops/gateway-rules/snapshots?limit=5');
+    expect(res.status).toBe(200);
+    expect(calls[0]).toMatchObject({ method: 'GET', path: '/api/paas/gateway-rules/snapshots?limit=5' });
+  });
+
+  it('GET snapshots 无 limit → 不带查询串', async () => {
+    nextResponse = [];
+    await operationsApp.request('/api/ops/gateway-rules/snapshots');
+    expect(calls[0]).toMatchObject({ method: 'GET', path: '/api/paas/gateway-rules/snapshots' });
+  });
+
+  it('POST rollback → /api/paas/gateway-rules:rollback，转发 body', async () => {
+    nextResponse = { snapshot_version: 12, reason: 'recover', created_by: 'ops' };
+    const res = await operationsApp.request('/api/ops/gateway-rules:rollback', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ snapshot_version: 8, reason: 'recover' }),
+    });
+    expect(res.status).toBe(200);
+    expect(calls[0]).toMatchObject({ method: 'POST', path: '/api/paas/gateway-rules:rollback' });
+    expect(calls[0].body).toMatchObject({ snapshot_version: 8, reason: 'recover' });
+  });
+
+  it('rollback 缺 reason 直接拒绝 400 且不转发下游', async () => {
+    const res = await operationsApp.request('/api/ops/gateway-rules:rollback', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ snapshot_version: 8 }),
+    });
+    expect(res.status).toBe(400);
+    expect(calls.length).toBe(0);
+  });
+
+  it('rollback reason 全空白也拒绝', async () => {
+    const res = await operationsApp.request('/api/ops/gateway-rules:rollback', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ snapshot_version: 8, reason: '   ' }),
+    });
+    expect(res.status).toBe(400);
+    expect(calls.length).toBe(0);
+  });
+
+  it('rollback 把 snapshot_version + reason 塞进审计 gatewayAudit', async () => {
+    nextResponse = { snapshot_version: 12, reason: 'recover', created_by: 'ops' };
+    let captured: unknown = null;
+    const { Hono } = await import('hono');
+    const probe = new Hono();
+    probe.use('*', async (c, next) => {
+      await next();
+      captured = c.get('gatewayAudit' as never);
+    });
+    probe.route('/', operationsApp);
+    await probe.request('/api/ops/gateway-rules:rollback', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ snapshot_version: 8, reason: 'recover' }),
+    });
+    expect(captured).toMatchObject({
+      reason: 'recover',
+      snapshot_version: 12,
+    });
+  });
+});
+
+describe('audit 中间件合并 gatewayAudit 进 params 顶层', () => {
+  it('handler 写操作把固定键 stash 到 c.set，中间件取出来落 params', async () => {
+    // 直接验证：disable handler 转发后，把下游 before/after 塞进了 context。
+    // 用一个 Hono app + 探针中间件读 c.get('gatewayAudit')。
+    nextResponse = { name: 'r1', before_enabled: true, after_enabled: false, version: 12 };
+    let captured: unknown = null;
+    const { Hono } = await import('hono');
+    const probe = new Hono();
+    probe.use('*', async (c, next) => {
+      await next();
+      captured = c.get('gatewayAudit' as never);
+    });
+    probe.route('/', operationsApp);
+    await probe.request('/api/ops/gateway-rules/r1:disable', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ reason: 'stop' }),
+    });
+    expect(captured).toEqual({
+      rule_name: 'r1',
+      reason: 'stop',
+      before: { enabled: true },
+      after: { enabled: false },
+      snapshot_version: 12,
+    });
+  });
+});

--- a/apps/monitor-dashboard/src/routes/operations.ts
+++ b/apps/monitor-dashboard/src/routes/operations.ts
@@ -1,7 +1,8 @@
 import { Hono } from 'hono';
+import type { AppEnv } from '../types';
 import { paasClient, larkClient } from '../paas-client';
 
-const app = new Hono();
+const app = new Hono<AppEnv>();
 
 // ---------- 读操作 ----------
 
@@ -169,6 +170,177 @@ app.post('/api/ops/trigger-weekly-review', async (c) => {
   const data = await paasClient.post(
     `/api/agent/admin/trigger-weekly-review?${new URLSearchParams(params).toString()}`,
   );
+  return c.json(data);
+});
+
+// ---------- gateway-rules 中转（流量调度安全入口） ----------
+//
+// 这一层是"安全入口"：人和 AI 通过 Dashboard 安全地列规则 / 看当前快照 / explain /
+// 增删改 / 止血。转发到 paas-engine 的 gateway-rules API（X-API-Key 由 paasClient 注入）。
+// 写操作（PUT/DELETE/disable/enable/set-weights）强制带 reason、缺失直接拒绝 400；
+// before/after/snapshot_version 的真值取自 paas-engine 写操作的响应体，回填进审计
+// （c.set('gatewayAudit')，由 audit 中间件落 audit_logs.params 顶层固定键）。
+
+/** 写操作 reason 必填：缺失或全空白返回非空错误信息，校验通过返回 null。 */
+function requireReason(reason: unknown): string | null {
+  if (typeof reason !== 'string' || reason.trim() === '') {
+    return 'reason is required for gateway-rules write operations';
+  }
+  return null;
+}
+
+/**
+ * 从 paas-engine 写操作响应提取审计 before/after/snapshot_version，固定五个顶层键。
+ * - disable/enable：下游 EnableChange {before_enabled, after_enabled, version}
+ * - set-weights：下游 WeightsChange {before_targets, after_targets, version}
+ * - upsert(update)：下游回结果规则 {..., version}，after = 规则本身、before 未知
+ * - delete：下游回 {deleted}，无 before/after/version
+ * before/after 都是下游响应的真值，不是中转层猜的。
+ */
+export function buildGatewayAuditParams(
+  action: string,
+  ruleName: string | null,
+  reason: string | null,
+  downstream: unknown,
+): Record<string, unknown> {
+  const d = (downstream && typeof downstream === 'object' ? downstream : {}) as Record<string, unknown>;
+  let before: unknown = null;
+  let after: unknown = null;
+  let snapshotVersion: unknown = null;
+
+  if (action === 'disable' || action === 'enable') {
+    before = { enabled: d.before_enabled ?? null };
+    after = { enabled: d.after_enabled ?? null };
+    snapshotVersion = d.version ?? null;
+  } else if (action === 'set-weights') {
+    before = { targets: d.before_targets ?? null };
+    after = { targets: d.after_targets ?? null };
+    snapshotVersion = d.version ?? null;
+  } else if (action === 'update') {
+    // upsert 下游返回写入后的规则本身（含 rule version）+ 事务分配的 snapshot_version。
+    // 审计游标取 snapshot_version，不是规则自己的 version（两者语义不同，不能混）。
+    after = downstream ?? null;
+    snapshotVersion = d.snapshot_version ?? null;
+  } else if (action === 'delete') {
+    // delete 下游回 {deleted, snapshot_version}，snapshot_version 是事务分配的快照版本。
+    after = downstream ?? null;
+    snapshotVersion = d.snapshot_version ?? null;
+  } else if (action === 'rollback') {
+    // rollback 下游回新生成的快照 {snapshot_version, reason, created_by}；
+    // after = 这条新快照、snapshot_version = 回滚后分配的更大新版本。
+    after = downstream ?? null;
+    snapshotVersion = d.snapshot_version ?? null;
+  }
+
+  return {
+    rule_name: ruleName,
+    reason: reason ?? null,
+    before,
+    after,
+    snapshot_version: snapshotVersion,
+  };
+}
+
+/** GET /api/ops/gateway-rules — 列出全部规则（只读，不要求 reason） */
+app.get('/api/ops/gateway-rules', async (c) => {
+  const data = await paasClient.get('/api/paas/gateway-rules/');
+  return c.json(data);
+});
+
+/** GET /api/ops/gateway-rules/snapshot — 看 paas-engine 当前下发的期望配置（version + 规则） */
+app.get('/api/ops/gateway-rules/snapshot', async (c) => {
+  const data = await paasClient.get('/internal/gateway-rules');
+  return c.json(data);
+});
+
+/** GET /api/ops/gateway-rules/snapshots — 列出最近 N 条规则快照历史（只读，透传 limit） */
+app.get('/api/ops/gateway-rules/snapshots', async (c) => {
+  const limit = c.req.query('limit');
+  const path = limit ? `/api/paas/gateway-rules/snapshots?limit=${encodeURIComponent(limit)}` : '/api/paas/gateway-rules/snapshots';
+  const data = await paasClient.get(path);
+  return c.json(data);
+});
+
+/** GET /api/ops/gateway-rules/:name — 看单条规则（只读） */
+app.get('/api/ops/gateway-rules/:name', async (c) => {
+  const data = await paasClient.get(`/api/paas/gateway-rules/${c.req.param('name')}`);
+  return c.json(data);
+});
+
+/** POST /api/ops/gateway-rules:explain — 预览命中（只读，不要求 reason） */
+app.post('/api/ops/gateway-rules:explain', async (c) => {
+  const data = await paasClient.post('/api/paas/gateway-rules:explain', await c.req.json());
+  return c.json(data);
+});
+
+/** POST /api/ops/gateway-rules:rollback — 回滚到历史某版本（写，强制 reason，落审计） */
+app.post('/api/ops/gateway-rules:rollback', async (c) => {
+  const body = (await c.req.json().catch(() => ({}))) as Record<string, unknown>;
+  const err = requireReason(body.reason);
+  if (err) return c.json({ message: err }, 400);
+
+  const data = await paasClient.post('/api/paas/gateway-rules:rollback', body);
+  c.set('gatewayAudit', buildGatewayAuditParams('rollback', null, body.reason as string, data));
+  return c.json(data);
+});
+
+/** PUT /api/ops/gateway-rules/:name — 创建/更新规则（写，强制 reason） */
+app.put('/api/ops/gateway-rules/:name', async (c) => {
+  const name = c.req.param('name');
+  const body = (await c.req.json()) as Record<string, unknown>;
+  const err = requireReason(body.reason);
+  if (err) return c.json({ message: err }, 400);
+
+  const data = await paasClient.put(`/api/paas/gateway-rules/${name}`, body);
+  c.set('gatewayAudit', buildGatewayAuditParams('update', name, body.reason as string, data));
+  return c.json(data);
+});
+
+/** DELETE /api/ops/gateway-rules/:name — 删除规则（写，强制 reason） */
+app.delete('/api/ops/gateway-rules/:name', async (c) => {
+  const name = c.req.param('name');
+  const body = (await c.req.json().catch(() => ({}))) as Record<string, unknown>;
+  const err = requireReason(body.reason);
+  if (err) return c.json({ message: err }, 400);
+
+  const data = await paasClient.del(`/api/paas/gateway-rules/${name}`, undefined, undefined, { reason: body.reason });
+  c.set('gatewayAudit', buildGatewayAuditParams('delete', name, body.reason as string, data));
+  return c.json(data);
+});
+
+/** POST /api/ops/gateway-rules/:name:disable — 止血禁用（写，强制 reason） */
+app.post('/api/ops/gateway-rules/:nameAction{[^/]+:disable}', async (c) => {
+  const name = c.req.param('nameAction').replace(/:disable$/, '');
+  const body = (await c.req.json()) as Record<string, unknown>;
+  const err = requireReason(body.reason);
+  if (err) return c.json({ message: err }, 400);
+
+  const data = await paasClient.post(`/api/paas/gateway-rules/${name}:disable`, body);
+  c.set('gatewayAudit', buildGatewayAuditParams('disable', name, body.reason as string, data));
+  return c.json(data);
+});
+
+/** POST /api/ops/gateway-rules/:name:enable — 恢复启用（写，强制 reason） */
+app.post('/api/ops/gateway-rules/:nameAction{[^/]+:enable}', async (c) => {
+  const name = c.req.param('nameAction').replace(/:enable$/, '');
+  const body = (await c.req.json()) as Record<string, unknown>;
+  const err = requireReason(body.reason);
+  if (err) return c.json({ message: err }, 400);
+
+  const data = await paasClient.post(`/api/paas/gateway-rules/${name}:enable`, body);
+  c.set('gatewayAudit', buildGatewayAuditParams('enable', name, body.reason as string, data));
+  return c.json(data);
+});
+
+/** POST /api/ops/gateway-rules/:name:set-weights — 整体调权（写，强制 reason） */
+app.post('/api/ops/gateway-rules/:nameAction{[^/]+:set-weights}', async (c) => {
+  const name = c.req.param('nameAction').replace(/:set-weights$/, '');
+  const body = (await c.req.json()) as Record<string, unknown>;
+  const err = requireReason(body.reason);
+  if (err) return c.json({ message: err }, 400);
+
+  const data = await paasClient.post(`/api/paas/gateway-rules/${name}:set-weights`, body);
+  c.set('gatewayAudit', buildGatewayAuditParams('set-weights', name, body.reason as string, data));
   return c.json(data);
 });
 

--- a/apps/monitor-dashboard/src/types.ts
+++ b/apps/monitor-dashboard/src/types.ts
@@ -2,5 +2,9 @@ export type AppEnv = {
   Variables: {
     caller: string;
     user: unknown;
+    // Structured audit payload stashed by ops handlers; merged into
+    // audit_logs.params top-level by the audit middleware. Fixed keys for
+    // gateway-rules write ops: rule_name/reason/before/after/snapshot_version.
+    gatewayAudit: Record<string, unknown>;
   };
 };

--- a/apps/paas-engine/internal/adapter/http/gateway_rule_handler.go
+++ b/apps/paas-engine/internal/adapter/http/gateway_rule_handler.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strconv"
 
 	"github.com/chiwei-platform/paas-engine/internal/domain"
 	"github.com/chiwei-platform/paas-engine/internal/service"
@@ -47,7 +48,8 @@ func (h *GatewayRuleHandler) Upsert(w http.ResponseWriter, r *http.Request) {
 		writeError(w, domain.ErrInvalidInput)
 		return
 	}
-	if err := h.svc.Upsert(r.Context(), name, req); err != nil {
+	snapVersion, err := h.svc.Upsert(r.Context(), name, req)
+	if err != nil {
 		writeError(w, err)
 		return
 	}
@@ -56,17 +58,24 @@ func (h *GatewayRuleHandler) Upsert(w http.ResponseWriter, r *http.Request) {
 		writeError(w, err)
 		return
 	}
-	writeJSON(w, http.StatusOK, rule)
+	// 平铺规则字段 + 事务分配的 snapshot_version（审计游标，区别于 rule.version）。
+	writeJSON(w, http.StatusOK, struct {
+		*domain.GatewayRule
+		SnapshotVersion int64 `json:"snapshot_version"`
+	}{rule, snapVersion})
 }
 
-// Delete 删除规则。
+// Delete 删除规则。reason 从 body 读（可空，仅落进快照历史）。
 func (h *GatewayRuleHandler) Delete(w http.ResponseWriter, r *http.Request) {
 	name := chi.URLParam(r, "name")
-	if err := h.svc.Delete(r.Context(), name); err != nil {
+	var req reasonRequest
+	_ = json.NewDecoder(r.Body).Decode(&req) // DELETE body 可空，解析失败按无 reason 处理
+	snapVersion, err := h.svc.Delete(r.Context(), name, req.Reason)
+	if err != nil {
 		writeError(w, err)
 		return
 	}
-	writeJSON(w, http.StatusOK, map[string]string{"deleted": name})
+	writeJSON(w, http.StatusOK, map[string]any{"deleted": name, "snapshot_version": snapVersion})
 }
 
 // explainRequest 是 POST /api/paas/gateway-rules:explain 的请求体。
@@ -140,6 +149,52 @@ func (h *GatewayRuleHandler) SetWeights(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 	res, err := h.svc.SetWeights(r.Context(), name, req)
+	if err != nil {
+		writeError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, res)
+}
+
+// ListSnapshots 返回最近 N 条规则快照历史（管理面，{data:[...]} 风格直接返数组）。
+// limit 来自查询参数 ?limit=，缺省/非法时默认 20、上限 200。
+func (h *GatewayRuleHandler) ListSnapshots(w http.ResponseWriter, r *http.Request) {
+	limit := 20
+	if v := r.URL.Query().Get("limit"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			limit = n
+		}
+	}
+	if limit > 200 {
+		limit = 200
+	}
+	snaps, err := h.svc.ListSnapshots(r.Context(), limit)
+	if err != nil {
+		writeError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, snaps)
+}
+
+// rollbackRequest 是 POST /gateway-rules:rollback 的请求体。
+type rollbackRequest struct {
+	SnapshotVersion int64  `json:"snapshot_version"`
+	Reason          string `json:"reason"`
+}
+
+// Rollback 把历史某版本规则集重新写入当前表，分配更大的新 snapshot_version。
+// 是 collection 级 custom method（:rollback），不针对单条规则。
+func (h *GatewayRuleHandler) Rollback(w http.ResponseWriter, r *http.Request) {
+	var req rollbackRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, domain.ErrInvalidInput)
+		return
+	}
+	if req.SnapshotVersion <= 0 {
+		writeError(w, fmt.Errorf("%w: snapshot_version is required and must be positive", domain.ErrInvalidInput))
+		return
+	}
+	res, err := h.svc.Rollback(r.Context(), req.SnapshotVersion, req.Reason)
 	if err != nil {
 		writeError(w, err)
 		return

--- a/apps/paas-engine/internal/adapter/http/gateway_rule_handler_test.go
+++ b/apps/paas-engine/internal/adapter/http/gateway_rule_handler_test.go
@@ -9,17 +9,56 @@ import (
 	"testing"
 
 	"github.com/chiwei-platform/paas-engine/internal/domain"
+	"github.com/chiwei-platform/paas-engine/internal/port"
 	"github.com/chiwei-platform/paas-engine/internal/service"
 	"github.com/go-chi/chi/v5"
 )
 
 // in-memory stub repo for handler tests
 type gwStubRepo struct {
-	rules map[string]*domain.GatewayRule
+	rules     map[string]*domain.GatewayRule
+	snapshots []domain.GatewayRuleSnapshot
+	seq       int64
 }
 
 func newGwStubRepo() *gwStubRepo {
 	return &gwStubRepo{rules: make(map[string]*domain.GatewayRule)}
+}
+
+func (r *gwStubRepo) Tx(_ context.Context, fn func(repo port.GatewayRuleRepository) error) error {
+	return fn(r)
+}
+func (r *gwStubRepo) SaveSnapshot(_ context.Context, rules []domain.GatewayRule, createdBy, reason string) (int64, error) {
+	r.seq++
+	cp := make([]domain.GatewayRule, len(rules))
+	copy(cp, rules)
+	r.snapshots = append(r.snapshots, domain.GatewayRuleSnapshot{
+		SnapshotVersion: r.seq, Rules: cp, CreatedBy: createdBy, Reason: reason,
+	})
+	return r.seq, nil
+}
+func (r *gwStubRepo) LatestSnapshotVersion(_ context.Context) (int64, error) {
+	return r.seq, nil
+}
+func (r *gwStubRepo) ListSnapshots(_ context.Context, limit int) ([]*domain.GatewayRuleSnapshot, error) {
+	out := make([]*domain.GatewayRuleSnapshot, 0, len(r.snapshots))
+	for i := len(r.snapshots) - 1; i >= 0; i-- {
+		cp := r.snapshots[i]
+		out = append(out, &cp)
+		if limit > 0 && len(out) >= limit {
+			break
+		}
+	}
+	return out, nil
+}
+func (r *gwStubRepo) GetSnapshot(_ context.Context, version int64) (*domain.GatewayRuleSnapshot, error) {
+	for i := range r.snapshots {
+		if r.snapshots[i].SnapshotVersion == version {
+			cp := r.snapshots[i]
+			return &cp, nil
+		}
+	}
+	return nil, domain.ErrGatewayRuleNotFound
 }
 
 func (r *gwStubRepo) Upsert(_ context.Context, rule *domain.GatewayRule) error {
@@ -271,5 +310,52 @@ func TestGatewayHandler_SnapshotPayloadShape(t *testing.T) {
 	}
 	if snap.Rules[0].Name != "default-agent-service-api" {
 		t.Errorf("rule name mismatch: %q", snap.Rules[0].Name)
+	}
+}
+
+// PUT/DELETE 必须在响应里带回事务分配的 snapshot_version，否则 Dashboard 审计
+// 拿不到改后快照版本（只能误取 rule.version 或记 null）。snapshot_version 与
+// rule.version 是两套版本号：前者是审计/回滚游标，后者是单条规则的修订计数。
+func TestGatewayHandler_PutAndDeleteReturnSnapshotVersion(t *testing.T) {
+	r, _ := newGatewayTestRouter()
+
+	rec := doReq(t, r, http.MethodPut, "/api/paas/gateway-rules/default-agent-service-api", validRuleBody())
+	if rec.Code != http.StatusOK {
+		t.Fatalf("PUT expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var putEnv struct {
+		Data struct {
+			Version         int64 `json:"version"`
+			SnapshotVersion int64 `json:"snapshot_version"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &putEnv); err != nil {
+		t.Fatalf("decode PUT: %v", err)
+	}
+	if putEnv.Data.SnapshotVersion != 1 {
+		t.Errorf("PUT response must carry tx-assigned snapshot_version=1, got %d", putEnv.Data.SnapshotVersion)
+	}
+	if putEnv.Data.Version != 1 {
+		t.Errorf("PUT response must still carry rule version=1, got %d", putEnv.Data.Version)
+	}
+
+	rec = doReq(t, r, http.MethodDelete, "/api/paas/gateway-rules/default-agent-service-api", "")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("DELETE expected 200, got %d", rec.Code)
+	}
+	var delEnv struct {
+		Data struct {
+			Deleted         string `json:"deleted"`
+			SnapshotVersion int64  `json:"snapshot_version"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &delEnv); err != nil {
+		t.Fatalf("decode DELETE: %v", err)
+	}
+	if delEnv.Data.SnapshotVersion != 2 {
+		t.Errorf("DELETE response must carry tx-assigned snapshot_version=2, got %d", delEnv.Data.SnapshotVersion)
+	}
+	if delEnv.Data.Deleted != "default-agent-service-api" {
+		t.Errorf("DELETE response must echo deleted name, got %q", delEnv.Data.Deleted)
 	}
 }

--- a/apps/paas-engine/internal/adapter/http/router.go
+++ b/apps/paas-engine/internal/adapter/http/router.go
@@ -156,8 +156,13 @@ func NewRouter(
 		// 字面后缀。explain 必须在 /gateway-rules 子路由之外注册，否则会变成
 		// "gateway-rules/:explain"（多一段斜杠），与对外契约不符。
 		r.Post("/gateway-rules:explain", gatewayRuleH.Explain)
+		// rollback 同 explain：collection 级 custom method，注册在 /gateway-rules 子路由
+		// 之外（冒号紧跟 collection，无斜杠），把历史某版本规则集回滚成当前配置。
+		r.Post("/gateway-rules:rollback", gatewayRuleH.Rollback)
 		r.Route("/gateway-rules", func(r chi.Router) {
 			r.Get("/", gatewayRuleH.List)
+			// snapshots 列表在 /{name} 之前注册，否则 "snapshots" 会被 {name} 误吃。
+			r.Get("/snapshots", gatewayRuleH.ListSnapshots)
 			r.Get("/{name}", gatewayRuleH.Get)
 			r.Put("/{name}", gatewayRuleH.Upsert)
 			r.Delete("/{name}", gatewayRuleH.Delete)

--- a/apps/paas-engine/internal/adapter/repository/db.go
+++ b/apps/paas-engine/internal/adapter/repository/db.go
@@ -27,6 +27,7 @@ func OpenDB(dsn string) (*gorm.DB, error) {
 		&DbMutationModel{},
 		&DynamicConfigModel{},
 		&GatewayRuleModel{},
+		&GatewayRuleSnapshotModel{},
 	); err != nil {
 		return nil, err
 	}

--- a/apps/paas-engine/internal/adapter/repository/gateway_rule_repo.go
+++ b/apps/paas-engine/internal/adapter/repository/gateway_rule_repo.go
@@ -190,9 +190,9 @@ func gatewayRuleToModel(rule *domain.GatewayRule) (*GatewayRuleModel, error) {
 	if err != nil {
 		return nil, fmt.Errorf("marshal targets: %w", err)
 	}
-	// Empty split list stays NULL in the jsonb column (rules without stable
-	// split); a configured list is stored as a JSON array.
-	splitKeyJSON := ""
+	// Empty split list 存 "[]"（合法 jsonb 空数组），不能存 ""——jsonb 列拒绝空字符串
+	// （22P02），会让整条 INSERT 失败。配置了的列表存成 JSON 数组。
+	splitKeyJSON := "[]"
 	if len(rule.SplitKeyHeaders) > 0 {
 		b, err := json.Marshal(rule.SplitKeyHeaders)
 		if err != nil {

--- a/apps/paas-engine/internal/adapter/repository/gateway_rule_repo.go
+++ b/apps/paas-engine/internal/adapter/repository/gateway_rule_repo.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/chiwei-platform/paas-engine/internal/domain"
 	"github.com/chiwei-platform/paas-engine/internal/port"
@@ -32,7 +33,7 @@ func (r *GatewayRuleRepo) Upsert(ctx context.Context, rule *domain.GatewayRule) 
 		Columns: []clause.Column{{Name: "name"}},
 		DoUpdates: clause.AssignmentColumns([]string{
 			"enabled", "priority", "path_prefix", "request_lane",
-			"match", "targets", "version", "updated_at",
+			"match", "targets", "split_key_headers", "version", "updated_at",
 		}),
 	}).Create(m).Error
 }
@@ -90,6 +91,96 @@ func (r *GatewayRuleRepo) Delete(ctx context.Context, name string) error {
 	return nil
 }
 
+// Tx 在一个 GORM 事务内执行 fn，传入一个事务作用域的 GatewayRuleRepo（同一 *gorm.DB
+// 事务句柄）。fn 返回非 nil 则整个事务回滚——"改规则 + 写快照"要么全成要么全不成。
+func (r *GatewayRuleRepo) Tx(ctx context.Context, fn func(repo port.GatewayRuleRepository) error) error {
+	return r.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		return fn(&GatewayRuleRepo{db: tx})
+	})
+}
+
+// SaveSnapshot 插入一条规则快照历史。snapshot_version 是 bigserial 主键，由 DB 序列
+// 在 INSERT 时原子分配（单调、并发安全），GORM 把分配到的值回填进模型后返回。
+func (r *GatewayRuleRepo) SaveSnapshot(ctx context.Context, rules []domain.GatewayRule, createdBy, reason string) (int64, error) {
+	rulesJSON, err := json.Marshal(rules)
+	if err != nil {
+		return 0, fmt.Errorf("marshal snapshot rules: %w", err)
+	}
+	m := &GatewayRuleSnapshotModel{
+		Rules:     string(rulesJSON),
+		CreatedBy: createdBy,
+		Reason:    reason,
+		CreatedAt: time.Now(),
+	}
+	if err := r.db.WithContext(ctx).Create(m).Error; err != nil {
+		return 0, err
+	}
+	return m.SnapshotVersion, nil
+}
+
+// LatestSnapshotVersion 返回最大的 snapshot_version（无快照返回 0）。
+func (r *GatewayRuleRepo) LatestSnapshotVersion(ctx context.Context) (int64, error) {
+	var version int64
+	err := r.db.WithContext(ctx).
+		Model(&GatewayRuleSnapshotModel{}).
+		Select("COALESCE(MAX(snapshot_version), 0)").
+		Scan(&version).Error
+	if err != nil {
+		return 0, err
+	}
+	return version, nil
+}
+
+// ListSnapshots 按 snapshot_version 倒序返回最近 limit 条快照（limit<=0 返回全部）。
+func (r *GatewayRuleRepo) ListSnapshots(ctx context.Context, limit int) ([]*domain.GatewayRuleSnapshot, error) {
+	q := r.db.WithContext(ctx).Order("snapshot_version desc")
+	if limit > 0 {
+		q = q.Limit(limit)
+	}
+	var models []GatewayRuleSnapshotModel
+	if err := q.Find(&models).Error; err != nil {
+		return nil, err
+	}
+	out := make([]*domain.GatewayRuleSnapshot, 0, len(models))
+	for i := range models {
+		snap, err := modelToGatewaySnapshot(&models[i])
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, snap)
+	}
+	return out, nil
+}
+
+// GetSnapshot 按版本号取一条快照，不存在返回 ErrGatewayRuleNotFound。
+func (r *GatewayRuleRepo) GetSnapshot(ctx context.Context, version int64) (*domain.GatewayRuleSnapshot, error) {
+	var m GatewayRuleSnapshotModel
+	result := r.db.WithContext(ctx).First(&m, "snapshot_version = ?", version)
+	if result.Error != nil {
+		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
+			return nil, domain.ErrGatewayRuleNotFound
+		}
+		return nil, result.Error
+	}
+	return modelToGatewaySnapshot(&m)
+}
+
+func modelToGatewaySnapshot(m *GatewayRuleSnapshotModel) (*domain.GatewayRuleSnapshot, error) {
+	rules := []domain.GatewayRule{}
+	if m.Rules != "" {
+		if err := json.Unmarshal([]byte(m.Rules), &rules); err != nil {
+			return nil, fmt.Errorf("unmarshal snapshot %d rules: %w", m.SnapshotVersion, err)
+		}
+	}
+	return &domain.GatewayRuleSnapshot{
+		SnapshotVersion: m.SnapshotVersion,
+		Rules:           rules,
+		CreatedBy:       m.CreatedBy,
+		Reason:          m.Reason,
+		CreatedAt:       m.CreatedAt,
+	}, nil
+}
+
 func gatewayRuleToModel(rule *domain.GatewayRule) (*GatewayRuleModel, error) {
 	matchJSON, err := json.Marshal(rule.Match)
 	if err != nil {
@@ -99,17 +190,28 @@ func gatewayRuleToModel(rule *domain.GatewayRule) (*GatewayRuleModel, error) {
 	if err != nil {
 		return nil, fmt.Errorf("marshal targets: %w", err)
 	}
+	// Empty split list stays NULL in the jsonb column (rules without stable
+	// split); a configured list is stored as a JSON array.
+	splitKeyJSON := ""
+	if len(rule.SplitKeyHeaders) > 0 {
+		b, err := json.Marshal(rule.SplitKeyHeaders)
+		if err != nil {
+			return nil, fmt.Errorf("marshal split_key_headers: %w", err)
+		}
+		splitKeyJSON = string(b)
+	}
 	return &GatewayRuleModel{
-		Name:        rule.Name,
-		Enabled:     rule.Enabled,
-		Priority:    rule.Priority,
-		PathPrefix:  rule.PathPrefix,
-		RequestLane: rule.RequestLane,
-		Match:       string(matchJSON),
-		Targets:     string(targetsJSON),
-		Version:     rule.Version,
-		CreatedAt:   rule.CreatedAt,
-		UpdatedAt:   rule.UpdatedAt,
+		Name:            rule.Name,
+		Enabled:         rule.Enabled,
+		Priority:        rule.Priority,
+		PathPrefix:      rule.PathPrefix,
+		RequestLane:     rule.RequestLane,
+		Match:           string(matchJSON),
+		Targets:         string(targetsJSON),
+		SplitKeyHeaders: splitKeyJSON,
+		Version:         rule.Version,
+		CreatedAt:       rule.CreatedAt,
+		UpdatedAt:       rule.UpdatedAt,
 	}, nil
 }
 
@@ -126,16 +228,23 @@ func modelToGatewayRule(m *GatewayRuleModel) (*domain.GatewayRule, error) {
 			return nil, fmt.Errorf("unmarshal targets for rule %q: %w", m.Name, err)
 		}
 	}
+	var splitKeyHeaders []string
+	if m.SplitKeyHeaders != "" {
+		if err := json.Unmarshal([]byte(m.SplitKeyHeaders), &splitKeyHeaders); err != nil {
+			return nil, fmt.Errorf("unmarshal split_key_headers for rule %q: %w", m.Name, err)
+		}
+	}
 	return &domain.GatewayRule{
-		Name:        m.Name,
-		Enabled:     m.Enabled,
-		Priority:    m.Priority,
-		PathPrefix:  m.PathPrefix,
-		RequestLane: m.RequestLane,
-		Match:       match,
-		Targets:     targets,
-		Version:     m.Version,
-		CreatedAt:   m.CreatedAt,
-		UpdatedAt:   m.UpdatedAt,
+		Name:            m.Name,
+		Enabled:         m.Enabled,
+		Priority:        m.Priority,
+		PathPrefix:      m.PathPrefix,
+		RequestLane:     m.RequestLane,
+		Match:           match,
+		Targets:         targets,
+		SplitKeyHeaders: splitKeyHeaders,
+		Version:         m.Version,
+		CreatedAt:       m.CreatedAt,
+		UpdatedAt:       m.UpdatedAt,
 	}, nil
 }

--- a/apps/paas-engine/internal/adapter/repository/gateway_rule_repo_test.go
+++ b/apps/paas-engine/internal/adapter/repository/gateway_rule_repo_test.go
@@ -115,3 +115,44 @@ func TestModelToGatewayRule_TargetsNeverNil(t *testing.T) {
 		t.Error("expected non-nil empty targets slice")
 	}
 }
+
+func TestModelToGatewaySnapshot_RoundTrip(t *testing.T) {
+	rules := []domain.GatewayRule{
+		{Name: "ra", PathPrefix: "/a/", Match: domain.GatewayMatch{PathPrefix: "/a/"}, Version: 2},
+		{Name: "rb", PathPrefix: "/b/", Match: domain.GatewayMatch{PathPrefix: "/b/"}, Version: 1},
+	}
+	rulesJSON, err := json.Marshal(rules)
+	if err != nil {
+		t.Fatalf("marshal rules: %v", err)
+	}
+	m := &GatewayRuleSnapshotModel{
+		SnapshotVersion: 7,
+		Rules:           string(rulesJSON),
+		CreatedBy:       "ops",
+		Reason:          "rollback to v2",
+		CreatedAt:       time.Now(),
+	}
+	got, err := modelToGatewaySnapshot(m)
+	if err != nil {
+		t.Fatalf("modelToGatewaySnapshot failed: %v", err)
+	}
+	if got.SnapshotVersion != 7 {
+		t.Errorf("snapshot_version mismatch: %d", got.SnapshotVersion)
+	}
+	if got.CreatedBy != "ops" || got.Reason != "rollback to v2" {
+		t.Errorf("created_by/reason not preserved: %q / %q", got.CreatedBy, got.Reason)
+	}
+	if len(got.Rules) != 2 || got.Rules[0].Name != "ra" || got.Rules[1].Name != "rb" {
+		t.Errorf("rules not round-tripped: %+v", got.Rules)
+	}
+}
+
+func TestModelToGatewaySnapshot_EmptyRulesNeverNil(t *testing.T) {
+	got, err := modelToGatewaySnapshot(&GatewayRuleSnapshotModel{SnapshotVersion: 1, Rules: ""})
+	if err != nil {
+		t.Fatalf("modelToGatewaySnapshot failed: %v", err)
+	}
+	if got.Rules == nil {
+		t.Error("expected non-nil empty rules slice")
+	}
+}

--- a/apps/paas-engine/internal/adapter/repository/gateway_rule_split_key_test.go
+++ b/apps/paas-engine/internal/adapter/repository/gateway_rule_split_key_test.go
@@ -41,6 +41,21 @@ func TestGatewayRuleRoundTrip_SplitKeyHeaders(t *testing.T) {
 	}
 }
 
+// TestGatewayRuleToModel_EmptySplitKeyHeadersIsValidJSONB: 空 split list 写入
+// jsonb 列必须是合法 JSON。存空字符串 '' 会被 PG jsonb 拒绝（22P02），导致
+// EnsureBaseline / Upsert 整条 INSERT 失败——真机泳道演练（ppe-gw3）抓到的回归。
+func TestGatewayRuleToModel_EmptySplitKeyHeadersIsValidJSONB(t *testing.T) {
+	rule := sampleGatewayRule()
+	rule.SplitKeyHeaders = nil
+	m, err := gatewayRuleToModel(rule)
+	if err != nil {
+		t.Fatalf("gatewayRuleToModel failed: %v", err)
+	}
+	if !json.Valid([]byte(m.SplitKeyHeaders)) {
+		t.Fatalf("empty split_key_headers must serialize to valid jsonb, got %q", m.SplitKeyHeaders)
+	}
+}
+
 // TestModelToGatewayRule_SplitKeyHeadersEmpty: an empty/absent jsonb column
 // decodes to an empty (nil) slice, not an error.
 func TestModelToGatewayRule_SplitKeyHeadersEmpty(t *testing.T) {

--- a/apps/paas-engine/internal/adapter/repository/gateway_rule_split_key_test.go
+++ b/apps/paas-engine/internal/adapter/repository/gateway_rule_split_key_test.go
@@ -1,0 +1,63 @@
+package repository
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// TestGatewayRuleToModel_SerializesSplitKeyHeaders: split_key_headers is stored
+// as a JSON array string (jsonb column).
+func TestGatewayRuleToModel_SerializesSplitKeyHeaders(t *testing.T) {
+	rule := sampleGatewayRule()
+	rule.SplitKeyHeaders = []string{"X-User-Id", "X-Trace-Id"}
+	m, err := gatewayRuleToModel(rule)
+	if err != nil {
+		t.Fatalf("gatewayRuleToModel failed: %v", err)
+	}
+	var got []string
+	if err := json.Unmarshal([]byte(m.SplitKeyHeaders), &got); err != nil {
+		t.Fatalf("split_key_headers not valid JSON: %v (raw=%q)", err, m.SplitKeyHeaders)
+	}
+	if len(got) != 2 || got[0] != "X-User-Id" || got[1] != "X-Trace-Id" {
+		t.Errorf("split_key_headers not preserved: %+v", got)
+	}
+}
+
+// TestGatewayRuleRoundTrip_SplitKeyHeaders: a configured split list survives
+// domain->model->domain.
+func TestGatewayRuleRoundTrip_SplitKeyHeaders(t *testing.T) {
+	original := sampleGatewayRule()
+	original.SplitKeyHeaders = []string{"X-User-Id"}
+	m, err := gatewayRuleToModel(original)
+	if err != nil {
+		t.Fatalf("toModel: %v", err)
+	}
+	got, err := modelToGatewayRule(m)
+	if err != nil {
+		t.Fatalf("toDomain: %v", err)
+	}
+	if len(got.SplitKeyHeaders) != 1 || got.SplitKeyHeaders[0] != "X-User-Id" {
+		t.Errorf("split_key_headers round-trip mismatch: %+v", got.SplitKeyHeaders)
+	}
+}
+
+// TestModelToGatewayRule_SplitKeyHeadersEmpty: an empty/absent jsonb column
+// decodes to an empty (nil) slice, not an error.
+func TestModelToGatewayRule_SplitKeyHeadersEmpty(t *testing.T) {
+	for _, raw := range []string{"", "[]", "null"} {
+		m := &GatewayRuleModel{
+			Name:            "x",
+			PathPrefix:      "/x/",
+			Match:           `{"path_prefix":"/x/"}`,
+			Targets:         "[]",
+			SplitKeyHeaders: raw,
+		}
+		got, err := modelToGatewayRule(m)
+		if err != nil {
+			t.Fatalf("raw=%q: modelToGatewayRule failed: %v", raw, err)
+		}
+		if len(got.SplitKeyHeaders) != 0 {
+			t.Errorf("raw=%q: expected no split headers, got %+v", raw, got.SplitKeyHeaders)
+		}
+	}
+}

--- a/apps/paas-engine/internal/adapter/repository/model.go
+++ b/apps/paas-engine/internal/adapter/repository/model.go
@@ -4,21 +4,21 @@ import "time"
 
 // AppModel 是 App 的数据库持久化模型。
 type AppModel struct {
-	Name              string `gorm:"primaryKey"`
-	Description       string
-	ImageRepoName     string
-	Port              int
-	ServiceAccount    string
-	Command           string // JSON 序列化的 []string
-	EnvFromSecrets    string // JSON 序列化的 []string
-	EnvFromConfigMaps string // JSON 序列化的 []string
-	Envs              string // JSON 序列化的 map[string]string
-	ConfigBundles     string // JSON 序列化的 []string
+	Name               string `gorm:"primaryKey"`
+	Description        string
+	ImageRepoName      string
+	Port               int
+	ServiceAccount     string
+	Command            string // JSON 序列化的 []string
+	EnvFromSecrets     string // JSON 序列化的 []string
+	EnvFromConfigMaps  string // JSON 序列化的 []string
+	Envs               string // JSON 序列化的 map[string]string
+	ConfigBundles      string // JSON 序列化的 []string
 	AllowedLaneClasses string // JSON 序列化的 []string
-	SidecarEnabled    bool
-	Volumes           string // JSON 序列化的 []VolumeMount
-	CreatedAt         time.Time
-	UpdatedAt         time.Time
+	SidecarEnabled     bool
+	Volumes            string // JSON 序列化的 []VolumeMount
+	CreatedAt          time.Time
+	UpdatedAt          time.Time
 }
 
 func (AppModel) TableName() string { return "apps" }
@@ -165,9 +165,9 @@ func (DbMutationModel) TableName() string { return "db_mutations" }
 
 // DynamicConfigModel 是 DynamicConfig 的数据库持久化模型。
 type DynamicConfigModel struct {
-	Key       string    `gorm:"primaryKey"`
-	Lane      string    `gorm:"primaryKey;default:prod"`
-	Value     string    `gorm:"not null"`
+	Key       string `gorm:"primaryKey"`
+	Lane      string `gorm:"primaryKey;default:prod"`
+	Value     string `gorm:"not null"`
 	UpdatedAt time.Time
 }
 
@@ -177,16 +177,34 @@ func (DynamicConfigModel) TableName() string { return "dynamic_configs" }
 // match / targets 用 jsonb 列存（写入 JSON 序列化字符串）；
 // path_prefix / request_lane 提到顶层列做索引与反查。
 type GatewayRuleModel struct {
-	Name        string    `gorm:"primaryKey"`
-	Enabled     bool      `gorm:"not null;default:true;index:idx_gateway_enabled_priority,priority:1"`
-	Priority    int       `gorm:"not null;default:100;index:idx_gateway_enabled_priority,sort:desc,priority:2"`
-	PathPrefix  string    `gorm:"not null;index"`
-	RequestLane string    `gorm:""`
-	Match       string    `gorm:"type:jsonb;not null"`
-	Targets     string    `gorm:"type:jsonb;not null"`
-	Version     int64     `gorm:"not null;default:1"`
-	CreatedAt   time.Time `gorm:"not null"`
-	UpdatedAt   time.Time `gorm:"not null"`
+	Name        string `gorm:"primaryKey"`
+	Enabled     bool   `gorm:"not null;default:true;index:idx_gateway_enabled_priority,priority:1"`
+	Priority    int    `gorm:"not null;default:100;index:idx_gateway_enabled_priority,sort:desc,priority:2"`
+	PathPrefix  string `gorm:"not null;index"`
+	RequestLane string `gorm:""`
+	Match       string `gorm:"type:jsonb;not null"`
+	Targets     string `gorm:"type:jsonb;not null"`
+	// SplitKeyHeaders holds a JSON array of header names for stable split.
+	// Nullable jsonb (pure-increment column): empty for rules with no stable
+	// split; AutoMigrate adds it without touching existing rows.
+	SplitKeyHeaders string    `gorm:"type:jsonb"`
+	Version         int64     `gorm:"not null;default:1"`
+	CreatedAt       time.Time `gorm:"not null"`
+	UpdatedAt       time.Time `gorm:"not null"`
 }
 
 func (GatewayRuleModel) TableName() string { return "gateway_routing_rules" }
+
+// GatewayRuleSnapshotModel 是 gateway 规则快照历史的持久化模型。
+// SnapshotVersion 是独立单调序列（bigserial / 事务内 max+1 分配），不依赖
+// max(rule.version)——这样删掉 version 最高的规则也不会让快照版本回退。
+// Rules 是当时完整规则集的 jsonb 序列化（[]domain.GatewayRule）。
+type GatewayRuleSnapshotModel struct {
+	SnapshotVersion int64     `gorm:"primaryKey;autoIncrement"`
+	Rules           string    `gorm:"type:jsonb;not null"`
+	CreatedBy       string    `gorm:"not null"`
+	Reason          string    `gorm:"type:text"`
+	CreatedAt       time.Time `gorm:"not null"`
+}
+
+func (GatewayRuleSnapshotModel) TableName() string { return "gateway_rule_snapshots" }

--- a/apps/paas-engine/internal/domain/gateway_explain.go
+++ b/apps/paas-engine/internal/domain/gateway_explain.go
@@ -60,6 +60,13 @@ type GatewayExplainResult struct {
 	// when Matched. WouldRedirect mirrors the matcher's trailing-slash 301.
 	WouldForward  bool `json:"would_forward"`
 	WouldRedirect bool `json:"would_redirect"`
+	// StableSplit reports whether the winning rule configures stable (sticky)
+	// target selection via split_key_headers. False means weighted-random.
+	StableSplit bool `json:"stable_split"`
+	// SplitKeyHeaders is the winning rule's ordered split key header list (the
+	// headers api-gateway probes, in order, for the stable-split key). Empty
+	// when StableSplit is false.
+	SplitKeyHeaders []string `json:"split_key_headers,omitempty"`
 	// CandidateTargets are the winning rule's targets with effective lanes.
 	CandidateTargets []GatewayExplainTarget `json:"candidate_targets,omitempty"`
 	// EffectiveLaneNote explains how effective lane is derived.
@@ -140,6 +147,8 @@ func ExplainGatewayMatch(rules []*GatewayRule, path, requestLane string) Gateway
 			result.WinningReason = entry.Reason
 			result.CandidateTargets = buildCandidates(r, requestLane)
 			result.EffectiveLaneNote = effectiveLaneNote(r, requestLane)
+			result.StableSplit = len(r.SplitKeyHeaders) > 0
+			result.SplitKeyHeaders = r.SplitKeyHeaders
 		default:
 			// Would have matched, but a higher-priority rule already won.
 			entry.Status = ExplainStatusShadowed

--- a/apps/paas-engine/internal/domain/gateway_explain_split_key_test.go
+++ b/apps/paas-engine/internal/domain/gateway_explain_split_key_test.go
@@ -1,0 +1,30 @@
+package domain
+
+import "testing"
+
+// TestExplainReportsStableSplit: when the winning rule has split_key_headers
+// configured, explain reports StableSplit=true and surfaces the header list;
+// otherwise StableSplit=false.
+func TestExplainReportsStableSplit(t *testing.T) {
+	withSplit := gwRule("agent", "/api/agent/", "", 100, true, tgt("agent-service", "", 8000, 100))
+	withSplit.SplitKeyHeaders = []string{"X-User-Id", "X-Trace-Id"}
+	res := ExplainGatewayMatch([]*GatewayRule{withSplit}, "/api/agent/health", "")
+	if !res.Matched {
+		t.Fatal("expected match")
+	}
+	if !res.StableSplit {
+		t.Error("expected StableSplit=true for rule with split_key_headers")
+	}
+	if len(res.SplitKeyHeaders) != 2 || res.SplitKeyHeaders[0] != "X-User-Id" {
+		t.Errorf("split_key_headers not surfaced: %+v", res.SplitKeyHeaders)
+	}
+
+	noSplit := gwRule("agent", "/api/agent/", "", 100, true, tgt("agent-service", "", 8000, 100))
+	res = ExplainGatewayMatch([]*GatewayRule{noSplit}, "/api/agent/health", "")
+	if res.StableSplit {
+		t.Error("expected StableSplit=false for rule without split_key_headers")
+	}
+	if len(res.SplitKeyHeaders) != 0 {
+		t.Errorf("expected no split_key_headers, got %+v", res.SplitKeyHeaders)
+	}
+}

--- a/apps/paas-engine/internal/domain/gateway_rule.go
+++ b/apps/paas-engine/internal/domain/gateway_rule.go
@@ -12,9 +12,14 @@ type GatewayRule struct {
 	RequestLane string          `json:"request_lane,omitempty"`
 	Match       GatewayMatch    `json:"match"`
 	Targets     []GatewayTarget `json:"targets"`
-	CreatedAt   time.Time       `json:"created_at"`
-	UpdatedAt   time.Time       `json:"updated_at"`
-	Version     int64           `json:"version"`
+	// SplitKeyHeaders is an ordered list of header names for stable (sticky)
+	// target selection in api-gateway: the first present, non-empty header value
+	// is hashed with the rule name to pick a target deterministically. Empty
+	// means weighted-random selection (no stable split).
+	SplitKeyHeaders []string  `json:"split_key_headers,omitempty"`
+	CreatedAt       time.Time `json:"created_at"`
+	UpdatedAt       time.Time `json:"updated_at"`
+	Version         int64     `json:"version"`
 }
 
 // GatewayMatch 是规则的匹配条件。
@@ -40,9 +45,22 @@ type GatewayTarget struct {
 }
 
 // GatewaySnapshot 是 /internal/gateway-rules 返回的完整快照。
-// Version 是 snapshot 级单调 int（取 max(rule.Version)），api-gateway 仅用于日志 / metric label。
+// Version 来自独立单调的 snapshot_version 序列（不再取 max(rule.Version)），
+// api-gateway 仅用于日志 / metric label，单调性由序列而非 max 保证。
 type GatewaySnapshot struct {
 	Version   int64         `json:"version"`
 	UpdatedAt time.Time     `json:"updated_at"`
 	Rules     []GatewayRule `json:"rules"`
+}
+
+// GatewayRuleSnapshot 是一份完整规则集的历史快照。每次规则写操作（upsert /
+// delete / disable / enable / set-weights / rollback）都在同一 DB 事务内追加一条，
+// SnapshotVersion 由独立单调序列分配——删掉 version 最高的规则也不会让它回退，
+// 回滚则是写入一个更大的新 SnapshotVersion，而非把版本号倒回去。
+type GatewayRuleSnapshot struct {
+	SnapshotVersion int64         `json:"snapshot_version"`
+	Rules           []GatewayRule `json:"rules"`
+	CreatedBy       string        `json:"created_by"`
+	Reason          string        `json:"reason"`
+	CreatedAt       time.Time     `json:"created_at"`
 }

--- a/apps/paas-engine/internal/domain/gateway_rule_split_key_test.go
+++ b/apps/paas-engine/internal/domain/gateway_rule_split_key_test.go
@@ -1,0 +1,44 @@
+package domain
+
+import "testing"
+
+// TestValidateGatewayRule_SplitKeyHeadersEmptyOK: nil and empty split key
+// headers are valid (no stable split configured).
+func TestValidateGatewayRule_SplitKeyHeadersEmptyOK(t *testing.T) {
+	r := validRule()
+	r.SplitKeyHeaders = nil
+	if err := ValidateGatewayRule(r); err != nil {
+		t.Fatalf("nil split_key_headers must pass, got: %v", err)
+	}
+	r.SplitKeyHeaders = []string{}
+	if err := ValidateGatewayRule(r); err != nil {
+		t.Fatalf("empty split_key_headers must pass, got: %v", err)
+	}
+}
+
+// TestValidateGatewayRule_SplitKeyHeadersValid: well-formed header names pass.
+func TestValidateGatewayRule_SplitKeyHeadersValid(t *testing.T) {
+	r := validRule()
+	r.SplitKeyHeaders = []string{"X-User-Id", "X-Trace-Id", "x-lane"}
+	if err := ValidateGatewayRule(r); err != nil {
+		t.Fatalf("valid header names must pass, got: %v", err)
+	}
+}
+
+// TestValidateGatewayRule_SplitKeyHeadersRejectEmptyElement: an empty string
+// element is meaningless and rejected.
+func TestValidateGatewayRule_SplitKeyHeadersRejectEmptyElement(t *testing.T) {
+	r := validRule()
+	r.SplitKeyHeaders = []string{"X-User-Id", ""}
+	assertReject(t, r, "split_key_headers")
+}
+
+// TestValidateGatewayRule_SplitKeyHeadersRejectInvalidName: header names with
+// spaces, colons, or other non-token characters are rejected.
+func TestValidateGatewayRule_SplitKeyHeadersRejectInvalidName(t *testing.T) {
+	for _, bad := range []string{"has space", "has:colon", "新建", "tab\there", "with/slash"} {
+		r := validRule()
+		r.SplitKeyHeaders = []string{bad}
+		assertReject(t, r, "split_key_headers")
+	}
+}

--- a/apps/paas-engine/internal/domain/gateway_rule_validate.go
+++ b/apps/paas-engine/internal/domain/gateway_rule_validate.go
@@ -39,6 +39,30 @@ func ValidateGatewayRule(rule GatewayRule) error {
 	if err := validateGatewayTargets(rule.Targets); err != nil {
 		return err
 	}
+	if err := validateGatewaySplitKeyHeaders(rule.SplitKeyHeaders); err != nil {
+		return err
+	}
+	return nil
+}
+
+// httpHeaderNamePattern matches an RFC 7230 header field-name (a token): one or
+// more token characters, no spaces / colons / control characters.
+var httpHeaderNamePattern = regexp.MustCompile(`^[A-Za-z0-9!#$%&'*+\-.^_` + "`" + `|~]+$`)
+
+// validateGatewaySplitKeyHeaders accepts an empty/nil list (no stable split);
+// when non-empty, every element must be a valid HTTP header name.
+func validateGatewaySplitKeyHeaders(headers []string) error {
+	for i, h := range headers {
+		if h == "" {
+			return fmt.Errorf("%w: split_key_headers[%d] must not be empty", ErrInvalidInput, i)
+		}
+		if !httpHeaderNamePattern.MatchString(h) {
+			return fmt.Errorf(
+				"%w: split_key_headers[%d] %q is not a valid HTTP header name",
+				ErrInvalidInput, i, h,
+			)
+		}
+	}
 	return nil
 }
 

--- a/apps/paas-engine/internal/port/repository.go
+++ b/apps/paas-engine/internal/port/repository.go
@@ -68,4 +68,20 @@ type GatewayRuleRepository interface {
 	FindByName(ctx context.Context, name string) (*domain.GatewayRule, error)
 	FindAll(ctx context.Context) ([]*domain.GatewayRule, error)
 	Delete(ctx context.Context, name string) error
+
+	// Tx 在一个 DB 事务内执行 fn，传入一个事务作用域的 repo。
+	// 每次规则写操作（含 delete / rollback）都用它把"改规则 + 分配新
+	// snapshot_version + 写快照"包成一个原子单元，保证 snapshot version 单调
+	// 前进、历史与当前一致、并发写不串版。
+	Tx(ctx context.Context, fn func(repo GatewayRuleRepository) error) error
+	// SaveSnapshot 在当前（事务）作用域内分配下一个独立单调 snapshot_version，
+	// 把传入的完整规则集连同 createdBy/reason 落一条历史，返回分配到的版本号。
+	SaveSnapshot(ctx context.Context, rules []domain.GatewayRule, createdBy, reason string) (int64, error)
+	// LatestSnapshotVersion 返回最新的 snapshot_version（无快照时返回 0）。
+	// 它是 api-gateway 拉取快照时 version 的唯一来源。
+	LatestSnapshotVersion(ctx context.Context) (int64, error)
+	// ListSnapshots 按 snapshot_version 倒序返回最近 limit 条历史快照。
+	ListSnapshots(ctx context.Context, limit int) ([]*domain.GatewayRuleSnapshot, error)
+	// GetSnapshot 按版本号取一条历史快照，不存在返回 ErrGatewayRuleNotFound。
+	GetSnapshot(ctx context.Context, version int64) (*domain.GatewayRuleSnapshot, error)
 }

--- a/apps/paas-engine/internal/service/gateway_rule_emergency.go
+++ b/apps/paas-engine/internal/service/gateway_rule_emergency.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/chiwei-platform/paas-engine/internal/domain"
+	"github.com/chiwei-platform/paas-engine/internal/port"
 )
 
 // EnableChange is the before/after audit payload for disable/enable.
@@ -55,24 +56,36 @@ func (s *GatewayRuleService) Enable(ctx context.Context, name, reason string) (*
 }
 
 func (s *GatewayRuleService) setEnabled(ctx context.Context, name string, enabled bool, reason string) (*EnableChange, error) {
-	rule, err := s.repo.FindByName(ctx, name)
+	var change *EnableChange
+	err := s.repo.Tx(ctx, func(txRepo port.GatewayRuleRepository) error {
+		rule, err := txRepo.FindByName(ctx, name)
+		if err != nil {
+			return err
+		}
+		before := rule.Enabled
+		rule.Enabled = enabled
+		rule.Version++
+		rule.UpdatedAt = time.Now()
+		if err := txRepo.Upsert(ctx, rule); err != nil {
+			return err
+		}
+		snapVersion, err := recordSnapshot(ctx, txRepo, reason)
+		if err != nil {
+			return err
+		}
+		change = &EnableChange{
+			Name:          name,
+			BeforeEnabled: before,
+			AfterEnabled:  enabled,
+			Reason:        reason,
+			Version:       snapVersion,
+		}
+		return nil
+	})
 	if err != nil {
 		return nil, err
 	}
-	before := rule.Enabled
-	rule.Enabled = enabled
-	rule.Version++
-	rule.UpdatedAt = time.Now()
-	if err := s.repo.Upsert(ctx, rule); err != nil {
-		return nil, err
-	}
-	return &EnableChange{
-		Name:          name,
-		BeforeEnabled: before,
-		AfterEnabled:  enabled,
-		Reason:        reason,
-		Version:       rule.Version,
-	}, nil
+	return change, nil
 }
 
 // SetWeights wholesale-replaces the weights of all targets in a rule. The
@@ -81,79 +94,91 @@ func (s *GatewayRuleService) setEnabled(ctx context.Context, name string, enable
 // allowed (to drain a target), negatives are rejected, and the sum must be 100.
 // The new weights are validated through the existing multi-target validator.
 func (s *GatewayRuleService) SetWeights(ctx context.Context, name string, req SetWeightsRequest) (*WeightsChange, error) {
-	rule, err := s.repo.FindByName(ctx, name)
+	var change *WeightsChange
+	err := s.repo.Tx(ctx, func(txRepo port.GatewayRuleRepository) error {
+		rule, err := txRepo.FindByName(ctx, name)
+		if err != nil {
+			return err
+		}
+
+		before := make([]domain.GatewayTarget, len(rule.Targets))
+		copy(before, rule.Targets)
+
+		if len(req.Weights) != len(rule.Targets) {
+			return fmt.Errorf(
+				"%w: weights must list exactly the rule's %d target(s), got %d",
+				domain.ErrInvalidInput, len(rule.Targets), len(req.Weights),
+			)
+		}
+
+		// Index incoming weights by service+lane; reject duplicate identities.
+		type key struct{ service, lane string }
+		incoming := make(map[key]int, len(req.Weights))
+		for _, w := range req.Weights {
+			k := key{w.Service, w.Lane}
+			if _, dup := incoming[k]; dup {
+				return fmt.Errorf(
+					"%w: duplicate target identity service=%q lane=%q in weights",
+					domain.ErrInvalidInput, w.Service, w.Lane,
+				)
+			}
+			incoming[k] = w.Weight
+		}
+
+		// Apply by matching each existing target to an incoming weight. A missing
+		// match means the request omitted a target; a leftover incoming entry means
+		// the request had an extra one.
+		after := make([]domain.GatewayTarget, len(rule.Targets))
+		copy(after, rule.Targets)
+		for i := range after {
+			k := key{after[i].Service, after[i].Lane}
+			w, ok := incoming[k]
+			if !ok {
+				return fmt.Errorf(
+					"%w: weights missing target service=%q lane=%q present in rule",
+					domain.ErrInvalidInput, after[i].Service, after[i].Lane,
+				)
+			}
+			after[i].Weight = w
+			delete(incoming, k)
+		}
+		if len(incoming) > 0 {
+			for k := range incoming {
+				return fmt.Errorf(
+					"%w: weights contains target service=%q lane=%q not present in rule",
+					domain.ErrInvalidInput, k.service, k.lane,
+				)
+			}
+		}
+
+		// Reuse the multi-target validator: enforces weight>=0 and sum==100 (plus
+		// service/lane/port, which are unchanged here and already valid).
+		rule.Targets = after
+		if err := domain.ValidateGatewayRule(*rule); err != nil {
+			return err
+		}
+
+		rule.Version++
+		rule.UpdatedAt = time.Now()
+		if err := txRepo.Upsert(ctx, rule); err != nil {
+			return err
+		}
+		snapVersion, err := recordSnapshot(ctx, txRepo, req.Reason)
+		if err != nil {
+			return err
+		}
+
+		change = &WeightsChange{
+			Name:          name,
+			BeforeTargets: before,
+			AfterTargets:  after,
+			Reason:        req.Reason,
+			Version:       snapVersion,
+		}
+		return nil
+	})
 	if err != nil {
 		return nil, err
 	}
-
-	before := make([]domain.GatewayTarget, len(rule.Targets))
-	copy(before, rule.Targets)
-
-	if len(req.Weights) != len(rule.Targets) {
-		return nil, fmt.Errorf(
-			"%w: weights must list exactly the rule's %d target(s), got %d",
-			domain.ErrInvalidInput, len(rule.Targets), len(req.Weights),
-		)
-	}
-
-	// Index incoming weights by service+lane; reject duplicate identities.
-	type key struct{ service, lane string }
-	incoming := make(map[key]int, len(req.Weights))
-	for _, w := range req.Weights {
-		k := key{w.Service, w.Lane}
-		if _, dup := incoming[k]; dup {
-			return nil, fmt.Errorf(
-				"%w: duplicate target identity service=%q lane=%q in weights",
-				domain.ErrInvalidInput, w.Service, w.Lane,
-			)
-		}
-		incoming[k] = w.Weight
-	}
-
-	// Apply by matching each existing target to an incoming weight. A missing
-	// match means the request omitted a target; a leftover incoming entry means
-	// the request had an extra one.
-	after := make([]domain.GatewayTarget, len(rule.Targets))
-	copy(after, rule.Targets)
-	for i := range after {
-		k := key{after[i].Service, after[i].Lane}
-		w, ok := incoming[k]
-		if !ok {
-			return nil, fmt.Errorf(
-				"%w: weights missing target service=%q lane=%q present in rule",
-				domain.ErrInvalidInput, after[i].Service, after[i].Lane,
-			)
-		}
-		after[i].Weight = w
-		delete(incoming, k)
-	}
-	if len(incoming) > 0 {
-		for k := range incoming {
-			return nil, fmt.Errorf(
-				"%w: weights contains target service=%q lane=%q not present in rule",
-				domain.ErrInvalidInput, k.service, k.lane,
-			)
-		}
-	}
-
-	// Reuse the multi-target validator: enforces weight>=0 and sum==100 (plus
-	// service/lane/port, which are unchanged here and already valid).
-	rule.Targets = after
-	if err := domain.ValidateGatewayRule(*rule); err != nil {
-		return nil, err
-	}
-
-	rule.Version++
-	rule.UpdatedAt = time.Now()
-	if err := s.repo.Upsert(ctx, rule); err != nil {
-		return nil, err
-	}
-
-	return &WeightsChange{
-		Name:          name,
-		BeforeTargets: before,
-		AfterTargets:  after,
-		Reason:        req.Reason,
-		Version:       rule.Version,
-	}, nil
+	return change, nil
 }

--- a/apps/paas-engine/internal/service/gateway_rule_seed.go
+++ b/apps/paas-engine/internal/service/gateway_rule_seed.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/chiwei-platform/paas-engine/internal/domain"
+	"github.com/chiwei-platform/paas-engine/internal/port"
 )
 
 // BaselineGatewayRule 是一条基线种子规则：name + 对应的 Upsert 请求体。
@@ -71,6 +72,22 @@ func (s *GatewayRuleService) EnsureBaseline(ctx context.Context) error {
 	for _, seed := range BaselineGatewayRules() {
 		if err := s.ensureRule(ctx, seed.Name, seed.Request); err != nil {
 			return fmt.Errorf("ensure baseline rule %q: %w", seed.Name, err)
+		}
+	}
+
+	// 启动期 ensure 走 insert-do-nothing，本身不写快照（否则每次重启都灌一条历史）。
+	// 但 snapshot_version 是 api-gateway 拉取快照的唯一版本来源——若历史为空（全新库
+	// 首启），补写一条 bootstrap 快照让基线规则有 version>0；已有历史则不动。
+	version, err := s.repo.LatestSnapshotVersion(ctx)
+	if err != nil {
+		return fmt.Errorf("read latest snapshot version: %w", err)
+	}
+	if version == 0 {
+		if err := s.repo.Tx(ctx, func(txRepo port.GatewayRuleRepository) error {
+			_, err := recordSnapshot(ctx, txRepo, "bootstrap baseline rules")
+			return err
+		}); err != nil {
+			return fmt.Errorf("bootstrap baseline snapshot: %w", err)
 		}
 	}
 	return nil

--- a/apps/paas-engine/internal/service/gateway_rule_seed_test.go
+++ b/apps/paas-engine/internal/service/gateway_rule_seed_test.go
@@ -177,7 +177,7 @@ func TestEnsureBaseline_DoesNotOverwriteManualEdit(t *testing.T) {
 	manual.Priority = 500
 	manual.PathPrefix = "/api/agent/"
 	manual.Match.PathPrefix = "/api/agent/"
-	if err := svc.Upsert(ctx, "default-agent-service-api", manual); err != nil {
+	if _, err := svc.Upsert(ctx, "default-agent-service-api", manual); err != nil {
 		t.Fatal(err)
 	}
 
@@ -234,7 +234,7 @@ func TestEnsureBaseline_DoesNotOverwriteEvenViaRepoPath(t *testing.T) {
 	manual.Match.PathPrefix = "/dashboard/"
 	manual.Targets[0].Service = "monitor-dashboard-web"
 	manual.Targets[0].Port = 80
-	if err := svc.Upsert(ctx, "default-monitor-dashboard-web", manual); err != nil {
+	if _, err := svc.Upsert(ctx, "default-monitor-dashboard-web", manual); err != nil {
 		t.Fatal(err)
 	}
 	repo.upsertCalls = 0 // 重置，只关心 ensure 是否再次 Upsert

--- a/apps/paas-engine/internal/service/gateway_rule_service.go
+++ b/apps/paas-engine/internal/service/gateway_rule_service.go
@@ -32,6 +32,37 @@ type UpsertGatewayRuleRequest struct {
 	RequestLane string                 `json:"request_lane"`
 	Match       domain.GatewayMatch    `json:"match"`
 	Targets     []domain.GatewayTarget `json:"targets"`
+	// SplitKeyHeaders configures stable (sticky) target selection downstream;
+	// nil/empty means weighted-random. Validated as HTTP header names.
+	SplitKeyHeaders []string `json:"split_key_headers"`
+	// Reason 是本次写操作的运维原因，落进快照历史的 reason 字段（供审计与回滚追溯）。
+	Reason string `json:"reason"`
+}
+
+// snapshotActor 是写快照时记录的 created_by 默认值。规则写操作都经 ops/Dashboard
+// 安全入口进来，真实调用方由 Dashboard audit 中间件单独记录；这里记一个来源标签
+// 表明快照由 ops 写操作产生。
+const snapshotActor = "ops"
+
+// recordSnapshot 读取当前完整规则集，在 txRepo（事务作用域）内分配下一个独立单调
+// snapshot_version 并落一条历史，返回分配到的版本号。所有写操作在同一事务里调它，
+// 保证"改规则 + 写快照"原子完成。
+//
+// 已知限制（接受风险、不加锁）：repo.Tx 是 Postgres 默认 READ COMMITTED、无写串行化。
+// 两个 gateway 规则写事务毫秒级重叠时，后提交者可能拿到更高的 snapshot_version 却没
+// FindAll 到先提交者的改动，导致"最高版本快照滞后于实际规则表"、回滚到最新版会丢那条
+// 改动。不加 advisory lock 是因为 gateway 规则是纯运维写、几乎天然串行，并发窗口极小；
+// 若未来写频升高（多副本自动化改规则）需重新评估，届时在此处加 pg_advisory_xact_lock。
+func recordSnapshot(ctx context.Context, txRepo port.GatewayRuleRepository, reason string) (int64, error) {
+	rules, err := txRepo.FindAll(ctx)
+	if err != nil {
+		return 0, err
+	}
+	full := make([]domain.GatewayRule, 0, len(rules))
+	for _, r := range rules {
+		full = append(full, *r)
+	}
+	return txRepo.SaveSnapshot(ctx, full, snapshotActor, reason)
 }
 
 // enabledOrDefault 解析 Enabled 三态：nil（未提供）-> true（规则默认启用）；
@@ -43,38 +74,50 @@ func (req UpsertGatewayRuleRequest) enabledOrDefault() bool {
 	return *req.Enabled
 }
 
-// Upsert 校验并写入一条规则（name 幂等 key）。
+// Upsert 校验并写入一条规则（name 幂等 key），返回本次事务分配的 snapshot_version。
 // 新建时 version=1、设置 created_at；更新时 version+1、保留原 created_at。
-func (s *GatewayRuleService) Upsert(ctx context.Context, name string, req UpsertGatewayRuleRequest) error {
+// 返回的 snapshot_version 是审计/回滚游标，与规则自身的 rule.Version 是两套版本号。
+func (s *GatewayRuleService) Upsert(ctx context.Context, name string, req UpsertGatewayRuleRequest) (int64, error) {
 	now := time.Now()
 	rule := domain.GatewayRule{
-		Name:        name,
-		Enabled:     req.enabledOrDefault(),
-		Priority:    req.Priority,
-		PathPrefix:  req.PathPrefix,
-		RequestLane: req.RequestLane,
-		Match:       req.Match,
-		Targets:     req.Targets,
-		UpdatedAt:   now,
+		Name:            name,
+		Enabled:         req.enabledOrDefault(),
+		Priority:        req.Priority,
+		PathPrefix:      req.PathPrefix,
+		RequestLane:     req.RequestLane,
+		Match:           req.Match,
+		Targets:         req.Targets,
+		SplitKeyHeaders: req.SplitKeyHeaders,
+		UpdatedAt:       now,
 	}
 
 	if err := domain.ValidateGatewayRule(rule); err != nil {
-		return err
+		return 0, err
 	}
 
-	existing, err := s.repo.FindByName(ctx, name)
-	switch {
-	case err == nil:
-		rule.CreatedAt = existing.CreatedAt
-		rule.Version = existing.Version + 1
-	case errors.Is(err, domain.ErrGatewayRuleNotFound):
-		rule.CreatedAt = now
-		rule.Version = 1
-	default:
+	var snapVersion int64
+	err := s.repo.Tx(ctx, func(txRepo port.GatewayRuleRepository) error {
+		existing, err := txRepo.FindByName(ctx, name)
+		switch {
+		case err == nil:
+			rule.CreatedAt = existing.CreatedAt
+			rule.Version = existing.Version + 1
+		case errors.Is(err, domain.ErrGatewayRuleNotFound):
+			rule.CreatedAt = now
+			rule.Version = 1
+		default:
+			return err
+		}
+		if err := txRepo.Upsert(ctx, &rule); err != nil {
+			return err
+		}
+		snapVersion, err = recordSnapshot(ctx, txRepo, req.Reason)
 		return err
+	})
+	if err != nil {
+		return 0, err
 	}
-
-	return s.repo.Upsert(ctx, &rule)
+	return snapVersion, nil
 }
 
 // ensureRule 校验后以 insert-do-nothing 写入一条规则（version=1，全新插入语义）。
@@ -82,16 +125,17 @@ func (s *GatewayRuleService) Upsert(ctx context.Context, name string, req Upsert
 func (s *GatewayRuleService) ensureRule(ctx context.Context, name string, req UpsertGatewayRuleRequest) error {
 	now := time.Now()
 	rule := domain.GatewayRule{
-		Name:        name,
-		Enabled:     req.enabledOrDefault(),
-		Priority:    req.Priority,
-		PathPrefix:  req.PathPrefix,
-		RequestLane: req.RequestLane,
-		Match:       req.Match,
-		Targets:     req.Targets,
-		Version:     1,
-		CreatedAt:   now,
-		UpdatedAt:   now,
+		Name:            name,
+		Enabled:         req.enabledOrDefault(),
+		Priority:        req.Priority,
+		PathPrefix:      req.PathPrefix,
+		RequestLane:     req.RequestLane,
+		Match:           req.Match,
+		Targets:         req.Targets,
+		SplitKeyHeaders: req.SplitKeyHeaders,
+		Version:         1,
+		CreatedAt:       now,
+		UpdatedAt:       now,
 	}
 	if err := domain.ValidateGatewayRule(rule); err != nil {
 		return err
@@ -117,9 +161,23 @@ func (s *GatewayRuleService) List(ctx context.Context) ([]*domain.GatewayRule, e
 	return rules, nil
 }
 
-// Delete 删除一条规则。
-func (s *GatewayRuleService) Delete(ctx context.Context, name string) error {
-	return s.repo.Delete(ctx, name)
+// Delete 删除一条规则，并在同一事务内写一条快照历史。
+// 含 delete 是关键：删掉 version 最高的规则后，独立 snapshot_version 仍单调前进，
+// 不像 max(rule.version) 那样回退。
+func (s *GatewayRuleService) Delete(ctx context.Context, name, reason string) (int64, error) {
+	var snapVersion int64
+	err := s.repo.Tx(ctx, func(txRepo port.GatewayRuleRepository) error {
+		if err := txRepo.Delete(ctx, name); err != nil {
+			return err
+		}
+		var err error
+		snapVersion, err = recordSnapshot(ctx, txRepo, reason)
+		return err
+	})
+	if err != nil {
+		return 0, err
+	}
+	return snapVersion, nil
 }
 
 // Explain 预览一个请求会命中哪条规则、为何命中、其余规则为何没命中。
@@ -134,30 +192,100 @@ func (s *GatewayRuleService) Explain(ctx context.Context, path, requestLane stri
 }
 
 // Snapshot 组装 /internal/gateway-rules 返回的快照。
-// Version 取 max(rule.version)（snapshot 级单调 int）；空表返回 version=0、空规则集。
+// Version 取最新的独立 snapshot_version（来自快照序列，而非 max(rule.version)）——
+// 这样删掉 version 最高的规则也不会回退。空历史返回 version=0。
 func (s *GatewayRuleService) Snapshot(ctx context.Context) (*domain.GatewaySnapshot, error) {
 	rules, err := s.List(ctx)
 	if err != nil {
 		return nil, err
 	}
 
+	version, err := s.repo.LatestSnapshotVersion(ctx)
+	if err != nil {
+		return nil, err
+	}
+
 	out := make([]domain.GatewayRule, 0, len(rules))
-	var maxVersion int64
 	var latestUpdate time.Time
 	for _, r := range rules {
 		out = append(out, *r)
-		if r.Version > maxVersion {
-			maxVersion = r.Version
-		}
 		if r.UpdatedAt.After(latestUpdate) {
 			latestUpdate = r.UpdatedAt
 		}
 	}
 
 	return &domain.GatewaySnapshot{
-		Version:   maxVersion,
+		Version:   version,
 		UpdatedAt: latestUpdate,
 		Rules:     out,
+	}, nil
+}
+
+// ListSnapshots 返回最近 limit 条规则快照历史（按 snapshot_version 倒序）。
+func (s *GatewayRuleService) ListSnapshots(ctx context.Context, limit int) ([]*domain.GatewayRuleSnapshot, error) {
+	snaps, err := s.repo.ListSnapshots(ctx, limit)
+	if err != nil {
+		return nil, err
+	}
+	if snaps == nil {
+		snaps = []*domain.GatewayRuleSnapshot{}
+	}
+	return snaps, nil
+}
+
+// GetSnapshot 取单条历史快照。
+func (s *GatewayRuleService) GetSnapshot(ctx context.Context, version int64) (*domain.GatewayRuleSnapshot, error) {
+	return s.repo.GetSnapshot(ctx, version)
+}
+
+// Rollback 把历史某版本的规则集重新写入当前 gateway_routing_rules，并在同一事务内
+// 分配一个更大的新 snapshot_version 写一条新快照——不是把版本号倒回去。
+// 当前表里有、目标快照里没有的规则会被删掉，使当前规则集与目标版本完全一致。
+func (s *GatewayRuleService) Rollback(ctx context.Context, version int64, reason string) (*domain.GatewayRuleSnapshot, error) {
+	var newVersion int64
+	err := s.repo.Tx(ctx, func(txRepo port.GatewayRuleRepository) error {
+		target, err := txRepo.GetSnapshot(ctx, version)
+		if err != nil {
+			return err
+		}
+
+		// 目标版本里应存在的规则名集合。
+		wanted := make(map[string]bool, len(target.Rules))
+		for _, r := range target.Rules {
+			wanted[r.Name] = true
+		}
+
+		// 删掉当前存在但目标版本没有的规则。
+		current, err := txRepo.FindAll(ctx)
+		if err != nil {
+			return err
+		}
+		for _, r := range current {
+			if !wanted[r.Name] {
+				if err := txRepo.Delete(ctx, r.Name); err != nil {
+					return err
+				}
+			}
+		}
+
+		// 把目标版本每条规则覆盖回当前表（保留其历史 version 字段值，按原样恢复）。
+		for i := range target.Rules {
+			rule := target.Rules[i]
+			if err := txRepo.Upsert(ctx, &rule); err != nil {
+				return err
+			}
+		}
+
+		newVersion, err = recordSnapshot(ctx, txRepo, reason)
+		return err
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &domain.GatewayRuleSnapshot{
+		SnapshotVersion: newVersion,
+		Reason:          reason,
+		CreatedBy:       snapshotActor,
 	}, nil
 }
 

--- a/apps/paas-engine/internal/service/gateway_rule_service_test.go
+++ b/apps/paas-engine/internal/service/gateway_rule_service_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/chiwei-platform/paas-engine/internal/domain"
+	"github.com/chiwei-platform/paas-engine/internal/port"
 )
 
 // --- stub for GatewayRuleRepository ---
@@ -14,10 +15,65 @@ type stubGatewayRuleRepo struct {
 	rules               map[string]*domain.GatewayRule
 	upsertCalls         int
 	insertIfAbsentCalls int
+
+	// 快照历史：snapshotSeq 模拟 PG 序列的独立单调分配（max(已分配)+1）。
+	snapshots   []domain.GatewayRuleSnapshot
+	snapshotSeq int64
 }
 
 func newStubGatewayRuleRepo() *stubGatewayRuleRepo {
 	return &stubGatewayRuleRepo{rules: make(map[string]*domain.GatewayRule)}
+}
+
+// Tx 内存实现：直接拿自己当事务 repo 跑 fn（无回滚，足够驱动 service 逻辑测试）。
+func (r *stubGatewayRuleRepo) Tx(_ context.Context, fn func(repo port.GatewayRuleRepository) error) error {
+	return fn(r)
+}
+
+// SaveSnapshot 分配下一个独立单调 snapshot_version 并落一条历史。
+func (r *stubGatewayRuleRepo) SaveSnapshot(_ context.Context, rules []domain.GatewayRule, createdBy, reason string) (int64, error) {
+	r.snapshotSeq++
+	cp := make([]domain.GatewayRule, len(rules))
+	copy(cp, rules)
+	r.snapshots = append(r.snapshots, domain.GatewayRuleSnapshot{
+		SnapshotVersion: r.snapshotSeq,
+		Rules:           cp,
+		CreatedBy:       createdBy,
+		Reason:          reason,
+	})
+	return r.snapshotSeq, nil
+}
+
+func (r *stubGatewayRuleRepo) LatestSnapshotVersion(_ context.Context) (int64, error) {
+	var maxV int64
+	for _, s := range r.snapshots {
+		if s.SnapshotVersion > maxV {
+			maxV = s.SnapshotVersion
+		}
+	}
+	return maxV, nil
+}
+
+func (r *stubGatewayRuleRepo) ListSnapshots(_ context.Context, limit int) ([]*domain.GatewayRuleSnapshot, error) {
+	out := make([]*domain.GatewayRuleSnapshot, 0, len(r.snapshots))
+	for i := len(r.snapshots) - 1; i >= 0; i-- {
+		cp := r.snapshots[i]
+		out = append(out, &cp)
+		if limit > 0 && len(out) >= limit {
+			break
+		}
+	}
+	return out, nil
+}
+
+func (r *stubGatewayRuleRepo) GetSnapshot(_ context.Context, version int64) (*domain.GatewayRuleSnapshot, error) {
+	for i := range r.snapshots {
+		if r.snapshots[i].SnapshotVersion == version {
+			cp := r.snapshots[i]
+			return &cp, nil
+		}
+	}
+	return nil, domain.ErrGatewayRuleNotFound
 }
 
 func (r *stubGatewayRuleRepo) Upsert(_ context.Context, rule *domain.GatewayRule) error {
@@ -87,7 +143,7 @@ type service_UpsertReq = UpsertGatewayRuleRequest
 
 func TestGatewayRuleService_UpsertThenGet(t *testing.T) {
 	svc := NewGatewayRuleService(newStubGatewayRuleRepo())
-	if err := svc.Upsert(context.Background(), "default-agent-service-api", validUpsertReq()); err != nil {
+	if _, err := svc.Upsert(context.Background(), "default-agent-service-api", validUpsertReq()); err != nil {
 		t.Fatal(err)
 	}
 	rule, err := svc.Get(context.Background(), "default-agent-service-api")
@@ -110,7 +166,7 @@ func TestGatewayRuleService_UpsertRejectsInvalid(t *testing.T) {
 	req := validUpsertReq()
 	req.PathPrefix = "no-slash/"
 	req.Match.PathPrefix = "no-slash/"
-	err := svc.Upsert(context.Background(), "bad-rule", req)
+	_, err := svc.Upsert(context.Background(), "bad-rule", req)
 	if err == nil {
 		t.Fatal("expected validation error")
 	}
@@ -121,7 +177,7 @@ func TestGatewayRuleService_UpsertRejectsInvalid(t *testing.T) {
 
 func TestGatewayRuleService_UpsertRejectsBadName(t *testing.T) {
 	svc := NewGatewayRuleService(newStubGatewayRuleRepo())
-	err := svc.Upsert(context.Background(), "Bad_Name", validUpsertReq())
+	_, err := svc.Upsert(context.Background(), "Bad_Name", validUpsertReq())
 	if !errors.Is(err, domain.ErrInvalidInput) {
 		t.Fatalf("expected ErrInvalidInput, got %v", err)
 	}
@@ -130,14 +186,14 @@ func TestGatewayRuleService_UpsertRejectsBadName(t *testing.T) {
 func TestGatewayRuleService_UpsertBumpsVersionAndPreservesCreatedAt(t *testing.T) {
 	svc := NewGatewayRuleService(newStubGatewayRuleRepo())
 	ctx := context.Background()
-	if err := svc.Upsert(ctx, "r1", validUpsertReq()); err != nil {
+	if _, err := svc.Upsert(ctx, "r1", validUpsertReq()); err != nil {
 		t.Fatal(err)
 	}
 	first, _ := svc.Get(ctx, "r1")
 
 	req := validUpsertReq()
 	req.Priority = 200
-	if err := svc.Upsert(ctx, "r1", req); err != nil {
+	if _, err := svc.Upsert(ctx, "r1", req); err != nil {
 		t.Fatal(err)
 	}
 	second, _ := svc.Get(ctx, "r1")
@@ -170,10 +226,10 @@ func TestGatewayRuleService_ListEmpty(t *testing.T) {
 func TestGatewayRuleService_Delete(t *testing.T) {
 	svc := NewGatewayRuleService(newStubGatewayRuleRepo())
 	ctx := context.Background()
-	if err := svc.Upsert(ctx, "r1", validUpsertReq()); err != nil {
+	if _, err := svc.Upsert(ctx, "r1", validUpsertReq()); err != nil {
 		t.Fatal(err)
 	}
-	if err := svc.Delete(ctx, "r1"); err != nil {
+	if _, err := svc.Delete(ctx, "r1", "test cleanup"); err != nil {
 		t.Fatal(err)
 	}
 	_, err := svc.Get(ctx, "r1")
@@ -184,7 +240,7 @@ func TestGatewayRuleService_Delete(t *testing.T) {
 
 func TestGatewayRuleService_DeleteMissing(t *testing.T) {
 	svc := NewGatewayRuleService(newStubGatewayRuleRepo())
-	err := svc.Delete(context.Background(), "nope")
+	_, err := svc.Delete(context.Background(), "nope", "test")
 	if !errors.Is(err, domain.ErrGatewayRuleNotFound) {
 		t.Fatalf("expected not found, got %v", err)
 	}
@@ -198,7 +254,7 @@ func TestGatewayRuleService_SnapshotVersionAndSort(t *testing.T) {
 	low.Priority = 50
 	low.PathPrefix = "/a/"
 	low.Match.PathPrefix = "/a/"
-	if err := svc.Upsert(ctx, "rule-low", low); err != nil {
+	if _, err := svc.Upsert(ctx, "rule-low", low); err != nil {
 		t.Fatal(err)
 	}
 
@@ -206,11 +262,11 @@ func TestGatewayRuleService_SnapshotVersionAndSort(t *testing.T) {
 	high.Priority = 200
 	high.PathPrefix = "/b/"
 	high.Match.PathPrefix = "/b/"
-	if err := svc.Upsert(ctx, "rule-high", high); err != nil {
+	if _, err := svc.Upsert(ctx, "rule-high", high); err != nil {
 		t.Fatal(err)
 	}
 	// bump rule-high again so its rule version is highest -> snapshot version
-	if err := svc.Upsert(ctx, "rule-high", high); err != nil {
+	if _, err := svc.Upsert(ctx, "rule-high", high); err != nil {
 		t.Fatal(err)
 	}
 
@@ -221,9 +277,10 @@ func TestGatewayRuleService_SnapshotVersionAndSort(t *testing.T) {
 	if len(snap.Rules) != 2 {
 		t.Fatalf("expected 2 rules in snapshot, got %d", len(snap.Rules))
 	}
-	// snapshot version = max(rule.version) = 2 (rule-high upserted twice)
-	if snap.Version != 2 {
-		t.Errorf("expected snapshot version 2 (max rule version), got %d", snap.Version)
+	// snapshot version 来自独立单调序列：3 次 upsert -> 3 条快照 -> version 3
+	// （不再是 max(rule.version)=2）。
+	if snap.Version != 3 {
+		t.Errorf("expected snapshot version 3 (independent sequence over 3 writes), got %d", snap.Version)
 	}
 	// sorted by priority desc -> rule-high (200) first
 	if snap.Rules[0].Name != "rule-high" {

--- a/apps/paas-engine/internal/service/gateway_rule_snapshot_test.go
+++ b/apps/paas-engine/internal/service/gateway_rule_snapshot_test.go
@@ -1,0 +1,188 @@
+package service
+
+import (
+	"context"
+	"testing"
+
+	"github.com/chiwei-platform/paas-engine/internal/domain"
+)
+
+func ruleReq(prefix string) UpsertGatewayRuleRequest {
+	enabled := true
+	return UpsertGatewayRuleRequest{
+		Enabled:    &enabled,
+		Priority:   100,
+		PathPrefix: prefix,
+		Match:      domain.GatewayMatch{PathPrefix: prefix},
+		Targets: []domain.GatewayTarget{
+			{Service: "agent-service", Lane: "prod", Port: 8000, Weight: 100},
+		},
+	}
+}
+
+// 核心断言①：连续若干次写操作（含一次 delete）后能列出对应数量历史快照、版本严格单调递增。
+func TestGatewaySnapshot_HistoryMonotonicAcrossWrites(t *testing.T) {
+	repo := newStubGatewayRuleRepo()
+	svc := NewGatewayRuleService(repo)
+	ctx := context.Background()
+
+	mustUpsert(t, svc, "ra", ruleReq("/a/"))         // write 1
+	mustUpsert(t, svc, "rb", ruleReq("/b/"))         // write 2
+	mustUpsert(t, svc, "ra", ruleReq("/a/"))         // write 3 (update)
+	if _, err := svc.Disable(ctx, "rb", "stop"); err != nil {   // write 4
+		t.Fatal(err)
+	}
+	mustDelete(t, svc, "ra", "cleanup") // write 5 (含 delete)
+
+	snaps, err := svc.ListSnapshots(ctx, 100)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(snaps) != 5 {
+		t.Fatalf("expected 5 history snapshots after 5 writes, got %d", len(snaps))
+	}
+	// newest first -> versions strictly decreasing as we go; collect and assert strict-monotone overall.
+	seen := make([]int64, 0, len(snaps))
+	for _, s := range snaps {
+		seen = append(seen, s.SnapshotVersion)
+	}
+	// snaps come newest-first; reverse to chronological and assert strictly increasing.
+	for i := 0; i < len(seen); i++ {
+		want := int64(len(seen) - i)
+		if seen[i] != want {
+			t.Fatalf("snapshot versions not strictly monotone (newest-first): got %v", seen)
+		}
+	}
+}
+
+// 核心断言②：删掉当前 version 最高的规则后，snapshot version 不回退（切独立序列的核心动机）。
+func TestGatewaySnapshot_DeleteHighestVersionRuleDoesNotRegress(t *testing.T) {
+	repo := newStubGatewayRuleRepo()
+	svc := NewGatewayRuleService(repo)
+	ctx := context.Background()
+
+	// rb 被反复 upsert，rule.Version 升到最高（旧逻辑 max(rule.version) 会盯它）。
+	mustUpsert(t, svc, "ra", ruleReq("/a/"))
+	mustUpsert(t, svc, "rb", ruleReq("/b/"))
+	mustUpsert(t, svc, "rb", ruleReq("/b/"))
+	mustUpsert(t, svc, "rb", ruleReq("/b/")) // rb.Version == 3, 全场最高
+
+	beforeSnap, err := svc.Snapshot(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// 删掉 version 最高的 rb：旧逻辑 max(rule.version) 会从 3 回退到 ra 的 1。
+	mustDelete(t, svc, "rb", "drop highest")
+
+	afterSnap, err := svc.Snapshot(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if afterSnap.Version <= beforeSnap.Version {
+		t.Fatalf("snapshot version regressed after deleting highest-rule-version: before=%d after=%d",
+			beforeSnap.Version, afterSnap.Version)
+	}
+}
+
+// 核心断言③：回滚到上一版后规则集恢复，且 snapshot version 是更大的新值（非倒退）。
+func TestGatewaySnapshot_RollbackRestoresRulesWithNewerVersion(t *testing.T) {
+	repo := newStubGatewayRuleRepo()
+	svc := NewGatewayRuleService(repo)
+	ctx := context.Background()
+
+	mustUpsert(t, svc, "ra", ruleReq("/a/"))
+	mustUpsert(t, svc, "rb", ruleReq("/b/")) // snapshot v2: {ra, rb}
+
+	snaps, err := svc.ListSnapshots(ctx, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	targetVersion := snaps[0].SnapshotVersion // 最新 = v2，含 {ra, rb}
+
+	// 把 rb 删掉，当前只剩 ra（snapshot v3）。
+	mustDelete(t, svc, "rb", "oops")
+	mid, _ := svc.List(ctx)
+	if len(mid) != 1 {
+		t.Fatalf("expected 1 rule after delete, got %d", len(mid))
+	}
+
+	// 回滚到 v2（含 {ra, rb}），应生成 snapshot v4。
+	rb, err := svc.Rollback(ctx, targetVersion, "rollback to v2")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rb.SnapshotVersion <= targetVersion {
+		t.Fatalf("rollback must assign a NEWER snapshot version, target=%d got=%d",
+			targetVersion, rb.SnapshotVersion)
+	}
+
+	restored, _ := svc.List(ctx)
+	if len(restored) != 2 {
+		t.Fatalf("expected ruleset restored to 2 rules after rollback, got %d", len(restored))
+	}
+	cur, err := svc.Snapshot(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cur.Version != rb.SnapshotVersion {
+		t.Fatalf("current snapshot version should equal rollback's new version: %d vs %d",
+			cur.Version, rb.SnapshotVersion)
+	}
+}
+
+// 核心断言④：事务边界——连续两次写不产生同版，且历史与当前一致（最新快照规则集 == 当前规则集）。
+func TestGatewaySnapshot_TxBoundaryNoDupVersionAndHistoryMatchesCurrent(t *testing.T) {
+	repo := newStubGatewayRuleRepo()
+	svc := NewGatewayRuleService(repo)
+	ctx := context.Background()
+
+	mustUpsert(t, svc, "ra", ruleReq("/a/"))
+	mustUpsert(t, svc, "rb", ruleReq("/b/"))
+
+	snaps, err := svc.ListSnapshots(ctx, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	versions := map[int64]bool{}
+	for _, s := range snaps {
+		if versions[s.SnapshotVersion] {
+			t.Fatalf("duplicate snapshot version produced: %d", s.SnapshotVersion)
+		}
+		versions[s.SnapshotVersion] = true
+	}
+
+	// 最新快照的规则集必须和当前 List 一致（历史与当前不脱节）。
+	latest := snaps[0]
+	current, _ := svc.List(ctx)
+	if len(latest.Rules) != len(current) {
+		t.Fatalf("latest snapshot ruleset size %d != current %d", len(latest.Rules), len(current))
+	}
+	names := map[string]bool{}
+	for _, r := range latest.Rules {
+		names[r.Name] = true
+	}
+	for _, r := range current {
+		if !names[r.Name] {
+			t.Fatalf("rule %q present currently but missing from latest snapshot", r.Name)
+		}
+	}
+}
+
+// mustUpsert / mustDelete 包掉 (snapshot_version, error) 返回，断言无错并回传版本号。
+func mustUpsert(t *testing.T, svc *GatewayRuleService, name string, req UpsertGatewayRuleRequest) int64 {
+	t.Helper()
+	v, err := svc.Upsert(context.Background(), name, req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return v
+}
+
+func mustDelete(t *testing.T, svc *GatewayRuleService, name, reason string) int64 {
+	t.Helper()
+	v, err := svc.Delete(context.Background(), name, reason)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return v
+}

--- a/apps/paas-engine/internal/service/gateway_rule_split_key_test.go
+++ b/apps/paas-engine/internal/service/gateway_rule_split_key_test.go
@@ -1,0 +1,99 @@
+package service
+
+import (
+	"context"
+	"testing"
+
+	"github.com/chiwei-platform/paas-engine/internal/domain"
+)
+
+func gwMatch(prefix, lane string) domain.GatewayMatch {
+	return domain.GatewayMatch{PathPrefix: prefix, RequestLane: lane}
+}
+
+func twoTargets() []domain.GatewayTarget {
+	return []domain.GatewayTarget{
+		{Service: "agent-a", Lane: "prod", Port: 8000, Weight: 90},
+		{Service: "agent-b", Lane: "ppe-new", Port: 8000, Weight: 10},
+	}
+}
+
+// TestUpsertPersistsSplitKeyHeaders: the upsert request carries
+// split_key_headers through to the stored rule.
+func TestUpsertPersistsSplitKeyHeaders(t *testing.T) {
+	repo := newStubGatewayRuleRepo()
+	svc := NewGatewayRuleService(repo)
+
+	enabled := true
+	req := UpsertGatewayRuleRequest{
+		Enabled:         &enabled,
+		Priority:        100,
+		PathPrefix:      "/api/agent/",
+		SplitKeyHeaders: []string{"X-User-Id", "X-Trace-Id"},
+		Match:           gwMatch("/api/agent/", ""),
+		Targets:         twoTargets(),
+	}
+	if _, err := svc.Upsert(context.Background(), "agent", req); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+	stored, err := svc.Get(context.Background(), "agent")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if len(stored.SplitKeyHeaders) != 2 ||
+		stored.SplitKeyHeaders[0] != "X-User-Id" ||
+		stored.SplitKeyHeaders[1] != "X-Trace-Id" {
+		t.Errorf("split_key_headers not persisted: %+v", stored.SplitKeyHeaders)
+	}
+}
+
+// TestSnapshotIncludesSplitKeyHeaders: the downstream snapshot carries
+// split_key_headers so api-gateway can do stable split.
+func TestSnapshotIncludesSplitKeyHeaders(t *testing.T) {
+	repo := newStubGatewayRuleRepo()
+	svc := NewGatewayRuleService(repo)
+
+	enabled := true
+	req := UpsertGatewayRuleRequest{
+		Enabled:         &enabled,
+		Priority:        100,
+		PathPrefix:      "/api/agent/",
+		SplitKeyHeaders: []string{"X-User-Id"},
+		Match:           gwMatch("/api/agent/", ""),
+		Targets:         twoTargets(),
+	}
+	if _, err := svc.Upsert(context.Background(), "agent", req); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+	snap, err := svc.Snapshot(context.Background())
+	if err != nil {
+		t.Fatalf("snapshot: %v", err)
+	}
+	if len(snap.Rules) != 1 {
+		t.Fatalf("expected 1 rule, got %d", len(snap.Rules))
+	}
+	got := snap.Rules[0].SplitKeyHeaders
+	if len(got) != 1 || got[0] != "X-User-Id" {
+		t.Errorf("snapshot rule split_key_headers: %+v", got)
+	}
+}
+
+// TestUpsertRejectsInvalidSplitKeyHeader: validation runs in the service path —
+// an invalid header name is rejected before persistence.
+func TestUpsertRejectsInvalidSplitKeyHeader(t *testing.T) {
+	repo := newStubGatewayRuleRepo()
+	svc := NewGatewayRuleService(repo)
+
+	enabled := true
+	req := UpsertGatewayRuleRequest{
+		Enabled:         &enabled,
+		Priority:        100,
+		PathPrefix:      "/api/agent/",
+		SplitKeyHeaders: []string{"bad header"},
+		Match:           gwMatch("/api/agent/", ""),
+		Targets:         twoTargets(),
+	}
+	if _, err := svc.Upsert(context.Background(), "agent", req); err == nil {
+		t.Fatal("expected upsert to reject invalid split_key_header name")
+	}
+}


### PR DESCRIPTION
## Summary
api-gateway 三期：把"引擎"变成可用"调度产品"。

- **MR1 Dashboard ops 中转 + 审计**：人/AI 经 Dashboard 安全列规则/看当前快照/explain/增删改/止血/回滚；写操作强制 reason；before/after/snapshot_version 取自 paas-engine 响应，提升进 audit_logs.params 顶层固定五键供 JSONB 检索。"看调度配置" = 查 paas-engine 当前快照，不给 api-gateway 加状态端点。
- **MR3 稳定权重分流**：split_key_headers 非空时按 hash(rule+首个命中 header 值)%100 累积权重选 target，同源稳定落同一 target；无 key 退化加权随机 + fallback metric。
- **MR4 快照历史 + 回滚**：独立单调 BIGSERIAL snapshot_version，所有写（含 DELETE）走事务原子完成"改规则+写快照"；删最高规则版本不回退；回滚写更大新版本而非倒回。

snapshot_version 与 rule.version 是两套版本号（审计/回滚游标 vs 单条规则修订计数），全程不混。schema 纯增量（split_key_headers 列 + gateway_rule_snapshots 表）由 AutoMigrate 自动迁移。

已知并发限制（接受风险）：repo.Tx 默认 READ COMMITTED 无写串行化，gateway 规则纯运维写几乎天然串行；写频升高时再加 advisory lock（见 recordSnapshot 注释）。

## Test plan
- [x] 三模块 build + 全量测试（paas-engine go test ./...、api-gateway go test ./...、monitor-dashboard 48 单测 + tsc）
- [x] codex T3 review 五条全消化
- [x] ppe-gw3 真机：jsonb fix（6 基线无 22P02）、快照表 AutoMigrate、必改1 端到端（upsert 回 snapshot_version≠rule.version）、MR3 stable_split=true、MR4 回滚 v1→新 v3
- [x] api-gateway 真流量 ppe-vs-prod 5 路径状态码 1:1，无回归

🤖 Generated with [Claude Code](https://claude.com/claude-code)