### PR TITLE
feat(media-sync-worker): mirror downloaded pixiv images to self-hosted MinIO

### DIFF
--- a/apps/media-sync-worker/.env.example
+++ b/apps/media-sync-worker/.env.example
@@ -23,6 +23,23 @@ HTTP_SECRET=your_random_secret_key_here
 # Bangumi API 访问令牌
 BANGUMI_ACCESS_TOKEN=your_bangumi_access_token_here
 
+# 阿里云 OSS（读取 pixiv 图片，必须用公网/外网 endpoint，worker 不在阿里云内网）
+END_POINT=https://oss-cn-xxxxxx.aliyuncs.com
+OSS_ACCESS_KEY_ID=your_oss_access_key_id_here
+OSS_ACCESS_KEY_SECRET=your_oss_access_key_secret_here
+OSS_BUCKET=your_oss_bucket_here
+
+# 自建 MinIO（内网训练缓存，ENDPOINT 用 DNS 名不是 IP）
+MINIO_ENDPOINT=minio.prod
+MINIO_PORT=9000
+MINIO_USE_SSL=false
+MINIO_ACCESS_KEY=your_minio_access_key_here
+MINIO_SECRET_KEY=your_minio_secret_key_here
+MINIO_BUCKET=pixiv
+# OSS→MinIO 同步总开关：默认关（不设置 / 任意其它值都视为关）。
+# 设为 true（或 1）才开启 per-page 同步；关闭时 worker 退回纯下载、零额外行为。
+MINIO_SYNC_ENABLED=false
+
 # 部署验证开关
 DISABLE_SCHEDULES=false
 DISABLE_CONSUMER=false

--- a/apps/media-sync-worker/package.json
+++ b/apps/media-sync-worker/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "start": "bun run src/index.ts",
     "dev": "bun --watch src/index.ts",
-    "check": "tsc --noEmit"
+    "check": "tsc --noEmit",
+    "test": "bun test"
   },
   "keywords": [],
   "author": "",
@@ -24,12 +25,14 @@
     "@inner/shared": "*",
     "@larksuiteoapi/node-sdk": "^1.38.0",
     "adm-zip": "^0.5.16",
+    "ali-oss": "^6.23.0",
     "axios": "^1.7.7",
     "dayjs": "^1.11.13",
     "dotenv": "^16.4.5",
     "feishu-card": "^0.0.18",
     "ioredis": "^5.4.1",
     "lodash": "^4.17.21",
+    "minio": "^8.0.1",
     "mongodb": "^6.10.0",
     "node-cron": "^3.0.3",
     "unzipper": "^0.12.3"

--- a/apps/media-sync-worker/src/env.d.ts
+++ b/apps/media-sync-worker/src/env.d.ts
@@ -17,5 +17,16 @@ declare namespace NodeJS {
     RUN_CONNECTIVITY_CHECK: string;
     DISABLE_SCHEDULES: string;
     DISABLE_CONSUMER: string;
+    END_POINT: string;
+    OSS_ACCESS_KEY_ID: string;
+    OSS_ACCESS_KEY_SECRET: string;
+    OSS_BUCKET: string;
+    MINIO_ENDPOINT: string;
+    MINIO_PORT: string;
+    MINIO_USE_SSL: string;
+    MINIO_ACCESS_KEY: string;
+    MINIO_SECRET_KEY: string;
+    MINIO_BUCKET: string;
+    MINIO_SYNC_ENABLED: string;
   }
 }

--- a/apps/media-sync-worker/src/index.ts
+++ b/apps/media-sync-worker/src/index.ts
@@ -69,6 +69,13 @@ async function checkDataConnections() {
   await redisClient.close();
 
   console.log('MongoDB and Redis connectivity check completed.');
+
+  console.log('Checking OSS and MinIO connectivity...');
+  const { checkStorageConnectivity } = await import('./storage/connectivity');
+  const storage = await checkStorageConnectivity();
+  console.log(
+    `Storage connectivity check completed: OSS=${storage.oss ? 'OK' : 'FAILED'}, MinIO=${storage.minio ? 'OK' : 'FAILED'}.`,
+  );
 }
 
 if (disableSchedules) {

--- a/apps/media-sync-worker/src/minio/client.ts
+++ b/apps/media-sync-worker/src/minio/client.ts
@@ -1,0 +1,29 @@
+import * as Minio from 'minio';
+
+let client: Minio.Client | null = null;
+
+/**
+ * 懒加载的自建 MinIO 客户端（单例），用作内网训练缓存。
+ *
+ * endPoint 是 DNS 主机名（如 minio.prod），不带 scheme、不是 IP。
+ * 所有连接参数从环境变量读取。
+ */
+export function getMinioClient(): Minio.Client {
+    if (!client) {
+        client = new Minio.Client({
+            endPoint: process.env.MINIO_ENDPOINT!,
+            port: Number.parseInt(process.env.MINIO_PORT ?? '9000', 10),
+            useSSL: process.env.MINIO_USE_SSL === 'true',
+            accessKey: process.env.MINIO_ACCESS_KEY!,
+            secretKey: process.env.MINIO_SECRET_KEY!,
+        });
+    }
+    return client;
+}
+
+/**
+ * MinIO 中 pixiv 图片缓存使用的 bucket 名（从环境变量读取，默认 pixiv）。
+ */
+export function getMinioBucket(): string {
+    return process.env.MINIO_BUCKET ?? 'pixiv';
+}

--- a/apps/media-sync-worker/src/mongo/service.test.ts
+++ b/apps/media-sync-worker/src/mongo/service.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'bun:test';
+import { buildImageByPixivAddrFilter } from './service';
+
+// buildImageByPixivAddrFilter is a pure query builder so it can be unit-tested
+// without importing ./client (which would trigger a real Mongo connect) and
+// without mock.module (which pollutes sibling tests in the same bun run).
+describe('buildImageByPixivAddrFilter', () => {
+    it('empty pixivAddr -> null (caller short-circuits to null doc)', () => {
+        expect(buildImageByPixivAddrFilter('')).toBeNull();
+    });
+
+    it('non-empty pixivAddr -> matches pixiv_addr AND requires a non-empty tos_file_name', () => {
+        const filter = buildImageByPixivAddrFilter('123_p0.png');
+
+        expect(filter).not.toBeNull();
+        expect(filter!.pixiv_addr).toBe('123_p0.png');
+
+        // a doc whose tos_file_name is missing or empty must NOT match this filter,
+        // so the $nin guard against null/'' must be present
+        expect(filter!.tos_file_name).toEqual({ $nin: [null, ''] } as any);
+    });
+});

--- a/apps/media-sync-worker/src/mongo/service.ts
+++ b/apps/media-sync-worker/src/mongo/service.ts
@@ -264,6 +264,48 @@ export async function checkExistPixivImg(imgName: string): Promise<boolean> {
 }
 
 /**
+ * 构建「取已落 OSS 的图片文档」的 Mongo 查询条件。
+ *
+ * 语义：按 pixiv_addr 命中，且只匹配 tos_file_name 非空（非 null、非空串）的文档——
+ * 历史上同一 pixiv_addr 可能有重复 / 空 tos_file_name 的文档，不加这个约束 findOne
+ * 可能挑到空 key 的那条，漏掉真实已写 OSS 的文档（MinIO 同步会拿不到 key 而跳过）。
+ *
+ * @param pixivAddr - Pixiv 图片名（imageUrl 最后一段）
+ * @returns 查询 filter；pixivAddr 为空串时返回 null（调用方据此短路成 null 文档）
+ */
+export function buildImageByPixivAddrFilter(
+  pixivAddr: string
+): Filter<PixivImageInfo> | null {
+  if (pixivAddr === "") {
+    return null;
+  }
+
+  return {
+    pixiv_addr: pixivAddr,
+    // DB 里 tos_file_name 实际可能为 null / 缺失 / 空串（比 TS interface 的 string 宽），
+    // $nin [null, ''] 同时排除这三种（$nin 含 null 时也排除字段缺失的文档）。
+    tos_file_name: { $nin: [null, ""] } as Filter<PixivImageInfo>["tos_file_name"],
+  };
+}
+
+/**
+ * 按 pixiv_addr 取一条已落 OSS 的图片文档（用于读取代理回填的 tos_file_name）。
+ * @param pixivAddr - Pixiv 图片名（imageUrl 最后一段）
+ * @returns 命中的文档；未命中（含 pixivAddr 为空 / 无非空 tos_file_name）返回 null
+ * @throws 数据库错误向上抛出，由调用方决定是否吞错（best-effort 同步在外层兜）
+ */
+export async function findImageByPixivAddr(
+  pixivAddr: string
+): Promise<PixivImageInfo | null> {
+  const filter = buildImageByPixivAddrFilter(pixivAddr);
+  if (filter === null) {
+    return null;
+  }
+
+  return ImgCollection.findOne(filter);
+}
+
+/**
  * 将字符串的前缀部分转换为整数，如果失败则返回默认值
  * @param pixivAddr - Pixiv 地址
  * @returns 提取到的 illust_id 或默认值 0

--- a/apps/media-sync-worker/src/oss/client.ts
+++ b/apps/media-sync-worker/src/oss/client.ts
@@ -1,0 +1,22 @@
+import OSS from 'ali-oss';
+
+let client: OSS | null = null;
+
+/**
+ * 懒加载的阿里云 OSS 读取客户端（单例）。
+ *
+ * 必须使用 OSS 公网/外网 endpoint —— 本 worker 运行在 k3s，不在阿里云内网，
+ * 不能使用内网 endpoint。所有连接参数从环境变量读取。
+ */
+export function getOssClient(): OSS {
+    if (!client) {
+        client = new OSS({
+            endpoint: process.env.END_POINT,
+            accessKeyId: process.env.OSS_ACCESS_KEY_ID!,
+            accessKeySecret: process.env.OSS_ACCESS_KEY_SECRET!,
+            bucket: process.env.OSS_BUCKET,
+            cname: true,
+        });
+    }
+    return client;
+}

--- a/apps/media-sync-worker/src/service/consumeService.ts
+++ b/apps/media-sync-worker/src/service/consumeService.ts
@@ -13,6 +13,7 @@ import { getIllustInfoWithCache, getIllustPageDetail } from "../pixiv/pixiv";
 import redisClient from "../redis/redisClient";
 import { MultiTag } from "../mongo/types";
 import { getContent } from "../pixiv/pixivProxy";
+import { bestEffortSyncToMinio } from "../storage/syncPage";
 
 // 异步消费下载任务的函数
 export async function consumeDownloadTaskAsync() {
@@ -189,7 +190,11 @@ async function downloadIllust(illustId: string) {
       console.error(
         `上传插画 ${illustId} 第 ${index + 1} 页失败: ${uploadError}`
       );
+      return;
     }
+
+    // addImage 成功后，best-effort 同步该图到自建 MinIO（内部已吞错，不影响主路径）
+    await bestEffortSyncToMinio(pixivAddr);
   });
 
   // 使用并发限制执行下载任务

