### PR TITLE
fix(channel-server): resolve image registry with global message_id

### DIFF
--- a/apps/channel-server/src/workers/chat-response-worker.image-registry.test.ts
+++ b/apps/channel-server/src/workers/chat-response-worker.image-registry.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'bun:test';
+
+import { reverseResolveForLark } from '../core/channels/outbound-pipeline';
+import { InMemoryIdentityResolver } from '../core/channels/identity-resolver';
+import { imageRegistryLookupId } from './image-registry-key';
+
+// 发图被吞回归钉死（trace aae2dd2cacbc711123da9e41d1525e4f）：
+//
+// agent-service 在 app/chat/context.py 用 ImageRegistry(req.message_id) 把
+// generate_image 产出的图片注册到 Redis，key = image_registry:{全局 internal
+// message_id ULID}。chat-response-worker 必须用【同一个全局 id】去查 registry。
+//
+// 多渠道改造（PR #228）后，worker 先把 payload.message_id 用
+// reverseResolveForLark 反查成飞书裸 om_* 再查 registry —— 那个裸键 agent-service
+// 从来没写过，registry 必 miss，resolveImageReferences 原样返回带 N.png 的文本，
+// markdownToPostContent 再静默跳过未解析的 N.png，最终用户什么图都收不到。
+//
+// 本测试钉死：image registry 的查询 id 是【全局 payload.message_id】，
+// 且它跟 reverseResolveForLark 反查出来的飞书裸 id 是不同的字符串 —— 用反查后的
+// 裸 id 查 registry 就是这个 bug 本身。
+
+describe('image registry 查询 id 契约：必须用全局 message_id，不能用反查后的飞书裸 id', () => {
+    it('registry 查询 id == 全局 payload.message_id（agent-service 注册用的同一个 key）', () => {
+        const globalMsg = '01ARZ3NDEKTSV4RRFFQ69G5FAV';
+        expect(imageRegistryLookupId({ message_id: globalMsg })).toBe(globalMsg);
+    });
+
+    it('全局 message_id 反查出的飞书裸 id 与全局 id 不同 —— 用裸 id 查 registry 必 miss（复现 bug）', async () => {
+        const r = new InMemoryIdentityResolver();
+        const globalMsg = await r.resolve('message', 'lark', 'om_real_msg');
+        const globalChat = await r.resolve('chat', 'lark', 'oc_real_chat');
+
+        const rr = await reverseResolveForLark({
+            resolver: r,
+            messageGlobalId: globalMsg,
+            chatGlobalId: globalChat,
+            rootGlobalId: undefined,
+        });
+
+        // 反查回的飞书裸 id 就是 om_real_msg，跟全局 ULID 是两个不同字符串
+        expect(rr.channelMessageId).toBe('om_real_msg');
+        expect(rr.channelMessageId).not.toBe(globalMsg);
+
+        // registry 查询必须用全局 id，绝不能用 rr.channelMessageId（bug 路径）
+        const lookupId = imageRegistryLookupId({ message_id: globalMsg });
+        expect(lookupId).toBe(globalMsg);
+        expect(lookupId).not.toBe(rr.channelMessageId);
+    });
+});

--- a/apps/channel-server/src/workers/chat-response-worker.ts
+++ b/apps/channel-server/src/workers/chat-response-worker.ts
@@ -37,6 +37,7 @@ import { MessageContentUtils } from 'core/models/message-content';
 import { reverseResolveForLark } from '@core/channels/outbound-pipeline';
 import { getIdentityResolver } from '@integrations/identity-resolver-runtime';
 import { hgetall } from '@cache/redis-client';
+import { imageRegistryLookupId } from './image-registry-key';
 import dayjs from 'dayjs';
 import { Readable } from 'stream';
 import { Counter, Histogram, Registry, collectDefaultMetrics } from 'prom-client';
