### PR TITLE
Fix Lark group message projection and dashboard rendering

### DIFF
--- a/apps/channel-server/src/core/channels/lane-routing/lane-router.test.ts
+++ b/apps/channel-server/src/core/channels/lane-routing/lane-router.test.ts
@@ -4,43 +4,79 @@ import { join } from 'node:path';
 
 import { LaneRouter, type LaneRoutingStore } from './lane-router';
 
-// LaneRouter 是平台无关的泳道决策能力（本期只做 bot 维度）。它的入参只认统一概念
-// （channel + 全局 bot 标识），绝不接触飞书原始字段。读取靠注入的结构型
+// LaneRouter 是平台无关的泳道决策能力。它的入参只认统一概念
+// （channel + common conversation + 全局 bot 标识），绝不接触飞书原始字段。读取靠注入的结构型
 // LaneRoutingStore（ORM-free，生产由 TypeORM 实现注入），所以本测试用内存 fake
 // 顶替真实 DB，纯跑、不连库。
 //
-// 这个 fake 忠实模拟真实 lane_routing 表的查询语义：按「全局 bot 标识」查命中的
-// lane_name；没绑定返回 null。LaneRouter 据此决定 lane：命中返回 lane_name，
-// 未命中返回 'prod'（本期决策优先级就两档：bot 命中 > prod 默认）。
+// 这个 fake 忠实模拟真实 lane_routing 表的查询语义：按「common conversation」
+// 优先查，再按「全局 bot 标识」查；没绑定返回 null。LaneRouter 据此决定 lane：
+// 命中返回 lane_name，未命中返回 'prod'。
 
 // 一个可计数、可重设绑定的内存 store，记录被查了几次，用来验证缓存命中不打 DB。
 class FakeLaneRoutingStore implements LaneRoutingStore {
+    findChatLaneCalls = 0;
     findBotLaneCalls = 0;
-    private bindings = new Map<string, string>();
+    private chatBindings = new Map<string, string>();
+    private botBindings = new Map<string, string>();
+
+    setChatBinding(commonConversationId: string, lane: string): void {
+        this.chatBindings.set(commonConversationId, lane);
+    }
 
     setBotBinding(botGlobalId: string, lane: string): void {
-        this.bindings.set(botGlobalId, lane);
+        this.botBindings.set(botGlobalId, lane);
     }
 
     removeBotBinding(botGlobalId: string): void {
-        this.bindings.delete(botGlobalId);
+        this.botBindings.delete(botGlobalId);
+    }
+
+    async findChatLane(commonConversationId: string): Promise<string | null> {
+        this.findChatLaneCalls += 1;
+        return this.chatBindings.get(commonConversationId) ?? null;
     }
 
     async findBotLane(botGlobalId: string): Promise<string | null> {
         this.findBotLaneCalls += 1;
-        return this.bindings.get(botGlobalId) ?? null;
+        return this.botBindings.get(botGlobalId) ?? null;
     }
 }
 
 const NOW = 1_700_000_000_000;
 
-describe('LaneRouter.resolveLane — 平台无关的 bot 维度泳道决策', () => {
+describe('LaneRouter.resolveLane — 平台无关的 chat/bot 泳道决策', () => {
+    it('chat 命中绑定：优先返回 chat lane，不再查 bot', async () => {
+        const store = new FakeLaneRoutingStore();
+        store.setChatBinding('018f-chat', 'ppe-chat');
+        store.setBotBinding('赤尾', 'ppe-bot');
+        const router = new LaneRouter(store);
+
+        const lane = await router.resolveLane('lark', '赤尾', '018f-chat');
+
+        expect(lane).toBe('ppe-chat');
+        expect(store.findChatLaneCalls).toBe(1);
+        expect(store.findBotLaneCalls).toBe(0);
+    });
+
+    it('chat 未命中时回退到 bot 绑定', async () => {
+        const store = new FakeLaneRoutingStore();
+        store.setBotBinding('赤尾', 'ppe-bot');
+        const router = new LaneRouter(store);
+
+        const lane = await router.resolveLane('lark', '赤尾', '018f-chat');
+
+        expect(lane).toBe('ppe-bot');
+        expect(store.findChatLaneCalls).toBe(1);
+        expect(store.findBotLaneCalls).toBe(1);
+    });
+
     it('bot 命中绑定：返回绑定的 lane_name', async () => {
         const store = new FakeLaneRoutingStore();
         store.setBotBinding('赤尾', 'ppe-foo');
         const router = new LaneRouter(store);
 
-        const lane = await router.resolveLane('lark', '赤尾');
+        const lane = await router.resolveLane('lark', '赤尾', undefined);
         expect(lane).toBe('ppe-foo');
     });
 
@@ -48,7 +84,7 @@ describe('LaneRouter.resolveLane — 平台无关的 bot 维度泳道决策', ()
         const store = new FakeLaneRoutingStore();
         const router = new LaneRouter(store);
 
-        const lane = await router.resolveLane('lark', '没绑定的bot');
+        const lane = await router.resolveLane('lark', '没绑定的bot', undefined);
         expect(lane).toBe('prod');
     });
 
@@ -57,7 +93,7 @@ describe('LaneRouter.resolveLane — 平台无关的 bot 维度泳道决策', ()
         store.setBotBinding('赤尾', 'prod');
         const router = new LaneRouter(store);
 
-        const lane = await router.resolveLane('lark', '赤尾');
+        const lane = await router.resolveLane('lark', '赤尾', undefined);
         expect(lane).toBe('prod');
     });
 
@@ -67,11 +103,11 @@ describe('LaneRouter.resolveLane — 平台无关的 bot 维度泳道决策', ()
         let clock = NOW;
         const router = new LaneRouter(store, () => clock);
 
-        expect(await router.resolveLane('lark', '赤尾')).toBe('ppe-foo');
-        expect(await router.resolveLane('lark', '赤尾')).toBe('ppe-foo');
+        expect(await router.resolveLane('lark', '赤尾', undefined)).toBe('ppe-foo');
+        expect(await router.resolveLane('lark', '赤尾', undefined)).toBe('ppe-foo');
         // TTL 内推进时间但不超过 30s：仍走缓存。
         clock = NOW + 29_999;
-        expect(await router.resolveLane('lark', '赤尾')).toBe('ppe-foo');
+        expect(await router.resolveLane('lark', '赤尾', undefined)).toBe('ppe-foo');
 
         expect(store.findBotLaneCalls).toBe(1);
     });
@@ -80,8 +116,8 @@ describe('LaneRouter.resolveLane — 平台无关的 bot 维度泳道决策', ()
         const store = new FakeLaneRoutingStore();
         const router = new LaneRouter(store);
 
-        expect(await router.resolveLane('lark', '没绑定')).toBe('prod');
-        expect(await router.resolveLane('lark', '没绑定')).toBe('prod');
+        expect(await router.resolveLane('lark', '没绑定', undefined)).toBe('prod');
+        expect(await router.resolveLane('lark', '没绑定', undefined)).toBe('prod');
         expect(store.findBotLaneCalls).toBe(1);
     });
 
@@ -91,11 +127,11 @@ describe('LaneRouter.resolveLane — 平台无关的 bot 维度泳道决策', ()
         let clock = NOW;
         const router = new LaneRouter(store, () => clock);
 
-        expect(await router.resolveLane('lark', '赤尾')).toBe('ppe-foo');
+        expect(await router.resolveLane('lark', '赤尾', undefined)).toBe('ppe-foo');
         expect(store.findBotLaneCalls).toBe(1);
         // 跨过 30s TTL：缓存失效，重新查 DB。
         clock = NOW + 30_001;
-        expect(await router.resolveLane('lark', '赤尾')).toBe('ppe-foo');
+        expect(await router.resolveLane('lark', '赤尾', undefined)).toBe('ppe-foo');
         expect(store.findBotLaneCalls).toBe(2);
     });
 
@@ -104,10 +140,10 @@ describe('LaneRouter.resolveLane — 平台无关的 bot 维度泳道决策', ()
         store.setBotBinding('赤尾', 'ppe-foo');
         const router = new LaneRouter(store);
 
-        expect(await router.resolveLane('lark', '赤尾')).toBe('ppe-foo');
+        expect(await router.resolveLane('lark', '赤尾', undefined)).toBe('ppe-foo');
         // store 只按 botGlobalId 查（本期 route_type=bot 单维度），另一个 channel
         // 的同名 bot 应触发一次新的 DB 查询，而不是命中 lark 的缓存。
-        await router.resolveLane('qq', '赤尾');
+        await router.resolveLane('qq', '赤尾', undefined);
         expect(store.findBotLaneCalls).toBe(2);
     });
 