--- a/apps/media-sync-worker/src/storage/connectivity.test.ts
+++ b/apps/media-sync-worker/src/storage/connectivity.test.ts
@@ -1,0 +1,140 @@
+import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test';
+
+import { checkStorageConnectivity } from './connectivity';
+
+/**
+ * 用依赖注入隔离真实 OSS / MinIO 客户端，避免 mock.module 全局污染。
+ * 每个用例自己组装 deps，覆盖一种成功 / 失败组合。
+ */
+
+const MINIO_BUCKET = 'pixiv';
+
+function makeOssDeps(listImpl: () => Promise<any>) {
+    const list = mock((_query: { 'max-keys': number }, _options: unknown) => listImpl());
+    return {
+        list,
+        getOssClient: () => ({ list }),
+    };
+}
+
+function makeMinioDeps(bucketExistsImpl: (bucket: string) => Promise<boolean>) {
+    const bucketExists = mock(bucketExistsImpl);
+    return {
+        bucketExists,
+        getMinioClient: () => ({ bucketExists }),
+        getMinioBucket: () => MINIO_BUCKET,
+    };
+}
+
+let logSpy: ReturnType<typeof mock>;
+let errorSpy: ReturnType<typeof mock>;
+let originalLog: typeof console.log;
+let originalError: typeof console.error;
+
+beforeEach(() => {
+    originalLog = console.log;
+    originalError = console.error;
+    logSpy = mock((..._args: any[]) => {});
+    errorSpy = mock((..._args: any[]) => {});
+    console.log = logSpy as unknown as typeof console.log;
+    console.error = errorSpy as unknown as typeof console.error;
+});
+
+afterEach(() => {
+    console.log = originalLog;
+    console.error = originalError;
+});
+
+function logMessages(spy: ReturnType<typeof mock>): string[] {
+    return spy.mock.calls.map((call) => String(call[0]));
+}
+
+describe('checkStorageConnectivity', () => {
+    it('both probes succeed -> {oss:true, minio:true} with one OK log each', async () => {
+        const oss = makeOssDeps(async () => ({ objects: [] }));
+        const minio = makeMinioDeps(async () => true);
+
+        const result = await checkStorageConnectivity({
+            getOssClient: oss.getOssClient,
+            getMinioClient: minio.getMinioClient,
+            getMinioBucket: minio.getMinioBucket,
+        });
+
+        expect(result).toEqual({ oss: true, minio: true });
+
+        // OSS 只读探测：list({'max-keys':1})
+        expect(oss.list).toHaveBeenCalledTimes(1);
+        expect(oss.list.mock.calls[0][0]).toEqual({ 'max-keys': 1 });
+
+        // MinIO 只读探测：bucketExists(bucket)
+        expect(minio.bucketExists).toHaveBeenCalledTimes(1);
+        expect(minio.bucketExists.mock.calls[0][0]).toBe(MINIO_BUCKET);
+
+        const logs = logMessages(logSpy);
+        expect(logs.some((m) => m.includes('OSS connectivity OK'))).toBe(true);
+        expect(logs.some((m) => m.includes('MinIO connectivity OK'))).toBe(true);
+        expect(errorSpy).not.toHaveBeenCalled();
+    });
+
+    it('OSS list throws -> {oss:false, minio:true}, OSS FAILED logged, no throw, MinIO still probed', async () => {
+        const oss = makeOssDeps(async () => {
+            throw new Error('OSS endpoint unreachable');
+        });
+        const minio = makeMinioDeps(async () => true);
+
+        // 函数本身不能 reject
+        const result = await checkStorageConnectivity({
+            getOssClient: oss.getOssClient,
+            getMinioClient: minio.getMinioClient,
+            getMinioBucket: minio.getMinioBucket,
+        });
+
+        expect(result).toEqual({ oss: false, minio: true });
+
+        // 一个失败不挡另一个：MinIO 仍被探测
+        expect(minio.bucketExists).toHaveBeenCalledTimes(1);
+
+        const errors = logMessages(errorSpy);
+        expect(errors.some((m) => m.includes('OSS connectivity FAILED'))).toBe(true);
+
+        const logs = logMessages(logSpy);
+        expect(logs.some((m) => m.includes('MinIO connectivity OK'))).toBe(true);
+    });
+
+    it('MinIO bucketExists throws -> {oss:true, minio:false}, MinIO FAILED logged, no throw', async () => {
+        const oss = makeOssDeps(async () => ({ objects: [] }));
+        const minio = makeMinioDeps(async () => {
+            throw new Error('MinIO DNS lookup failed');
+        });
+
+        const result = await checkStorageConnectivity({
+            getOssClient: oss.getOssClient,
+            getMinioClient: minio.getMinioClient,
+            getMinioBucket: minio.getMinioBucket,
+        });
+
+        expect(result).toEqual({ oss: true, minio: false });
+
+        const errors = logMessages(errorSpy);
+        expect(errors.some((m) => m.includes('MinIO connectivity FAILED'))).toBe(true);
+
+        const logs = logMessages(logSpy);
+        expect(logs.some((m) => m.includes('OSS connectivity OK'))).toBe(true);
+    });
+
+    it('MinIO bucketExists returns false -> {minio:false}, MinIO FAILED logged, no throw', async () => {
+        const oss = makeOssDeps(async () => ({ objects: [] }));
+        const minio = makeMinioDeps(async () => false);
+
+        const result = await checkStorageConnectivity({
+            getOssClient: oss.getOssClient,
+            getMinioClient: minio.getMinioClient,
+            getMinioBucket: minio.getMinioBucket,
+        });
+
+        expect(result.minio).toBe(false);
+
+        const errors = logMessages(errorSpy);
+        expect(errors.some((m) => m.includes('MinIO connectivity FAILED'))).toBe(true);
+    });
+});

--- a/apps/media-sync-worker/src/storage/connectivity.ts
+++ b/apps/media-sync-worker/src/storage/connectivity.ts
@@ -1,0 +1,85 @@
+import { getMinioBucket, getMinioClient } from '../minio/client';
+import { getOssClient } from '../oss/client';
+
+/**
+ * 存储连通性自检结果。每个外部依赖一个 boolean，true=探测通过、false=探测失败。
+ * 注意：探测失败只反映在 boolean 上，本检查不抛错——冒烟时即使某连接不通，
+ * pod 也别 crashloop，错误要清楚打在日志里供人看。
+ */
+export interface StorageConnectivityResult {
+    oss: boolean;
+    minio: boolean;
+}
+
+/**
+ * 探测只用到的最小能力面：OSS 只需 list，MinIO 只需 bucketExists。
+ * 用窄接口而非完整 OSS / Minio.Client 类型，单测注入 mock 时不用实现整套接口。
+ */
+interface OssProbeClient {
+    list(query: { 'max-keys': number }, options: unknown): Promise<unknown>;
+}
+
+interface MinioProbeClient {
+    bucketExists(bucket: string): Promise<boolean>;
+}
+
+/**
+ * 可注入依赖，默认走真实客户端。单测注入 mock，避免连真实 OSS / MinIO，
+ * 也避免 mock.module 全局污染别的测试文件。
+ */
+export interface StorageConnectivityDeps {
+    getOssClient: () => OssProbeClient;
+    getMinioClient: () => MinioProbeClient;
+    getMinioBucket: () => string;
+}
+
+const DEFAULT_DEPS: StorageConnectivityDeps = {
+    getOssClient,
+    getMinioClient,
+    getMinioBucket,
+};
+
+/**
+ * 对 OSS 和 MinIO 各做一次只读探测，用于泳道部署时的冒烟验证
+ * （不跑下载消费循环也能确认外部连接通）。
+ *
+ * - OSS：`list({'max-keys':1})` 列 1 个对象，验证 endpoint + 凭证 + bucket 通。
+ * - MinIO：`bucketExists(bucket)` 验证 DNS + 凭证 + bucket；返回 false 或 throw 都算失败。
+ *
+ * 每个依赖各自 try/catch、各自打清晰日志，一个失败不挡另一个；本函数永不抛错，
+ * 把成功 / 失败收集进 {oss, minio} 返回，由调用方决定怎么处理。
+ */
+export async function checkStorageConnectivity(
+    deps: StorageConnectivityDeps = DEFAULT_DEPS,
+): Promise<StorageConnectivityResult> {
+    const oss = await probeOss(deps);
+    const minio = await probeMinio(deps);
+    return { oss, minio };
+}
+
+async function probeOss(deps: StorageConnectivityDeps): Promise<boolean> {
+    try {
+        await deps.getOssClient().list({ 'max-keys': 1 }, {});
+        console.log('OSS connectivity OK');
+        return true;
+    } catch (err) {
+        console.error('OSS connectivity FAILED:', err);
+        return false;
+    }
+}
+
+async function probeMinio(deps: StorageConnectivityDeps): Promise<boolean> {
+    const bucket = deps.getMinioBucket();
+    try {
+        const exists = await deps.getMinioClient().bucketExists(bucket);
+        if (!exists) {
+            console.error(`MinIO connectivity FAILED: bucket "${bucket}" not found`);
+            return false;
+        }
+        console.log(`MinIO connectivity OK (bucket=${bucket})`);
+        return true;
+    } catch (err) {
+        console.error('MinIO connectivity FAILED:', err);
+        return false;
+    }
+}

