### PR TITLE
feat(gateway): add routing management dashboard UI

### DIFF
--- a/apps/monitor-dashboard-web/nginx.conf
+++ b/apps/monitor-dashboard-web/nginx.conf
@@ -3,7 +3,7 @@ server {
     absolute_redirect off;
 
     location /dashboard/api/ {
-        proxy_pass http://monitor-dashboard-${LANE}.prod.svc.cluster.local:3002/dashboard/api/;
+        proxy_pass http://api-gateway:8080/dashboard/api/;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/apps/monitor-dashboard-web/src/App.tsx
+++ b/apps/monitor-dashboard-web/src/App.tsx
@@ -17,6 +17,7 @@ import {
   MenuUnfoldOutlined,
   ThunderboltOutlined,
   AuditOutlined,
+  DeploymentUnitOutlined,
   EditOutlined,
   SettingOutlined,
 } from '@ant-design/icons';
@@ -39,6 +40,7 @@ const AuditLogs = lazy(() => import('./pages/AuditLogs'));
 const DbMutations = lazy(() => import('./pages/DbMutations'));
 const DynamicConfig = lazy(() => import('./pages/DynamicConfig'));
 const Skills = lazy(() => import('./pages/Skills'));
+const GatewayRouting = lazy(() => import('./pages/GatewayRouting'));
 import { themeConfig } from './theme';
 import { clearToken, getLane } from './api/client';
 
@@ -60,6 +62,7 @@ const menuItems: MenuItem[] = [
   { key: '/messages', icon: <MessageOutlined />, label: '消息记录' },
   { key: '/audit-logs', icon: <AuditOutlined />, label: '审计日志' },
   { key: '/db-mutations', icon: <EditOutlined />, label: 'DB 变更' },
+  { key: '/gateway-routing', icon: <DeploymentUnitOutlined />, label: '网关调度' },
   { type: 'divider' },
   { key: '/providers', icon: <CloudServerOutlined />, label: '服务商' },
   { key: '/model-mappings', icon: <ApiOutlined />, label: '模型映射' },
@@ -283,6 +286,7 @@ export default function App() {
                   <Route path="/activity" element={<Activity />} />
                   <Route path="/audit-logs" element={<AuditLogs />} />
                   <Route path="/db-mutations" element={<DbMutations />} />
+                  <Route path="/gateway-routing" element={<GatewayRouting />} />
                   <Route path="/kibana" element={<Kibana />} />
                   <Route path="/langfuse" element={<Langfuse />} />
                   <Route path="/messages" element={<Messages />} />

--- a/apps/monitor-dashboard-web/src/pages/AuditLogs.tsx
+++ b/apps/monitor-dashboard-web/src/pages/AuditLogs.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState, useCallback } from 'react';
 import { Card, Table, Tag, Typography, Space, Select, DatePicker, Input, Button, Tooltip } from 'antd';
 import { ReloadOutlined, SearchOutlined } from '@ant-design/icons';
 import dayjs, { type Dayjs } from 'dayjs';
+import { useSearchParams } from 'react-router-dom';
 import { api } from '../api/client';
 
 const { Title, Text } = Typography;
@@ -30,13 +31,14 @@ const resultColors: Record<string, string> = {
 };
 
 export default function AuditLogs() {
+  const [searchParams] = useSearchParams();
   const [data, setData] = useState<AuditLogItem[]>([]);
   const [total, setTotal] = useState(0);
   const [loading, setLoading] = useState(true);
   const [page, setPage] = useState(1);
   const [pageSize, setPageSize] = useState(50);
   const [caller, setCaller] = useState<string>();
-  const [action, setAction] = useState<string>();
+  const [action, setAction] = useState<string>(() => searchParams.get('action') || undefined);
   const [result, setResult] = useState<string>();
   const [dateRange, setDateRange] = useState<[Dayjs | null, Dayjs | null]>();
 
@@ -66,6 +68,11 @@ export default function AuditLogs() {
   useEffect(() => {
     fetchData();
   }, [fetchData]);
+
+  useEffect(() => {
+    setAction(searchParams.get('action') || undefined);
+    setPage(1);
+  }, [searchParams]);
 
   const columns = [
     {

--- a/apps/monitor-dashboard-web/src/pages/GatewayRouting.tsx
+++ b/apps/monitor-dashboard-web/src/pages/GatewayRouting.tsx
@@ -7,6 +7,7 @@ import {
   Col,
   Descriptions,
   Divider,
+  Dropdown,
   Drawer,
   Empty,
   Form,
@@ -32,8 +33,10 @@ import {
   EditOutlined,
   EyeOutlined,
   HistoryOutlined,
+  MoreOutlined,
   PauseCircleOutlined,
   PlayCircleOutlined,
+  QuestionCircleOutlined,
   ReloadOutlined,
   RetweetOutlined,
   RollbackOutlined,
@@ -163,11 +166,11 @@ const statusMeta: Record<string, { label: string; color: string }> = {
 };
 
 function requestLaneLabel(lane?: string) {
-  return lane ? lane : '跟随请求 x-lane';
+  return lane ? `只匹配 ${lane}` : '不限制请求泳道';
 }
 
 function targetLaneLabel(lane?: string) {
-  return lane ? lane : '跟随请求';
+  return lane ? `${lane} 泳道` : '跟随请求泳道（x-lane）';
 }
 
 function formatTime(value?: string) {
@@ -192,18 +195,77 @@ function getErrorMessage(error: unknown) {
 }
 
 function targetIdentity(target: Pick<GatewayTarget, 'service' | 'lane'>) {
-  return `${target.service} / ${targetLaneLabel(target.lane)}`;
+  return `${target.service}（${targetLaneLabel(target.lane)}）`;
 }
 
 function targetSummary(targets: GatewayTarget[]) {
   if (targets.length === 0) {
-    return '无 target';
+    return '未配置转发目标';
   }
-  return targets.map((target) => `${targetIdentity(target)} ${target.weight}`).join(' · ');
+  return `转发：${targets.map((target) => `${target.service}（${targetLaneLabel(target.lane)}，${target.weight}%）`).join('；')}`;
 }
 
 function stableSplitLabel(rule: GatewayRule) {
-  return rule.split_key_headers?.length ? rule.split_key_headers.join(', ') : '未开启';
+  return rule.split_key_headers?.length ? `按 ${rule.split_key_headers.join(', ')} 固定分流` : '按流量比例随机分配';
+}
+
+function splitHelpLabel() {
+  return (
+    <Space size={4}>
+      <span>稳定分流依据</span>
+      <Tooltip title="可选。配置后，同一个请求来源会稳定落到同一个目标，常用于灰度；为空时按流量比例随机分配。">
+        <QuestionCircleOutlined style={{ color: '#94a3b8' }} />
+      </Tooltip>
+    </Space>
+  );
+}
+
+function pathRewriteHelpLabel() {
+  return (
+    <Space size={4}>
+      <span>路径处理</span>
+      <Tooltip title="转发前是否去掉某段路径前缀，或把路径改写成另一个前缀。多数规则不需要配置。">
+        <QuestionCircleOutlined style={{ color: '#94a3b8' }} />
+      </Tooltip>
+    </Space>
+  );
+}
+
+function formatPathRewrite(target: GatewayTarget) {
+  const items = [];
+  if (target.strip_prefix) {
+    items.push(`去掉 ${target.strip_prefix}`);
+  }
+  if (target.rewrite_prefix) {
+    items.push(`改写为 ${target.rewrite_prefix}`);
+  }
+  return items.length ? items.join('，') : '不改路径';
+}
+
+function explainRuleReason(record: GatewayRuleExplain) {
+  switch (record.status) {
+    case 'winner':
+      return '按路径、泳道和优先级命中';
+    case 'shadowed':
+      return '也能匹配，但已有更靠前的规则命中';
+    case 'disabled':
+      return '规则已停用';
+    case 'request_lane_mismatch':
+      return '请求 x-lane 不符合该规则要求';
+    case 'path_prefix_mismatch':
+      return '路径前缀不匹配';
+    default:
+      return record.reason || '-';
+  }
+}
+
+function explainTargetSummary(targets?: GatewayExplainTarget[]) {
+  if (!targets?.length) {
+    return '无候选目标';
+  }
+  return targets
+    .map((target) => `${target.service}（${target.effective_lane || '默认泳道'}，${target.weight}%）`)
+    .join('；');
 }
 
 function pathMatchesPrefix(path: string, prefix: string) {
@@ -314,7 +376,7 @@ export default function GatewayRouting() {
       onOk: async () => {
         const trimmed = reason.trim();
         if (!trimmed) {
-          message.error('reason 必填');
+          message.error('操作原因必填');
           throw new Error('reason required');
         }
         await onConfirm(trimmed);
@@ -382,11 +444,11 @@ export default function GatewayRouting() {
     const values = await ruleForm.validateFields();
     const weightSum = values.targets.reduce((sum, target) => sum + Number(target.weight || 0), 0);
     if (weightSum !== 100) {
-      message.error(`targets weight 总和必须为 100，当前为 ${weightSum}`);
+      message.error(`流量比例总和必须为 100%，当前为 ${weightSum}%`);
       return;
     }
     if (!canCreateWithPreview(values)) {
-      message.error('新建规则前必须先在 Preview 面板预览覆盖该 path_prefix 的请求');
+      message.error('新建规则前必须先在预览面板验证覆盖该匹配路径的请求');
       return;
     }
 
@@ -463,22 +525,22 @@ export default function GatewayRouting() {
     }));
     const sum = weights.reduce((acc, target) => acc + target.weight, 0);
     if (sum !== 100) {
-      message.error(`targets weight 总和必须为 100，当前为 ${sum}`);
+      message.error(`流量比例总和必须为 100%，当前为 ${sum}%`);
       return;
     }
-    await setRuleWeights(selectedRule, weights, values.reason.trim(), '权重已更新');
+    await setRuleWeights(selectedRule, weights, values.reason.trim(), '流量比例已更新');
     setWeightsModalOpen(false);
   };
 
   const cutBackToProd = (rule: GatewayRule) => {
     const prodTargets = rule.targets.filter((target) => target.lane === 'prod');
     if (prodTargets.length !== 1) {
-      message.error('切回 prod 需要且只能有一个 lane=prod 的 target');
+      message.error('当前规则没有唯一的 prod 目标，无法一键切回 prod');
       return;
     }
     withReason(
       '切回 prod',
-      <Text type="secondary">会把 lane=prod 的 target 权重设为 100，其他 target 权重设为 0。</Text>,
+      <Text type="secondary">会把 prod 目标设为 100%，其他目标设为 0%。</Text>,
       async (reason) => {
         const weights = rule.targets.map((target) => ({
           service: target.service,
@@ -493,15 +555,15 @@ export default function GatewayRouting() {
   const toggleRule = (rule: GatewayRule) => {
     const action = rule.enabled ? 'disable' : 'enable';
     withReason(
-      rule.enabled ? '禁用规则' : '启用规则',
-      <Text type="secondary">{rule.enabled ? '禁用后 matcher 会跳过该规则。' : '启用后该规则会重新参与 matcher。'}</Text>,
+      rule.enabled ? '停用规则' : '启用规则',
+      <Text type="secondary">{rule.enabled ? '停用后，请求不会再命中这条规则。' : '启用后，这条规则会重新参与匹配。'}</Text>,
       async (reason) => {
         await runWrite(
           `${action}-${rule.name}`,
           async () => {
             await api.post(`/ops/gateway-rules/${encodeURIComponent(rule.name)}:${action}`, { reason });
           },
-          rule.enabled ? '规则已禁用' : '规则已启用',
+          rule.enabled ? '规则已停用' : '规则已启用',
         );
       },
     );
@@ -510,7 +572,7 @@ export default function GatewayRouting() {
   const deleteRule = (rule: GatewayRule) => {
     withReason(
       '删除规则',
-      <Text type="danger">删除会生成新的期望快照，历史快照仍可用于回滚。</Text>,
+      <Text type="danger">删除后仍可从历史快照回滚。</Text>,
       async (reason) => {
         await runWrite(
           `delete-${rule.name}`,
@@ -530,7 +592,7 @@ export default function GatewayRouting() {
         <Alert
           showIcon
           type="warning"
-          message="会把当前规则恢复为该快照内容，并生成一个新的 snapshot_version。不是把版本号倒回去。"
+          message="会把当前规则恢复为该快照内容，并记录一条新的回滚操作。"
         />
       ),
       async (reason) => {
@@ -570,59 +632,54 @@ export default function GatewayRouting() {
 
   const targetColumns: ColumnsType<GatewayTarget> = [
     {
-      title: 'service',
+      title: '服务',
       dataIndex: 'service',
       render: (value: string) => <Text strong>{value}</Text>,
     },
     {
-      title: 'lane',
+      title: '目标泳道',
       dataIndex: 'lane',
       render: (value: string) => <Tag bordered={false}>{targetLaneLabel(value)}</Tag>,
     },
     {
-      title: 'port',
+      title: '端口',
       dataIndex: 'port',
       width: 80,
     },
     {
-      title: 'weight',
+      title: '流量比例',
       dataIndex: 'weight',
       width: 90,
-      render: (value: number) => <Text strong>{value}</Text>,
+      render: (value: number) => <Text strong>{value}%</Text>,
     },
     {
-      title: 'strip / rewrite',
+      title: pathRewriteHelpLabel(),
       key: 'rewrite',
-      render: (_: unknown, target) => (
-        <Space direction="vertical" size={2}>
-          <Text type="secondary" style={{ fontSize: 12 }}>strip: {target.strip_prefix || '-'}</Text>
-          <Text type="secondary" style={{ fontSize: 12 }}>rewrite: {target.rewrite_prefix || '-'}</Text>
-        </Space>
-      ),
+      render: (_: unknown, target) => <Text type="secondary">{formatPathRewrite(target)}</Text>,
     },
   ];
 
   const candidateColumns: ColumnsType<GatewayExplainTarget> = [
     {
-      title: 'service',
+      title: '服务',
       dataIndex: 'service',
       render: (value: string) => <Text strong>{value}</Text>,
     },
     {
-      title: 'lane',
+      title: '配置泳道',
       dataIndex: 'lane',
       render: (value: string) => <Tag bordered={false}>{targetLaneLabel(value)}</Tag>,
     },
     {
-      title: 'effective lane',
+      title: '实际泳道',
       dataIndex: 'effective_lane',
-      render: (value: string) => <Tag color={value ? 'blue' : 'default'} bordered={false}>{value || '空'}</Tag>,
+      render: (value: string) => <Tag color={value ? 'blue' : 'default'} bordered={false}>{value || '默认泳道'}</Tag>,
     },
     {
-      title: 'weight',
+      title: '流量比例',
       dataIndex: 'weight',
       width: 90,
-      render: (value: number) => <Text strong>{value}</Text>,
+      render: (value: number) => <Text strong>{value}%</Text>,
     },
   ];
 
@@ -649,7 +706,7 @@ export default function GatewayRouting() {
     {
       title: '原因',
       dataIndex: 'reason',
-      render: (value: string) => <Text type="secondary">{value}</Text>,
+      render: (_: string, record) => <Text type="secondary">{explainRuleReason(record)}</Text>,
     },
   ];
 
@@ -677,7 +734,7 @@ export default function GatewayRouting() {
       render: (value: string) => value || <Text type="secondary">-</Text>,
     },
     {
-      title: 'created_by',
+      title: '创建人',
       dataIndex: 'created_by',
       width: 120,
       render: (value: string) => <Tag bordered={false}>{value}</Tag>,
@@ -717,7 +774,7 @@ export default function GatewayRouting() {
         <div>
           <h1 className="page-title">网关调度</h1>
           <Text type="secondary" style={{ marginTop: 8, display: 'block' }}>
-            api-gateway 动态路由规则、命中预览与快照回滚
+            管理入口路径、流量比例和快照回滚
           </Text>
         </div>
         <Space wrap>
@@ -733,35 +790,28 @@ export default function GatewayRouting() {
         </Space>
       </div>
 
-      <Alert
-        showIcon
-        type="info"
-        className="gateway-alert"
-        message="这里展示的是 paas-engine 期望配置，不是 gateway 实例运行状态。"
-      />
-
       <Row gutter={[16, 16]} className="gateway-stats">
         <Col xs={24} sm={12} lg={6}>
           <Card bordered={false} className="content-card" bodyStyle={{ padding: '18px 20px' }}>
-            <Statistic title="期望快照" value={`v${snapshot.version || 0}`} prefix={<HistoryOutlined />} />
+            <Statistic title="当前快照" value={`v${snapshot.version || 0}`} prefix={<HistoryOutlined />} />
           </Card>
         </Col>
         <Col xs={24} sm={12} lg={6}>
           <Card bordered={false} className="content-card" bodyStyle={{ padding: '18px 20px' }}>
-            <Statistic title="规则总数" value={rules.length} suffix={`启用 ${enabledCount}`} />
+            <Statistic title="规则状态" value={`${rules.length} 条`} />
+            <Text type="secondary" style={{ display: 'block', marginTop: 4 }}>
+              启用 {enabledCount} 条，停用 {disabledCount} 条
+            </Text>
           </Card>
         </Col>
         <Col xs={24} sm={12} lg={6}>
           <Card bordered={false} className="content-card" bodyStyle={{ padding: '18px 20px' }}>
-            <Statistic title="禁用规则" value={disabledCount} valueStyle={{ color: disabledCount ? '#dc2626' : undefined }} />
+            <Statistic title="停用规则" value={`${disabledCount} 条`} valueStyle={{ color: disabledCount ? '#dc2626' : undefined }} />
           </Card>
         </Col>
         <Col xs={24} sm={12} lg={6}>
           <Card bordered={false} className="content-card" bodyStyle={{ padding: '18px 20px' }}>
             <Statistic title="最近变更" value={latestSnapshot ? formatTime(latestSnapshot.created_at) : '-'} />
-            <Text type="secondary" ellipsis style={{ display: 'block', marginTop: 4 }}>
-              {latestSnapshot?.reason || '暂无快照原因'}
-            </Text>
           </Card>
         </Col>
       </Row>
@@ -786,15 +836,14 @@ export default function GatewayRouting() {
                   <div className="gateway-rule-line">
                     <Space>
                       <Tag bordered={false} color={rule.enabled ? 'green' : 'red'}>
-                        {rule.enabled ? '启用' : '禁用'}
+                        {rule.enabled ? '启用' : '停用'}
                       </Tag>
                       <Text strong>{rule.name}</Text>
                     </Space>
-                    <Text type="secondary">P{rule.priority}</Text>
                   </div>
                   <Text code className="gateway-rule-path">{rule.path_prefix}</Text>
                   <div className="gateway-rule-meta">
-                    <Text type="secondary">lane: {requestLaneLabel(rule.request_lane)}</Text>
+                    <Text type="secondary">匹配泳道：{requestLaneLabel(rule.request_lane)} · 优先级 {rule.priority}</Text>
                     <Text type="secondary">{targetSummary(rule.targets)}</Text>
                   </div>
                 </button>
@@ -809,48 +858,70 @@ export default function GatewayRouting() {
               <div className="gateway-panel-header">
                 <div>
                   <Title level={4}>{selectedRule.name}</Title>
-                  <Text type="secondary">version {selectedRule.version} · 更新 {formatTime(selectedRule.updated_at)}</Text>
+                  <Text type="secondary">规则版本 {selectedRule.version} · 更新 {formatTime(selectedRule.updated_at)}</Text>
                 </div>
                 <Space wrap>
                   <Button icon={<EditOutlined />} onClick={() => openEditRule(selectedRule)}>
                     编辑
                   </Button>
                   <Button icon={<SwapOutlined />} onClick={() => openWeights(selectedRule)}>
-                    调权
+                    调整流量
                   </Button>
-                  <Button icon={<RetweetOutlined />} onClick={() => cutBackToProd(selectedRule)}>
-                    切回 prod
-                  </Button>
-                  <Button
-                    danger={selectedRule.enabled}
-                    icon={selectedRule.enabled ? <PauseCircleOutlined /> : <PlayCircleOutlined />}
-                    loading={actionLoading === `${selectedRule.enabled ? 'disable' : 'enable'}-${selectedRule.name}`}
-                    onClick={() => toggleRule(selectedRule)}
+                  <Dropdown
+                    menu={{
+                      items: [
+                        {
+                          key: 'cut-prod',
+                          icon: <RetweetOutlined />,
+                          label: '切回 prod',
+                        },
+                        {
+                          key: 'toggle',
+                          icon: selectedRule.enabled ? <PauseCircleOutlined /> : <PlayCircleOutlined />,
+                          label: selectedRule.enabled ? '停用规则' : '启用规则',
+                        },
+                        {
+                          type: 'divider',
+                        },
+                        {
+                          key: 'delete',
+                          danger: true,
+                          icon: <DeleteOutlined />,
+                          label: '删除规则',
+                        },
+                      ],
+                      onClick: ({ key }) => {
+                        if (key === 'cut-prod') {
+                          cutBackToProd(selectedRule);
+                        } else if (key === 'toggle') {
+                          toggleRule(selectedRule);
+                        } else if (key === 'delete') {
+                          deleteRule(selectedRule);
+                        }
+                      },
+                    }}
                   >
-                    {selectedRule.enabled ? '禁用' : '启用'}
-                  </Button>
-                  <Button danger icon={<DeleteOutlined />} onClick={() => deleteRule(selectedRule)}>
-                    删除
-                  </Button>
+                    <Button icon={<MoreOutlined />}>更多操作</Button>
+                  </Dropdown>
                 </Space>
               </div>
 
               <Descriptions bordered size="small" column={{ xs: 1, md: 2 }}>
-                <Descriptions.Item label="enabled">
+                <Descriptions.Item label="状态">
                   <Tag bordered={false} color={selectedRule.enabled ? 'green' : 'red'}>
-                    {selectedRule.enabled ? 'true' : 'false'}
+                    {selectedRule.enabled ? '启用中' : '已停用'}
                   </Tag>
                 </Descriptions.Item>
-                <Descriptions.Item label="priority">{selectedRule.priority}</Descriptions.Item>
-                <Descriptions.Item label="path_prefix">
+                <Descriptions.Item label="优先级">{selectedRule.priority}</Descriptions.Item>
+                <Descriptions.Item label="匹配路径">
                   <Text code>{selectedRule.path_prefix}</Text>
                 </Descriptions.Item>
-                <Descriptions.Item label="request_lane">{requestLaneLabel(selectedRule.request_lane)}</Descriptions.Item>
-                <Descriptions.Item label="split_key_headers">{stableSplitLabel(selectedRule)}</Descriptions.Item>
-                <Descriptions.Item label="created_at">{fullTime(selectedRule.created_at)}</Descriptions.Item>
+                <Descriptions.Item label="匹配泳道">{requestLaneLabel(selectedRule.request_lane)}</Descriptions.Item>
+                <Descriptions.Item label={splitHelpLabel()}>{stableSplitLabel(selectedRule)}</Descriptions.Item>
+                <Descriptions.Item label="创建时间">{fullTime(selectedRule.created_at)}</Descriptions.Item>
               </Descriptions>
 
-              <Divider orientation="left">targets</Divider>
+              <Divider orientation="left">转发目标</Divider>
               <Table
                 rowKey={(target) => `${target.service}:${target.lane}:${target.port}`}
                 columns={targetColumns}
@@ -868,8 +939,8 @@ export default function GatewayRouting() {
       <section className="gateway-panel gateway-preview-panel">
         <div className="gateway-panel-header">
           <div>
-            <Title level={5}>Preview</Title>
-            <Text type="secondary">输入 path + 可选 x-lane，预览当前期望规则会如何匹配。</Text>
+            <Title level={5}>预览</Title>
+            <Text type="secondary">输入请求路径和可选泳道，查看当前规则会如何匹配。</Text>
           </div>
         </div>
         <Form
@@ -881,15 +952,15 @@ export default function GatewayRouting() {
           <Form.Item
             name="path"
             rules={[
-              { required: true, message: '请输入 path' },
-              { pattern: /^\//, message: 'path 必须以 / 开头' },
+              { required: true, message: '请输入请求路径' },
+              { pattern: /^\//, message: '请求路径必须以 / 开头' },
             ]}
             style={{ flex: 1, minWidth: 260 }}
           >
             <Input prefix={<AimOutlined />} placeholder="/api/agent/health" />
           </Form.Item>
           <Form.Item name="x_lane" style={{ width: 220 }}>
-            <Input placeholder="x-lane 空=未指定" />
+            <Input placeholder="请求泳道，不填=未指定" />
           </Form.Item>
           <Form.Item>
             <Button type="primary" loading={actionLoading === 'preview'} onClick={preview}>
@@ -910,8 +981,8 @@ export default function GatewayRouting() {
               }
               description={
                 explainResult.matched
-                  ? `${explainResult.winning_reason || ''}；${explainResult.stable_split ? `稳定分流：${explainResult.split_key_headers?.join(', ')}` : '未开启稳定分流'}`
-                  : '请求会落入 api-gateway 的未匹配处理。'
+                  ? `候选目标：${explainTargetSummary(explainResult.candidate_targets)}；${explainResult.stable_split ? `稳定分流依据：${explainResult.split_key_headers?.join(', ')}` : '按流量比例随机分配'}`
+                  : '这类请求不会被当前规则处理。'
               }
             />
             {explainResult.candidate_targets?.length ? (
@@ -938,7 +1009,7 @@ export default function GatewayRouting() {
         <div className="gateway-panel-header">
           <div>
             <Title level={5}>快照历史</Title>
-            <Text type="secondary">最近 20 条期望配置快照。</Text>
+            <Text type="secondary">最近 20 条快照历史。</Text>
           </div>
         </div>
         <Table
@@ -970,7 +1041,7 @@ export default function GatewayRouting() {
             <Col xs={24} md={12}>
               <Form.Item
                 name="name"
-                label="name"
+                label="规则名"
                 rules={[
                   { required: true, message: '请输入规则名' },
                   { pattern: /^[a-z0-9][a-z0-9-]*$/, message: '仅支持小写字母、数字和 -' },
@@ -980,12 +1051,12 @@ export default function GatewayRouting() {
               </Form.Item>
             </Col>
             <Col xs={12} md={6}>
-              <Form.Item name="enabled" label="enabled" valuePropName="checked">
+              <Form.Item name="enabled" label="状态" valuePropName="checked">
                 <Switch checkedChildren="启用" unCheckedChildren="禁用" />
               </Form.Item>
             </Col>
             <Col xs={12} md={6}>
-              <Form.Item name="priority" label="priority" rules={[{ required: true, message: '请输入优先级' }]}>
+              <Form.Item name="priority" label="优先级" rules={[{ required: true, message: '请输入优先级' }]}>
                 <InputNumber min={0} precision={0} style={{ width: '100%' }} />
               </Form.Item>
             </Col>
@@ -994,26 +1065,26 @@ export default function GatewayRouting() {
             <Col xs={24} md={12}>
               <Form.Item
                 name="path_prefix"
-                label="path_prefix"
+                label="匹配路径"
                 rules={[
-                  { required: true, message: '请输入 path_prefix' },
-                  { pattern: /^\/.*\/$/, message: 'path_prefix 必须以 / 开头并以 / 结尾' },
+                  { required: true, message: '请输入匹配路径' },
+                  { pattern: /^\/.*\/$/, message: '匹配路径必须以 / 开头并以 / 结尾' },
                 ]}
               >
                 <Input placeholder="/api/agent/" />
               </Form.Item>
             </Col>
             <Col xs={24} md={12}>
-              <Form.Item name="request_lane" label="request_lane">
-                <Input placeholder="空=不限制请求 x-lane" />
+              <Form.Item name="request_lane" label="匹配泳道">
+                <Input placeholder="不填=不限制请求 x-lane" />
               </Form.Item>
             </Col>
           </Row>
-          <Form.Item name="split_key_headers" label="split_key_headers">
+          <Form.Item name="split_key_headers" label={splitHelpLabel()}>
             <Select mode="tags" placeholder="例如 x-user-id" tokenSeparators={[',']} />
           </Form.Item>
 
-          <Divider orientation="left">targets</Divider>
+          <Divider orientation="left">转发目标</Divider>
           <Form.List name="targets">
             {(fields, { add, remove }) => (
               <Space direction="vertical" size={12} style={{ width: '100%' }}>
@@ -1024,23 +1095,23 @@ export default function GatewayRouting() {
                         <Form.Item
                           {...field}
                           name={[field.name, 'service']}
-                          label="service"
-                          rules={[{ required: true, message: 'service 必填' }]}
+                          label="服务"
+                          rules={[{ required: true, message: '服务必填' }]}
                         >
                           <Input placeholder="agent-service" />
                         </Form.Item>
                       </Col>
                       <Col xs={24} md={5}>
-                        <Form.Item {...field} name={[field.name, 'lane']} label="lane">
-                          <Input placeholder="空=跟随请求" />
+                        <Form.Item {...field} name={[field.name, 'lane']} label="目标泳道">
+                          <Input placeholder="不填=使用请求里的 x-lane" />
                         </Form.Item>
                       </Col>
                       <Col xs={12} md={4}>
                         <Form.Item
                           {...field}
                           name={[field.name, 'port']}
-                          label="port"
-                          rules={[{ required: true, message: 'port 必填' }]}
+                          label="端口"
+                          rules={[{ required: true, message: '端口必填' }]}
                         >
                           <InputNumber min={1} precision={0} style={{ width: '100%' }} />
                         </Form.Item>
@@ -1049,8 +1120,8 @@ export default function GatewayRouting() {
                         <Form.Item
                           {...field}
                           name={[field.name, 'weight']}
-                          label="weight"
-                          rules={[{ required: true, message: 'weight 必填' }]}
+                          label="流量比例"
+                          rules={[{ required: true, message: '流量比例必填' }]}
                         >
                           <InputNumber min={0} max={100} precision={0} style={{ width: '100%' }} />
                         </Form.Item>
@@ -1065,12 +1136,12 @@ export default function GatewayRouting() {
                     </Row>
                     <Row gutter={12}>
                       <Col xs={24} md={12}>
-                        <Form.Item {...field} name={[field.name, 'strip_prefix']} label="strip_prefix">
+                        <Form.Item {...field} name={[field.name, 'strip_prefix']} label="去掉路径前缀">
                           <Input placeholder="可选" />
                         </Form.Item>
                       </Col>
                       <Col xs={24} md={12}>
-                        <Form.Item {...field} name={[field.name, 'rewrite_prefix']} label="rewrite_prefix">
+                        <Form.Item {...field} name={[field.name, 'rewrite_prefix']} label="改写路径前缀">
                           <Input placeholder="可选" />
                         </Form.Item>
                       </Col>
@@ -1078,26 +1149,26 @@ export default function GatewayRouting() {
                   </div>
                 ))}
                 <Button block onClick={() => add({ service: '', lane: '', port: 80, weight: 0 })}>
-                  添加 target
+                  添加转发目标
                 </Button>
               </Space>
             )}
           </Form.List>
 
           <Divider />
-          <Form.Item name="reason" label="reason" rules={[{ required: true, whitespace: true, message: 'reason 必填' }]}>
+          <Form.Item name="reason" label="变更原因" rules={[{ required: true, whitespace: true, message: '变更原因必填' }]}>
             <Input.TextArea autoSize={{ minRows: 3, maxRows: 5 }} placeholder="填写本次规则变更原因" />
           </Form.Item>
         </Form>
       </Modal>
 
       <Modal
-        title={selectedRule ? `调权 ${selectedRule.name}` : '调权'}
+        title={selectedRule ? `调整流量 ${selectedRule.name}` : '调整流量'}
         open={weightsModalOpen}
         onOk={saveWeights}
         onCancel={() => setWeightsModalOpen(false)}
         confirmLoading={actionLoading?.startsWith('weights-')}
-        okText="保存权重"
+        okText="保存比例"
         cancelText="取消"
         width={640}
         destroyOnClose
@@ -1109,11 +1180,11 @@ export default function GatewayRouting() {
                 <div key={`${target.service}:${target.lane}`} className="gateway-weight-row">
                   <div>
                     <Text strong>{targetIdentity(target)}</Text>
-                    <Text type="secondary" style={{ display: 'block', fontSize: 12 }}>port {target.port}</Text>
+                    <Text type="secondary" style={{ display: 'block', fontSize: 12 }}>端口 {target.port}</Text>
                   </div>
                   <Form.Item
                     name={['weights', index, 'weight']}
-                    rules={[{ required: true, message: 'weight 必填' }]}
+                    rules={[{ required: true, message: '流量比例必填' }]}
                     style={{ margin: 0 }}
                   >
                     <InputNumber min={0} max={100} precision={0} addonAfter="%" />
@@ -1123,11 +1194,11 @@ export default function GatewayRouting() {
             </Space>
             <Form.Item
               name="reason"
-              label="reason"
-              rules={[{ required: true, whitespace: true, message: 'reason 必填' }]}
+              label="变更原因"
+              rules={[{ required: true, whitespace: true, message: '变更原因必填' }]}
               style={{ marginTop: 20 }}
             >
-              <Input.TextArea autoSize={{ minRows: 3, maxRows: 5 }} placeholder="填写本次调权原因" />
+              <Input.TextArea autoSize={{ minRows: 3, maxRows: 5 }} placeholder="填写本次调整原因" />
             </Form.Item>
           </Form>
         )}
@@ -1142,10 +1213,10 @@ export default function GatewayRouting() {
         {snapshotDrawer && (
           <Space direction="vertical" size={16} style={{ width: '100%' }}>
             <Descriptions bordered size="small" column={1}>
-              <Descriptions.Item label="created_at">{fullTime(snapshotDrawer.created_at)}</Descriptions.Item>
-              <Descriptions.Item label="created_by">{snapshotDrawer.created_by}</Descriptions.Item>
-              <Descriptions.Item label="reason">{snapshotDrawer.reason || '-'}</Descriptions.Item>
-              <Descriptions.Item label="rules_count">{snapshotDrawer.rules.length}</Descriptions.Item>
+              <Descriptions.Item label="创建时间">{fullTime(snapshotDrawer.created_at)}</Descriptions.Item>
+              <Descriptions.Item label="创建人">{snapshotDrawer.created_by}</Descriptions.Item>
+              <Descriptions.Item label="原因">{snapshotDrawer.reason || '-'}</Descriptions.Item>
+              <Descriptions.Item label="规则数">{snapshotDrawer.rules.length}</Descriptions.Item>
             </Descriptions>
             <pre className="json-preview">{JSON.stringify(snapshotDrawer.rules, null, 2)}</pre>
           </Space>

--- a/apps/monitor-dashboard-web/src/pages/GatewayRouting.tsx
+++ b/apps/monitor-dashboard-web/src/pages/GatewayRouting.tsx
@@ -1,0 +1,1156 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import type { ReactNode } from 'react';
+import {
+  Alert,
+  Button,
+  Card,
+  Col,
+  Descriptions,
+  Divider,
+  Drawer,
+  Empty,
+  Form,
+  Input,
+  InputNumber,
+  Modal,
+  Row,
+  Select,
+  Space,
+  Statistic,
+  Switch,
+  Table,
+  Tag,
+  Tooltip,
+  Typography,
+  message,
+} from 'antd';
+import type { ColumnsType } from 'antd/es/table';
+import {
+  AimOutlined,
+  CheckCircleOutlined,
+  DeleteOutlined,
+  EditOutlined,
+  EyeOutlined,
+  HistoryOutlined,
+  PauseCircleOutlined,
+  PlayCircleOutlined,
+  ReloadOutlined,
+  RetweetOutlined,
+  RollbackOutlined,
+  SafetyOutlined,
+  SaveOutlined,
+  SwapOutlined,
+} from '@ant-design/icons';
+import dayjs from 'dayjs';
+import { useNavigate } from 'react-router-dom';
+import { api, getLane } from '../api/client';
+
+const { Text, Title } = Typography;
+
+interface GatewayTarget {
+  service: string;
+  lane: string;
+  port: number;
+  weight: number;
+  strip_prefix?: string;
+  rewrite_prefix?: string;
+}
+
+interface GatewayMatch {
+  path_prefix: string;
+  request_lane?: string;
+  method?: string;
+  headers?: Record<string, string>;
+  query?: Record<string, string>;
+  cookies?: Record<string, string>;
+}
+
+interface GatewayRule {
+  name: string;
+  enabled: boolean;
+  priority: number;
+  path_prefix: string;
+  request_lane?: string;
+  match: GatewayMatch;
+  targets: GatewayTarget[];
+  split_key_headers?: string[];
+  created_at: string;
+  updated_at: string;
+  version: number;
+  snapshot_version?: number;
+}
+
+interface GatewaySnapshot {
+  version: number;
+  updated_at: string;
+  rules: GatewayRule[];
+}
+
+interface GatewayRuleSnapshot {
+  snapshot_version: number;
+  rules: GatewayRule[];
+  created_by: string;
+  reason: string;
+  created_at: string;
+}
+
+interface GatewayExplainTarget {
+  service: string;
+  lane: string;
+  port: number;
+  weight: number;
+  effective_lane: string;
+}
+
+interface GatewayRuleExplain {
+  name: string;
+  priority: number;
+  path_prefix: string;
+  request_lane?: string;
+  enabled: boolean;
+  status: string;
+  reason: string;
+}
+
+interface GatewayExplainResult {
+  path: string;
+  request_lane?: string;
+  matched: boolean;
+  winning_rule?: string;
+  winning_reason?: string;
+  would_forward: boolean;
+  would_redirect: boolean;
+  stable_split: boolean;
+  split_key_headers?: string[];
+  candidate_targets?: GatewayExplainTarget[];
+  effective_lane_note?: string;
+  rules: GatewayRuleExplain[];
+}
+
+interface RuleFormValues {
+  name: string;
+  enabled: boolean;
+  priority: number;
+  path_prefix: string;
+  request_lane?: string;
+  split_key_headers?: string[];
+  targets: GatewayTarget[];
+  reason: string;
+}
+
+interface WeightsFormValues {
+  reason: string;
+  weights: Array<{ weight: number }>;
+}
+
+interface PreviewFormValues {
+  path: string;
+  x_lane?: string;
+}
+
+const emptySnapshot: GatewaySnapshot = {
+  version: 0,
+  updated_at: '',
+  rules: [],
+};
+
+const statusMeta: Record<string, { label: string; color: string }> = {
+  winner: { label: '命中', color: 'green' },
+  shadowed: { label: '被遮挡', color: 'gold' },
+  disabled: { label: '已禁用', color: 'red' },
+  request_lane_mismatch: { label: '泳道不匹配', color: 'blue' },
+  path_prefix_mismatch: { label: '路径不匹配', color: 'default' },
+};
+
+function requestLaneLabel(lane?: string) {
+  return lane ? lane : '跟随请求 x-lane';
+}
+
+function targetLaneLabel(lane?: string) {
+  return lane ? lane : '跟随请求';
+}
+
+function formatTime(value?: string) {
+  if (!value || value.startsWith('0001-')) {
+    return '-';
+  }
+  const parsed = dayjs(value);
+  return parsed.isValid() ? parsed.format('MM-DD HH:mm:ss') : '-';
+}
+
+function fullTime(value?: string) {
+  if (!value || value.startsWith('0001-')) {
+    return '-';
+  }
+  const parsed = dayjs(value);
+  return parsed.isValid() ? parsed.format('YYYY-MM-DD HH:mm:ss') : '-';
+}
+
+function getErrorMessage(error: unknown) {
+  const responseData = (error as { response?: { data?: { message?: string; error?: string } } })?.response?.data;
+  return responseData?.message || responseData?.error || (error instanceof Error ? error.message : '操作失败');
+}
+
+function targetIdentity(target: Pick<GatewayTarget, 'service' | 'lane'>) {
+  return `${target.service} / ${targetLaneLabel(target.lane)}`;
+}
+
+function targetSummary(targets: GatewayTarget[]) {
+  if (targets.length === 0) {
+    return '无 target';
+  }
+  return targets.map((target) => `${targetIdentity(target)} ${target.weight}`).join(' · ');
+}
+
+function stableSplitLabel(rule: GatewayRule) {
+  return rule.split_key_headers?.length ? rule.split_key_headers.join(', ') : '未开启';
+}
+
+function pathMatchesPrefix(path: string, prefix: string) {
+  if (path.startsWith(prefix)) {
+    return true;
+  }
+  return prefix.endsWith('/') && path === prefix.slice(0, -1);
+}
+
+function normalizeOptional(value?: string) {
+  return value?.trim() || '';
+}
+
+export default function GatewayRouting() {
+  const navigate = useNavigate();
+  const [rules, setRules] = useState<GatewayRule[]>([]);
+  const [snapshot, setSnapshot] = useState<GatewaySnapshot>(emptySnapshot);
+  const [snapshots, setSnapshots] = useState<GatewayRuleSnapshot[]>([]);
+  const [selectedRuleName, setSelectedRuleName] = useState<string>();
+  const [loading, setLoading] = useState(true);
+  const [actionLoading, setActionLoading] = useState<string>();
+  const [ruleModalOpen, setRuleModalOpen] = useState(false);
+  const [weightsModalOpen, setWeightsModalOpen] = useState(false);
+  const [editingRuleName, setEditingRuleName] = useState<string | null>(null);
+  const [snapshotDrawer, setSnapshotDrawer] = useState<GatewayRuleSnapshot | null>(null);
+  const [explainResult, setExplainResult] = useState<GatewayExplainResult | null>(null);
+  const [previewProbe, setPreviewProbe] = useState<{ path: string; xLane: string } | null>(null);
+  const [ruleForm] = Form.useForm<RuleFormValues>();
+  const [weightsForm] = Form.useForm<WeightsFormValues>();
+  const [previewForm] = Form.useForm<PreviewFormValues>();
+
+  const fetchData = useCallback(async () => {
+    setLoading(true);
+    try {
+      const [rulesRes, snapshotRes, snapshotsRes] = await Promise.all([
+        api.get<GatewayRule[]>('/ops/gateway-rules'),
+        api.get<GatewaySnapshot>('/ops/gateway-rules/snapshot'),
+        api.get<GatewayRuleSnapshot[]>('/ops/gateway-rules/snapshots', { params: { limit: 20 } }),
+      ]);
+      if (!Array.isArray(rulesRes.data)) {
+        throw new Error('gateway-rules list response must be an array');
+      }
+      if (!Array.isArray(snapshotRes.data.rules)) {
+        throw new Error('gateway-rules snapshot response must contain rules');
+      }
+      if (!Array.isArray(snapshotsRes.data)) {
+        throw new Error('gateway-rules snapshots response must be an array');
+      }
+      setRules(rulesRes.data);
+      setSnapshot(snapshotRes.data);
+      setSnapshots(snapshotsRes.data);
+      setSelectedRuleName((current) => {
+        if (current && rulesRes.data.some((rule) => rule.name === current)) {
+          return current;
+        }
+        return rulesRes.data[0]?.name;
+      });
+    } catch (error) {
+      message.error(getErrorMessage(error));
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchData();
+  }, [fetchData]);
+
+  const selectedRule = useMemo(() => {
+    if (!selectedRuleName) {
+      return rules[0] ?? null;
+    }
+    return rules.find((rule) => rule.name === selectedRuleName) ?? rules[0] ?? null;
+  }, [rules, selectedRuleName]);
+
+  const latestSnapshot = snapshots[0];
+  const enabledCount = rules.filter((rule) => rule.enabled).length;
+  const disabledCount = rules.length - enabledCount;
+
+  const openAuditLogs = () => {
+    const params = new URLSearchParams({ action: 'ops.gateway-rules' });
+    const lane = getLane();
+    if (lane) {
+      params.set('x-lane', lane);
+    }
+    navigate(`/audit-logs?${params.toString()}`);
+  };
+
+  const withReason = (title: string, content: ReactNode, onConfirm: (reason: string) => Promise<void>) => {
+    let reason = '';
+    Modal.confirm({
+      title,
+      content: (
+        <Space direction="vertical" size={12} style={{ width: '100%' }}>
+          {content}
+          <Input.TextArea
+            autoSize={{ minRows: 3, maxRows: 5 }}
+            placeholder="填写本次操作原因"
+            onChange={(event) => {
+              reason = event.target.value;
+            }}
+          />
+        </Space>
+      ),
+      okText: '确认执行',
+      cancelText: '取消',
+      width: 520,
+      onOk: async () => {
+        const trimmed = reason.trim();
+        if (!trimmed) {
+          message.error('reason 必填');
+          throw new Error('reason required');
+        }
+        await onConfirm(trimmed);
+      },
+    });
+  };
+
+  const runWrite = async (key: string, operation: () => Promise<void>, successText: string) => {
+    setActionLoading(key);
+    try {
+      await operation();
+      message.success(successText);
+      await fetchData();
+    } catch (error) {
+      message.error(getErrorMessage(error));
+      throw error;
+    } finally {
+      setActionLoading(undefined);
+    }
+  };
+
+  const openCreateRule = () => {
+    setEditingRuleName(null);
+    ruleForm.resetFields();
+    ruleForm.setFieldsValue({
+      enabled: true,
+      priority: 100,
+      path_prefix: '/',
+      request_lane: '',
+      split_key_headers: [],
+      targets: [{ service: '', lane: 'prod', port: 80, weight: 100 }],
+      reason: '',
+    });
+    setRuleModalOpen(true);
+  };
+
+  const openEditRule = (rule: GatewayRule) => {
+    setEditingRuleName(rule.name);
+    ruleForm.setFieldsValue({
+      name: rule.name,
+      enabled: rule.enabled,
+      priority: rule.priority,
+      path_prefix: rule.path_prefix || rule.match?.path_prefix,
+      request_lane: rule.request_lane || rule.match?.request_lane || '',
+      split_key_headers: rule.split_key_headers || [],
+      targets: rule.targets.map((target) => ({ ...target })),
+      reason: '',
+    });
+    setRuleModalOpen(true);
+  };
+
+  const canCreateWithPreview = (values: RuleFormValues) => {
+    if (editingRuleName) {
+      return true;
+    }
+    if (!previewProbe) {
+      return false;
+    }
+    const pathPrefix = values.path_prefix.trim();
+    const requestLane = normalizeOptional(values.request_lane);
+    return pathMatchesPrefix(previewProbe.path, pathPrefix) && (!requestLane || previewProbe.xLane === requestLane);
+  };
+
+  const saveRule = async () => {
+    const values = await ruleForm.validateFields();
+    const weightSum = values.targets.reduce((sum, target) => sum + Number(target.weight || 0), 0);
+    if (weightSum !== 100) {
+      message.error(`targets weight 总和必须为 100，当前为 ${weightSum}`);
+      return;
+    }
+    if (!canCreateWithPreview(values)) {
+      message.error('新建规则前必须先在 Preview 面板预览覆盖该 path_prefix 的请求');
+      return;
+    }
+
+    const pathPrefix = values.path_prefix.trim();
+    const requestLane = normalizeOptional(values.request_lane);
+    const payload = {
+      enabled: values.enabled,
+      priority: Number(values.priority),
+      path_prefix: pathPrefix,
+      request_lane: requestLane,
+      match: {
+        path_prefix: pathPrefix,
+        request_lane: requestLane,
+      },
+      split_key_headers: values.split_key_headers || [],
+      targets: values.targets.map((target) => ({
+        service: target.service.trim(),
+        lane: normalizeOptional(target.lane),
+        port: Number(target.port),
+        weight: Number(target.weight),
+        strip_prefix: normalizeOptional(target.strip_prefix),
+        rewrite_prefix: normalizeOptional(target.rewrite_prefix),
+      })),
+      reason: values.reason.trim(),
+    };
+
+    await runWrite(
+      `save-${values.name}`,
+      async () => {
+        await api.put(`/ops/gateway-rules/${encodeURIComponent(values.name)}`, payload);
+      },
+      editingRuleName ? '规则已更新' : '规则已创建',
+    );
+    setRuleModalOpen(false);
+    setEditingRuleName(null);
+  };
+
+  const openWeights = (rule: GatewayRule) => {
+    weightsForm.resetFields();
+    weightsForm.setFieldsValue({
+      reason: '',
+      weights: rule.targets.map((target) => ({ weight: target.weight })),
+    });
+    setWeightsModalOpen(true);
+  };
+
+  const setRuleWeights = async (
+    rule: GatewayRule,
+    weights: Array<{ service: string; lane: string; weight: number }>,
+    reason: string,
+    successText: string,
+  ) => {
+    await runWrite(
+      `weights-${rule.name}`,
+      async () => {
+        await api.post(`/ops/gateway-rules/${encodeURIComponent(rule.name)}:set-weights`, {
+          reason,
+          weights,
+        });
+      },
+      successText,
+    );
+  };
+
+  const saveWeights = async () => {
+    if (!selectedRule) {
+      return;
+    }
+    const values = await weightsForm.validateFields();
+    const weights = selectedRule.targets.map((target, index) => ({
+      service: target.service,
+      lane: target.lane,
+      weight: Number(values.weights[index]?.weight ?? 0),
+    }));
+    const sum = weights.reduce((acc, target) => acc + target.weight, 0);
+    if (sum !== 100) {
+      message.error(`targets weight 总和必须为 100，当前为 ${sum}`);
+      return;
+    }
+    await setRuleWeights(selectedRule, weights, values.reason.trim(), '权重已更新');
+    setWeightsModalOpen(false);
+  };
+
+  const cutBackToProd = (rule: GatewayRule) => {
+    const prodTargets = rule.targets.filter((target) => target.lane === 'prod');
+    if (prodTargets.length !== 1) {
+      message.error('切回 prod 需要且只能有一个 lane=prod 的 target');
+      return;
+    }
+    withReason(
+      '切回 prod',
+      <Text type="secondary">会把 lane=prod 的 target 权重设为 100，其他 target 权重设为 0。</Text>,
+      async (reason) => {
+        const weights = rule.targets.map((target) => ({
+          service: target.service,
+          lane: target.lane,
+          weight: target.lane === 'prod' ? 100 : 0,
+        }));
+        await setRuleWeights(rule, weights, reason, '已切回 prod');
+      },
+    );
+  };
+
+  const toggleRule = (rule: GatewayRule) => {
+    const action = rule.enabled ? 'disable' : 'enable';
+    withReason(
+      rule.enabled ? '禁用规则' : '启用规则',
+      <Text type="secondary">{rule.enabled ? '禁用后 matcher 会跳过该规则。' : '启用后该规则会重新参与 matcher。'}</Text>,
+      async (reason) => {
+        await runWrite(
+          `${action}-${rule.name}`,
+          async () => {
+            await api.post(`/ops/gateway-rules/${encodeURIComponent(rule.name)}:${action}`, { reason });
+          },
+          rule.enabled ? '规则已禁用' : '规则已启用',
+        );
+      },
+    );
+  };
+
+  const deleteRule = (rule: GatewayRule) => {
+    withReason(
+      '删除规则',
+      <Text type="danger">删除会生成新的期望快照，历史快照仍可用于回滚。</Text>,
+      async (reason) => {
+        await runWrite(
+          `delete-${rule.name}`,
+          async () => {
+            await api.delete(`/ops/gateway-rules/${encodeURIComponent(rule.name)}`, { data: { reason } });
+          },
+          '规则已删除',
+        );
+      },
+    );
+  };
+
+  const rollbackSnapshot = (item: GatewayRuleSnapshot) => {
+    withReason(
+      `回滚到 v${item.snapshot_version}`,
+      (
+        <Alert
+          showIcon
+          type="warning"
+          message="会把当前规则恢复为该快照内容，并生成一个新的 snapshot_version。不是把版本号倒回去。"
+        />
+      ),
+      async (reason) => {
+        await runWrite(
+          `rollback-${item.snapshot_version}`,
+          async () => {
+            await api.post('/ops/gateway-rules:rollback', {
+              snapshot_version: item.snapshot_version,
+              reason,
+            });
+          },
+          '已创建回滚快照',
+        );
+      },
+    );
+  };
+
+  const preview = async () => {
+    const values = await previewForm.validateFields();
+    const path = values.path.trim();
+    const xLane = normalizeOptional(values.x_lane);
+    setActionLoading('preview');
+    try {
+      const { data } = await api.post<GatewayExplainResult>('/ops/gateway-rules:explain', {
+        path,
+        x_lane: xLane,
+      });
+      setExplainResult(data);
+      setPreviewProbe({ path, xLane });
+      message.success('预览完成');
+    } catch (error) {
+      message.error(getErrorMessage(error));
+    } finally {
+      setActionLoading(undefined);
+    }
+  };
+
+  const targetColumns: ColumnsType<GatewayTarget> = [
+    {
+      title: 'service',
+      dataIndex: 'service',
+      render: (value: string) => <Text strong>{value}</Text>,
+    },
+    {
+      title: 'lane',
+      dataIndex: 'lane',
+      render: (value: string) => <Tag bordered={false}>{targetLaneLabel(value)}</Tag>,
+    },
+    {
+      title: 'port',
+      dataIndex: 'port',
+      width: 80,
+    },
+    {
+      title: 'weight',
+      dataIndex: 'weight',
+      width: 90,
+      render: (value: number) => <Text strong>{value}</Text>,
+    },
+    {
+      title: 'strip / rewrite',
+      key: 'rewrite',
+      render: (_: unknown, target) => (
+        <Space direction="vertical" size={2}>
+          <Text type="secondary" style={{ fontSize: 12 }}>strip: {target.strip_prefix || '-'}</Text>
+          <Text type="secondary" style={{ fontSize: 12 }}>rewrite: {target.rewrite_prefix || '-'}</Text>
+        </Space>
+      ),
+    },
+  ];
+
+  const candidateColumns: ColumnsType<GatewayExplainTarget> = [
+    {
+      title: 'service',
+      dataIndex: 'service',
+      render: (value: string) => <Text strong>{value}</Text>,
+    },
+    {
+      title: 'lane',
+      dataIndex: 'lane',
+      render: (value: string) => <Tag bordered={false}>{targetLaneLabel(value)}</Tag>,
+    },
+    {
+      title: 'effective lane',
+      dataIndex: 'effective_lane',
+      render: (value: string) => <Tag color={value ? 'blue' : 'default'} bordered={false}>{value || '空'}</Tag>,
+    },
+    {
+      title: 'weight',
+      dataIndex: 'weight',
+      width: 90,
+      render: (value: number) => <Text strong>{value}</Text>,
+    },
+  ];
+
+  const explainColumns: ColumnsType<GatewayRuleExplain> = [
+    {
+      title: '规则',
+      dataIndex: 'name',
+      render: (value: string, record) => (
+        <Space direction="vertical" size={0}>
+          <Text strong>{value}</Text>
+          <Text type="secondary" style={{ fontSize: 12 }}>{record.path_prefix}</Text>
+        </Space>
+      ),
+    },
+    {
+      title: '状态',
+      dataIndex: 'status',
+      width: 120,
+      render: (value: string) => {
+        const meta = statusMeta[value] || { label: value, color: 'default' };
+        return <Tag bordered={false} color={meta.color}>{meta.label}</Tag>;
+      },
+    },
+    {
+      title: '原因',
+      dataIndex: 'reason',
+      render: (value: string) => <Text type="secondary">{value}</Text>,
+    },
+  ];
+
+  const snapshotColumns: ColumnsType<GatewayRuleSnapshot> = [
+    {
+      title: '版本',
+      dataIndex: 'snapshot_version',
+      width: 100,
+      render: (value: number) => <Tag color="blue" bordered={false}>v{value}</Tag>,
+    },
+    {
+      title: '时间',
+      dataIndex: 'created_at',
+      width: 160,
+      render: (value: string) => (
+        <Tooltip title={fullTime(value)}>
+          <Text type="secondary">{formatTime(value)}</Text>
+        </Tooltip>
+      ),
+    },
+    {
+      title: '原因',
+      dataIndex: 'reason',
+      ellipsis: true,
+      render: (value: string) => value || <Text type="secondary">-</Text>,
+    },
+    {
+      title: 'created_by',
+      dataIndex: 'created_by',
+      width: 120,
+      render: (value: string) => <Tag bordered={false}>{value}</Tag>,
+    },
+    {
+      title: '规则数',
+      key: 'rules_count',
+      width: 90,
+      render: (_: unknown, item) => item.rules.length,
+    },
+    {
+      title: '操作',
+      key: 'actions',
+      width: 180,
+      render: (_: unknown, item) => (
+        <Space>
+          <Button size="small" icon={<EyeOutlined />} onClick={() => setSnapshotDrawer(item)}>
+            查看
+          </Button>
+          <Button
+            size="small"
+            danger
+            icon={<RollbackOutlined />}
+            loading={actionLoading === `rollback-${item.snapshot_version}`}
+            onClick={() => rollbackSnapshot(item)}
+          >
+            回滚到此版
+          </Button>
+        </Space>
+      ),
+    },
+  ];
+
+  return (
+    <div className="page-container gateway-routing-page">
+      <div className="page-header">
+        <div>
+          <h1 className="page-title">网关调度</h1>
+          <Text type="secondary" style={{ marginTop: 8, display: 'block' }}>
+            api-gateway 动态路由规则、命中预览与快照回滚
+          </Text>
+        </div>
+        <Space wrap>
+          <Button icon={<SafetyOutlined />} onClick={openAuditLogs}>
+            查看审计
+          </Button>
+          <Button icon={<ReloadOutlined />} loading={loading} onClick={fetchData}>
+            刷新
+          </Button>
+          <Button type="primary" icon={<SaveOutlined />} onClick={openCreateRule}>
+            新建规则
+          </Button>
+        </Space>
+      </div>
+
+      <Alert
+        showIcon
+        type="info"
+        className="gateway-alert"
+        message="这里展示的是 paas-engine 期望配置，不是 gateway 实例运行状态。"
+      />
+
+      <Row gutter={[16, 16]} className="gateway-stats">
+        <Col xs={24} sm={12} lg={6}>
+          <Card bordered={false} className="content-card" bodyStyle={{ padding: '18px 20px' }}>
+            <Statistic title="期望快照" value={`v${snapshot.version || 0}`} prefix={<HistoryOutlined />} />
+          </Card>
+        </Col>
+        <Col xs={24} sm={12} lg={6}>
+          <Card bordered={false} className="content-card" bodyStyle={{ padding: '18px 20px' }}>
+            <Statistic title="规则总数" value={rules.length} suffix={`启用 ${enabledCount}`} />
+          </Card>
+        </Col>
+        <Col xs={24} sm={12} lg={6}>
+          <Card bordered={false} className="content-card" bodyStyle={{ padding: '18px 20px' }}>
+            <Statistic title="禁用规则" value={disabledCount} valueStyle={{ color: disabledCount ? '#dc2626' : undefined }} />
+          </Card>
+        </Col>
+        <Col xs={24} sm={12} lg={6}>
+          <Card bordered={false} className="content-card" bodyStyle={{ padding: '18px 20px' }}>
+            <Statistic title="最近变更" value={latestSnapshot ? formatTime(latestSnapshot.created_at) : '-'} />
+            <Text type="secondary" ellipsis style={{ display: 'block', marginTop: 4 }}>
+              {latestSnapshot?.reason || '暂无快照原因'}
+            </Text>
+          </Card>
+        </Col>
+      </Row>
+
+      <div className="gateway-workbench">
+        <section className="gateway-panel gateway-rule-list-panel">
+          <div className="gateway-panel-header">
+            <Title level={5}>规则列表</Title>
+            <Tag bordered={false}>{rules.length} 条</Tag>
+          </div>
+          <div className="gateway-rule-list">
+            {rules.length === 0 && !loading ? (
+              <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description="暂无规则" />
+            ) : (
+              rules.map((rule) => (
+                <button
+                  key={rule.name}
+                  type="button"
+                  className={`gateway-rule-item ${selectedRule?.name === rule.name ? 'active' : ''}`}
+                  onClick={() => setSelectedRuleName(rule.name)}
+                >
+                  <div className="gateway-rule-line">
+                    <Space>
+                      <Tag bordered={false} color={rule.enabled ? 'green' : 'red'}>
+                        {rule.enabled ? '启用' : '禁用'}
+                      </Tag>
+                      <Text strong>{rule.name}</Text>
+                    </Space>
+                    <Text type="secondary">P{rule.priority}</Text>
+                  </div>
+                  <Text code className="gateway-rule-path">{rule.path_prefix}</Text>
+                  <div className="gateway-rule-meta">
+                    <Text type="secondary">lane: {requestLaneLabel(rule.request_lane)}</Text>
+                    <Text type="secondary">{targetSummary(rule.targets)}</Text>
+                  </div>
+                </button>
+              ))
+            )}
+          </div>
+        </section>
+
+        <section className="gateway-panel gateway-detail-panel">
+          {selectedRule ? (
+            <>
+              <div className="gateway-panel-header">
+                <div>
+                  <Title level={4}>{selectedRule.name}</Title>
+                  <Text type="secondary">version {selectedRule.version} · 更新 {formatTime(selectedRule.updated_at)}</Text>
+                </div>
+                <Space wrap>
+                  <Button icon={<EditOutlined />} onClick={() => openEditRule(selectedRule)}>
+                    编辑
+                  </Button>
+                  <Button icon={<SwapOutlined />} onClick={() => openWeights(selectedRule)}>
+                    调权
+                  </Button>
+                  <Button icon={<RetweetOutlined />} onClick={() => cutBackToProd(selectedRule)}>
+                    切回 prod
+                  </Button>
+                  <Button
+                    danger={selectedRule.enabled}
+                    icon={selectedRule.enabled ? <PauseCircleOutlined /> : <PlayCircleOutlined />}
+                    loading={actionLoading === `${selectedRule.enabled ? 'disable' : 'enable'}-${selectedRule.name}`}
+                    onClick={() => toggleRule(selectedRule)}
+                  >
+                    {selectedRule.enabled ? '禁用' : '启用'}
+                  </Button>
+                  <Button danger icon={<DeleteOutlined />} onClick={() => deleteRule(selectedRule)}>
+                    删除
+                  </Button>
+                </Space>
+              </div>
+
+              <Descriptions bordered size="small" column={{ xs: 1, md: 2 }}>
+                <Descriptions.Item label="enabled">
+                  <Tag bordered={false} color={selectedRule.enabled ? 'green' : 'red'}>
+                    {selectedRule.enabled ? 'true' : 'false'}
+                  </Tag>
+                </Descriptions.Item>
+                <Descriptions.Item label="priority">{selectedRule.priority}</Descriptions.Item>
+                <Descriptions.Item label="path_prefix">
+                  <Text code>{selectedRule.path_prefix}</Text>
+                </Descriptions.Item>
+                <Descriptions.Item label="request_lane">{requestLaneLabel(selectedRule.request_lane)}</Descriptions.Item>
+                <Descriptions.Item label="split_key_headers">{stableSplitLabel(selectedRule)}</Descriptions.Item>
+                <Descriptions.Item label="created_at">{fullTime(selectedRule.created_at)}</Descriptions.Item>
+              </Descriptions>
+
+              <Divider orientation="left">targets</Divider>
+              <Table
+                rowKey={(target) => `${target.service}:${target.lane}:${target.port}`}
+                columns={targetColumns}
+                dataSource={selectedRule.targets}
+                pagination={false}
+                size="small"
+              />
+            </>
+          ) : (
+            <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description="选择一条规则查看详情" />
+          )}
+        </section>
+      </div>
+
+      <section className="gateway-panel gateway-preview-panel">
+        <div className="gateway-panel-header">
+          <div>
+            <Title level={5}>Preview</Title>
+            <Text type="secondary">输入 path + 可选 x-lane，预览当前期望规则会如何匹配。</Text>
+          </div>
+        </div>
+        <Form
+          form={previewForm}
+          layout="inline"
+          className="gateway-preview-form"
+          initialValues={{ path: '/api/agent/health', x_lane: '' }}
+        >
+          <Form.Item
+            name="path"
+            rules={[
+              { required: true, message: '请输入 path' },
+              { pattern: /^\//, message: 'path 必须以 / 开头' },
+            ]}
+            style={{ flex: 1, minWidth: 260 }}
+          >
+            <Input prefix={<AimOutlined />} placeholder="/api/agent/health" />
+          </Form.Item>
+          <Form.Item name="x_lane" style={{ width: 220 }}>
+            <Input placeholder="x-lane 空=未指定" />
+          </Form.Item>
+          <Form.Item>
+            <Button type="primary" loading={actionLoading === 'preview'} onClick={preview}>
+              预览命中
+            </Button>
+          </Form.Item>
+        </Form>
+
+        {explainResult && (
+          <div className="gateway-preview-result">
+            <Alert
+              showIcon
+              type={explainResult.matched ? 'success' : 'warning'}
+              message={
+                explainResult.matched
+                  ? `命中 ${explainResult.winning_rule}`
+                  : '没有命中任何规则'
+              }
+              description={
+                explainResult.matched
+                  ? `${explainResult.winning_reason || ''}；${explainResult.stable_split ? `稳定分流：${explainResult.split_key_headers?.join(', ')}` : '未开启稳定分流'}`
+                  : '请求会落入 api-gateway 的未匹配处理。'
+              }
+            />
+            {explainResult.candidate_targets?.length ? (
+              <Table
+                rowKey={(target) => `${target.service}:${target.lane}:${target.port}`}
+                columns={candidateColumns}
+                dataSource={explainResult.candidate_targets}
+                pagination={false}
+                size="small"
+              />
+            ) : null}
+            <Table
+              rowKey={(item) => item.name}
+              columns={explainColumns}
+              dataSource={explainResult.rules}
+              pagination={false}
+              size="small"
+            />
+          </div>
+        )}
+      </section>
+
+      <section className="gateway-panel">
+        <div className="gateway-panel-header">
+          <div>
+            <Title level={5}>快照历史</Title>
+            <Text type="secondary">最近 20 条期望配置快照。</Text>
+          </div>
+        </div>
+        <Table
+          rowKey="snapshot_version"
+          columns={snapshotColumns}
+          dataSource={snapshots}
+          loading={loading}
+          pagination={false}
+          size="middle"
+        />
+      </section>
+
+      <Modal
+        title={editingRuleName ? `编辑 ${editingRuleName}` : '新建网关规则'}
+        open={ruleModalOpen}
+        onOk={saveRule}
+        onCancel={() => {
+          setRuleModalOpen(false);
+          setEditingRuleName(null);
+        }}
+        confirmLoading={actionLoading?.startsWith('save-')}
+        okText={editingRuleName ? '保存' : '创建'}
+        cancelText="取消"
+        width={860}
+        destroyOnClose
+      >
+        <Form form={ruleForm} layout="vertical" requiredMark={false}>
+          <Row gutter={16}>
+            <Col xs={24} md={12}>
+              <Form.Item
+                name="name"
+                label="name"
+                rules={[
+                  { required: true, message: '请输入规则名' },
+                  { pattern: /^[a-z0-9][a-z0-9-]*$/, message: '仅支持小写字母、数字和 -' },
+                ]}
+              >
+                <Input disabled={!!editingRuleName} placeholder="agent-canary" />
+              </Form.Item>
+            </Col>
+            <Col xs={12} md={6}>
+              <Form.Item name="enabled" label="enabled" valuePropName="checked">
+                <Switch checkedChildren="启用" unCheckedChildren="禁用" />
+              </Form.Item>
+            </Col>
+            <Col xs={12} md={6}>
+              <Form.Item name="priority" label="priority" rules={[{ required: true, message: '请输入优先级' }]}>
+                <InputNumber min={0} precision={0} style={{ width: '100%' }} />
+              </Form.Item>
+            </Col>
+          </Row>
+          <Row gutter={16}>
+            <Col xs={24} md={12}>
+              <Form.Item
+                name="path_prefix"
+                label="path_prefix"
+                rules={[
+                  { required: true, message: '请输入 path_prefix' },
+                  { pattern: /^\/.*\/$/, message: 'path_prefix 必须以 / 开头并以 / 结尾' },
+                ]}
+              >
+                <Input placeholder="/api/agent/" />
+              </Form.Item>
+            </Col>
+            <Col xs={24} md={12}>
+              <Form.Item name="request_lane" label="request_lane">
+                <Input placeholder="空=不限制请求 x-lane" />
+              </Form.Item>
+            </Col>
+          </Row>
+          <Form.Item name="split_key_headers" label="split_key_headers">
+            <Select mode="tags" placeholder="例如 x-user-id" tokenSeparators={[',']} />
+          </Form.Item>
+
+          <Divider orientation="left">targets</Divider>
+          <Form.List name="targets">
+            {(fields, { add, remove }) => (
+              <Space direction="vertical" size={12} style={{ width: '100%' }}>
+                {fields.map((field) => (
+                  <div key={field.key} className="gateway-target-editor">
+                    <Row gutter={12}>
+                      <Col xs={24} md={7}>
+                        <Form.Item
+                          {...field}
+                          name={[field.name, 'service']}
+                          label="service"
+                          rules={[{ required: true, message: 'service 必填' }]}
+                        >
+                          <Input placeholder="agent-service" />
+                        </Form.Item>
+                      </Col>
+                      <Col xs={24} md={5}>
+                        <Form.Item {...field} name={[field.name, 'lane']} label="lane">
+                          <Input placeholder="空=跟随请求" />
+                        </Form.Item>
+                      </Col>
+                      <Col xs={12} md={4}>
+                        <Form.Item
+                          {...field}
+                          name={[field.name, 'port']}
+                          label="port"
+                          rules={[{ required: true, message: 'port 必填' }]}
+                        >
+                          <InputNumber min={1} precision={0} style={{ width: '100%' }} />
+                        </Form.Item>
+                      </Col>
+                      <Col xs={12} md={4}>
+                        <Form.Item
+                          {...field}
+                          name={[field.name, 'weight']}
+                          label="weight"
+                          rules={[{ required: true, message: 'weight 必填' }]}
+                        >
+                          <InputNumber min={0} max={100} precision={0} style={{ width: '100%' }} />
+                        </Form.Item>
+                      </Col>
+                      <Col xs={24} md={4}>
+                        <Form.Item label="操作">
+                          <Button danger block disabled={fields.length === 1} onClick={() => remove(field.name)}>
+                            删除
+                          </Button>
+                        </Form.Item>
+                      </Col>
+                    </Row>
+                    <Row gutter={12}>
+                      <Col xs={24} md={12}>
+                        <Form.Item {...field} name={[field.name, 'strip_prefix']} label="strip_prefix">
+                          <Input placeholder="可选" />
+                        </Form.Item>
+                      </Col>
+                      <Col xs={24} md={12}>
+                        <Form.Item {...field} name={[field.name, 'rewrite_prefix']} label="rewrite_prefix">
+                          <Input placeholder="可选" />
+                        </Form.Item>
+                      </Col>
+                    </Row>
+                  </div>
+                ))}
+                <Button block onClick={() => add({ service: '', lane: '', port: 80, weight: 0 })}>
+                  添加 target
+                </Button>
+              </Space>
+            )}
+          </Form.List>
+
+          <Divider />
+          <Form.Item name="reason" label="reason" rules={[{ required: true, whitespace: true, message: 'reason 必填' }]}>
+            <Input.TextArea autoSize={{ minRows: 3, maxRows: 5 }} placeholder="填写本次规则变更原因" />
+          </Form.Item>
+        </Form>
+      </Modal>
+
+      <Modal
+        title={selectedRule ? `调权 ${selectedRule.name}` : '调权'}
+        open={weightsModalOpen}
+        onOk={saveWeights}
+        onCancel={() => setWeightsModalOpen(false)}
+        confirmLoading={actionLoading?.startsWith('weights-')}
+        okText="保存权重"
+        cancelText="取消"
+        width={640}
+        destroyOnClose
+      >
+        {selectedRule && (
+          <Form form={weightsForm} layout="vertical" requiredMark={false}>
+            <Space direction="vertical" size={12} style={{ width: '100%' }}>
+              {selectedRule.targets.map((target, index) => (
+                <div key={`${target.service}:${target.lane}`} className="gateway-weight-row">
+                  <div>
+                    <Text strong>{targetIdentity(target)}</Text>
+                    <Text type="secondary" style={{ display: 'block', fontSize: 12 }}>port {target.port}</Text>
+                  </div>
+                  <Form.Item
+                    name={['weights', index, 'weight']}
+                    rules={[{ required: true, message: 'weight 必填' }]}
+                    style={{ margin: 0 }}
+                  >
+                    <InputNumber min={0} max={100} precision={0} addonAfter="%" />
+                  </Form.Item>
+                </div>
+              ))}
+            </Space>
+            <Form.Item
+              name="reason"
+              label="reason"
+              rules={[{ required: true, whitespace: true, message: 'reason 必填' }]}
+              style={{ marginTop: 20 }}
+            >
+              <Input.TextArea autoSize={{ minRows: 3, maxRows: 5 }} placeholder="填写本次调权原因" />
+            </Form.Item>
+          </Form>
+        )}
+      </Modal>
+
+      <Drawer
+        title={snapshotDrawer ? `快照 v${snapshotDrawer.snapshot_version}` : '快照'}
+        open={!!snapshotDrawer}
+        onClose={() => setSnapshotDrawer(null)}
+        width={720}
+      >
+        {snapshotDrawer && (
+          <Space direction="vertical" size={16} style={{ width: '100%' }}>
+            <Descriptions bordered size="small" column={1}>
+              <Descriptions.Item label="created_at">{fullTime(snapshotDrawer.created_at)}</Descriptions.Item>
+              <Descriptions.Item label="created_by">{snapshotDrawer.created_by}</Descriptions.Item>
+              <Descriptions.Item label="reason">{snapshotDrawer.reason || '-'}</Descriptions.Item>
+              <Descriptions.Item label="rules_count">{snapshotDrawer.rules.length}</Descriptions.Item>
+            </Descriptions>
+            <pre className="json-preview">{JSON.stringify(snapshotDrawer.rules, null, 2)}</pre>
+          </Space>
+        )}
+      </Drawer>
+    </div>
+  );
+}

--- a/apps/monitor-dashboard-web/src/pages/GatewayRouting.tsx
+++ b/apps/monitor-dashboard-web/src/pages/GatewayRouting.tsx
@@ -791,25 +791,24 @@ export default function GatewayRouting() {
       </div>
 
       <Row gutter={[16, 16]} className="gateway-stats">
-        <Col xs={24} sm={12} lg={6}>
+        <Col xs={24} sm={12} lg={8}>
           <Card bordered={false} className="content-card" bodyStyle={{ padding: '18px 20px' }}>
             <Statistic title="当前快照" value={`v${snapshot.version || 0}`} prefix={<HistoryOutlined />} />
           </Card>
         </Col>
-        <Col xs={24} sm={12} lg={6}>
+        <Col xs={24} sm={12} lg={8}>
           <Card bordered={false} className="content-card" bodyStyle={{ padding: '18px 20px' }}>
-            <Statistic title="规则状态" value={`${rules.length} 条`} />
-            <Text type="secondary" style={{ display: 'block', marginTop: 4 }}>
-              启用 {enabledCount} 条，停用 {disabledCount} 条
-            </Text>
+            <Text type="secondary" className="gateway-stat-title">规则状态（总数 / 停用 / 启用）</Text>
+            <div className="gateway-rule-status-counts">
+              <span className="total">{rules.length}</span>
+              <span className="separator">/</span>
+              <span className="disabled">{disabledCount}</span>
+              <span className="separator">/</span>
+              <span className="enabled">{enabledCount}</span>
+            </div>
           </Card>
         </Col>
-        <Col xs={24} sm={12} lg={6}>
-          <Card bordered={false} className="content-card" bodyStyle={{ padding: '18px 20px' }}>
-            <Statistic title="停用规则" value={`${disabledCount} 条`} valueStyle={{ color: disabledCount ? '#dc2626' : undefined }} />
-          </Card>
-        </Col>
-        <Col xs={24} sm={12} lg={6}>
+        <Col xs={24} sm={12} lg={8}>
           <Card bordered={false} className="content-card" bodyStyle={{ padding: '18px 20px' }}>
             <Statistic title="最近变更" value={latestSnapshot ? formatTime(latestSnapshot.created_at) : '-'} />
           </Card>

--- a/apps/monitor-dashboard-web/src/styles.css
+++ b/apps/monitor-dashboard-web/src/styles.css
@@ -327,6 +327,135 @@ a {
   box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.05);
 }
 
+/* Gateway routing workbench */
+.gateway-routing-page {
+  --gateway-border: #dbe3ef;
+  --gateway-ink: #0f172a;
+  --gateway-muted: #64748b;
+  --gateway-soft: #f8fafc;
+}
+
+.gateway-alert,
+.gateway-stats {
+  margin-bottom: 16px;
+}
+
+.gateway-workbench {
+  display: grid;
+  grid-template-columns: minmax(280px, 0.9fr) minmax(0, 1.8fr);
+  gap: 16px;
+  align-items: stretch;
+  margin-bottom: 16px;
+}
+
+.gateway-panel {
+  background: #ffffff;
+  border: 1px solid var(--gateway-border);
+  border-radius: 16px;
+  padding: 20px;
+  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.05);
+}
+
+.gateway-panel + .gateway-panel {
+  margin-top: 16px;
+}
+
+.gateway-panel-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 16px;
+  margin-bottom: 16px;
+}
+
+.gateway-panel-header h4,
+.gateway-panel-header h5 {
+  margin: 0;
+}
+
+.gateway-rule-list-panel,
+.gateway-detail-panel {
+  min-height: 440px;
+}
+
+.gateway-rule-list {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  max-height: 560px;
+  overflow: auto;
+  padding-right: 4px;
+}
+
+.gateway-rule-item {
+  width: 100%;
+  border: 1px solid #e2e8f0;
+  background: #ffffff;
+  border-radius: 12px;
+  padding: 14px;
+  text-align: left;
+  cursor: pointer;
+  transition: border-color 0.18s ease, box-shadow 0.18s ease, transform 0.18s ease;
+}
+
+.gateway-rule-item:hover,
+.gateway-rule-item.active {
+  border-color: #2563eb;
+  box-shadow: 0 10px 24px rgba(37, 99, 235, 0.1);
+}
+
+.gateway-rule-item.active {
+  background: linear-gradient(180deg, #ffffff 0%, #f7fbff 100%);
+}
+
+.gateway-rule-line,
+.gateway-rule-meta,
+.gateway-weight-row {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  align-items: center;
+}
+
+.gateway-rule-path {
+  display: inline-block;
+  margin: 10px 0 8px;
+}
+
+.gateway-rule-meta {
+  align-items: flex-start;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.gateway-preview-panel {
+  margin-bottom: 16px;
+}
+
+.gateway-preview-form {
+  row-gap: 12px;
+}
+
+.gateway-preview-result {
+  display: grid;
+  gap: 14px;
+  margin-top: 16px;
+}
+
+.gateway-target-editor {
+  border: 1px solid #e2e8f0;
+  border-radius: 12px;
+  padding: 12px;
+  background: #f8fafc;
+}
+
+.gateway-weight-row {
+  border: 1px solid #e2e8f0;
+  border-radius: 10px;
+  padding: 12px;
+  background: #f8fafc;
+}
+
 @keyframes page-enter {
   from {
     opacity: 0;
@@ -564,6 +693,14 @@ a {
 
   .filter-actions {
     justify-content: flex-start;
+  }
+
+  .gateway-workbench {
+    grid-template-columns: 1fr;
+  }
+
+  .gateway-panel-header {
+    flex-direction: column;
   }
 }
 

--- a/apps/monitor-dashboard-web/src/styles.css
+++ b/apps/monitor-dashboard-web/src/styles.css
@@ -340,6 +340,40 @@ a {
   margin-bottom: 16px;
 }
 
+.gateway-stat-title {
+  display: block;
+  margin-bottom: 4px;
+  color: #64748b;
+  font-size: 14px;
+}
+
+.gateway-rule-status-counts {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  min-height: 38px;
+  font-size: 30px;
+  line-height: 1.2;
+  font-weight: 600;
+}
+
+.gateway-rule-status-counts .total {
+  color: #0f172a;
+}
+
+.gateway-rule-status-counts .disabled {
+  color: #dc2626;
+}
+
+.gateway-rule-status-counts .enabled {
+  color: #16a34a;
+}
+
+.gateway-rule-status-counts .separator {
+  color: #cbd5e1;
+  font-weight: 500;
+}
+
 .gateway-workbench {
   display: grid;
   grid-template-columns: minmax(280px, 0.9fr) minmax(0, 1.8fr);


### PR DESCRIPTION
## Summary

在 monitor-dashboard-web 增加网关调度页面，用前端管理 api-gateway 路由规则的查看、预览、编辑、权重调整、启停、删除和快照回滚。

- 新增 `/gateway-routing` 页面和侧边栏入口，展示当前快照、规则状态、规则列表、规则详情、预览结果和快照历史。
- 前端 `/dashboard/api/` 统一通过 api-gateway 访问，避免测试泳道必须同时部署 `monitor-dashboard` 后端。
- 补充审计页按 action / x-lane 跳转查询，便于从网关调度页面直接查看相关操作记录。
- 按可读性要求清理 UI 文案：隐藏内部实现口径，解释稳定分流和路径处理，常用操作只保留编辑、调整流量、更多操作，规则状态改成 `总数 / 停用 / 启用` 一行展示。

## Validation

- [x] `bun run --cwd apps/monitor-dashboard-web build`
- [x] 部署 `monitor-dashboard-web` 到 `ppe-gateway-routing`，验证 Pod Ready、页面入口 200、网关规则快照接口 200。
- [x] 删除同泳道 `monitor-dashboard` 后端发布后重新验证前端仍可通过 api-gateway 访问 API，确认已解耦同泳道后端依赖。
- [x] 合并后部署生产 `monitor-dashboard-web:1.0.0.63`，验证 prod Pod Ready、`/dashboard/gateway-routing` 200、快照接口 200、静态资源包含网关调度页面和规则状态样式。
- [x] 清理测试泳道 `ppe-gateway-routing` 并解绑 dev bot。

## Framework Layer

Framework-Layer-Spec:

- [x] This PR does not change the agent-service framework layer.
- [ ] This PR changes the framework layer and cites the spec above.

Framework layer means `apps/agent-service/app/runtime/**`, wiring,
deployment bindings, runtime entrypoints, framework docs, or CI gates.