@@ -116,14 +152,14 @@ describe('LaneRouter.resolveLane — 平台无关的 bot 维度泳道决策', ()
         store.setBotBinding('赤尾', 'ppe-foo');
         const router = new LaneRouter(store);
 
-        expect(await router.resolveLane('lark', '赤尾')).toBe('ppe-foo');
+        expect(await router.resolveLane('lark', '赤尾', undefined)).toBe('ppe-foo');
         expect(store.findBotLaneCalls).toBe(1);
 
         // 模拟 admin 改绑定：换 lane 后主动 clearCache，下一次决策必须看到新值。
         store.setBotBinding('赤尾', 'ppe-bar');
         router.clearCache();
 
-        expect(await router.resolveLane('lark', '赤尾')).toBe('ppe-bar');
+        expect(await router.resolveLane('lark', '赤尾', undefined)).toBe('ppe-bar');
         expect(store.findBotLaneCalls).toBe(2);
     });
 
@@ -132,12 +168,12 @@ describe('LaneRouter.resolveLane — 平台无关的 bot 维度泳道决策', ()
         store.setBotBinding('赤尾', 'ppe-foo');
         const router = new LaneRouter(store);
 
-        expect(await router.resolveLane('lark', '赤尾')).toBe('ppe-foo');
+        expect(await router.resolveLane('lark', '赤尾', undefined)).toBe('ppe-foo');
 
         store.removeBotBinding('赤尾');
         router.clearCache();
 
-        expect(await router.resolveLane('lark', '赤尾')).toBe('prod');
+        expect(await router.resolveLane('lark', '赤尾', undefined)).toBe('prod');
     });
 });
 
@@ -156,8 +192,7 @@ describe('LaneRouter 平台无关红线 — 决策能力源码不含任何飞书
             /\bevent\b/,
         ];
         for (const f of FORBIDDEN_LARK_FIELDS) {
-            const hit =
-                typeof f === 'string' ? src.includes(f) : f.test(src);
+            const hit = typeof f === 'string' ? src.includes(f) : f.test(src);
             expect(hit).toBe(false);
         }
     });

--- a/apps/channel-server/src/core/channels/lane-routing/lane-router.ts
+++ b/apps/channel-server/src/core/channels/lane-routing/lane-router.ts
@@ -1,9 +1,9 @@
-// 平台无关的泳道决策能力（lane-routing-redesign §3）。本期只做 bot 维度：
-// 在 lark common projector 收敛出 common id 之后，基于平台无关的「全局 Bot
-// 概念」算出这条消息该走哪个 lane。
+// 平台无关的泳道决策能力（lane-routing-redesign §3）。在 lark common
+// projector 收敛出 common id 之后，基于平台无关的「会话 / 全局 Bot」
+// 概念算出这条消息该走哪个 lane。
 //
-// 决策优先级本期就两档（§3.2）：
-//   bot 维度命中 lane_routing  >  prod（默认）
+// 决策优先级：
+//   chat 维度命中 lane_routing > bot 维度命中 lane_routing > prod（默认）
 //
 // 平台无关红线（§3.2）：resolveLane 的入参只认 channel + 全局 bot 标识，
 // 绝不出现任何飞书原始消息体字段名。平台插件负责把渠道内标识收敛成 common
@@ -11,7 +11,7 @@
 //
 // 与 ORM 解耦：本模块只依赖结构型接口 LaneRoutingStore，不 import 任何
 // TypeORM 实体或数据源，单测可纯跑。生产运行时由 infrastructure 层提供一个
-// TypeORM 实现（读 lane_routing 表 route_type=Bot）注入进来。
+// TypeORM 实现（读 lane_routing 表）注入进来。
 //
 // 缓存：沿用 lane_routing 决策已验证的 30s 内存缓存语义——决策走
 // 本地缓存，不为每条消息打 DB；缓存 key 含 channel + 全局 bot 标识，跨 channel
@@ -26,8 +26,11 @@ const DEFAULT_LANE = 'prod';
 const CACHE_TTL_MS = 30_000;
 
 // LaneRouter 对底层存储的全部需求。结构型接口，不绑 ORM。