--- a/apps/media-sync-worker/src/storage/syncPage.test.ts
+++ b/apps/media-sync-worker/src/storage/syncPage.test.ts
@@ -1,0 +1,203 @@
+import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test';
+import type { PixivImageInfo } from '../mongo/types';
+import { bestEffortSyncToMinio, type BestEffortSyncDeps } from './syncPage';
+
+// Dependencies are injected (not mock.module) so this test can't pollute the
+// real ./syncToMinio module for sibling test files in the same bun run.
+let findImpl: (pixivAddr: string) => Promise<PixivImageInfo | null> = async () => null;
+let syncImpl: (key: string) => Promise<void> = async () => {};
+
+const findImageByPixivAddr = mock((pixivAddr: string) => findImpl(pixivAddr));
+const syncOssObjectToMinio = mock((key: string) => syncImpl(key));
+
+const deps: BestEffortSyncDeps = {
+    findImageByPixivAddr,
+    syncOssObjectToMinio,
+};
+
+function resetMocks() {
+    findImageByPixivAddr.mockClear();
+    syncOssObjectToMinio.mockClear();
+    // default: a doc with a non-empty tos_file_name, sync succeeds
+    findImpl = async () => ({
+        visible: true,
+        pixiv_addr: '123_p0.png',
+        tos_file_name: 'pixiv_img_v2/20260604/123_p0.png',
+    });
+    syncImpl = async () => {};
+}
+
+const ENV_KEY = 'MINIO_SYNC_ENABLED';
+
+// env.d.ts declares MINIO_SYNC_ENABLED as a (non-optional) string for prod, so
+// `delete process.env.MINIO_SYNC_ENABLED` is a type error. Tests still need to
+// simulate "unset", so go through a loosely-typed view of process.env here.
+const mutableEnv = process.env as Record<string, string | undefined>;
+
+function setEnv(value: string | undefined): void {
+    if (value === undefined) {
+        delete mutableEnv[ENV_KEY];
+    } else {
+        mutableEnv[ENV_KEY] = value;
+    }
+}
+
+describe('bestEffortSyncToMinio', () => {
+    // The whole feature sits behind MINIO_SYNC_ENABLED (default OFF). The cases
+    // below assert "what happens once the switch is ON", so flip it ON per-test
+    // and restore the original env afterwards to avoid leaking into siblings.
+    let originalEnv: string | undefined;
+
+    beforeEach(() => {
+        resetMocks();
+        originalEnv = process.env[ENV_KEY];
+        setEnv('true');
+    });
+
+    afterEach(() => {
+        setEnv(originalEnv);
+    });
+
+    it('happy path: found non-empty tos_file_name -> calls syncOssObjectToMinio once with that key', async () => {
+        findImpl = async () => ({
+            visible: true,
+            pixiv_addr: '123_p0.png',
+            tos_file_name: 'pixiv_img_v2/20260604/123_p0.png',
+        });
+
+        await bestEffortSyncToMinio('123_p0.png', deps);
+
+        expect(findImageByPixivAddr).toHaveBeenCalledTimes(1);
+        expect(findImageByPixivAddr.mock.calls[0][0]).toBe('123_p0.png');
+
+        expect(syncOssObjectToMinio).toHaveBeenCalledTimes(1);
+        expect(syncOssObjectToMinio.mock.calls[0][0]).toBe('pixiv_img_v2/20260604/123_p0.png');
+    });
+
+    it('best-effort: syncOssObjectToMinio throws -> does NOT reject, swallows error with a log', async () => {
+        const warnSpy = mock((..._args: any[]) => {});
+        const originalWarn = console.warn;
+        console.warn = warnSpy as any;
+
+        syncImpl = async () => {
+            throw new Error('MinIO put boom');
+        };
+
+        try {
+            // must NOT reject
+            await bestEffortSyncToMinio('123_p0.png', deps);
+        } finally {
+            console.warn = originalWarn;
+        }
+
+        // it did attempt the sync
+        expect(syncOssObjectToMinio).toHaveBeenCalledTimes(1);
+        // the error was swallowed and logged (with the pixivAddr for locating misses)
+        expect(warnSpy).toHaveBeenCalled();
+        const logged = warnSpy.mock.calls.map((c) => c.join(' ')).join(' ');
+        expect(logged).toContain('123_p0.png');
+    });
+
+    it('no tos_file_name (doc missing) -> does NOT call syncOssObjectToMinio, does NOT throw', async () => {
+        findImpl = async () => null;
+
+        await bestEffortSyncToMinio('123_p0.png', deps);
+
+        expect(findImageByPixivAddr).toHaveBeenCalledTimes(1);
+        expect(syncOssObjectToMinio).not.toHaveBeenCalled();
+    });
+
+    it('empty tos_file_name -> does NOT call syncOssObjectToMinio, does NOT throw', async () => {
+        findImpl = async () => ({
+            visible: true,
+            pixiv_addr: '123_p0.png',
+            tos_file_name: '',
+        });
+
+        await bestEffortSyncToMinio('123_p0.png', deps);
+
+        expect(syncOssObjectToMinio).not.toHaveBeenCalled();
+    });
+
+    it('best-effort: findImageByPixivAddr throws -> does NOT reject, does NOT call sync', async () => {
+        findImpl = async () => {
+            throw new Error('mongo boom');
+        };
+
+        await bestEffortSyncToMinio('123_p0.png', deps);
+
+        expect(syncOssObjectToMinio).not.toHaveBeenCalled();
+    });
+
+    it('time-bounded: syncOssObjectToMinio hangs forever -> resolves after timeout, logs with pixivAddr, does NOT hang/reject', async () => {
+        const warnSpy = mock((..._args: any[]) => {});
+        const originalWarn = console.warn;
+        console.warn = warnSpy as any;
+
+        // never resolves -> would hold the concurrency slot forever without a timeout
+        syncImpl = () => new Promise<void>(() => {});
+
+        const start = Date.now();
+        try {
+            await bestEffortSyncToMinio('123_p0.png', {
+                ...deps,
+                timeoutMs: 20,
+            });
+        } finally {
+            console.warn = originalWarn;
+        }
+        const elapsed = Date.now() - start;
+
+        // it attempted the sync but bailed out via timeout, not via the hung promise
+        expect(syncOssObjectToMinio).toHaveBeenCalledTimes(1);
+        expect(elapsed).toBeLessThan(2000);
+
+        // the timeout was logged with the pixivAddr for locating misses
+        expect(warnSpy).toHaveBeenCalled();
+        const logged = warnSpy.mock.calls.map((c) => c.join(' ')).join(' ');
+        expect(logged).toContain('123_p0.png');
+    });
+
+    it('switch ON via "1": runs the original flow (found key -> calls sync once)', async () => {
+        setEnv('1');
+
+        await bestEffortSyncToMinio('123_p0.png', deps);
+
+        expect(findImageByPixivAddr).toHaveBeenCalledTimes(1);
+        expect(syncOssObjectToMinio).toHaveBeenCalledTimes(1);
+        expect(syncOssObjectToMinio.mock.calls[0][0]).toBe('pixiv_img_v2/20260604/123_p0.png');
+    });
+});
+
+describe('bestEffortSyncToMinio: MINIO_SYNC_ENABLED switch OFF (default)', () => {
+    let originalEnv: string | undefined;
+
+    beforeEach(() => {
+        resetMocks();
+        originalEnv = process.env[ENV_KEY];
+    });
+
+    afterEach(() => {
+        setEnv(originalEnv);
+    });
+
+    const offCases: Array<[string, string | undefined]> = [
+        ['unset', undefined],
+        ['"false"', 'false'],
+        ['"0"', '0'],
+        ['"FALSE"', 'FALSE'],
+        ['arbitrary string', 'yes'],
+    ];
+
+    for (const [label, value] of offCases) {
+        it(`${label} -> immediate no-op: no Mongo lookup, no sync, no throw`, async () => {
+            setEnv(value);
+
+            await bestEffortSyncToMinio('123_p0.png', deps);
+
+            // OFF means full no-op: never touches Mongo / OSS / MinIO.
+            expect(findImageByPixivAddr).not.toHaveBeenCalled();
+            expect(syncOssObjectToMinio).not.toHaveBeenCalled();
+        });
+    }
+});