@@ -290,15 +291,20 @@ async function handleChatResponse(msg: ConsumeMessage): Promise<void> {
             const larkChatId = rr.channelChatId;
             const larkRootId = rr.channelRootId;
 
-            // 群聊中将 @用户名 替换为 <at union_id="xxx">用户名</at>
-            // 解析 @N.png 引用 → 下载 TOS → 上传飞书 → 替换为 image_key
-            // 用反查回的飞书裸 ID（resolveMentionsForGroup 走飞书群成员、
-            // resolveImageReferences 走 redis image_registry，均按飞书裸键）。
+            // 群聊中将 @用户名 替换为 <at union_id="xxx">用户名</at>：走飞书群成员，
+            // 必须用反查回的飞书裸 chatId（larkChatId）。
+            // 解析 N.png 引用 → 下载 TOS → 上传飞书 → 替换为 image_key：走 redis
+            // image_registry，agent-service 用【全局 internal message_id】注册（见
+            // image-registry-key.ts），所以这里必须用全局 message_id 查，绝不能用
+            // 反查后的飞书裸 om_*（那个键从没写过，会 miss → 图片被静默吞掉）。
             const tResolve0 = Date.now();
             let resolvedContent = is_p2p
                 ? content
                 : await resolveMentionsForGroup(content, larkChatId);
-            resolvedContent = await resolveImageReferences(resolvedContent, larkMessageId);
+            resolvedContent = await resolveImageReferences(
+                resolvedContent,
+                imageRegistryLookupId(payload),
+            );
             const resolveMs = Date.now() - tResolve0;
             chatResponseDuration.labels({ stage: 'resolve' }).observe(resolveMs / 1000);
 

--- a/apps/channel-server/src/workers/image-registry-key.ts
+++ b/apps/channel-server/src/workers/image-registry-key.ts
@@ -1,0 +1,10 @@
+/**
+ * agent-service 用 ImageRegistry(req.message_id) 把 generate_image 产出的图片注册到
+ * Redis，key = `image_registry:{全局 internal message_id}`（见 agent-service
+ * app/chat/context.py + app/infra/image.py）。chat-response-worker 渲染回复时必须用
+ * 这个【同一个全局 id】查 registry，绝不能用 reverseResolveForLark 反查出来的飞书裸
+ * om_* —— 那个裸键 agent-service 从来没写过，registry 必 miss，图片被静默吞掉。
+ */
+export function imageRegistryLookupId(payload: { message_id: string }): string {
+    return payload.message_id;
+}


### PR DESCRIPTION
## Summary

Generated images were silently dropped from Feishu replies (trace `aae2dd2cacbc711123da9e41d1525e4f`). The LLM correctly emitted the `![desc](1.png)` markdown placeholder and `generate_image` successfully produced the image, but the user never received it.

**Root cause** — a regression from the multi-channel cutover (#228) that introduced global internal message IDs:

- `agent-service` registers generated images in Redis under the **global internal `message_id`** (ULID): `ImageRegistry(req.message_id)` → key `image_registry:{ULID}` (`apps/agent-service/app/chat/context.py`, `app/infra/image.py`).
- `chat-response-worker` looked the registry up under the **reverse-resolved Feishu bare ID** (`om_*`): it ran `payload.message_id` through `reverseResolveForLark` first, then queried `image_registry:{om_*}`.

Those two keys are different strings, so the lookup always missed. On a miss `resolveImageReferences` returns the text unchanged (still containing `1.png`), and `markdownToPostContent` then silently `continue`s past any unresolved `N.png` placeholder — so the image, and its alt text, vanished with no error.

## Fix

- `chat-response-worker` now looks up the image registry with the **global `message_id`** (the same value `agent-service` registered under), not the reverse-resolved bare ID.
- `resolveMentionsForGroup` still uses the reverse-resolved Feishu bare `chatId`, which is correct (group-member lookup needs the native chat ID) and is left untouched.
- Added `image-registry-key.ts` (`imageRegistryLookupId`) as the single seam for the registry-lookup ID. The worker module runs `main()` on import, so the handler itself isn't unit-testable; this seam lets a test pin the invariant and guards against regressing back to the bare ID (the old, misleading comment had pointed that way).
- Corrected the comment that wrongly claimed the registry is keyed by the Feishu bare ID.

## Test plan

- [x] `bun test` — new `chat-response-worker.image-registry.test.ts` uses the real `reverseResolveForLark` to prove the global ID and the reverse-resolved bare ID are distinct strings, pinning that the registry must be queried with the global ID.
- [x] Deployed to lane `ppe-imgfix`, bound the dev bot, asked the bot to draw an image. `chat-response-worker` log confirms the registry now hits: `Resolved 1.png -> img_v3_... (size=145KB download=102ms upload=629ms)`, with no `No image registry found` warnings. Image is delivered to the user.

🤖 Generated with [Claude Code](https://claude.com/claude-code)