-// 本期只有 bot 维度，所以只暴露按全局 bot 标识查 lane 这一个能力。
 export interface LaneRoutingStore {
+    // 按平台无关 common_conversation_id 查 lane（对应 lane_routing 表
+    // route_type=chat AND route_key=commonConversationId AND is_active=true）。
+    // 没有绑定返回 null。
+    findChatLane(commonConversationId: string): Promise<string | null>;
     // 按全局 bot 标识查它当前绑定的 lane（对应 lane_routing 表
     // route_type=Bot AND route_key=botGlobalId AND is_active=true）。
     // 没有绑定返回 null。
@@ -48,10 +51,14 @@ export class LaneRouter {
         private readonly now: () => number = Date.now,
     ) {}
 
-    // 平台无关的泳道决策：只认 channel + 全局 bot 标识。
+    // 平台无关的泳道决策：只认 channel + common conversation + 全局 bot 标识。
     // 命中绑定返回 lane_name，未命中返回 prod 默认。
-    async resolveLane(channel: string, botGlobalId: string): Promise<string> {
-        const cacheKey = `${channel}:${botGlobalId}`;
+    async resolveLane(
+        channel: string,
+        botGlobalId: string,
+        commonConversationId: string | undefined,
+    ): Promise<string> {
+        const cacheKey = `${channel}:${commonConversationId ?? '-'}:${botGlobalId}`;
         const now = this.now();
 
         const cached = this.cache.get(cacheKey);
@@ -59,8 +66,17 @@ export class LaneRouter {
             return cached.lane;
         }
 
-        const bound = await this.store.findBotLane(botGlobalId);
-        const lane = bound ?? DEFAULT_LANE;
+        const bound =
+            commonConversationId !== undefined
+                ? await this.store.findChatLane(commonConversationId)
+                : null;
+        if (bound !== null) {
+            this.cache.set(cacheKey, { lane: bound, expiry: now + CACHE_TTL_MS });
+            return bound;
+        }
+
+        const botBound = await this.store.findBotLane(botGlobalId);
+        const lane = botBound ?? DEFAULT_LANE;
         this.cache.set(cacheKey, { lane, expiry: now + CACHE_TTL_MS });
         return lane;
     }

--- a/apps/channel-server/src/core/services/ai/reply.pending-trigger.test.ts
+++ b/apps/channel-server/src/core/services/ai/reply.pending-trigger.test.ts
@@ -25,6 +25,7 @@ mock.module('@integrations/rabbitmq', () => ({
 }));
 mock.module('@cache/redis-client', () => ({
     setNx: setNxMock,
+    evalScript: mock(async () => 1),
     exists: mock(async () => 0),
 }));
 mock.module('@repositories/repositories', () => ({

--- a/apps/channel-server/src/infrastructure/dal/repositories/lane-routing-store.test.ts
+++ b/apps/channel-server/src/infrastructure/dal/repositories/lane-routing-store.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, mock, beforeEach } from 'bun:test';
 
-// 钉死 TypeOrmLaneRoutingStore.findBotLane 的 wire 契约：lane_routing.route_type
+// 钉死 TypeOrmLaneRoutingStore 的 wire 契约：lane_routing.route_type
 // 列在真实 @chiwei 业务库里是 character varying（字符串），值是 'bot' / 'chat' /
 // 'group'。生产查询写法必须是 WHERE route_type = 'bot' 字符串。
 //
@@ -25,15 +25,14 @@ interface CapturedWhere {
 let capturedWheres: CapturedWhere[] = [];
 let nextRow: { lane_name: string } | null = null;
 
-const findOneMock = mock(
-    async (opts: { where: CapturedWhere }): Promise<unknown> => {
-        capturedWheres.push(opts.where);
-        return nextRow;
-    },
-);
+const findOneMock = mock(async (opts: { where: CapturedWhere }): Promise<unknown> => {
+    capturedWheres.push(opts.where);
+    return nextRow;
+});
 
 mock.module('@ormconfig', () => ({
     default: {
+        createEntityManager: mock(() => ({})),
         getRepository: () => ({ findOne: findOneMock }),
     },
 }));
@@ -46,7 +45,7 @@ mock.module('@entities/lane-routing', () => ({
 
 const { TypeOrmLaneRoutingStore } = await import('./lane-routing-store');
 
-describe('TypeOrmLaneRoutingStore.findBotLane — route_type wire 契约（字符串 bot）', () => {
+describe('TypeOrmLaneRoutingStore — route_type wire 契约（字符串 chat/bot）', () => {
     beforeEach(() => {
         capturedWheres = [];
         nextRow = null;
@@ -70,6 +69,22 @@ describe('TypeOrmLaneRoutingStore.findBotLane — route_type wire 契约（字�
         expect(typeof where.route_type).toBe('string');
         // route_key 透传全局 bot 标识；is_active 只取生效绑定。
         expect(where.route_key).toBe('赤尾');
+        expect(where.is_active).toBe(true);
+    });
+
+    it('chat 查询条件 route_type 必须是字符串字面量 chat，route_key 是 common_conversation_id', async () => {
+        nextRow = { lane_name: 'ppe-chat' };
+
+        const store = new TypeOrmLaneRoutingStore();
+        const lane = await store.findChatLane('018f-common-chat');
+
+        expect(lane).toBe('ppe-chat');
+        expect(capturedWheres).toHaveLength(1);
+
+        const where = capturedWheres[0]!;
+        expect(where.route_type).toBe('chat');
+        expect(typeof where.route_type).toBe('string');
+        expect(where.route_key).toBe('018f-common-chat');
         expect(where.is_active).toBe(true);
     });
 

--- a/apps/channel-server/src/infrastructure/dal/repositories/lane-routing-store.ts
+++ b/apps/channel-server/src/infrastructure/dal/repositories/lane-routing-store.ts
@@ -1,10 +1,9 @@
 // 生产运行时的 LaneRoutingStore 实现：用 TypeORM 复用 channel-server 现有的
-// AppDataSource（@chiwei 业务库，不新开 PG Pool）读 lane_routing 表。本期只读
-// bot 维度（route_type='bot'），满足 core LaneRouter 钉死的结构型契约。
+// AppDataSource（@chiwei 业务库，不新开 PG Pool）读 lane_routing 表。
 //
 // 查询语义与现行 lane_routing 数据口径一致：
 //   SELECT lane_name FROM lane_routing
-//   WHERE route_type = 'bot' AND route_key = $botGlobalId AND is_active = true LIMIT 1
+//   WHERE route_type = $type AND route_key = $key AND is_active = true LIMIT 1
 // route_type 是字符串判别值（真实 @chiwei 库该列是 character varying，值
 // 'bot' / 'chat' / 'group'）。
 //
@@ -15,17 +14,25 @@ import AppDataSource from '@ormconfig';
 import { LaneRouting } from '@entities/lane-routing';
 import type { LaneRoutingStore } from '@core/channels/lane-routing/lane-router';
 
-// 本期只读 bot 维度。route_type 是字符串判别值，生产写法固定为
-// WHERE route_type = 'bot'。
+// route_type 是字符串判别值，生产写法固定为 'chat' / 'bot'。
+const CHAT_ROUTE_TYPE = 'chat';
 const BOT_ROUTE_TYPE = 'bot';
 
 export class TypeOrmLaneRoutingStore implements LaneRoutingStore {
+    async findChatLane(commonConversationId: string): Promise<string | null> {
+        return this.findLane(CHAT_ROUTE_TYPE, commonConversationId);
+    }
+
     async findBotLane(botGlobalId: string): Promise<string | null> {
+        return this.findLane(BOT_ROUTE_TYPE, botGlobalId);
+    }
+
+    private async findLane(routeType: string, routeKey: string): Promise<string | null> {
         const repo = AppDataSource.getRepository(LaneRouting);
         const row = await repo.findOne({
             where: {
-                route_type: BOT_ROUTE_TYPE,
-                route_key: botGlobalId,
+                route_type: routeType,
+                route_key: routeKey,
                 is_active: true,
             },
         });

--- a/apps/channel-server/src/infrastructure/integrations/inbound-lane-decision.test.ts
+++ b/apps/channel-server/src/infrastructure/integrations/inbound-lane-decision.test.ts
@@ -12,6 +12,7 @@ describe('resolveInboundDispatch（入站分流决策）', () => {
             currentLane: 'prod',
             channel: 'lark',
             botGlobalId: 'bot-1',
+            commonConversationId: '018f-chat',
             resolveLane: async () => {
                 called = true;
                 return 'ppe-foo';
@@ -27,6 +28,7 @@ describe('resolveInboundDispatch（入站分流决策）', () => {
             currentLane: 'prod',
             channel: 'lark',
             botGlobalId: 'bot-1',
+            commonConversationId: '018f-chat',
             resolveLane: async () => 'prod',
         });
         expect(r.action).toBe('local');
@@ -39,6 +41,7 @@ describe('resolveInboundDispatch（入站分流决策）', () => {
             currentLane: 'prod',
             channel: 'lark',
             botGlobalId: 'bot-1',
+            commonConversationId: '018f-chat',
             resolveLane: async () => 'ppe-foo',
         });
         expect(r.action).toBe('dispatch');
@@ -51,8 +54,25 @@ describe('resolveInboundDispatch（入站分流决策）', () => {
             currentLane: 'ppe-foo',
             channel: 'lark',
             botGlobalId: 'bot-1',
+            commonConversationId: '018f-chat',
             resolveLane: async () => 'ppe-foo',
         });
         expect(r.action).toBe('local');
+    });
+
+    it('flag on → 把 commonConversationId 传给 resolveLane', async () => {
+        let seenConversationId: string | undefined;
+        await resolveInboundDispatch({
+            flagEnabled: true,
+            currentLane: 'prod',
+            channel: 'lark',
+            botGlobalId: 'bot-1',
+            commonConversationId: '018f-chat',
+            resolveLane: async (_channel, _bot, commonConversationId) => {
+                seenConversationId = commonConversationId;
+                return 'prod';
+            },
+        });
+        expect(seenConversationId).toBe('018f-chat');
     });
 });

--- a/apps/channel-server/src/infrastructure/integrations/inbound-lane-decision.ts
+++ b/apps/channel-server/src/infrastructure/integrations/inbound-lane-decision.ts
@@ -5,7 +5,7 @@
 //   flag on + lane!=本进程lane → dispatch（投 inbound_lane.{lane}，本地不再处理）
 //
 // resolveLane 由调用方注入（生产=getLaneRouter().resolveLane），决策只看平台无关
-// 的 channel + 全局 bot 标识（§3.2 平台无关红线）。
+// 的 channel + common conversation + 全局 bot 标识（§3.2 平台无关红线）。
 
 export interface InboundDispatchInput {
     // 动态 flag「是否启用处理层分流」（§3 / Task 10）。默认 off = 现状行为。
@@ -14,8 +14,13 @@ export interface InboundDispatchInput {
     currentLane: string;
     channel: string;
     botGlobalId: string;
+    commonConversationId?: string;
     // 平台无关的 lane 决策（注入，便于测试 + 解耦 ORM）。
-    resolveLane: (channel: string, botGlobalId: string) => Promise<string>;
+    resolveLane: (
+        channel: string,
+        botGlobalId: string,
+        commonConversationId: string | undefined,
+    ) => Promise<string>;
 }
 
 export interface InboundDispatchDecision {
@@ -32,7 +37,11 @@ export async function resolveInboundDispatch(
         return { action: 'local', lane: input.currentLane };
     }
 
-    const lane = await input.resolveLane(input.channel, input.botGlobalId);
+    const lane = await input.resolveLane(
+        input.channel,
+        input.botGlobalId,
+        input.commonConversationId,
+    );
 
     // lane == 本进程 lane（含 prod 占绝大多数）：本地处理，绝不投 MQ（§4.2 prod 不发
     // MQ；也防把消息投给自己造成双跑）。

--- a/apps/channel-server/src/infrastructure/integrations/inbound-lane-dispatch.test.ts
+++ b/apps/channel-server/src/infrastructure/integrations/inbound-lane-dispatch.test.ts
@@ -19,10 +19,15 @@ mock.module('./inbound-lane-flag', () => ({
     isInboundLaneDispatchEnabled: async () => flagValue,
 }));
 
-let resolveLaneImpl: (channel: string, bot: string) => Promise<string> = async () => 'prod';
+let resolveLaneImpl: (
+    channel: string,
+    bot: string,
+    commonConversationId: string | undefined,
+) => Promise<string> = async () => 'prod';
 mock.module('./lane-router-runtime', () => ({
     getLaneRouter: () => ({
-        resolveLane: (channel: string, bot: string) => resolveLaneImpl(channel, bot),
+        resolveLane: (channel: string, bot: string, commonConversationId: string | undefined) =>
+            resolveLaneImpl(channel, bot, commonConversationId),
     }),
 }));
 
@@ -32,6 +37,7 @@ const baseInput = {
     currentLane: 'prod',
     channel: 'lark',
     botGlobalId: 'chiwei',
+    commonConversationId: '018f-chat',
     eventType: 'im.message.receive_v1',
     globalMessageId: 'gmid-1',
     traceId: 'trace-1',
@@ -85,5 +91,18 @@ describe('dispatchInboundIfNeeded', () => {
             bot_name: 'chiwei',
             params: baseInput.params,
         });
+    });
+
+    it('passes commonConversationId into lane resolution for chat binding', async () => {
+        flagValue = true;
+        let seenConversationId: string | undefined;
+        resolveLaneImpl = async (_channel, _bot, commonConversationId) => {
+            seenConversationId = commonConversationId;
+            return 'prod';
+        };
+
+        await dispatchInboundIfNeeded(baseInput);
+
+        expect(seenConversationId).toBe('018f-chat');
     });
 });

--- a/apps/channel-server/src/infrastructure/integrations/inbound-lane-dispatch.ts
+++ b/apps/channel-server/src/infrastructure/integrations/inbound-lane-dispatch.ts
@@ -21,6 +21,7 @@ export interface InboundDispatchContext {
     currentLane: string;
     channel: string;
     botGlobalId: string;
+    commonConversationId?: string;
     eventType: string;
     globalMessageId: string;
     traceId: string;
@@ -29,17 +30,16 @@ export interface InboundDispatchContext {
 }
 
 // 返回 true = 已投到别的 lane，handler 应 return；false = 本地继续处理。
-export async function dispatchInboundIfNeeded(
-    ctx: InboundDispatchContext,
-): Promise<boolean> {
+export async function dispatchInboundIfNeeded(ctx: InboundDispatchContext): Promise<boolean> {
     const flagEnabled = await isInboundLaneDispatchEnabled();
     const decision = await resolveInboundDispatch({
         flagEnabled,
         currentLane: ctx.currentLane,
         channel: ctx.channel,
         botGlobalId: ctx.botGlobalId,
-        resolveLane: (channel, botGlobalId) =>
-            getLaneRouter().resolveLane(channel, botGlobalId),
+        commonConversationId: ctx.commonConversationId,
+        resolveLane: (channel, botGlobalId, commonConversationId) =>
+            getLaneRouter().resolveLane(channel, botGlobalId, commonConversationId),
     });
 
     if (decision.action === 'local') {

--- a/apps/channel-server/src/infrastructure/integrations/lark/events/handlers.plugin-registration.test.ts
+++ b/apps/channel-server/src/infrastructure/integrations/lark/events/handlers.plugin-registration.test.ts
@@ -14,6 +14,7 @@ mock.module('@aliyun/oss', () => ({
 mock.module('@cache/redis-client', () => ({
     hgetall: mock(async () => ({})),
     setNx: mock(async () => 'OK'),
+    evalScript: mock(async () => 1),
     exists: mock(async () => 0),
 }));
 mock.module('@infrastructure/lane-router', () => ({

--- a/apps/channel-server/src/infrastructure/integrations/lark/events/handlers.ts
+++ b/apps/channel-server/src/infrastructure/integrations/lark/events/handlers.ts
@@ -13,13 +13,12 @@ import type {
 import { EventHandler } from './event-registry';
 import { runRules } from 'core/rules/engine';
 import { MessageTransferer } from './factory';
-import {
-    UpdatePhotoCard,
-    FetchPhotoDetails,
-    UpdateDailyPhotoCard,
-} from 'types/lark';
+import { UpdatePhotoCard, FetchPhotoDetails, UpdateDailyPhotoCard } from 'types/lark';
 import { fetchAndSendPhotoDetail } from '@plugins/lark/services/callback/fetch-photo-detail';
-import { handleUpdatePhotoCard, handleUpdateDailyPhotoCard } from '@plugins/lark/services/callback/update-card';
+import {
+    handleUpdatePhotoCard,
+    handleUpdateDailyPhotoCard,
+} from '@plugins/lark/services/callback/update-card';
 import { LarkGroupMember, LarkUser } from 'infrastructure/dal/entities';
 import { LarkUserOpenId } from 'infrastructure/dal/entities/lark-user-open-id';
 import { getUserInfo } from 'infrastructure/integrations/lark-client';
@@ -52,6 +51,7 @@ import {
     ensureLarkCommonConversation,
     prepareLarkInboundProjection,
     storeLarkInboundMessage,
+    withLarkInboundProjectionLock,
 } from '@plugins/lark/common-projector';
 
 async function upsertCommonBotPresence(
@@ -114,18 +114,20 @@ export class LarkEventHandlers {
                 const toolClient = laneRouter.createClient('tool-service');
                 const botName = context.getBotName();
                 for (const imageKey of message.imageKeys()) {
-                    toolClient.post(
-                        '/api/image-pipeline/process',
-                        { message_id: message.messageId, file_key: imageKey },
-                        {
-                            headers: {
-                                Authorization: `Bearer ${process.env.INNER_HTTP_SECRET}`,
-                                'X-App-Name': botName,
+                    toolClient
+                        .post(
+                            '/api/image-pipeline/process',
+                            { message_id: message.messageId, file_key: imageKey },
+                            {
+                                headers: {
+                                    Authorization: `Bearer ${process.env.INNER_HTTP_SECRET}`,
+                                    'X-App-Name': botName,
+                                },
                             },
-                        },
-                    ).catch((err) => {
-                        console.error('Error in upload image:', err);
-                    });
+                        )
+                        .catch((err) => {
+                            console.error('Error in upload image:', err);
+                        });
                 }
             }
 
@@ -178,137 +180,139 @@ export class LarkEventHandlers {
                         `lark_message_id=${message.messageId} reason=${reason}`,
                 ),
             );
-            const projection = await prepareLarkInboundProjection(
-                params,
-                message,
-                inbound,
-            );
-            upsertCommonBotPresence(
-                projection.commonConversationId,
-                context.getBotName(),
-                true,
-            ).catch((err) => console.warn('[CommonBotPresence] upsert failed:', err));
+            // 同一条飞书 om_id 会被同群多个 bot 并发处理。这里在 lark 层按
+            // om_id 串行到 store 完成：第一个 bot 生成并写入 common_id，后续
+            // bot 进入 prepare 时必须读到同一个 common_id，不能再造 bot 维度
+            // 的 orphan common_message。
+            await withLarkInboundProjectionLock(params.message.message_id, async () => {
+                const projection = await prepareLarkInboundProjection(params, message, inbound);
+                upsertCommonBotPresence(
+                    projection.commonConversationId,
+                    context.getBotName(),
+                    true,
+                ).catch((err) => console.warn('[CommonBotPresence] upsert failed:', err));
 
-            // ---- 处理层泳道分流决策点（lane-routing-redesign §3.1）----
-            // 全局 ID 就绪后、派生 RuleMessage / 入库 / 发 MQ 之前：按统一概念
-            // （channel + 全局 bot）算 lane。非本进程 lane → 投 inbound_lane.{lane}
-            // 给目标 lane 的 channel-server，本地到此为止；本进程 lane → 继续现状链路。
-            // flag 默认 off = 完全旁路（dispatchInboundIfNeeded 内零回归），现状行为不变。
-            const dispatched = await dispatchInboundIfNeeded({
-                currentLane: getLane() ?? 'prod',
-                channel: botConfig.channel,
-                botGlobalId: botName ?? '',
-                eventType: 'im.message.receive_v1',
-                globalMessageId: projection.commonMessageId,
-                traceId: context.getTraceId(),
-                params,
-            });
-            if (dispatched) {
-                // 已投到目标 lane 的 inbound_lane 队列，本进程不再入库/发 MQ
-                // （目标 lane channel-server 消费后走入站后半段）。此处尚未
-                // buildLarkRuleMessage、还没写 lark store entry，无需 clear。
-                return;
-            }
-
-            // 全局 ID 就绪。派生平台无关 RuleMessage。飞书强绑能力（admin/群
-            // 信息/原始 message_id 等）不再旁挂在 RuleMessage 上：buildLarkRuleMessage
-            // 把飞书 Message put 进 lark 私有 store（key=全局 commonMessageId），
-            // lark 谓词/handler 按此 key get 取回（B2，#228 的 larkMessage 逃生口已删）。
-            const ruleMessage = buildLarkRuleMessage(message, {
-                botName: botName ?? '',
-                commonUserId: projection.commonUserId,
-                commonConversationId: projection.commonConversationId,
-                commonMessageId: projection.commonMessageId,
-                commonRootMessageId: projection.commonRootMessageId,
-                // addressedTargetIds 与 hasMention(union_id) 同源
-                // （plugins/lark inbound 的 addressing_hints[].targetId = union_id）。
-                addressedTargetIds: inbound.addressing_hints.map((h) => h.targetId),
-            });
-
-            // 本条消息处理结束（无论命中哪条退出路径）后，clear lark store entry，
-            // 避免 Map 无限增长（内存泄漏）。finally 覆盖 store 失败 return、
-            // 抢锁失败 return、publish 成功等所有路径。
-            try {
-            // ---- 5b 入站重排（决策一/二/三）：顺序硬钉 ----
-            //   resolve(契约链, 已完成) → runRules(规则判定 + 各 utility/native
-            //   副作用，persona 主链路**不实际 publish**，只把待发 ChatTrigger
-            //   意图登记到 RuleTerminalState.pendingChatTrigger)
-            //   → storeLarkInboundMessage(无条件执行，不看 terminal kind ——
-            //   非 @bot 群消息复读照常入库，飞书逐场景零变化)
-            //   → 若 terminal 带 pending 意图：取去重锁；拿到锁才 publish。
-            //
-            // 为什么 common message 写入必须先于 publish：下游 agent-service
-            // chat_node 按 message_id 回查 common_message，读空会短路
-            // emit "未找到相关消息记录"。先存后发是硬依赖。
-            //
-            // runRules 单一终态出口，不向调用方抛错（决策四），所有退出路径
-            // 收敛成 RuleTerminalState。blocked / no_match / handler_error
-            // 等终态 store 仍无条件执行（与现状一致、行为不变），
-            // 只有 pendingChatTrigger 存在才 publish。
-            const terminal = await runRules(ruleMessage);
-
-            // storeLarkInboundMessage 写 common_message + lark_message。无条件执行
-            // （保住非 @bot 群消息照常入库）。
-            // reply_message_id 是飞书"回复某条消息"锚点，与 root 一样由 lark
-            // common projector 收敛为 common_message_id 再落库，避免渠道裸 id
-            // 与 common_message_id 混用导致回复链断开。
-            // 无 parent 时 projection.commonReplyMessageId 为 undefined，保持原"空就空"
-            // 语义，不凭空造 id。
-            //
-            // fail-loud（5b 新增语义）：store 失败 → 记可查错误日志
-            // 并 return，**绝不 publish**（否则下游回查读空走"未找到消息
-            // 记录"短路，等于发了个注定失败的请求）。
-            try {
-                await storeLarkInboundMessage(params, projection, message);
-            } catch (storeErr) {
-                console.error(
-                    `[inbound] storeLarkInboundMessage failed (fail-loud, ` +
-                        `ChatTrigger NOT published): ` +
-                        `message=${projection.commonMessageId} ` +
-                        `chat=${projection.commonConversationId} ` +
-                        `detail=${(storeErr as Error).message}`,
-                );
-                return;
-            }
-
-            // common/lark message 已成功。若 runRules 登记了待发 ChatTrigger 意图
-            // （仅 persona 文本主链路命中时），现在才取去重锁、落 pending
-            // 行、发 MQ。三者紧邻（决策二 / 必改2）：多 bot 同群时同一
-            // common_message_id 只有第一个拿到锁的 bot 落 common_agent_response pending
-            // 行并真正发，其余静默跳过、不写孤儿 pending 行；锁后移避免拿
-            // 锁后 store 失败导致锁空占 60s。
-            if (terminal.pendingChatTrigger) {
-                const { payload, lane, dedupeKey, savePending } =
-                    terminal.pendingChatTrigger;
-                const lock = await setNx(dedupeKey, '1', 60);
-                if (lock === null) {
-                    console.info(
-                        `[inbound] duplicate ChatTrigger skipped (lock held by ` +
-                            `another bot): message=${projection.commonMessageId}`,
-                    );
+                // ---- 处理层泳道分流决策点（lane-routing-redesign §3.1）----
+                // 全局 ID 就绪后、派生 RuleMessage / 入库 / 发 MQ 之前：按统一概念
+                // （channel + 全局 bot）算 lane。非本进程 lane → 投 inbound_lane.{lane}
+                // 给目标 lane 的 channel-server，本地到此为止；本进程 lane → 继续现状链路。
+                // flag 默认 off = 完全旁路（dispatchInboundIfNeeded 内零回归），现状行为不变。
+                const dispatched = await dispatchInboundIfNeeded({
+                    currentLane: getLane() ?? 'prod',
+                    channel: botConfig.channel,
+                    botGlobalId: botName ?? '',
+                    eventType: 'im.message.receive_v1',
+                    globalMessageId: projection.commonMessageId,
+                    traceId: context.getTraceId(),
+                    params,
+                });
+                if (dispatched) {
+                    // 已投到目标 lane 的 inbound_lane 队列，本进程不再入库/发 MQ
+                    // （目标 lane channel-server 消费后走入站后半段）。此处尚未
+                    // buildLarkRuleMessage、还没写 lark store entry，无需 clear。
                     return;
                 }
-                // 抢到锁才落 common_agent_response pending 行（必改2）：未抢锁的
-                // bot 已在上面 return，不会到这里 → 不留永不完成的孤儿行。
-                await savePending();
-                await rabbitmqClient.publish(
-                    CHAT_REQUEST,
-                    payload as unknown as Record<string, unknown>,
-                    undefined,
-                    undefined,
-                    lane,
-                );
-                console.info(
-                    `[inbound] Published chat.request: ` +
-                        `session_id=${payload.session_id}, ` +
-                        `message=${projection.commonMessageId}, ` +
-                        `lane=${lane || 'prod'}`,
-                );
-            }
-            } finally {
-                // 处理结束清理 lark store entry（无内存泄漏）。
-                larkContextStore.clear(ruleMessage);
-            }
+
+                // 全局 ID 就绪。派生平台无关 RuleMessage。飞书强绑能力（admin/群
+                // 信息/原始 message_id 等）不再旁挂在 RuleMessage 上：buildLarkRuleMessage
+                // 把飞书 Message put 进 lark 私有 store（key=全局 commonMessageId），
+                // lark 谓词/handler 按此 key get 取回（B2，#228 的 larkMessage 逃生口已删）。
+                const ruleMessage = buildLarkRuleMessage(message, {
+                    botName: botName ?? '',
+                    commonUserId: projection.commonUserId,
+                    commonConversationId: projection.commonConversationId,
+                    commonMessageId: projection.commonMessageId,
+                    commonRootMessageId: projection.commonRootMessageId,
+                    // addressedTargetIds 与 hasMention(union_id) 同源
+                    // （plugins/lark inbound 的 addressing_hints[].targetId = union_id）。
+                    addressedTargetIds: inbound.addressing_hints.map((h) => h.targetId),
+                });
+
+                // 本条消息处理结束（无论命中哪条退出路径）后，clear lark store entry，
+                // 避免 Map 无限增长（内存泄漏）。finally 覆盖 store 失败 return、
+                // 抢锁失败 return、publish 成功等所有路径。
+                try {
+                    // ---- 5b 入站重排（决策一/二/三）：顺序硬钉 ----
+                    //   resolve(契约链, 已完成) → runRules(规则判定 + 各 utility/native
+                    //   副作用，persona 主链路**不实际 publish**，只把待发 ChatTrigger
+                    //   意图登记到 RuleTerminalState.pendingChatTrigger)
+                    //   → storeLarkInboundMessage(无条件执行，不看 terminal kind ——
+                    //   非 @bot 群消息复读照常入库，飞书逐场景零变化)
+                    //   → 若 terminal 带 pending 意图：取去重锁；拿到锁才 publish。
+                    //
+                    // 为什么 common message 写入必须先于 publish：下游 agent-service
+                    // chat_node 按 message_id 回查 common_message，读空会短路
+                    // emit "未找到相关消息记录"。先存后发是硬依赖。
+                    //
+                    // runRules 单一终态出口，不向调用方抛错（决策四），所有退出路径
+                    // 收敛成 RuleTerminalState。blocked / no_match / handler_error
+                    // 等终态 store 仍无条件执行（与现状一致、行为不变），
+                    // 只有 pendingChatTrigger 存在才 publish。
+                    const terminal = await runRules(ruleMessage);
+
+                    // storeLarkInboundMessage 写 common_message + lark_message。无条件执行
+                    // （保住非 @bot 群消息照常入库）。
+                    // reply_message_id 是飞书"回复某条消息"锚点，与 root 一样由 lark
+                    // common projector 收敛为 common_message_id 再落库，避免渠道裸 id
+                    // 与 common_message_id 混用导致回复链断开。
+                    // 无 parent 时 projection.commonReplyMessageId 为 undefined，保持原"空就空"
+                    // 语义，不凭空造 id。
+                    //
+                    // fail-loud（5b 新增语义）：store 失败 → 记可查错误日志
+                    // 并 return，**绝不 publish**（否则下游回查读空走"未找到消息
+                    // 记录"短路，等于发了个注定失败的请求）。
+                    try {
+                        await storeLarkInboundMessage(params, projection, message);
+                    } catch (storeErr) {
+                        console.error(
+                            `[inbound] storeLarkInboundMessage failed (fail-loud, ` +
+                                `ChatTrigger NOT published): ` +
+                                `message=${projection.commonMessageId} ` +
+                                `chat=${projection.commonConversationId} ` +
+                                `detail=${(storeErr as Error).message}`,
+                        );
+                        return;
+                    }
+
+                    // common/lark message 已成功。若 runRules 登记了待发 ChatTrigger 意图
+                    // （仅 persona 文本主链路命中时），现在才取去重锁、落 pending
+                    // 行、发 MQ。三者紧邻（决策二 / 必改2）：多 bot 同群时同一
+                    // common_message_id 只有第一个拿到锁的 bot 落 common_agent_response pending
+                    // 行并真正发，其余静默跳过、不写孤儿 pending 行；锁后移避免拿
+                    // 锁后 store 失败导致锁空占 60s。
+                    if (terminal.pendingChatTrigger) {
+                        const { payload, lane, dedupeKey, savePending } =
+                            terminal.pendingChatTrigger;
+                        const lock = await setNx(dedupeKey, '1', 60);
+                        if (lock === null) {
+                            console.info(
+                                `[inbound] duplicate ChatTrigger skipped (lock held by ` +
+                                    `another bot): message=${projection.commonMessageId}`,
+                            );
+                            return;
+                        }
+                        // 抢到锁才落 common_agent_response pending 行（必改2）：未抢锁的
+                        // bot 已在上面 return，不会到这里 → 不留永不完成的孤儿行。
+                        await savePending();
+                        await rabbitmqClient.publish(
+                            CHAT_REQUEST,
+                            payload as unknown as Record<string, unknown>,
+                            undefined,
+                            undefined,
+                            lane,
+                        );
+                        console.info(
+                            `[inbound] Published chat.request: ` +
+                                `session_id=${payload.session_id}, ` +
+                                `message=${projection.commonMessageId}, ` +
+                                `lane=${lane || 'prod'}`,
+                        );
+                    }
+                } finally {
+                    // 处理结束清理 lark store entry（无内存泄漏）。
+                    larkContextStore.clear(ruleMessage);
+                }
+            });
         } catch (error) {
             console.error(
                 'Error handling message receive:',

--- a/apps/channel-server/src/infrastructure/integrations/lark/events/handlers.ts
+++ b/apps/channel-server/src/infrastructure/integrations/lark/events/handlers.ts
@@ -201,6 +201,7 @@ export class LarkEventHandlers {
                     currentLane: getLane() ?? 'prod',
                     channel: botConfig.channel,
                     botGlobalId: botName ?? '',
+                    commonConversationId: projection.commonConversationId,
                     eventType: 'im.message.receive_v1',
                     globalMessageId: projection.commonMessageId,
                     traceId: context.getTraceId(),

--- a/apps/channel-server/src/plugins/lark/common-projector.store.test.ts
+++ b/apps/channel-server/src/plugins/lark/common-projector.store.test.ts
@@ -4,6 +4,7 @@ const larkMessages = new Map<string, { om_id: string; common_message_id: string 
 const commonMessages = new Set<string>();
 const larkInsertCalls: unknown[] = [];
 const vectorizePublishes: unknown[] = [];
+let larkInsertRaceWinner: { om_id: string; common_message_id: string } | null = null;
 
 function insertBuilder() {
     let target: { name?: string } | undefined;
@@ -35,6 +36,12 @@ function insertBuilder() {
             if (target?.name === 'LarkMessage') {
                 larkInsertCalls.push(payload);
                 const omId = payload.om_id as string;
+                if (larkInsertRaceWinner?.om_id === omId) {
+                    larkMessages.set(omId, larkInsertRaceWinner);
+                    throw new Error(
+                        'duplicate key value violates unique constraint "lark_message_pkey"',
+                    );
+                }
                 if (!larkMessages.has(omId)) {
                     larkMessages.set(omId, {
                         om_id: omId,
@@ -76,21 +83,32 @@ mock.module('ormconfig', () => ({
                 upsert: mock(async () => ({ identifiers: [] })),
             };
         },
-        transaction: async (task: (manager: unknown) => Promise<void>) =>
-            task({
-                getRepository: (entity: { name?: string }) => {
-                    if (entity.name === 'LarkMessage') {
-                        return {
-                            findOne: mock(
-                                async ({ where }: { where: { om_id: string } }) =>
-                                    larkMessages.get(where.om_id) ?? null,
-                            ),
-                        };
-                    }
-                    throw new Error(`unexpected repository: ${entity.name}`);
-                },
-                createQueryBuilder: () => insertBuilder(),
-            }),
+        transaction: async (task: (manager: unknown) => Promise<void>) => {
+            const commonSnapshot = new Set(commonMessages);
+            const larkSnapshot = new Map(larkMessages);
+            try {
+                return await task({
+                    getRepository: (entity: { name?: string }) => {
+                        if (entity.name === 'LarkMessage') {
+                            return {
+                                findOne: mock(
+                                    async ({ where }: { where: { om_id: string } }) =>
+                                        larkMessages.get(where.om_id) ?? null,
+                                ),
+                            };
+                        }
+                        throw new Error(`unexpected repository: ${entity.name}`);
+                    },
+                    createQueryBuilder: () => insertBuilder(),
+                });
+            } catch (err) {
+                commonMessages.clear();
+                for (const id of commonSnapshot) commonMessages.add(id);
+                larkMessages.clear();
+                for (const [omId, row] of larkSnapshot) larkMessages.set(omId, row);
+                throw err;
+            }
+        },
     },
 }));
 
@@ -167,6 +185,7 @@ describe('storeLarkInboundMessage', () => {
         commonMessages.clear();
         larkInsertCalls.length = 0;
         vectorizePublishes.length = 0;
+        larkInsertRaceWinner = null;
     });
 
     it('writes the lark mapping once for a new om_id', async () => {
@@ -199,5 +218,20 @@ describe('storeLarkInboundMessage', () => {
         await expect(
             storeLarkInboundMessage(event('om_1') as any, projection('018f-common-new'), message),
         ).rejects.toThrow(/already maps to 018f-common-existing/);
+    });
+
+    it('rolls back common_message when lark_message insert loses a race', async () => {
+        larkInsertRaceWinner = {
+            om_id: 'om_1',
+            common_message_id: '018f-common-existing',
+        };
+
+        await expect(
+            storeLarkInboundMessage(event('om_1') as any, projection('018f-common-new'), message),
+        ).rejects.toThrow(/mapping insert failed/);
+
+        expect(commonMessages.has('018f-common-new')).toBe(false);
+        expect(larkMessages.has('om_1')).toBe(false);
+        expect(vectorizePublishes.length).toBe(0);
     });
 });

--- a/apps/channel-server/src/plugins/lark/common-projector.store.test.ts
+++ b/apps/channel-server/src/plugins/lark/common-projector.store.test.ts
@@ -1,0 +1,203 @@
+import { beforeEach, describe, expect, it, mock } from 'bun:test';
+
+const larkMessages = new Map<string, { om_id: string; common_message_id: string }>();
+const commonMessages = new Set<string>();
+const larkInsertCalls: unknown[] = [];
+const vectorizePublishes: unknown[] = [];
+
+function insertBuilder() {
+    let target: { name?: string } | undefined;
+    let payload: Record<string, unknown> = {};
+    return {
+        insert() {
+            return this;
+        },
+        into(entity: { name?: string }) {
+            target = entity;
+            return this;
+        },
+        values(value: Record<string, unknown>) {
+            payload = value;
+            return this;
+        },
+        orIgnore() {
+            return this;
+        },
+        async execute() {
+            if (target?.name === 'CommonMessage') {
+                const id = payload.common_message_id as string;
+                if (commonMessages.has(id)) {
+                    return { identifiers: [] };
+                }
+                commonMessages.add(id);
+                return { identifiers: [{ common_message_id: id }] };
+            }
+            if (target?.name === 'LarkMessage') {
+                larkInsertCalls.push(payload);
+                const omId = payload.om_id as string;
+                if (!larkMessages.has(omId)) {
+                    larkMessages.set(omId, {
+                        om_id: omId,
+                        common_message_id: payload.common_message_id as string,
+                    });
+                }
+                return { identifiers: [{ om_id: omId }] };
+            }
+            throw new Error(`unexpected insert target: ${target?.name}`);
+        },
+    };
+}
+
+mock.module('ormconfig', () => ({
+    default: {
+        createEntityManager: mock(() => ({})),
+        getRepository: (entity: { name?: string }) => {
+            if (entity.name === 'LarkMessage') {
+                return {
+                    findOne: mock(
+                        async ({
+                            where,
+                        }: {
+                            where: { om_id?: string; common_message_id?: string };
+                        }) => {
+                            if (where.om_id) return larkMessages.get(where.om_id) ?? null;
+                            return null;
+                        },
+                    ),
+                };
+            }
+            return {
+                findOne: mock(async () => null),
+                findOneOrFail: mock(async () => ({})),
+                find: mock(async () => []),
+                save: mock(async (value: unknown) => value),
+                create: mock((value: unknown) => value),
+                update: mock(async () => ({ affected: 0 })),
+                upsert: mock(async () => ({ identifiers: [] })),
+            };
+        },
+        transaction: async (task: (manager: unknown) => Promise<void>) =>
+            task({
+                getRepository: (entity: { name?: string }) => {
+                    if (entity.name === 'LarkMessage') {
+                        return {
+                            findOne: mock(
+                                async ({ where }: { where: { om_id: string } }) =>
+                                    larkMessages.get(where.om_id) ?? null,
+                            ),
+                        };
+                    }
+                    throw new Error(`unexpected repository: ${entity.name}`);
+                },
+                createQueryBuilder: () => insertBuilder(),
+            }),
+    },
+}));
+
+mock.module('@cache/redis-client', () => ({
+    get: mock(async () => null),
+    setWithExpire: mock(async () => 'OK'),
+    hgetall: mock(async () => ({})),
+    setNx: mock(async () => 'OK'),
+    evalScript: mock(async () => 1),
+    exists: mock(async () => 0),
+}));
+mock.module('@middleware/context', () => ({
+    context: {
+        getBotName: () => 'chiwei',
+        getLane: () => undefined,
+    },
+}));
+mock.module('@integrations/rabbitmq', () => ({
+    VECTORIZE: 'vectorize',
+    PROACTIVE_EVAL: 'proactive_eval',
+    CHAT_REQUEST: 'chat_request',
+    getLane: () => undefined,
+    getRabbitChannel: () => ({
+        assertQueue: mock(async () => undefined),
+        sendToQueue: mock(() => true),
+    }),
+    rabbitmqClient: {
+        publish: mock(async (...args: unknown[]) => {
+            vectorizePublishes.push(args);
+        }),
+    },
+}));
+const { storeLarkInboundMessage } = await import('./common-projector');
+
+function event(omId: string) {
+    return {
+        sender: {
+            sender_id: {
+                open_id: 'ou_sender',
+                union_id: 'on_sender',
+            },
+        },
+        message: {
+            message_id: omId,
+            chat_id: 'oc_chat',
+            root_id: undefined,
+            parent_id: undefined,
+            message_type: 'text',
+            create_time: '1780309200000',
+        },
+    };
+}
+
+const message = {
+    senderInfo: { name: 'sender' },
+} as any;
+
+function projection(commonMessageId: string) {
+    return {
+        commonUserId: '018f-user',
+        commonConversationId: '018f-chat',
+        commonMessageId,
+        commonRootMessageId: commonMessageId,
+        commonReplyMessageId: undefined,
+        content: [{ kind: 'text', text: 'hello' }],
+        contentText: 'hello',
+        scope: 'group',
+    } as const;
+}
+
+describe('storeLarkInboundMessage', () => {
+    beforeEach(() => {
+        larkMessages.clear();
+        commonMessages.clear();
+        larkInsertCalls.length = 0;
+        vectorizePublishes.length = 0;
+    });
+
+    it('writes the lark mapping once for a new om_id', async () => {
+        await storeLarkInboundMessage(event('om_1') as any, projection('018f-common-1'), message);
+
+        expect(larkMessages.get('om_1')?.common_message_id).toBe('018f-common-1');
+        expect(larkInsertCalls.length).toBe(1);
+        expect(vectorizePublishes.length).toBe(1);
+    });
+
+    it('skips lark_message insert when the om_id already maps to the same common id', async () => {
+        commonMessages.add('018f-common-1');
+        larkMessages.set('om_1', {
+            om_id: 'om_1',
+            common_message_id: '018f-common-1',
+        });
+
+        await storeLarkInboundMessage(event('om_1') as any, projection('018f-common-1'), message);
+
+        expect(larkInsertCalls.length).toBe(0);
+        expect(vectorizePublishes.length).toBe(0);
+    });
+
+    it('fails loud when an om_id is already mapped to another common id', async () => {
+        larkMessages.set('om_1', {
+            om_id: 'om_1',
+            common_message_id: '018f-common-existing',
+        });
+
+        await expect(
+            storeLarkInboundMessage(event('om_1') as any, projection('018f-common-new'), message),
+        ).rejects.toThrow(/already maps to 018f-common-existing/);
+    });
+});

--- a/apps/channel-server/src/plugins/lark/common-projector.ts
+++ b/apps/channel-server/src/plugins/lark/common-projector.ts
@@ -11,6 +11,7 @@ import { LarkUserOpenId } from '@entities/lark-user-open-id';
 import { context } from '@middleware/context';
 import { rabbitmqClient, VECTORIZE } from '@integrations/rabbitmq';
 import { getBotAppId } from '@core/services/bot/bot-var';
+import { evalScript, setNx } from '@cache/redis-client';
 import type { LarkReceiveMessage } from 'types/lark';
 
 interface EnsureCommonUserInput {
@@ -39,6 +40,51 @@ export interface LarkInboundProjection {
     content: ContentItem[];
     contentText: string | undefined;
     scope: string;
+}
+
+const LARK_MESSAGE_PROJECTION_LOCK_TTL_SECONDS = 120;
+const LARK_MESSAGE_PROJECTION_LOCK_TIMEOUT_MS = 60_000;
+const LARK_MESSAGE_PROJECTION_LOCK_RETRY_MS = 25;
+const RELEASE_LOCK_SCRIPT = `
+if redis.call("GET", KEYS[1]) == ARGV[1] then
+    return redis.call("DEL", KEYS[1])
+end
+return 0
+`;
+
+function sleep(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export async function withLarkInboundProjectionLock<T>(
+    omId: string,
+    task: () => Promise<T>,
+): Promise<T> {
+    const key = `lock:lark:message-projection:${omId}`;
+    const token = uuidv7();
+    const deadline = Date.now() + LARK_MESSAGE_PROJECTION_LOCK_TIMEOUT_MS;
+
+    for (;;) {
+        const acquired = await setNx(key, token, LARK_MESSAGE_PROJECTION_LOCK_TTL_SECONDS);
+        if (acquired === 'OK') break;
+        if (Date.now() >= deadline) {
+            throw new Error(`timeout acquiring lark message projection lock: ${omId}`);
+        }
+        await sleep(LARK_MESSAGE_PROJECTION_LOCK_RETRY_MS);
+    }
+
+    try {
+        return await task();
+    } finally {
+        try {
+            await evalScript(RELEASE_LOCK_SCRIPT, 1, key, token);
+        } catch (err) {
+            console.warn(
+                `[lark common projector] failed to release projection lock ` +
+                    `om_id=${omId}: ${(err as Error).message}`,
+            );
+        }
+    }
 }
 
 function textProjection(content: ContentItem[]): string | undefined {
@@ -198,9 +244,7 @@ export async function prepareLarkInboundProjection(
     const commonConversationId = await ensureLarkCommonConversation({
         chatId: event.message.chat_id,
         scope: inbound.conversation_scope,
-        displayName: message.isP2P()
-            ? message.senderInfo?.name
-            : message.groupChatInfo?.name,
+        displayName: message.isP2P() ? message.senderInfo?.name : message.groupChatInfo?.name,
         avatarUrl: message.isP2P()
             ? message.senderInfo?.avatar_origin
             : message.groupChatInfo?.avatar,
@@ -209,9 +253,7 @@ export async function prepareLarkInboundProjection(
         downloadAllowed: message.allowDownloadResource(),
     });
 
-    const existingCommonMessageId = await findCommonMessageIdByOmId(
-        event.message.message_id,
-    );
+    const existingCommonMessageId = await findCommonMessageIdByOmId(event.message.message_id);
     const commonMessageId = existingCommonMessageId ?? uuidv7();
     const commonRootMessageId =
         (await resolveReferencedMessage(
@@ -248,6 +290,20 @@ export async function storeLarkInboundMessage(
     let inserted = false;
 
     await AppDataSource.transaction(async (manager) => {
+        const existingLarkMessage = await manager.getRepository(LarkMessage).findOne({
+            where: { om_id: event.message.message_id },
+        });
+        if (
+            existingLarkMessage &&
+            existingLarkMessage.common_message_id !== projection.commonMessageId
+        ) {
+            throw new Error(
+                `lark message ${event.message.message_id} already maps to ` +
+                    `${existingLarkMessage.common_message_id}, not ` +
+                    `${projection.commonMessageId}`,
+            );
+        }
+
         const insertResult = await manager
             .createQueryBuilder()
             .insert()
@@ -272,23 +328,25 @@ export async function storeLarkInboundMessage(
             .execute();
         inserted = insertResult.identifiers.length > 0;
 
-        await manager
-            .createQueryBuilder()
-            .insert()
-            .into(LarkMessage)
-            .values({
-                om_id: event.message.message_id,
-                common_message_id: projection.commonMessageId,
-                chat_id: event.message.chat_id,
-                sender_open_id: event.sender.sender_id?.open_id,
-                sender_union_id: event.sender.sender_id?.union_id,
-                root_om_id: event.message.root_id,
-                reply_om_id: event.message.parent_id,
-                message_type: event.message.message_type,
-                raw_event: event as any,
-            })
-            .orIgnore()
-            .execute();
+        if (!existingLarkMessage) {
+            await manager
+                .createQueryBuilder()
+                .insert()
+                .into(LarkMessage)
+                .values({
+                    om_id: event.message.message_id,
+                    common_message_id: projection.commonMessageId,
+                    chat_id: event.message.chat_id,
+                    sender_open_id: event.sender.sender_id?.open_id,
+                    sender_union_id: event.sender.sender_id?.union_id,
+                    root_om_id: event.message.root_id,
+                    reply_om_id: event.message.parent_id,
+                    message_type: event.message.message_type,
+                    raw_event: event as any,
+                })
+                .orIgnore()
+                .execute();
+        }
     });
 
     if (inserted && projection.contentText) {

--- a/apps/channel-server/src/plugins/lark/common-projector.ts
+++ b/apps/channel-server/src/plugins/lark/common-projector.ts
@@ -329,23 +329,29 @@ export async function storeLarkInboundMessage(
         inserted = insertResult.identifiers.length > 0;
 
         if (!existingLarkMessage) {
-            await manager
-                .createQueryBuilder()
-                .insert()
-                .into(LarkMessage)
-                .values({
-                    om_id: event.message.message_id,
-                    common_message_id: projection.commonMessageId,
-                    chat_id: event.message.chat_id,
-                    sender_open_id: event.sender.sender_id?.open_id,
-                    sender_union_id: event.sender.sender_id?.union_id,
-                    root_om_id: event.message.root_id,
-                    reply_om_id: event.message.parent_id,
-                    message_type: event.message.message_type,
-                    raw_event: event as any,
-                })
-                .orIgnore()
-                .execute();
+            try {
+                await manager
+                    .createQueryBuilder()
+                    .insert()
+                    .into(LarkMessage)
+                    .values({
+                        om_id: event.message.message_id,
+                        common_message_id: projection.commonMessageId,
+                        chat_id: event.message.chat_id,
+                        sender_open_id: event.sender.sender_id?.open_id,
+                        sender_union_id: event.sender.sender_id?.union_id,
+                        root_om_id: event.message.root_id,
+                        reply_om_id: event.message.parent_id,
+                        message_type: event.message.message_type,
+                        raw_event: event as any,
+                    })
+                    .execute();
+            } catch (err) {
+                throw new Error(
+                    `lark message ${event.message.message_id} mapping insert failed; ` +
+                        `common_message insert rolled back: ${(err as Error).message}`,
+                );
+            }
         }
     });
 

--- a/apps/channel-server/src/plugins/lark/lark-plugin.test.ts
+++ b/apps/channel-server/src/plugins/lark/lark-plugin.test.ts
@@ -12,6 +12,7 @@ const redisMock = {
     setWithExpire: mock(async () => undefined),
     hgetall: mock(async () => ({})),
     setNx: mock(async () => 'OK'),
+    evalScript: mock(async () => 1),
     exists: mock(async () => 0),
 };
 mock.module('@cache/redis-client', () => redisMock);

--- a/apps/channel-server/src/plugins/lark/webhook/dispatch.test.ts
+++ b/apps/channel-server/src/plugins/lark/webhook/dispatch.test.ts
@@ -49,6 +49,7 @@ mock.module('@aliyun/oss', () => ({
 mock.module('@cache/redis-client', () => ({
     hgetall: mock(async () => ({})),
     setNx: mock(async () => 'OK'),
+    evalScript: mock(async () => 1),
     exists: mock(async () => 0),
 }));
 mock.module('@infrastructure/lane-router', () => ({

--- a/apps/monitor-dashboard-web/src/pages/Messages.tsx
+++ b/apps/monitor-dashboard-web/src/pages/Messages.tsx
@@ -38,7 +38,8 @@ interface MessageRow {
   chat_name: string;
   chat_type: string;
   bot_name?: string | null;
-  content: string;
+  content: unknown;
+  content_text?: string | null;
   message_type?: string | null;
   root_message_id: string;
   reply_message_id?: string | null;
@@ -175,6 +176,87 @@ const fallbackCopy = (text: string, successMessage: string) => {
     message.error('复制失败');
   }
 };
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function nonEmptyString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim().length > 0 ? value : undefined;
+}
+
+function safeJsonStringify(value: unknown): string {
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}
+
+function parseMaybeJson(value: unknown): unknown {
+  if (typeof value !== 'string') return value;
+  const trimmed = value.trim();
+  if (!trimmed.startsWith('{') && !trimmed.startsWith('[')) return value;
+  try {
+    return JSON.parse(trimmed);
+  } catch {
+    return value;
+  }
+}
+
+function renderContentItem(item: unknown): string {
+  if (typeof item === 'string') return item;
+  if (!isRecord(item)) return item == null ? '' : String(item);
+
+  const kind = typeof item.kind === 'string' ? item.kind : 'unsupported';
+  const text = nonEmptyString(item.text);
+  if (text) return text;
+
+  const meta = isRecord(item.meta) ? item.meta : undefined;
+  const fileName = nonEmptyString(meta?.file_name) || nonEmptyString(meta?.name);
+  const labelMap: Record<string, string> = {
+    image: '图片',
+    audio: '音频',
+    file: '文件',
+    sticker: '表情',
+    unsupported: '不支持',
+  };
+  const label = labelMap[kind] || kind;
+  return fileName ? `[${label}: ${fileName}]` : `[${label}]`;
+}
+
+function renderMessageContent(content: unknown): string {
+  const parsed = parseMaybeJson(content);
+
+  if (typeof parsed === 'string') return parsed;
+  if (Array.isArray(parsed)) return parsed.map(renderContentItem).join('');
+  if (isRecord(parsed)) {
+    const text = nonEmptyString(parsed.text);
+    if (text) return text;
+    if (Array.isArray(parsed.items)) return renderMessageContent(parsed.items);
+    if (typeof parsed.kind === 'string') return renderContentItem(parsed);
+    return safeJsonStringify(parsed);
+  }
+  if (parsed == null) return '';
+  return String(parsed);
+}
+
+function normalizeMessageContent(row: MessageRow) {
+  const parsed = parseMaybeJson(row.content);
+  const displayText = nonEmptyString(row.content_text) || renderMessageContent(parsed);
+
+  let structureData: unknown | null = null;
+  if (isRecord(parsed) && Array.isArray(parsed.items)) {
+    structureData = parsed.items;
+  } else if (Array.isArray(parsed) || isRecord(parsed)) {
+    structureData = parsed;
+  }
+
+  return {
+    displayText: displayText || '-',
+    structureData,
+  };
+}
 
 // --- Component ---
 
@@ -419,32 +501,21 @@ export default function Messages() {
         title: '内容',
         dataIndex: 'content',
         width: 300,
-        render: (text: string) => {
-          if (!text) return '-';
-          let displayText = text;
-          let itemsData = null;
-          try {
-            const parsed = typeof text === 'string' ? JSON.parse(text) : text;
-            if (parsed && typeof parsed === 'object') {
-              if (parsed.text) displayText = parsed.text;
-              if (parsed.items) itemsData = parsed.items;
-            }
-          } catch (e) {
-            // ignore error, use original text
-          }
+        render: (_content: unknown, record) => {
+          const { displayText, structureData } = normalizeMessageContent(record);
 
-          const handleCopyItems = () => {
-            if (itemsData) {
-              copyToClipboard(JSON.stringify(itemsData, null, 2), '已复制 items 结构');
+          const handleCopyStructure = () => {
+            if (structureData) {
+              copyToClipboard(JSON.stringify(structureData, null, 2), '已复制内容结构');
             }
           };
 
           const popoverContent = (
             <div style={{ maxWidth: 400, maxHeight: 300, overflow: 'auto' }}>
               <div style={{ marginBottom: 8, whiteSpace: 'pre-wrap' }}>{displayText}</div>
-              {itemsData && (
-                <Button size="small" icon={<CopyOutlined />} onClick={handleCopyItems}>
-                  复制 Items 结构
+              {structureData && (
+                <Button size="small" icon={<CopyOutlined />} onClick={handleCopyStructure}>
+                  复制内容结构
                 </Button>
               )}
             </div>


### PR DESCRIPTION
## Summary
- Make Lark inbound projection converge on one common message per Lark message, including chat-level lane routing for group PPE validation.
- Prevent orphan common_message rows when concurrent Lark bot handlers race on the same om_id mapping.
- Fix the monitor dashboard message page so structured common_message.content values render as text instead of React children objects.

## Testing
- bun test src/plugins/lark/common-projector.store.test.ts
- bun test (apps/channel-server)
- bun run build (apps/channel-server)
- bun run build (apps/monitor-dashboard-web)

## Deployment notes
- Deploy channel-server from main; Makefile will synchronize recall-worker and chat-response-worker because they share the channel-server image.
- Deploy monitor-dashboard-web from main after merge.