--- a/apps/media-sync-worker/src/storage/syncPage.ts
+++ b/apps/media-sync-worker/src/storage/syncPage.ts
@@ -1,0 +1,112 @@
+import { findImageByPixivAddr } from '../mongo/service';
+import { syncOssObjectToMinio } from './syncToMinio';
+import type { PixivImageInfo } from '../mongo/types';
+
+/**
+ * 可注入的依赖。生产用默认实现（真实 Mongo 查询 + Task1 同步），
+ * 测试传入 mock —— 避免 mock.module('./syncToMinio') 污染同进程其它测试。
+ */
+export interface BestEffortSyncDeps {
+    findImageByPixivAddr: (pixivAddr: string) => Promise<PixivImageInfo | null>;
+    syncOssObjectToMinio: (key: string) => Promise<void>;
+    /**
+     * 单次 OSS→MinIO 同步的硬超时（毫秒）。超时按 best-effort miss 处理：
+     * log 一句、不抛、不拖住 per-page 并发槽。默认 30000，可被注入覆盖（测试用）
+     * 或由 env MINIO_SYNC_TIMEOUT_MS 覆盖（生产用）。
+     */
+    timeoutMs?: number;
+}
+
+const DEFAULT_SYNC_TIMEOUT_MS = 30000;
+
+/**
+ * 同款 env flag 判定（与 index.ts 的 isEnabled 一致）：'1' 或 'true'（大小写不敏感）
+ * 才算开，其它（含未设置）都算关。
+ */
+function isEnabled(value: string | undefined): boolean {
+    return value === '1' || value?.toLowerCase() === 'true';
+}
+
+function resolveTimeoutMs(deps: BestEffortSyncDeps): number {
+    if (typeof deps.timeoutMs === 'number') {
+        return deps.timeoutMs;
+    }
+    const fromEnv = Number.parseInt(process.env.MINIO_SYNC_TIMEOUT_MS ?? '', 10);
+    return Number.isNaN(fromEnv) ? DEFAULT_SYNC_TIMEOUT_MS : fromEnv;
+}
+
+const defaultDeps: BestEffortSyncDeps = {
+    findImageByPixivAddr,
+    syncOssObjectToMinio,
+};
+
+/** 超时哨兵：区分「同步真完成」和「等超了」。 */
+const SYNC_TIMEOUT = Symbol('minio-sync-timeout');
+
+/**
+ * Best-effort 地把某张 pixiv 图从 OSS 同步进 MinIO。
+ *
+ * 流程：按 pixiv_addr 查 Mongo 拿代理回填的 tos_file_name（OSS object key 的唯一可信来源，
+ * 不自己拼 key）→ 若拿到非空 key 则调用 Task1 的 syncOssObjectToMinio。
+ *
+ * best-effort 语义：整段包在 try/catch，任何失败（查库失败 / OSS 读失败 / MinIO 写失败）
+ * 只 console.warn（带 pixivAddr 便于定位漏同步），绝不抛出，不拖垮下载主路径；
+ * 查不到 tos_file_name（null / 空）就 log 一句跳过、也不抛。
+ *
+ * @param pixivAddr - Pixiv 图片名（imageUrl 最后一段），用于反查 tos_file_name
+ * @param deps - 可注入依赖，默认走真实 Mongo / Task1 实现
+ */
+export async function bestEffortSyncToMinio(
+    pixivAddr: string,
+    deps: BestEffortSyncDeps = defaultDeps
+): Promise<void> {
+    // 安全闸：MINIO_SYNC_ENABLED 默认关。关闭时第一件事就 return —— 不查 Mongo、
+    // 不读 OSS、不写 MinIO、不抛错，worker 退回纯下载。per-page 每张图都会进来，
+    // 关闭时保持静默不刷屏。
+    if (!isEnabled(process.env.MINIO_SYNC_ENABLED)) {
+        return;
+    }
+
+    try {
+        const doc = await deps.findImageByPixivAddr(pixivAddr);
+        const key = doc?.tos_file_name;
+
+        if (!key) {
+            console.warn(
+                `跳过 MinIO 同步：pixiv_addr=${pixivAddr} 未查到 tos_file_name`
+            );
+            return;
+        }
+
+        const timeoutMs = resolveTimeoutMs(deps);
+
+        // 超时后底层 sync promise 仍可能在跑（OSS/MinIO 半断时挂住），
+        // 给它挂 .catch 避免 unhandledRejection；它的结果丢弃即可。
+        const syncPromise = deps.syncOssObjectToMinio(key);
+        syncPromise.catch(() => {});
+
+        let timer: ReturnType<typeof setTimeout> | undefined;
+        const timeoutPromise = new Promise<typeof SYNC_TIMEOUT>((resolve) => {
+            timer = setTimeout(() => resolve(SYNC_TIMEOUT), timeoutMs);
+        });
+
+        try {
+            const result = await Promise.race([syncPromise, timeoutPromise]);
+            if (result === SYNC_TIMEOUT) {
+                console.warn(
+                    `MinIO 同步超时（best-effort，已跳过，${timeoutMs}ms）pixiv_addr=${pixivAddr}`
+                );
+                return;
+            }
+        } finally {
+            if (timer) {
+                clearTimeout(timer);
+            }
+        }
+    } catch (err) {
+        console.warn(
+            `MinIO 同步失败（best-effort，已忽略）pixiv_addr=${pixivAddr}:`,
+            err
+        );
+    }
+}

--- a/apps/media-sync-worker/src/storage/syncToMinio.test.ts
+++ b/apps/media-sync-worker/src/storage/syncToMinio.test.ts
@@ -1,0 +1,174 @@
+import { beforeEach, describe, expect, it, mock } from 'bun:test';
+
+// ---- mock OSS client module ----
+let ossGetImpl: (fileName: string) => Promise<any> = async () => ({ content: Buffer.from('') });
+const ossGet = mock((fileName: string) => ossGetImpl(fileName));
+
+mock.module('../oss/client', () => ({
+    getOssClient: () => ({
+        get: ossGet,
+    }),
+}));
+
+// ---- mock MinIO client module ----
+let statImpl: (bucket: string, key: string) => Promise<any> = async () => ({});
+let putImpl: (bucket: string, key: string, buf: Buffer) => Promise<any> = async () => ({});
+const statObject = mock((bucket: string, key: string) => statImpl(bucket, key));
+const putObject = mock((bucket: string, key: string, buf: Buffer) => putImpl(bucket, key, buf));
+
+const MINIO_BUCKET = 'pixiv';
+
+mock.module('../minio/client', () => ({
+    getMinioClient: () => ({
+        statObject,
+        putObject,
+    }),
+    getMinioBucket: () => MINIO_BUCKET,
+}));
+
+const { syncOssObjectToMinio } = await import('./syncToMinio');
+
+function resetMocks() {
+    ossGet.mockClear();
+    statObject.mockClear();
+    putObject.mockClear();
+    // default: OSS returns bytes, object does NOT exist in MinIO, put succeeds
+    ossGetImpl = async () => ({ content: Buffer.from('IMAGE-BYTES') });
+    statImpl = async () => {
+        const err: any = new Error('Not Found');
+        err.code = 'NotFound';
+        throw err;
+    };
+    putImpl = async () => ({ etag: 'etag-123' });
+}
+
+describe('syncOssObjectToMinio', () => {
+    beforeEach(() => {
+        resetMocks();
+    });
+
+    it('happy path: reads from OSS, finds object missing, writes to MinIO with correct bucket/key/bytes', async () => {
+        const bytes = Buffer.from('HELLO-IMAGE');
+        ossGetImpl = async () => ({ content: bytes });
+
+        await syncOssObjectToMinio('123_p0.png');
+
+        // OSS read with the given key
+        expect(ossGet).toHaveBeenCalledTimes(1);
+        expect(ossGet.mock.calls[0][0]).toBe('123_p0.png');
+
+        // existence check on the pixiv bucket with the same key
+        expect(statObject).toHaveBeenCalledTimes(1);
+        expect(statObject.mock.calls[0][0]).toBe('pixiv');
+        expect(statObject.mock.calls[0][1]).toBe('123_p0.png');
+
+        // put with bucket / key / exact bytes
+        expect(putObject).toHaveBeenCalledTimes(1);
+        expect(putObject.mock.calls[0][0]).toBe('pixiv');
+        expect(putObject.mock.calls[0][1]).toBe('123_p0.png');
+        expect(putObject.mock.calls[0][2]).toBe(bytes);
+    });
+
+    it('path-prefixed key: OSS read uses full key, MinIO stat/put use basename only', async () => {
+        const bytes = Buffer.from('HELLO-IMAGE');
+        ossGetImpl = async () => ({ content: bytes });
+
+        await syncOssObjectToMinio('pixiv_img_v2/20260604/123_p0.png');
+
+        // OSS read with the FULL path-prefixed key (OSS object lives at that path)
+        expect(ossGet).toHaveBeenCalledTimes(1);
+        expect(ossGet.mock.calls[0][0]).toBe('pixiv_img_v2/20260604/123_p0.png');
+
+        // existence check on the pixiv bucket with the BASENAME only (flat MinIO layout)
+        expect(statObject).toHaveBeenCalledTimes(1);
+        expect(statObject.mock.calls[0][0]).toBe('pixiv');
+        expect(statObject.mock.calls[0][1]).toBe('123_p0.png');
+
+        // put with bucket / basename key / exact bytes
+        expect(putObject).toHaveBeenCalledTimes(1);
+        expect(putObject.mock.calls[0][0]).toBe('pixiv');
+        expect(putObject.mock.calls[0][1]).toBe('123_p0.png');
+        expect(putObject.mock.calls[0][2]).toBe(bytes);
+    });
+
+    it('idempotent with path-prefixed key: statObject checks basename, skips when present', async () => {
+        statImpl = async () => ({ size: 42, etag: 'existing' }); // exists -> no throw
+
+        await syncOssObjectToMinio('pixiv_img_v2/20260604/123_p0.png');
+
+        expect(statObject).toHaveBeenCalledTimes(1);
+        expect(statObject.mock.calls[0][1]).toBe('123_p0.png');
+        expect(putObject).not.toHaveBeenCalled();
+        expect(ossGet).not.toHaveBeenCalled();
+    });
+
+    it('idempotent: object already exists in MinIO, skips putObject and returns normally', async () => {
+        statImpl = async () => ({ size: 42, etag: 'existing' }); // exists -> no throw
+
+        await syncOssObjectToMinio('123_p0.png');
+
+        expect(statObject).toHaveBeenCalledTimes(1);
+        expect(putObject).not.toHaveBeenCalled();
+        // OSS read must NOT happen when object already present (no point downloading)
+        expect(ossGet).not.toHaveBeenCalled();
+    });
+
+    it('propagates OSS read failure (does not swallow)', async () => {
+        ossGetImpl = async () => {
+            throw new Error('OSS boom');
+        };
+
+        await expect(syncOssObjectToMinio('123_p0.png')).rejects.toThrow('OSS boom');
+        expect(putObject).not.toHaveBeenCalled();
+    });
+
+    it('propagates MinIO putObject failure (does not swallow)', async () => {
+        putImpl = async () => {
+            throw new Error('MinIO put boom');
+        };
+
+        await expect(syncOssObjectToMinio('123_p0.png')).rejects.toThrow('MinIO put boom');
+        expect(putObject).toHaveBeenCalledTimes(1);
+    });
+
+    it('treats statObject 404 (statusCode, no code) as not-found -> reads OSS, writes MinIO', async () => {
+        statImpl = async () => {
+            const err: any = new Error('Not Found');
+            err.statusCode = 404; // gateway / SDK variant: only statusCode, no code field
+            throw err;
+        };
+        const bytes = Buffer.from('IMAGE-BYTES');
+        ossGetImpl = async () => ({ content: bytes });
+
+        await syncOssObjectToMinio('123_p0.png');
+
+        expect(ossGet).toHaveBeenCalledTimes(1);
+        expect(putObject).toHaveBeenCalledTimes(1);
+        expect(putObject.mock.calls[0][2]).toBe(bytes);
+    });
+
+    it('treats statObject 404 ($metadata.httpStatusCode, no code) as not-found -> reads OSS, writes MinIO', async () => {
+        statImpl = async () => {
+            const err: any = new Error('Not Found');
+            err.$metadata = { httpStatusCode: 404 }; // AWS-SDK-style metadata, no code field
+            throw err;
+        };
+
+        await syncOssObjectToMinio('123_p0.png');
+
+        expect(ossGet).toHaveBeenCalledTimes(1);
+        expect(putObject).toHaveBeenCalledTimes(1);
+    });
+
+    it('propagates a real non-404 statObject error (e.g. AccessDenied) -> does NOT write', async () => {
+        statImpl = async () => {
+            const err: any = new Error('Access Denied');
+            err.code = 'AccessDenied';
+            throw err;
+        };
+
+        await expect(syncOssObjectToMinio('123_p0.png')).rejects.toThrow('Access Denied');
+        expect(ossGet).not.toHaveBeenCalled();
+        expect(putObject).not.toHaveBeenCalled();
+    });
+});

