### PR TITLE
fix(pixiv-client): add proxy request timeout

### DIFF
--- a/packages/pixiv-client/src/auth.ts
+++ b/packages/pixiv-client/src/auth.ts
@@ -1,6 +1,8 @@
 import axios, { AxiosResponse } from 'axios';
 import crypto from 'crypto';
 
+const PROXY_REQUEST_TIMEOUT_MS = 180_000;
+
 /**
  * 生成随机盐
  */
@@ -42,6 +44,7 @@ export async function sendAuthenticatedRequest<T>(
                 'X-Token': token,
                 'Content-Type': 'application/json',
             },
+            timeout: PROXY_REQUEST_TIMEOUT_MS,
         });
 
         return response.data;


### PR DESCRIPTION
## Summary
- Add a 180s timeout to authenticated Pixiv proxy POST requests so media-sync-worker does not hang forever on a stuck proxy call.
- Keep download schedule controlled by runtime config, not code defaults.

## Rollout
- DOWNLOAD_CRON has been set through ConfigBundle to `45 10 * * *` for prod.
- Deploy media-sync-worker from main to pick up the timeout change.