--- a/apps/media-sync-worker/src/storage/syncToMinio.ts
+++ b/apps/media-sync-worker/src/storage/syncToMinio.ts
@@ -1,0 +1,86 @@
+import { getMinioBucket, getMinioClient } from '../minio/client';
+import { getOssClient } from '../oss/client';
+
+/**
+ * 把一个 OSS 对象同步进自建 MinIO 的 pixiv bucket（内网训练缓存）。
+ *
+ * 语义：
+ * - 给定 OSS object key（即 Mongo 里的 tos_file_name，带路径前缀，如
+ *   `pixiv_img_v2/20260604/12345678_p0.png`），先查 MinIO 是否已存在该对象；
+ *   已存在则直接跳过、正常返回（幂等，不重复读 OSS、不重复写）。
+ * - 不存在则从 OSS 读出字节、写进 MinIO 的 pixiv bucket。
+ *
+ * key 用法（不对称）：
+ * - OSS 读用 **完整带路径的 key**——OSS 对象就在那个路径下。
+ * - MinIO 的 statObject / putObject 用 key 的 **basename**（最后一段文件名）。
+ *   pixiv 文件名含 illust_id+页码全局唯一、扁平存放无碰撞，训练脚本按文件名直接取，
+ *   所以 MinIO 不带 `pixiv_img_v2/日期/` 前缀。
+ *
+ * 错误语义（best-effort 的吞错由调用方负责，本函数保持清晰语义）：
+ * - 真实失败（OSS 读失败、MinIO 写失败）一律抛出，不在本函数 try/catch 吞掉。
+ * - “对象已存在”不是失败，正常返回（跳过）。
+ *
+ * @param key OSS object key（带路径前缀）；MinIO 侧用其 basename
+ */
+export async function syncOssObjectToMinio(key: string): Promise<void> {
+    const bucket = getMinioBucket();
+    const minio = getMinioClient();
+    const minioKey = minioObjectName(key);
+
+    if (await minioObjectExists(minio, bucket, minioKey)) {
+        return;
+    }
+
+    const ossObject = await getOssClient().get(key);
+    const content: Buffer = ossObject.content;
+
+    await minio.putObject(bucket, minioKey, content);
+}
+
+/**
+ * 从带路径前缀的 OSS key 取出 MinIO 侧扁平存放用的 object name（basename）。
+ * 防御：basename 为空（理论不会，如 key 以 `/` 结尾）时回退用原 key，
+ * 避免写出空 object name。
+ */
+function minioObjectName(key: string): string {
+    const basename = key.split('/').pop();
+    return basename ? basename : key;
+}
+
+/**
+ * 判断 MinIO 里是否已存在某对象。
+ *
+ * MinIO SDK 的 statObject 在对象不存在时会 throw，据此判断：throw 即视为不存在。
+ * 其它异常（网络 / 权限等）原样抛出，交给调用方处理。
+ */
+async function minioObjectExists(
+    minio: ReturnType<typeof getMinioClient>,
+    bucket: string,
+    key: string,
+): Promise<boolean> {
+    try {
+        await minio.statObject(bucket, key);
+        return true;
+    } catch (err: any) {
+        if (isObjectNotFound(err)) {
+            return false;
+        }
+        throw err;
+    }
+}
+
+function isObjectNotFound(err: any): boolean {
+    const code = err?.code;
+    if (code === 'NotFound' || code === 'NoSuchKey') {
+        return true;
+    }
+    // 某些网关 / SDK 版本只给 HTTP 404、不带 code，仍是「对象不存在」，
+    // 不识别会被误判成真实故障 → syncOssObjectToMinio 抛错 → 那张图漏同步。
+    if (err?.statusCode === 404) {
+        return true;
+    }
+    if (err?.$metadata?.httpStatusCode === 404) {
+        return true;
+    }
+    return false;
+}

--- a/bun.lock
+++ b/bun.lock
@@ -63,12 +63,14 @@
         "@inner/shared": "*",
         "@larksuiteoapi/node-sdk": "^1.38.0",
         "adm-zip": "^0.5.16",
+        "ali-oss": "^6.23.0",
         "axios": "^1.7.7",
         "dayjs": "^1.11.13",
         "dotenv": "^16.4.5",
         "feishu-card": "^0.0.18",
         "ioredis": "^5.4.1",
         "lodash": "^4.17.21",
+        "minio": "^8.0.1",
         "mongodb": "^6.10.0",
         "node-cron": "^3.0.3",
         "unzipper": "^0.12.3",
@@ -339,6 +341,8 @@
 
     "@noble/hashes": ["@noble/hashes@1.8.0", "https://bnpm.byted.org/@noble/hashes/-/hashes-1.8.0.tgz", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
 
+    "@nodable/entities": ["@nodable/entities@2.1.1", "https://bnpm.byted.org/@nodable/entities/-/entities-2.1.1.tgz", {}, "sha512-Pig3HxDIoMgjdEH8OCf/dkcTmLFjJRjWuq8jSnklu284/TKOPibSRERmOykiwmyXTtv61mP+44f3GMx0tLAyjg=="],
+
     "@opentelemetry/api": ["@opentelemetry/api@1.9.0", "https://bnpm.byted.org/@opentelemetry/api/-/api-1.9.0.tgz", {}, "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg=="],
 
     "@paralleldrive/cuid2": ["@paralleldrive/cuid2@2.3.1", "https://bnpm.byted.org/@paralleldrive/cuid2/-/cuid2-2.3.1.tgz", { "dependencies": { "@noble/hashes": "^1.1.5" } }, "sha512-XO7cAxhnTZl0Yggq6jOgjiOHhbgcO4NqFqwSmQpjK3b6TEE6Uj/jfSk6wzYyemh3+I0sHirKSetjQwn5cZktFw=="],
@@ -561,7 +565,7 @@
 
     "ansi-escapes": ["ansi-escapes@7.3.0", "https://bnpm.byted.org/ansi-escapes/-/ansi-escapes-7.3.0.tgz", { "dependencies": { "environment": "^1.0.0" } }, "sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg=="],
 
-    "ansi-regex": ["ansi-regex@5.0.1", "https://bnpm.byted.org/ansi-regex/-/ansi-regex-5.0.1.tgz", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+    "ansi-regex": ["ansi-regex@6.2.2", "https://bnpm.byted.org/ansi-regex/-/ansi-regex-6.2.2.tgz", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
 
     "ansi-styles": ["ansi-styles@4.3.0", "https://bnpm.byted.org/ansi-styles/-/ansi-styles-4.3.0.tgz", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
@@ -599,6 +603,8 @@
 
     "bintrees": ["bintrees@1.0.2", "https://bnpm.byted.org/bintrees/-/bintrees-1.0.2.tgz", {}, "sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw=="],
 
+    "block-stream2": ["block-stream2@2.1.0", "https://bnpm.byted.org/block-stream2/-/block-stream2-2.1.0.tgz", { "dependencies": { "readable-stream": "^3.4.0" } }, "sha512-suhjmLI57Ewpmq00qaygS8UgEq2ly2PCItenIyhMqVjo4t4pGzqMvfgJuX8iWTeSDdfSSqS6j38fL4ToNL7Pfg=="],
+
     "bluebird": ["bluebird@3.7.2", "https://bnpm.byted.org/bluebird/-/bluebird-3.7.2.tgz", {}, "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="],
 
     "bowser": ["bowser@1.9.4", "https://bnpm.byted.org/bowser/-/bowser-1.9.4.tgz", {}, "sha512-9IdMmj2KjigRq6oWhmwv1W36pDuA4STQZ8q6YO9um+x07xgYNCD3Oou+WP/3L1HNz7iqythGet3/p4wvc8AAwQ=="],
@@ -607,11 +613,15 @@
 
     "braces": ["braces@3.0.3", "https://bnpm.byted.org/braces/-/braces-3.0.3.tgz", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
 
+    "browser-or-node": ["browser-or-node@2.1.1", "https://bnpm.byted.org/browser-or-node/-/browser-or-node-2.1.1.tgz", {}, "sha512-8CVjaLJGuSKMVTxJ2DpBl5XnlNDiT4cQFeuCJJrvJmts9YrTZDizTX7PjC2s6W4x+MBGZeEY6dGMrF04/6Hgqg=="],
+
     "browserslist": ["browserslist@4.28.1", "https://bnpm.byted.org/browserslist/-/browserslist-4.28.1.tgz", { "dependencies": { "baseline-browser-mapping": "^2.9.0", "caniuse-lite": "^1.0.30001759", "electron-to-chromium": "^1.5.263", "node-releases": "^2.0.27", "update-browserslist-db": "^1.2.0" }, "bin": { "browserslist": "cli.js" } }, "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA=="],
 
     "bson": ["bson@6.10.4", "https://bnpm.byted.org/bson/-/bson-6.10.4.tgz", {}, "sha512-WIsKqkSC0ABoBJuT1LEX+2HEvNmNKKgnTAyd0fL8qzK4SH2i9NXg+t08YtdZp/V9IZ33cxe3iV4yM0qg8lMQng=="],
 
     "buffer": ["buffer@6.0.3", "https://bnpm.byted.org/buffer/-/buffer-6.0.3.tgz", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.2.1" } }, "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA=="],
+
+    "buffer-crc32": ["buffer-crc32@1.0.0", "https://bnpm.byted.org/buffer-crc32/-/buffer-crc32-1.0.0.tgz", {}, "sha512-Db1SbgBS/fg/392AblrMJk97KggmvYhr4pB5ZIMTWtaivCPMWLkmb7m21cJvpvgK+J3nsU2CmmixNBZx4vFj/w=="],
 
     "buffer-equal-constant-time": ["buffer-equal-constant-time@1.0.1", "https://bnpm.byted.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz", {}, "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="],
 
@@ -690,6 +700,8 @@
     "dayjs": ["dayjs@1.11.19", "https://bnpm.byted.org/dayjs/-/dayjs-1.11.19.tgz", {}, "sha512-t5EcLVS6QPBNqM2z8fakk/NKel+Xzshgt8FFKAn+qwlD1pzZWxh0nVCrvFK7ZDb6XucZeF9z8C7CBWTRIVApAw=="],
 
     "debug": ["debug@4.4.3", "https://bnpm.byted.org/debug/-/debug-4.4.3.tgz", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "decode-uri-component": ["decode-uri-component@0.2.2", "https://bnpm.byted.org/decode-uri-component/-/decode-uri-component-0.2.2.tgz", {}, "sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ=="],
 
     "dedent": ["dedent@1.7.1", "https://bnpm.byted.org/dedent/-/dedent-1.7.1.tgz", { "peerDependencies": { "babel-plugin-macros": "^3.1.0" }, "optionalPeers": ["babel-plugin-macros"] }, "sha512-9JmrhGZpOlEgOLdQgSm0zxFaYoQon408V1v49aqTWuXENVlnCuY9JBZcXZiCsZQWDjTm5Qf/nIvAy77mXDAjEg=="],
 
@@ -787,6 +799,10 @@
 
     "fast-safe-stringify": ["fast-safe-stringify@2.1.1", "https://bnpm.byted.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz", {}, "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA=="],
 
+    "fast-xml-builder": ["fast-xml-builder@1.2.0", "https://bnpm.byted.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz", { "dependencies": { "path-expression-matcher": "^1.5.0", "xml-naming": "^0.1.0" } }, "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q=="],
+
+    "fast-xml-parser": ["fast-xml-parser@5.8.0", "https://bnpm.byted.org/fast-xml-parser/-/fast-xml-parser-5.8.0.tgz", { "dependencies": { "@nodable/entities": "^2.1.0", "fast-xml-builder": "^1.2.0", "path-expression-matcher": "^1.5.0", "strnum": "^2.3.0", "xml-naming": "^0.1.0" }, "bin": { "fxparser": "src/cli/cli.js" } }, "sha512-6bIM7fsJxeo3uXv7OncQYsBAMPJ7V16Slahl/6M98C/i2q+vB1+4a0MtrvYwDFEUrwDSbAmeLDRXsOBwrL7yAg=="],
+
     "fdir": ["fdir@6.5.0", "https://bnpm.byted.org/fdir/-/fdir-6.5.0.tgz", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
 
     "fecha": ["fecha@4.2.3", "https://bnpm.byted.org/fecha/-/fecha-4.2.3.tgz", {}, "sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw=="],
@@ -796,6 +812,8 @@
     "file-entry-cache": ["file-entry-cache@8.0.0", "https://bnpm.byted.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz", { "dependencies": { "flat-cache": "^4.0.0" } }, "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ=="],
 
     "fill-range": ["fill-range@7.1.1", "https://bnpm.byted.org/fill-range/-/fill-range-7.1.1.tgz", { "dependencies": { "to-regex-range": "^5.0.1" } }, "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg=="],
+
+    "filter-obj": ["filter-obj@1.1.0", "https://bnpm.byted.org/filter-obj/-/filter-obj-1.1.0.tgz", {}, "sha512-8rXg1ZnX7xzy2NGDVkBVaAy+lSlPNwad13BtgSlLuxfIslyt5Vg64U7tFcCt4WS1R0hvtnQybT/IyCkGZ3DpXQ=="],
 
     "find-up": ["find-up@5.0.0", "https://bnpm.byted.org/find-up/-/find-up-5.0.0.tgz", { "dependencies": { "locate-path": "^6.0.0", "path-exists": "^4.0.0" } }, "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng=="],
 
@@ -889,6 +907,8 @@
 
     "ip-address": ["ip-address@10.1.0", "https://bnpm.byted.org/ip-address/-/ip-address-10.1.0.tgz", {}, "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q=="],
 
+    "ipaddr.js": ["ipaddr.js@2.4.0", "https://bnpm.byted.org/ipaddr.js/-/ipaddr.js-2.4.0.tgz", {}, "sha512-9VGk3HGanVE6JoZXHiCpnGy5X0jYDnN4EA4lntFPj+1vIWlFhIylq2CrrCOJH9EAhc5CYhq18F2Av2tgoAPsYQ=="],
+
     "is-callable": ["is-callable@1.2.7", "https://bnpm.byted.org/is-callable/-/is-callable-1.2.7.tgz", {}, "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA=="],
 
     "is-class-hotfix": ["is-class-hotfix@0.0.6", "https://bnpm.byted.org/is-class-hotfix/-/is-class-hotfix-0.0.6.tgz", {}, "sha512-0n+pzCC6ICtVr/WXnN2f03TK/3BfXY7me4cjCAqT8TYXEl0+JBRoqBo94JJHXcyDSLUeWbNX8Fvy5g5RJdAstQ=="],
@@ -911,7 +931,7 @@
 
     "is-typed-array": ["is-typed-array@1.1.15", "https://bnpm.byted.org/is-typed-array/-/is-typed-array-1.1.15.tgz", { "dependencies": { "which-typed-array": "^1.1.16" } }, "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ=="],
 
-    "isarray": ["isarray@2.0.5", "https://bnpm.byted.org/isarray/-/isarray-2.0.5.tgz", {}, "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="],
+    "isarray": ["isarray@1.0.0", "https://bnpm.byted.org/isarray/-/isarray-1.0.0.tgz", {}, "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="],
 
     "isexe": ["isexe@2.0.0", "https://bnpm.byted.org/isexe/-/isexe-2.0.0.tgz", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
 
@@ -1027,6 +1047,8 @@
 
     "minimist": ["minimist@1.2.8", "https://bnpm.byted.org/minimist/-/minimist-1.2.8.tgz", {}, "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="],
 
+    "minio": ["minio@8.0.7", "https://bnpm.byted.org/minio/-/minio-8.0.7.tgz", { "dependencies": { "async": "^3.2.4", "block-stream2": "^2.1.0", "browser-or-node": "^2.1.1", "buffer-crc32": "^1.0.0", "eventemitter3": "^5.0.1", "fast-xml-parser": "^5.3.4", "ipaddr.js": "^2.0.1", "lodash": "^4.17.21", "mime-types": "^2.1.35", "query-string": "^7.1.3", "stream-json": "^1.8.0", "through2": "^4.0.2", "xml2js": "^0.5.0 || ^0.6.2" } }, "sha512-E737MgufW8CeQAsTAtnEMrxZ9scMSf29kkhZoXzDTKj/Jszzo2SfeZUH9wbDQH2Rsq6TCtl/yQL0+XdVKZansQ=="],
+
     "minipass": ["minipass@7.1.3", "https://bnpm.byted.org/minipass/-/minipass-7.1.3.tgz", {}, "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A=="],
 
     "mkdirp": ["mkdirp@0.5.6", "https://bnpm.byted.org/mkdirp/-/mkdirp-0.5.6.tgz", { "dependencies": { "minimist": "^1.2.6" }, "bin": { "mkdirp": "bin/cmd.js" } }, "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw=="],
@@ -1091,6 +1113,8 @@
 
     "path-exists": ["path-exists@4.0.0", "https://bnpm.byted.org/path-exists/-/path-exists-4.0.0.tgz", {}, "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="],
 
+    "path-expression-matcher": ["path-expression-matcher@1.5.0", "https://bnpm.byted.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz", {}, "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ=="],
+
     "path-key": ["path-key@3.1.1", "https://bnpm.byted.org/path-key/-/path-key-3.1.1.tgz", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
 
     "path-scurry": ["path-scurry@1.11.1", "https://bnpm.byted.org/path-scurry/-/path-scurry-1.11.1.tgz", { "dependencies": { "lru-cache": "^10.2.0", "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0" } }, "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA=="],
@@ -1152,6 +1176,8 @@
     "punycode": ["punycode@2.3.1", "https://bnpm.byted.org/punycode/-/punycode-2.3.1.tgz", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
 
     "qs": ["qs@6.15.0", "https://bnpm.byted.org/qs/-/qs-6.15.0.tgz", { "dependencies": { "side-channel": "^1.1.0" } }, "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ=="],
+
+    "query-string": ["query-string@7.1.3", "https://bnpm.byted.org/query-string/-/query-string-7.1.3.tgz", { "dependencies": { "decode-uri-component": "^0.2.2", "filter-obj": "^1.1.0", "split-on-first": "^1.0.0", "strict-uri-encode": "^2.0.0" } }, "sha512-hh2WYhq4fi8+b+/2Kg9CEge4fDPvHS534aOOvOZeQ3+Vf2mCFsaFBYj0i+iXcAq6I9Vzp5fjMFBlONvayDC1qg=="],
 
     "querystringify": ["querystringify@2.2.0", "https://bnpm.byted.org/querystringify/-/querystringify-2.2.0.tgz", {}, "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ=="],
 
@@ -1305,6 +1331,8 @@
 
     "sparse-bitfield": ["sparse-bitfield@3.0.3", "https://bnpm.byted.org/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz", { "dependencies": { "memory-pager": "^1.0.2" } }, "sha512-kvzhi7vqKTfkh0PZU+2D2PIllw2ymqJKujUcyPMd9Y75Nv4nPbGJZXNhxsgdQab2BmlDct1YnfQCguEvHr7VsQ=="],
 
+    "split-on-first": ["split-on-first@1.1.0", "https://bnpm.byted.org/split-on-first/-/split-on-first-1.1.0.tgz", {}, "sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw=="],
+
     "split2": ["split2@4.2.0", "https://bnpm.byted.org/split2/-/split2-4.2.0.tgz", {}, "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg=="],
 
     "sql-highlight": ["sql-highlight@6.1.0", "https://bnpm.byted.org/sql-highlight/-/sql-highlight-6.1.0.tgz", {}, "sha512-ed7OK4e9ywpE7pgRMkMQmZDPKSVdm0oX5IEtZiKnFucSF0zu6c80GZBe38UqHuVhTWJ9xsKgSMjCG2bml86KvA=="],
@@ -1317,9 +1345,15 @@
 
     "statuses": ["statuses@1.5.0", "https://bnpm.byted.org/statuses/-/statuses-1.5.0.tgz", {}, "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA=="],
 
+    "stream-chain": ["stream-chain@2.2.5", "https://bnpm.byted.org/stream-chain/-/stream-chain-2.2.5.tgz", {}, "sha512-1TJmBx6aSWqZ4tx7aTpBDXK0/e2hhcNSTV8+CbFJtDjbb+I1mZ8lHit0Grw9GRT+6JbIrrDd8esncgBi8aBXGA=="],
+
     "stream-http": ["stream-http@2.8.2", "https://bnpm.byted.org/stream-http/-/stream-http-2.8.2.tgz", { "dependencies": { "builtin-status-codes": "^3.0.0", "inherits": "^2.0.1", "readable-stream": "^2.3.6", "to-arraybuffer": "^1.0.0", "xtend": "^4.0.0" } }, "sha512-QllfrBhqF1DPcz46WxKTs6Mz1Bpc+8Qm6vbqOpVav5odAXwbyzwnEczoWqtxrsmlO+cJqtPrp/8gWKWjaKLLlA=="],
 
+    "stream-json": ["stream-json@1.9.1", "https://bnpm.byted.org/stream-json/-/stream-json-1.9.1.tgz", { "dependencies": { "stream-chain": "^2.2.5" } }, "sha512-uWkjJ+2Nt/LO9Z/JyKZbMusL8Dkh97uUBTv3AJQ74y07lVahLY4eEFsPsE97pxYBwr8nnjMAIch5eqI0gPShyw=="],
+
     "stream-wormhole": ["stream-wormhole@1.1.0", "https://bnpm.byted.org/stream-wormhole/-/stream-wormhole-1.1.0.tgz", {}, "sha512-gHFfL3px0Kctd6Po0M8TzEvt3De/xu6cnRrjlfYNhwbhLPLwigI2t1nc6jrzNuaYg5C4YF78PPFuQPzRiqn9ew=="],
+
+    "strict-uri-encode": ["strict-uri-encode@2.0.0", "https://bnpm.byted.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz", {}, "sha512-QwiXZgpRcKkhTj2Scnn++4PKtWsH0kpzZ62L2R6c/LUVYv7hVnZqcg2+sMuT6R7Jusu1vviK/MFsu6kNJfWlEQ=="],
 
     "string-argv": ["string-argv@0.3.2", "https://bnpm.byted.org/string-argv/-/string-argv-0.3.2.tgz", {}, "sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q=="],
 
@@ -1331,13 +1365,15 @@
 
     "string_decoder": ["string_decoder@1.3.0", "https://bnpm.byted.org/string_decoder/-/string_decoder-1.3.0.tgz", { "dependencies": { "safe-buffer": "~5.2.0" } }, "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA=="],
 
-    "strip-ansi": ["strip-ansi@6.0.1", "https://bnpm.byted.org/strip-ansi/-/strip-ansi-6.0.1.tgz", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+    "strip-ansi": ["strip-ansi@7.1.2", "https://bnpm.byted.org/strip-ansi/-/strip-ansi-7.1.2.tgz", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA=="],
 
     "strip-ansi-cjs": ["strip-ansi@6.0.1", "https://bnpm.byted.org/strip-ansi/-/strip-ansi-6.0.1.tgz", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
     "strip-final-newline": ["strip-final-newline@3.0.0", "https://bnpm.byted.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz", {}, "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw=="],
 
     "strip-json-comments": ["strip-json-comments@3.1.1", "https://bnpm.byted.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz", {}, "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig=="],
+
+    "strnum": ["strnum@2.3.0", "https://bnpm.byted.org/strnum/-/strnum-2.3.0.tgz", {}, "sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q=="],
 
     "stylis": ["stylis@4.3.6", "https://bnpm.byted.org/stylis/-/stylis-4.3.6.tgz", {}, "sha512-yQ3rwFWRfwNUY7H5vpU0wfdkNSnvnJinhF9830Swlaxl03zsOjCfmX0ugac+3LtK0lYSgwL/KXc8oYL3mG4YFQ=="],
 
@@ -1358,6 +1394,8 @@
     "throttle-debounce": ["throttle-debounce@5.0.2", "https://bnpm.byted.org/throttle-debounce/-/throttle-debounce-5.0.2.tgz", {}, "sha512-B71/4oyj61iNH0KeCamLuE2rmKuTO5byTOSVwECM5FA7TiAiAW+UqTKZ9ERueC4qvgSttUhdmq1mXC3kJqGX7A=="],
 
     "through": ["through@2.3.8", "https://bnpm.byted.org/through/-/through-2.3.8.tgz", {}, "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg=="],
+
+    "through2": ["through2@4.0.2", "https://bnpm.byted.org/through2/-/through2-4.0.2.tgz", { "dependencies": { "readable-stream": "3" } }, "sha512-iOqSav00cVxEEICeD7TjLB1sueEL+81Wpzp2bY17uZjZN0pWZPuo4suZ/61VujxmqSGFfgOcNuTZ85QJwNZQpw=="],
 
     "tinyglobby": ["tinyglobby@0.2.15", "https://bnpm.byted.org/tinyglobby/-/tinyglobby-0.2.15.tgz", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.3" } }, "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ=="],
 
@@ -1437,6 +1475,8 @@
 
     "ws": ["ws@8.19.0", "https://bnpm.byted.org/ws/-/ws-8.19.0.tgz", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg=="],
 
+    "xml-naming": ["xml-naming@0.1.0", "https://bnpm.byted.org/xml-naming/-/xml-naming-0.1.0.tgz", {}, "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw=="],
+
     "xml2js": ["xml2js@0.6.2", "https://bnpm.byted.org/xml2js/-/xml2js-0.6.2.tgz", { "dependencies": { "sax": ">=0.6.0", "xmlbuilder": "~11.0.0" } }, "sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA=="],
 
     "xmlbuilder": ["xmlbuilder@11.0.1", "https://bnpm.byted.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz", {}, "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA=="],
@@ -1467,8 +1507,6 @@
 
     "@isaacs/cliui/string-width": ["string-width@5.1.2", "https://bnpm.byted.org/string-width/-/string-width-5.1.2.tgz", { "dependencies": { "eastasianwidth": "^0.2.0", "emoji-regex": "^9.2.2", "strip-ansi": "^7.0.1" } }, "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA=="],
 
-    "@isaacs/cliui/strip-ansi": ["strip-ansi@7.1.2", "https://bnpm.byted.org/strip-ansi/-/strip-ansi-7.1.2.tgz", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA=="],
-
     "@isaacs/cliui/wrap-ansi": ["wrap-ansi@8.1.0", "https://bnpm.byted.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz", { "dependencies": { "ansi-styles": "^6.1.0", "string-width": "^5.0.1", "strip-ansi": "^7.0.1" } }, "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ=="],
 
     "@types/unzipper/@types/node": ["@types/node@22.19.19", "https://bnpm.byted.org/@types/node/-/node-22.19.19.tgz", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew=="],
@@ -1482,6 +1520,8 @@
     "channel-server/mongodb": ["mongodb@5.9.2", "https://bnpm.byted.org/mongodb/-/mongodb-5.9.2.tgz", { "dependencies": { "bson": "^5.5.0", "mongodb-connection-string-url": "^2.6.0", "socks": "^2.7.1" }, "optionalDependencies": { "@mongodb-js/saslprep": "^1.1.0" }, "peerDependencies": { "@aws-sdk/credential-providers": "^3.188.0", "@mongodb-js/zstd": "^1.0.0", "kerberos": "^1.0.0 || ^2.0.0", "mongodb-client-encryption": ">=2.3.0 <3", "snappy": "^7.2.2" }, "optionalPeers": ["@aws-sdk/credential-providers", "@mongodb-js/zstd", "kerberos", "mongodb-client-encryption", "snappy"] }, "sha512-H60HecKO4Bc+7dhOv4sJlgvenK4fQNqqUIlXxZYQNbfEWSALGAwGoyJd/0Qwk4TttFXUOHJ2ZJQe/52ScaUwtQ=="],
 
     "cli-truncate/string-width": ["string-width@7.2.0", "https://bnpm.byted.org/string-width/-/string-width-7.2.0.tgz", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
+
+    "cliui/strip-ansi": ["strip-ansi@6.0.1", "https://bnpm.byted.org/strip-ansi/-/strip-ansi-6.0.1.tgz", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
     "cliui/wrap-ansi": ["wrap-ansi@7.0.0", "https://bnpm.byted.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
 
@@ -1503,8 +1543,6 @@
 
     "log-update/slice-ansi": ["slice-ansi@7.1.2", "https://bnpm.byted.org/slice-ansi/-/slice-ansi-7.1.2.tgz", { "dependencies": { "ansi-styles": "^6.2.1", "is-fullwidth-code-point": "^5.0.0" } }, "sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w=="],
 
-    "log-update/strip-ansi": ["strip-ansi@7.1.2", "https://bnpm.byted.org/strip-ansi/-/strip-ansi-7.1.2.tgz", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA=="],
-
     "media-sync-worker/@types/node": ["@types/node@22.19.19", "https://bnpm.byted.org/@types/node/-/node-22.19.19.tgz", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew=="],
 
     "media-sync-worker/feishu-card": ["feishu-card@0.0.18", "https://bnpm.byted.org/feishu-card/-/feishu-card-0.0.18.tgz", {}, "sha512-p4C2rfFG5UxiKxb7LZjCwYbXRimrtg3bTifr+Hew4CN56QG7NqMekfxZXpb8oHYZieEW8UC3uM5AmDH/PHDnpw=="],
@@ -1523,7 +1561,15 @@
 
     "stream-http/readable-stream": ["readable-stream@2.3.8", "https://bnpm.byted.org/readable-stream/-/readable-stream-2.3.8.tgz", { "dependencies": { "core-util-is": "~1.0.0", "inherits": "~2.0.3", "isarray": "~1.0.0", "process-nextick-args": "~2.0.0", "safe-buffer": "~5.1.1", "string_decoder": "~1.1.1", "util-deprecate": "~1.0.1" } }, "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA=="],
 
+    "string-width/strip-ansi": ["strip-ansi@6.0.1", "https://bnpm.byted.org/strip-ansi/-/strip-ansi-6.0.1.tgz", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
+    "string-width-cjs/strip-ansi": ["strip-ansi@6.0.1", "https://bnpm.byted.org/strip-ansi/-/strip-ansi-6.0.1.tgz", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
+    "strip-ansi-cjs/ansi-regex": ["ansi-regex@5.0.1", "https://bnpm.byted.org/ansi-regex/-/ansi-regex-5.0.1.tgz", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
     "tinyglobby/picomatch": ["picomatch@4.0.3", "https://bnpm.byted.org/picomatch/-/picomatch-4.0.3.tgz", {}, "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="],
+
+    "to-buffer/isarray": ["isarray@2.0.5", "https://bnpm.byted.org/isarray/-/isarray-2.0.5.tgz", {}, "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="],
 
     "typeorm/reflect-metadata": ["reflect-metadata@0.2.2", "https://bnpm.byted.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz", {}, "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q=="],
 
@@ -1535,11 +1581,9 @@
 
     "wrap-ansi/string-width": ["string-width@7.2.0", "https://bnpm.byted.org/string-width/-/string-width-7.2.0.tgz", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
 
-    "wrap-ansi/strip-ansi": ["strip-ansi@7.1.2", "https://bnpm.byted.org/strip-ansi/-/strip-ansi-7.1.2.tgz", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA=="],
+    "wrap-ansi-cjs/strip-ansi": ["strip-ansi@6.0.1", "https://bnpm.byted.org/strip-ansi/-/strip-ansi-6.0.1.tgz", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
     "@isaacs/cliui/string-width/emoji-regex": ["emoji-regex@9.2.2", "https://bnpm.byted.org/emoji-regex/-/emoji-regex-9.2.2.tgz", {}, "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="],
-
-    "@isaacs/cliui/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "https://bnpm.byted.org/ansi-regex/-/ansi-regex-6.2.2.tgz", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
 
     "@isaacs/cliui/wrap-ansi/ansi-styles": ["ansi-styles@6.2.3", "https://bnpm.byted.org/ansi-styles/-/ansi-styles-6.2.3.tgz", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
 
@@ -1553,11 +1597,9 @@
 
     "cli-truncate/string-width/emoji-regex": ["emoji-regex@10.6.0", "https://bnpm.byted.org/emoji-regex/-/emoji-regex-10.6.0.tgz", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
 
-    "cli-truncate/string-width/strip-ansi": ["strip-ansi@7.1.2", "https://bnpm.byted.org/strip-ansi/-/strip-ansi-7.1.2.tgz", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA=="],
+    "cliui/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "https://bnpm.byted.org/ansi-regex/-/ansi-regex-5.0.1.tgz", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
     "color/color-convert/color-name": ["color-name@2.1.0", "https://bnpm.byted.org/color-name/-/color-name-2.1.0.tgz", {}, "sha512-1bPaDNFm0axzE4MEAzKPuqKWeRaT43U/hyxKPBdqTfmPF+d6n7FSoTFxLVULUJOmiLp01KjhIPPH+HrXZJN4Rg=="],
-
-    "duplexer2/readable-stream/isarray": ["isarray@1.0.0", "https://bnpm.byted.org/isarray/-/isarray-1.0.0.tgz", {}, "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="],
 
     "duplexer2/readable-stream/safe-buffer": ["safe-buffer@5.1.2", "https://bnpm.byted.org/safe-buffer/-/safe-buffer-5.1.2.tgz", {}, "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="],
 
@@ -1569,29 +1611,27 @@
 
     "log-update/slice-ansi/is-fullwidth-code-point": ["is-fullwidth-code-point@5.1.0", "https://bnpm.byted.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz", { "dependencies": { "get-east-asian-width": "^1.3.1" } }, "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ=="],
 
-    "log-update/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "https://bnpm.byted.org/ansi-regex/-/ansi-regex-6.2.2.tgz", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
-
     "media-sync-worker/@types/node/undici-types": ["undici-types@6.21.0", "https://bnpm.byted.org/undici-types/-/undici-types-6.21.0.tgz", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
 
     "media-sync-worker/node-cron/uuid": ["uuid@8.3.2", "https://bnpm.byted.org/uuid/-/uuid-8.3.2.tgz", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="],
-
-    "stream-http/readable-stream/isarray": ["isarray@1.0.0", "https://bnpm.byted.org/isarray/-/isarray-1.0.0.tgz", {}, "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="],
 
     "stream-http/readable-stream/safe-buffer": ["safe-buffer@5.1.2", "https://bnpm.byted.org/safe-buffer/-/safe-buffer-5.1.2.tgz", {}, "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="],
 
     "stream-http/readable-stream/string_decoder": ["string_decoder@1.1.1", "https://bnpm.byted.org/string_decoder/-/string_decoder-1.1.1.tgz", { "dependencies": { "safe-buffer": "~5.1.0" } }, "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg=="],
 
-    "wrap-ansi/string-width/emoji-regex": ["emoji-regex@10.6.0", "https://bnpm.byted.org/emoji-regex/-/emoji-regex-10.6.0.tgz", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
+    "string-width-cjs/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "https://bnpm.byted.org/ansi-regex/-/ansi-regex-5.0.1.tgz", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
-    "wrap-ansi/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "https://bnpm.byted.org/ansi-regex/-/ansi-regex-6.2.2.tgz", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
+    "string-width/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "https://bnpm.byted.org/ansi-regex/-/ansi-regex-5.0.1.tgz", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
+    "wrap-ansi-cjs/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "https://bnpm.byted.org/ansi-regex/-/ansi-regex-5.0.1.tgz", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
+    "wrap-ansi/string-width/emoji-regex": ["emoji-regex@10.6.0", "https://bnpm.byted.org/emoji-regex/-/emoji-regex-10.6.0.tgz", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
 
     "@typescript-eslint/typescript-estree/minimatch/brace-expansion/balanced-match": ["balanced-match@4.0.4", "https://bnpm.byted.org/balanced-match/-/balanced-match-4.0.4.tgz", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
 
     "channel-server/mongodb/mongodb-connection-string-url/@types/whatwg-url": ["@types/whatwg-url@8.2.2", "https://bnpm.byted.org/@types/whatwg-url/-/whatwg-url-8.2.2.tgz", { "dependencies": { "@types/node": "*", "@types/webidl-conversions": "*" } }, "sha512-FtQu10RWgn3D9U4aazdwIE2yzphmTJREDqNdODHrbrZmmMqI0vMheC/6NE/J1Yveaj8H+ela+YwWTjq5PGmuhA=="],
 
     "channel-server/mongodb/mongodb-connection-string-url/whatwg-url": ["whatwg-url@11.0.0", "https://bnpm.byted.org/whatwg-url/-/whatwg-url-11.0.0.tgz", { "dependencies": { "tr46": "^3.0.0", "webidl-conversions": "^7.0.0" } }, "sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ=="],
-
-    "cli-truncate/string-width/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "https://bnpm.byted.org/ansi-regex/-/ansi-regex-6.2.2.tgz", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
 
     "glob/minimatch/brace-expansion/balanced-match": ["balanced-match@4.0.4", "https://bnpm.byted.org/balanced-match/-/balanced-match-4.0.4.tgz", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
 

--- a/infra/k8s/infra-services/kustomization.yaml
+++ b/infra/k8s/infra-services/kustomization.yaml
@@ -9,5 +9,6 @@ resources:
   - redis/
   - qdrant/
   - rabbitmq/
+  - minio/
   - meme/
   - forward-proxy/

--- a/infra/k8s/infra-services/minio/kustomization.yaml
+++ b/infra/k8s/infra-services/minio/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: prod
+
+resources:
+  - service.yaml

--- a/infra/k8s/infra-services/minio/service.yaml
+++ b/infra/k8s/infra-services/minio/service.yaml
@@ -1,0 +1,18 @@
+# MinIO 运行在宿主机 Docker 上，通过 headless Service + Endpoints 代理
+# Endpoints 包含宿主机 IP，不纳入版本管理，需手动 kubectl apply
+# 参考: kubectl -n prod apply -f <endpoints.yaml>
+apiVersion: v1
+kind: Service
+metadata:
+  name: minio
+  namespace: prod
+  labels:
+    app: minio
+    tier: infra
+spec:
+  ports:
+    - name: s3
+      port: 9000
+      targetPort: 9000
+      protocol: TCP
+  clusterIP: None


### PR DESCRIPTION
Best-effort sync of each newly downloaded pixiv image from Aliyun OSS to the self-hosted MinIO pixiv bucket (internal training cache). Flag-gated by MINIO_SYNC_ENABLED, fail-open (failures swallowed, never block the download pipeline), 30s time-bounded, idempotent, flat object key (no path). Adds a MinIO headless Service for in-cluster access and an OSS/MinIO connectivity self-check for deploy smoke tests.