### PR TITLE
Transcript sedimentation + life feed whitelist

### DIFF
--- a/apps/agent-service/app/agent/sediment.py
+++ b/apps/agent-service/app/agent/sediment.py
@@ -1,0 +1,269 @@
+"""沉淀 agent — 被折叠的当天轮次整篇重写成「她自己的回忆」（沉淀 Task 2）.
+
+:mod:`app.agent.session_fold` 是折叠机制（何时折、折成什么形态、marker 怎么保全），
+它把「沉淀正文从哪来」留成 ``SedimentWriter`` 回调契约；本模块是该契约的两个实现：
+
+  * **life**（:func:`build_life_fold_policy`）：以该 persona 第一人称，把（旧沉淀 +
+    被折叠的轮消息）整篇重写成「这一天到此刻为止」的当天回忆——langfuse prompt
+    ``life_sediment``，prompt_vars 契约 = {persona_name, persona_lite}（与
+    life_day_review 同款薄契约）。
+  * **world**（:func:`build_world_fold_policy`）：以推演者口吻整篇重写成「这一天到
+    此刻为止世界怎么流过来」的客观梗概——langfuse prompt ``world_sediment``，
+    prompt_vars = {}（零 vars）。
+
+机制硬约束（照 :mod:`app.world.reflection` / :mod:`app.life.review` 的范式）：
+
+  * **无会话 + 无工具 + offline-model + max_retries=1**：一次 LLM 调用整篇重写。
+    ``run`` 绝不传 session_id——沉淀正是在改写这条 transcript，续接它即自指。
+    langfuse 归组走 ``AgentContext.session_id``（只做 trace 标签）。
+  * **硬超时**：:data:`SEDIMENT_TIMEOUT_SECONDS` 的 ``asyncio.wait_for`` 包住 LLM
+    调用（远小于 life / world 单飞锁 TTL 600s）。超时 / LLM 抛错 / 空产出都**向上
+    抛**——fail-open 收口在 ``fold_session``（本版不折、transcript 原样不动、下轮
+    再试），这里不吞。空产出必须拦：空沉淀替掉整卷 = 真失忆，正是本块要消灭的。
+  * **成本独立入账、不嵌套污染**：回调内自带 ``collect_usage`` 作用域包住沉淀调用，
+    actor = ``{persona_id}:sediment`` / ``world:sediment``；round_id 从
+    (session_id, 触发折叠的那轮 round_id) 派生幂等——durable 重投同一轮再触发折叠
+    时 ``insert_idempotent`` 不重复计。调用点（life/world 轮收口）必须在轮自己的
+    ``collect_usage`` 作用域之外，沉淀的 token 绝不算进本体 actor。
+  * **证据条目控制、绝不字符截断**：被折叠的轮按条目逐条铺开（USER=当时的输入 /
+    感知、ASSISTANT=当时所想所写；TOOL 机械确认不进），round marker 摘干净（机制
+    载荷不是内容，铁律②）。条目数天然被折叠阈值（100 条）封顶，不另设截断。
+
+写成什么样、留哪些细节由沉淀 agent 自己判断——写作纪律（口吻 / 人设 / 纪律）在
+langfuse prompt 层约束，本模块的 instruction 只承载任务语义与输出形态，零剧情
+事实（赤尾宪法）。
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import uuid
+
+from app.agent.context import AgentContext
+from app.agent.core import Agent, AgentConfig
+from app.agent.neutral import Message, Role
+from app.agent.session_fold import FoldPolicy, strip_round_markers
+from app.agent.trace import collect_usage
+from app.domain.thinking_cost import record_round_cost
+from app.infra import cst_time
+from app.memory._persona import load_persona  # module-level so tests can monkeypatch
+
+logger = logging.getLogger(__name__)
+
+# 沉淀调用的硬超时：一次离线模型整篇重写（无工具循环），分钟级足够；必须远小于
+# life / world 单飞锁 TTL（600s）——轮收口后的折叠步骤仍在锁内，绝不把锁拖到过期
+# （过期后新一轮并发写同一 transcript，fold 的读改写会丢轮）。超时抛 TimeoutError
+# 走 fold_session 的 fail-open。
+SEDIMENT_TIMEOUT_SECONDS = 120
+
+# 两口吻各一个独立 AgentConfig：prompt id 钉为 langfuse 上的 "life_sediment" /
+# "world_sediment"（prompt 本体由主会话发布；prompt_vars 契约见模块 docstring）。
+# prompt 缺失 = 沉淀失败 = fold_session fail-open（本版不折、下轮再试）。
+_LIFE_SEDIMENT_CFG = AgentConfig("life_sediment", "offline-model", "life-sediment")
+_WORLD_SEDIMENT_CFG = AgentConfig("world_sediment", "offline-model", "world-sediment")
+
+
+def life_sediment_instruction() -> str:
+    """life 沉淀的任务指令（代码侧只承载任务语义与输出形态；零剧情事实——宪法）。"""
+    return (
+        "这一天过到现在，前面的经历要沉成你随身记得的回忆了。下面给你两样东西：你"
+        "此前已经沉淀过的当天回忆（可能还没有），和这之后你新经历的一段原始意识流。"
+        "以你本人的第一人称，把两样合在一起整篇重写成一段「这一天到此刻为止」的"
+        "回忆——这一天到现在留下了什么：发生过的事、触动你的瞬间、还悬着没落地的"
+        "念头。只写真实经历过的，绝不编没发生的事。新的一版取代旧的一版。\n\n"
+        "直接输出重写后的回忆正文——不要标题、不要列表、不要解释说明、不要任何"
+        "机器标记。"
+    )
+
+
+def world_sediment_instruction() -> str:
+    """world 沉淀的任务指令（推演者口吻、纯客观；零剧情事实——宪法）。"""
+    return (
+        "你是这个世界的推演层。今天到现在为止的推演记录要压成一段「这一天到此刻」"
+        "的世界梗概了。下面给你两样东西：此前已经沉淀过的当天梗概（可能还没有），"
+        "和这之后新的推演记录。以推演者的口吻，把两样合在一起整篇重写成一段「这一天"
+        "到此刻为止」世界怎么流过来的客观叙述——谁大致做了什么、世界发生了哪些客观"
+        "变化、现在停在什么样子。只写记录里真实出现过的，绝不编造，也绝不写情绪、"
+        "心情或主观解读。新的一版取代旧的一版。\n\n"
+        "直接输出重写后的梗概正文——不要标题、不要列表、不要解释说明、不要任何"
+        "机器标记。"
+    )
+
+
+def _sediment_round_id(session_id: str, trigger_round_id: str) -> str:
+    """沉淀成本的 round_id：从 (session_id, 触发折叠的那轮) 派生幂等。
+
+    durable 重投 / 整轮重试会让同一轮的收口再触发一次折叠——派生出同一 round_id，
+    ``ThinkingTokensSpent`` 的 ``insert_idempotent`` 按 (lane, actor, round_id)
+    去重、不重复计成本。换一轮触发（下次再折）是另一件事、另一个 id。
+    """
+    return uuid.uuid5(
+        uuid.NAMESPACE_OID, f"sediment\x1f{session_id}\x1f{trigger_round_id}"
+    ).hex
+
+
+def _rounds_evidence(
+    rounds: list[Message], *, user_label: str, assistant_label: str
+) -> str:
+    """被折叠的轮 → 逐条铺开的证据段（条目级取舍、绝不字符截断）。
+
+    USER / ASSISTANT 各按口吻标签呈现；TOOL 机械确认文本（"状态已更新"）不进；
+    round marker 是 turn 幂等的机制载荷、不是内容，摘干净（铁律②：喂进去只会被
+    模型复述、再被 build_fold_message 净化，徒增噪声）。各段原文里的时刻行
+    （life 的「现在是 X」/ world 的【现实此刻】）原样保留——这就是每段的时间标注。
+    """
+    lines: list[str] = []
+    for m in rounds:
+        if m.role not in (Role.USER, Role.ASSISTANT):
+            continue
+        text = strip_round_markers(m.text()).strip()
+        if not text:
+            continue
+        label = user_label if m.role == Role.USER else assistant_label
+        lines.append(f"〔{label}〕{text}")
+    if not lines:
+        return "（这段时间没有留下可读的记录。）"
+    return "\n".join(lines)
+
+
+def _life_sediment_messages(
+    *, now_iso: str, prior: str | None, rounds: list[Message]
+) -> list[Message]:
+    """life 沉淀的输入：单条 user 消息（无会话、一次喂全；模板零剧情事实）。"""
+    prior_text = (
+        prior
+        if prior is not None and prior.strip()
+        else "（这是这一天的第一次沉淀——之前还没有写下过当天的回忆。）"
+    )
+    evidence = _rounds_evidence(
+        rounds, user_label="你当时感知到", assistant_label="你当时想着 / 说做了"
+    )
+    user_content = (
+        f"{life_sediment_instruction()}\n\n"
+        f"【现实此刻】{now_iso}\n\n"
+        f"【你此前已沉淀的当天回忆】\n{prior_text}\n\n"
+        f"【这之后你新经历的原始意识流】（按先后排列；各段里标注的时刻就是它发生"
+        f"的时刻）\n{evidence}"
+    )
+    return [Message(role=Role.USER, content=user_content)]
+
+
+def _world_sediment_messages(
+    *, now_iso: str, prior: str | None, rounds: list[Message]
+) -> list[Message]:
+    """world 沉淀的输入：单条 user 消息（推演口吻的证据标签）。"""
+    prior_text = (
+        prior
+        if prior is not None and prior.strip()
+        else "（这是这一天的第一次沉淀——之前还没有写下过当天的梗概。）"
+    )
+    evidence = _rounds_evidence(
+        rounds, user_label="当时给你的输入", assistant_label="你当时的推演"
+    )
+    user_content = (
+        f"{world_sediment_instruction()}\n\n"
+        f"【现实此刻】{now_iso}\n\n"
+        f"【此前已沉淀的当天梗概】\n{prior_text}\n\n"
+        f"【这之后的推演记录】（按先后排列；各段里标注的时刻就是它发生的时刻）\n"
+        f"{evidence}"
+    )
+    return [Message(role=Role.USER, content=user_content)]
+
+
+async def _run_sediment(
+    *,
+    cfg: AgentConfig,
+    messages: list[Message],
+    prompt_vars: dict[str, str],
+    context: AgentContext,
+    lane: str,
+    actor: str,
+    cost_round_id: str,
+    observed_at: str,
+) -> str:
+    """跑一次沉淀调用：硬超时 + 独立成本作用域 + 空产出拦截。失败向上抛（fail-open 在 fold_session）。
+
+    成本与 run 成败的口径：run 正常返回（含空产出）→ token 真烧了、照记（同
+    review「无论成败都记」）；run 抛错 / 超时被掐 → 不记（usage 不完整，同
+    reflection 失败路径）。
+    """
+    with collect_usage() as usage:
+        result = await asyncio.wait_for(
+            Agent(cfg).run(
+                messages,
+                prompt_vars=prompt_vars,
+                context=context,
+                max_retries=1,
+            ),
+            timeout=SEDIMENT_TIMEOUT_SECONDS,
+        )
+    await record_round_cost(
+        lane=lane,
+        actor=actor,
+        round_id=cost_round_id,
+        usage=usage,
+        observed_at=observed_at,
+    )
+    sediment = result.text().strip()
+    if not sediment:
+        # 机制安全阀（不是内容检测器）：空沉淀替掉整卷 = 真失忆。抛出去走
+        # fold_session 的 fail-open——本版不折、下轮再试。
+        raise ValueError("sediment agent returned empty text; keep transcript unfolded")
+    return sediment
+
+
+def build_life_fold_policy(
+    *, lane: str, persona_id: str, session_id: str, round_id: str
+) -> FoldPolicy:
+    """life 轮收口用的折叠策略：沉淀回调 = 该 persona 第一人称的当天回忆。
+
+    ``round_id`` 是触发折叠的那轮 life round（成本 round_id 从它派生幂等）；
+    ``session_id`` 是她当天的意识流 transcript key，兼作 langfuse 归组标签。
+    """
+    cost_round_id = _sediment_round_id(session_id, round_id)
+
+    async def write_life_sediment(prior: str | None, rounds: list[Message]) -> str:
+        now = cst_time.now_cst()
+        pc = await load_persona(persona_id)
+        return await _run_sediment(
+            cfg=_LIFE_SEDIMENT_CFG,
+            messages=_life_sediment_messages(
+                now_iso=now.isoformat(), prior=prior, rounds=rounds
+            ),
+            prompt_vars={
+                "persona_name": pc.display_name,
+                "persona_lite": pc.persona_lite,
+            },
+            context=AgentContext(persona_id=persona_id, session_id=session_id),
+            lane=lane,
+            actor=f"{persona_id}:sediment",
+            cost_round_id=cost_round_id,
+            observed_at=now.isoformat(),
+        )
+
+    return FoldPolicy(write_sediment=write_life_sediment)
+
+
+def build_world_fold_policy(
+    *, lane: str, session_id: str, round_id: str
+) -> FoldPolicy:
+    """world 轮收口用的折叠策略：沉淀回调 = 推演者口吻的当天世界梗概（零 prompt_vars）。"""
+    cost_round_id = _sediment_round_id(session_id, round_id)
+
+    async def write_world_sediment(prior: str | None, rounds: list[Message]) -> str:
+        now = cst_time.now_cst()
+        return await _run_sediment(
+            cfg=_WORLD_SEDIMENT_CFG,
+            messages=_world_sediment_messages(
+                now_iso=now.isoformat(), prior=prior, rounds=rounds
+            ),
+            prompt_vars={},
+            context=AgentContext(session_id=session_id),
+            lane=lane,
+            actor="world:sediment",
+            cost_round_id=cost_round_id,
+            observed_at=now.isoformat(),
+        )
+
+    return FoldPolicy(write_sediment=write_world_sediment)

--- a/apps/agent-service/app/agent/session.py
+++ b/apps/agent-service/app/agent/session.py
@@ -76,19 +76,34 @@ async def load_session(session_id: str) -> list[Message]:
     value (should not happen — we write it) is treated the same way, logged,
     rather than crashing the run.
     """
+    messages, _ver = await load_session_versioned(session_id)
+    return messages
+
+
+async def load_session_versioned(session_id: str) -> tuple[list[Message], int]:
+    """Like :func:`load_session`, but also return the stored version it read.
+
+    The version is the optimistic-concurrency token for
+    :func:`replace_session`'s ``expected_ver``: a fold loads ``(messages,
+    ver)``, spends a long LLM call, then replaces only if the transcript is
+    still at that ver (nobody appended meanwhile). Missing row → ``([], 0)``
+    (cold start; ver 0 matches ``insert_append``'s ``COALESCE(MAX(ver), 0)``
+    base). A corrupt value still reports the row's real ver — the caller is
+    looking at *that* version, however unreadable its payload.
+    """
     row = await select_latest(SessionTranscript, {"session_id": session_id})
     if row is None:
-        return []
+        return [], 0
     try:
         payload = json.loads(row.transcript_json)
-        return [Message.from_replay_dict(d) for d in payload]
+        return [Message.from_replay_dict(d) for d in payload], row.ver
     except (json.JSONDecodeError, KeyError, TypeError) as exc:
         logger.warning(
             "agent session %s transcript unreadable, cold-starting: %s",
             session_id,
             exc,
         )
-        return []
+        return [], row.ver
 
 
 async def append_session(session_id: str, new_messages: list[Message]) -> None:
@@ -102,13 +117,57 @@ async def append_session(session_id: str, new_messages: list[Message]) -> None:
     if not new_messages:
         return
     existing = await load_session(session_id)
-    combined = _cap_transcript(existing + new_messages, session_id)
+    await _store_transcript(session_id, existing + new_messages)
+
+
+async def replace_session(
+    session_id: str,
+    messages: list[Message],
+    *,
+    expected_ver: int | None = None,
+) -> bool:
+    """Overwrite the transcript wholesale as a new version (折叠写回用).
+
+    Unlike ``append_session`` this does NOT read-modify-write: the caller
+    (``app.agent.session_fold``) has already computed the full replacement.
+    A wholesale overwrite computed from a *stale* read would silently swallow
+    whatever was appended in between, so the caller passes ``expected_ver`` —
+    the version it loaded the transcript at (:func:`load_session_versioned`).
+    The write only lands if the stored version is still exactly that
+    (``insert_append``'s atomic check-and-insert); returns whether it landed.
+    ``False`` = somebody appended meanwhile (e.g. the serialisation lock
+    expired mid-LLM and a new round slipped in) — nothing was written, the
+    caller decides what losing the race means. ``expected_ver=None`` keeps
+    the unconditional overwrite (still under the caller's serialisation
+    guarantee). Old versions stay as durable history. Empty ``messages`` is
+    a no-op (never wipe a transcript by accident) and reports ``False`` —
+    nothing was written.
+    """
+    if not messages:
+        return False
+    return await _store_transcript(session_id, messages, expected_ver=expected_ver)
+
+
+async def _store_transcript(
+    session_id: str,
+    messages: list[Message],
+    *,
+    expected_ver: int | None = None,
+) -> bool:
+    """Cap, serialise losslessly, and write one new ``SessionTranscript`` version.
+
+    With ``expected_ver`` the write is the CAS variant (see
+    :func:`replace_session`); returns whether a row was actually written.
+    """
+    combined = _cap_transcript(messages, session_id)
     transcript_json = json.dumps(
         [m.to_replay_dict() for m in combined], ensure_ascii=False
     )
-    await insert_append(
-        SessionTranscript(session_id=session_id, transcript_json=transcript_json)
+    written = await insert_append(
+        SessionTranscript(session_id=session_id, transcript_json=transcript_json),
+        expected_current_ver=expected_ver,
     )
+    return written == 1
 
 
 def _replay_bytes(messages: list[Message]) -> int:

--- a/apps/agent-service/app/agent/session_fold.py
+++ b/apps/agent-service/app/agent/session_fold.py
@@ -1,0 +1,237 @@
+"""Transcript 折叠 — 当天意识流到阈值整卷压成「她自己的沉淀」（沉淀 Task 1，纯逻辑层）.
+
+按天滚动的 world/life 会话 transcript 每轮全量重发，现有保护只有 200 条 / 256KB
+硬截断——较早的经历直接蒸发（失忆），且每次掐头都重写消息前缀、逐轮 bust prompt
+cache。本模块把「截断」换成「沉淀」（spec 决策 2/4）：transcript 达到
+:data:`FOLD_TRIGGER_MESSAGES` 时整卷压成**单条合成 USER 消息**——
+
+  * 上半 = **沉淀正文**：她自己口吻的当天回忆，由可注入的异步回调产生（真正的
+    沉淀 agent 是 Task 2 的事，这里只定回调契约）；
+  * 尾部 = **机制载荷段**：被折叠各轮的完整 round marker 字符串逐行保全——
+    life turn 幂等靠在 USER 消息里扫 marker 子串、world 游标补推靠从 marker 解析
+    终点，两套现有机制对折叠后的 transcript 零改动继续命中（spec 决策 3）。
+
+折叠后 transcript 只剩这一条，新轮继续 append；再次达阈值时重折叠：旧沉淀 +
+新轮交回调**整篇重写**，marker 由**代码做并集**、绝不经 LLM（铁律①）。
+
+机制载荷三条铁律（spec 决策 3，codex T1 必改）：
+  ① 重折叠时 marker 由代码并集合并，绝不交给沉淀回调改写；
+  ② marker 字符串不得混进沉淀正文——:func:`build_fold_message` 净化 + warning；
+  ③ 睡前回顾证据拼装过滤掉机制载荷（见 ``app.life.review``，用本模块的
+     :func:`split_fold_message` / :func:`strip_round_markers`）。
+
+两阶段解耦（spec 决策 5）：折叠**不**内联在轮写回里——``append_session`` 照常
+（与现状字节级一致），:func:`fold_session` 是其后的独立步骤，由调用方在同一
+串行窗口内显式调用（调用点 Task 2 接线）。策略 ``None`` = 完全不折叠（chat 等
+不带策略的调用方零感知）。回调异常 / 超时 = 本版不折、原样不动（fail-open），
+200 条 / 256KB 硬截断保留作最后兜底。
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from collections.abc import Awaitable, Callable, Iterable
+from dataclasses import dataclass
+
+from app.agent.neutral import Message, Role
+from app.agent.session import load_session_versioned, replace_session
+
+logger = logging.getLogger(__name__)
+
+# 折叠触发阈值（spec 决策 4，bezhai 拍板）：transcript 达到 100 条整卷压一条。
+# 到 200 条硬上限（TRANSCRIPT_MAX_MESSAGES）余量 = 整整一倍触发间距——正常路径
+# 永远到不了硬截断，硬截断只剩「折叠一直失败」时的最后兜底。
+FOLD_TRIGGER_MESSAGES = 100
+
+# 折叠消息的两个段标记（固定行级常量，机读用）：首行 FOLD_HEADER 标识这条消息
+# 是折叠产物；最后一个 FOLD_MARKERS_HEADER 行之后是机制载荷段（每行一条完整
+# round marker）。两行之间是沉淀正文。Task 2 的沉淀 agent 与所有读取方都按这
+# 两个常量识别，不得另造。
+FOLD_HEADER = "[transcript-fold]"
+FOLD_MARKERS_HEADER = "[fold-markers]"
+
+# round marker 的结构语法：life ``[life-round:{rid}]`` 与 world
+# ``[world-round:{rid}|end:...]`` 共享 ``[<kind>-round:...]`` 形态。这里只认
+# 这个**结构**、不复刻两边的具体格式（具体格式的权威仍在 life_wake / world
+# engine 各自的 _ROUND_MARKER_PREFIX）；新增不符合此形态的 marker 种类时折叠
+# 会漏保全——由 tests/unit/agent/test_session_fold.py 直接调两边扫描函数钉死。
+_ROUND_MARKER_RE = re.compile(r"\[[a-z]+-round:[^\]]*\]")
+
+# 沉淀回调契约（Task 2 的沉淀 agent 按它接）：
+#   入参 = (旧沉淀正文 | None 首折, 本次被折叠的轮消息序列)
+#   返回 = 整篇重写后的沉淀正文（她口吻的自然语言段，**不含任何 marker**——
+#          marker 由代码并集，混进来也会被 build_fold_message 净化掉）
+# 异常 / 超时（回调自己包 wait_for 后抛 TimeoutError）= fail-open，本版不折。
+SedimentWriter = Callable[[str | None, list[Message]], Awaitable[str]]
+
+
+@dataclass(slots=True)
+class FoldPolicy:
+    """折叠策略——由调用方显式注入，写回路径默认没有它（不折叠）。"""
+
+    write_sediment: SedimentWriter
+    trigger_messages: int = FOLD_TRIGGER_MESSAGES
+
+
+def is_fold_message(message: Message) -> bool:
+    """这条消息是不是折叠产物：USER role 且首行恰为 :data:`FOLD_HEADER`。
+
+    role 必须收口在 USER——life / world 两套幂等扫描都只看 USER 消息，折叠产物
+    不是 USER 时载荷段里的 marker 就够不着了。
+    """
+    if message.role != Role.USER:
+        return False
+    return message.text().split("\n", 1)[0] == FOLD_HEADER
+
+
+def split_fold_message(message: Message) -> tuple[str, list[str]]:
+    """把折叠消息拆回（沉淀正文, marker 列表）。非折叠消息抛 ``ValueError``。
+
+    按**最后一个** :data:`FOLD_MARKERS_HEADER` 行切分——build 时已净化沉淀正文、
+    其中不会再有这个标记行，取最后一个是防御（marker 行自身不含换行，不会伪造
+    出更晚的标记行）。
+    """
+    if not is_fold_message(message):
+        raise ValueError("not a fold message")
+    lines = message.text().split("\n")
+    try:
+        sep_at = len(lines) - 1 - lines[::-1].index(FOLD_MARKERS_HEADER)
+    except ValueError as exc:
+        raise ValueError("fold message has no markers section") from exc
+    sediment = "\n".join(lines[1:sep_at])
+    markers = [line for line in lines[sep_at + 1 :] if line.strip()]
+    return sediment, markers
+
+
+def extract_round_markers(messages: Iterable[Message]) -> list[str]:
+    """从轮消息序列里提取完整 round marker 字符串（保序、去重）。
+
+    只扫 USER 消息——与 life / world 两套幂等扫描同一口径（marker 印在 USER
+    stimulus 里；ASSISTANT 复述出的 marker 从来不参与幂等判定，折叠也不保全它）。
+    """
+    seen: list[str] = []
+    for m in messages:
+        if m.role != Role.USER:
+            continue
+        for match in _ROUND_MARKER_RE.finditer(m.text()):
+            marker = match.group(0)
+            if marker not in seen:
+                seen.append(marker)
+    return seen
+
+
+def strip_round_markers(text: str) -> str:
+    """把文本里的 round marker 摘干净（回顾证据过滤用，铁律③）。
+
+    marker 独占一行 → 整行删（不留空壳行）；混在行内 → 只摘 marker 子串、其余
+    原样保留。没有 marker 的行逐字节不动。
+    """
+    kept: list[str] = []
+    for line in text.split("\n"):
+        if _ROUND_MARKER_RE.search(line):
+            line = _ROUND_MARKER_RE.sub("", line)
+            if not line.strip():
+                continue
+        kept.append(line)
+    return "\n".join(kept)
+
+
+def build_fold_message(sediment: str, markers: list[str]) -> Message:
+    """拼装折叠产物：单条合成 USER 消息 = 沉淀正文 + 机制载荷段。
+
+    铁律②在这里落地：沉淀正文里若混进了 marker 字符串或段标记行（回调是 LLM、
+    管不住嘴），净化掉 + warning（不静默）——否则载荷段的可靠切分和幂等扫描的
+    「marker 只出现在载荷段」语义都会被污染。载荷 marker 保序去重。
+    """
+    clean_lines: list[str] = []
+    sanitized = False
+    for line in sediment.split("\n"):
+        if line.strip() in (FOLD_HEADER, FOLD_MARKERS_HEADER):
+            sanitized = True
+            continue
+        if _ROUND_MARKER_RE.search(line):
+            sanitized = True
+            line = _ROUND_MARKER_RE.sub("", line)
+            if not line.strip():
+                continue
+        clean_lines.append(line)
+    if sanitized:
+        logger.warning(
+            "fold sediment contained mechanism marker text; sanitized it out "
+            "(markers must never be written by the sediment callback)"
+        )
+
+    unique_markers: list[str] = []
+    for marker in markers:
+        if marker not in unique_markers:
+            unique_markers.append(marker)
+
+    parts = [FOLD_HEADER, "\n".join(clean_lines), FOLD_MARKERS_HEADER]
+    if unique_markers:
+        parts.append("\n".join(unique_markers))
+    return Message(role=Role.USER, content="\n".join(parts))
+
+
+async def fold_session(session_id: str, policy: FoldPolicy | None) -> bool:
+    """轮写回之后的独立折叠步骤：达阈值就整卷压一条，返回是否折了。
+
+    策略 ``None`` = 完全不折叠（连 load 都不做，chat 等调用方零感知）。整段
+    fail-open：任何失败（回调炸 / 超时 / 写库炸）只 warning + 返回 False，
+    transcript 原样不动——本轮写回已 durable 落定，折叠失败下轮再试，硬截断
+    兜底。调用方须在与写回相同的串行窗口内调（同 session 无并发写，与
+    ``append_session`` 的串行约定一致）。
+
+    版本 CAS 兜底（codex T3 必改 2）：串行窗口靠单飞锁，但锁 TTL（600s）不续租
+    ——本体轮 + 沉淀 LLM（最长 120s）极端超过 TTL 时锁过期、新一轮进入并
+    append，旧 fold 的整卷覆写会把新 append 吞掉。所以 load 时记下当时的最新
+    ver，``replace_session(expected_ver=)`` 条件写入（校验与写入是同一条 SQL，
+    无 TOCTOU）：期间有人 append → 放弃本次折叠（warning + False，下次到阈值
+    再折），新 append 一条不丢。
+    """
+    if policy is None:
+        return False
+    try:
+        messages, loaded_ver = await load_session_versioned(session_id)
+        if len(messages) < policy.trigger_messages:
+            return False
+
+        # 旧折叠消息（若有，必在卷首——折叠产物之后只会 append 新轮）拆出旧沉淀
+        # 与旧 marker；其余是本次要折叠的轮。
+        if messages and is_fold_message(messages[0]):
+            prior_sediment, markers = split_fold_message(messages[0])
+            rounds = messages[1:]
+        else:
+            prior_sediment = None
+            markers = []
+            rounds = messages
+
+        # 铁律①：marker 并集由代码做（旧载荷 ∪ 新轮提取，保序去重），绝不经回调。
+        for marker in extract_round_markers(rounds):
+            if marker not in markers:
+                markers.append(marker)
+
+        sediment = await policy.write_sediment(prior_sediment, rounds)
+        folded = build_fold_message(sediment, markers)
+        if not await replace_session(session_id, [folded], expected_ver=loaded_ver):
+            # 沉淀期间 transcript 版本前进了（锁过期、新一轮 append）：整卷覆写
+            # 基于的是过时的卷，落库会吞掉新 append。放弃本次折叠（fail-open，
+            # 新轮原样在、下次到阈值再折），不静默。
+            logger.warning(
+                "agent session %s fold abandoned: transcript advanced past "
+                "ver %d during sedimentation (concurrent append, e.g. expired "
+                "serialisation lock); fail-open, will refold at a later "
+                "threshold",
+                session_id,
+                loaded_ver,
+            )
+            return False
+        return True
+    except Exception:
+        logger.warning(
+            "agent session %s fold failed; fail-open: transcript left as-is, "
+            "retry on a later round (hard caps still guard)",
+            session_id,
+            exc_info=True,
+        )
+        return False

--- a/apps/agent-service/app/life/feed_whitelist.py
+++ b/apps/agent-service/app/life/feed_whitelist.py
@@ -1,0 +1,59 @@
+"""life 感知白名单：哪些会话的聊天回灌进 life engine。
+
+成本止血（spec Task 5）：现在每条群消息都在唤醒 life 轮。收窄为只有白名单内
+的群的消息进 life 成为她的经历；其他群只走 chat 被动回复路径（回复不受影响，
+只是这段对话不再回灌进她的信箱）。
+
+配置形态：Dynamic Config key ``life_feed_chat_whitelist``，值=逗号分隔的
+common_conversation_id 列表，由运维侧配置——群 id 不硬编码进代码。
+
+口径（bezhai 拍板）：
+- p2p 私聊不过滤（用户口径只针对"群"），p2p 短路时不消费配置
+- fail-closed：配置缺失/为空 → 所有群聊回灌全部跳过。配置系统挂了宁可她
+  暂时听不见群聊，也不能成本失控。
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+from inner_shared.dynamic_config import dynamic_config
+
+logger = logging.getLogger(__name__)
+
+LIFE_FEED_CHAT_WHITELIST_KEY = "life_feed_chat_whitelist"
+
+
+def parse_whitelist(raw: str) -> frozenset[str]:
+    """逗号分隔的配置串 -> 白名单集合（去空格、剔除空项）。"""
+    return frozenset(part.strip() for part in raw.split(",") if part.strip())
+
+
+async def should_feed_chat_to_life(*, chat_id: str | None, is_p2p: bool) -> bool:
+    """这次对话是否回灌进 life（成为她的经历 / 唤醒 life 轮）。
+
+    Dynamic Config 的拉取是同步 httpx（10s 缓存），走 ``asyncio.to_thread``
+    避免缓存刷新那一次阻塞事件循环。
+
+    白名单**为空**（配置缺失 / 空串）时的挡下要打 warning（codex T3 小改）：
+    fail-closed 把"配置丢失"和"正常名单外"挡成同一个 False，配置系统挂了 /
+    key 被误删若不可感知，止血会无声变成"她永远听不见群聊"。名单非空、单纯
+    不在名单内的挡下是预期行为，由调用方（chat_node 挡点）记 info。
+    """
+    if is_p2p:
+        return True
+    raw = await asyncio.to_thread(
+        dynamic_config.get, LIFE_FEED_CHAT_WHITELIST_KEY, default="",
+    )
+    whitelist = parse_whitelist(raw)
+    if not whitelist:
+        logger.warning(
+            "dynamic config %s is empty/missing; fail-closed: blocking ALL "
+            "group-chat life feeds (chat %s skipped) — check the config if "
+            "this is not intended",
+            LIFE_FEED_CHAT_WHITELIST_KEY,
+            chat_id,
+        )
+        return False
+    return bool(chat_id) and chat_id in whitelist

--- a/apps/agent-service/app/life/review.py
+++ b/apps/agent-service/app/life/review.py
@@ -44,6 +44,11 @@ from app.agent.context import AgentContext
 from app.agent.core import Agent, AgentConfig
 from app.agent.neutral import Message, Role
 from app.agent.session import load_session  # module-level so tests can monkeypatch
+from app.agent.session_fold import (
+    is_fold_message,
+    split_fold_message,
+    strip_round_markers,
+)
 from app.agent.trace import collect_usage, make_session_id
 from app.data.message_record import CommonMessageRecord
 from app.data.queries.acts import (  # module-level so tests can monkeypatch
@@ -135,13 +140,25 @@ def _transcript_evidence(day_sessions: list[tuple[str, list[Message]]]) -> str:
 
     工具结果（TOOL role）是机械确认文本（"状态已更新"），不进证据；空文本条目跳过。
     两个自然日都空 → 如实说没有记录。条目级取舍、绝不字符截断。
+
+    机制载荷过滤（折叠铁律③）：round marker 是 turn 幂等的机器标记、不是她的感知，
+    绝不能喂给回顾——折叠消息只取沉淀正文（那是她的记忆固化，载荷段整段丢）；
+    普通 stimulus 里的 marker 行摘掉后正文照常进证据。
     """
     sections: list[str] = []
     for date, history in day_sessions:
         lines = []
         for m in history:
-            text = m.text().strip()
-            if not text or m.role not in (Role.USER, Role.ASSISTANT):
+            if m.role not in (Role.USER, Role.ASSISTANT):
+                continue
+            if is_fold_message(m):
+                sediment, _markers = split_fold_message(m)
+                sediment = sediment.strip()
+                if sediment:
+                    lines.append(f"〔这之前的经历，你记得〕{sediment}")
+                continue
+            text = strip_round_markers(m.text()).strip()
+            if not text:
                 continue
             prefix = "你当时感知到" if m.role == Role.USER else "你当时想着 / 说做了"
             lines.append(f"〔{prefix}〕{text}")

--- a/apps/agent-service/app/nodes/chat_node.py
+++ b/apps/agent-service/app/nodes/chat_node.py
@@ -36,6 +36,7 @@ from app.data.queries.mailbox import deliver_event
 from app.domain.chat_dataflow import ChatRequest, ChatResponseSegment, ChatTrigger
 from app.domain.world_events import EVENT_KIND_EXTERNAL
 from app.infra.cst_time import now_cst_iso
+from app.life.feed_whitelist import should_feed_chat_to_life
 from app.nodes._chat_pre_safety import _resolve_pre_safety_for_part
 from app.runtime import node
 from app.runtime.emit import emit
@@ -373,6 +374,16 @@ async def _replay_conversation_to_mailbox(
         logger.info(
             "skip conversation replay: session_id missing (persona=%s, user=%s)",
             req.persona_id, req.user_id,
+        )
+        return
+    # life 感知白名单（spec Task 5 成本止血）：只有白名单内的群的对话回灌进
+    # life；白名单外/空配置（fail-closed）的群聊跳过。p2p 不过滤。这里只挡
+    # deliver_event 这一处回灌——chat 回复和安全链早已走完，不受影响。
+    if not await should_feed_chat_to_life(chat_id=req.chat_id, is_p2p=req.is_p2p):
+        logger.info(
+            "skip life feed: chat %s not in life_feed_chat_whitelist "
+            "(persona=%s)",
+            req.chat_id, req.persona_id,
         )
         return
     lane = current_deployment_lane() or "prod"

--- a/apps/agent-service/app/nodes/life_wake.py
+++ b/apps/agent-service/app/nodes/life_wake.py
@@ -54,7 +54,9 @@ from typing import Annotated
 from app.agent.context import AgentContext
 from app.agent.core import Agent, AgentConfig
 from app.agent.neutral import Message, Role
+from app.agent.sediment import build_life_fold_policy
 from app.agent.session import load_session
+from app.agent.session_fold import fold_session
 from app.agent.trace import collect_usage, make_session_id
 from app.data.queries.mailbox import list_unread_events, mark_events_read
 from app.domain.arc_awareness import render_arc_awareness
@@ -800,6 +802,25 @@ async def _run_life_round(
     # 一次 update 都没调也照常标已读——她看了但没改状态，正常。self 唤醒空信箱时
     # read_ids 为空，mark_events_read([]) 无副作用、安全。
     await mark_events_read(lane=lane, persona_id=persona_id, event_ids=read_ids)
+
+    # transcript 沉淀折叠（沉淀 Task 2，spec 决策 4/5）：本轮写回已在 Agent.run 里
+    # durable 落定（两阶段解耦），这里在同一串行窗口（仍在单飞锁内）做其后的独立
+    # 折叠步骤——达到阈值就把整卷压成她自己口吻的沉淀段 + marker 保全行。位置在
+    # 标已读之后、**排下次醒之前**（codex T3 必改 1）：沉淀是一次离线 LLM 调用
+    # （最长 120s，硬超时见 app.agent.sediment），全程占着单飞锁——若先排
+    # self-wake，短延迟的自排会在折叠期间到达撞锁，而 self tick 撞锁是直接被吞
+    # 的（不像事件唤醒有 reschedule 保底）；fold 完成后才开始给下一轮自排计时，
+    # 撞锁窗口消失。fold_session 整段 fail-open（绝不抛），失败本版不折、下轮
+    # 再试。也在睡前回顾之前：回顾读到的就是折叠后形态（沉淀段+近期原文，spec
+    # 钉为设计行为）。成本入账在沉淀回调内自带独立 collect_usage 作用域
+    # （actor = f"{persona_id}:sediment"），在上面本轮 collect_usage 之外调用
+    # ——绝不混进已落账的本体 usage。
+    await fold_session(
+        session_id,
+        build_life_fold_policy(
+            lane=lane, persona_id=persona_id, session_id=session_id, round_id=round_id
+        ),
+    )
 
     # 收口排下次醒（阶段 1B Task 2）：本轮若调过 schedule，self_wake 里有 delay_ms ——
     # fire 算目标时刻、写进 LifeState.next_wake_at、emit 至多一条 self LifeWakeTick

--- a/apps/agent-service/app/runtime/bootstrap.py
+++ b/apps/agent-service/app/runtime/bootstrap.py
@@ -107,12 +107,23 @@ async def prepare_for_run(
 ) -> None:
     """Unified startup helper for FastAPI + worker entries. See module docstring.
 
-    Phase order is load-graph -> register-trigger-wire -> (opt)
-    declare-durable-topology. Reversing any of these would either let
-    compile_graph snapshot a registry without the trigger wire (durable
+    Phase order is config-wiring -> load-graph -> register-trigger-wire ->
+    (opt) declare-durable-topology. Reversing the graph phases would either
+    let compile_graph snapshot a registry without the trigger wire (durable
     consumers then drop trigger envelopes) or let a producer publish
     before its consumer's queue exists (broker silently drops).
     """
+    # Phase 0: process-level config wiring. Dynamic Config resolves
+    # per-lane; both entries (FastAPI lifespan / worker runtime_entry) go
+    # through here, so the provider is set no matter which process boots —
+    # wiring it in only one entry would leave the other reading prod
+    # config on coe/ppe lanes (the classic dual-entry footgun).
+    from inner_shared.dynamic_config import dynamic_config
+
+    from app.runtime.lane_policy import current_deployment_lane
+
+    dynamic_config.set_lane_provider(current_deployment_lane)
+
     # Phase 1+2: register all @node / wire() / bind() side-effects, then
     # compile_graph to validate the topology.
     load_dataflow_graph()

--- a/apps/agent-service/app/runtime/persist.py
+++ b/apps/agent-service/app/runtime/persist.py
@@ -4,7 +4,9 @@ Four operations, deliberately minimal:
 
   - :func:`insert_append` — durable write with runtime-maintained ``Version``
     auto-increment. Concurrency-safe via ``pg_advisory_xact_lock`` keyed on
-    the natural-key tuple.
+    the natural-key tuple. Optional ``expected_current_ver`` turns the append
+    into an optimistic CAS (write only if ``MAX(ver)`` is still the version
+    the caller loaded; the check rides inside the INSERT statement itself).
   - :func:`insert_idempotent` — ``INSERT ... ON CONFLICT (<target>) DO
     NOTHING RETURNING 1``. Conflict target is ``Meta.dedup_column`` when
     the Data class specifies one (adoption mode for pre-existing tables
@@ -144,7 +146,9 @@ def _dedup_hash(obj: Data) -> str:
     return hashlib.sha256(payload.encode()).hexdigest()
 
 
-async def insert_append(obj: Data) -> int:
+async def insert_append(
+    obj: Data, *, expected_current_ver: int | None = None
+) -> int:
     """Append ``obj`` as a new row; auto-assign ``Version`` if declared.
 
     Holds a per-key ``pg_advisory_xact_lock`` during ``MAX(ver)`` read and
@@ -155,15 +159,29 @@ async def insert_append(obj: Data) -> int:
     unrelated keys are benign (they serialize more than strictly necessary,
     never miss a lock).
 
-    Always returns ``1`` on success. A ``UniqueViolation`` on
-    ``dedup_hash`` is raised (not swallowed): because the version column
-    is folded into the hash, a collision means two writers slipped past
-    the advisory lock — an upstream bug worth surfacing loudly.
+    ``expected_current_ver`` (optimistic concurrency, requires a ``Version``
+    column): append only if the key's current ``MAX(ver)`` still equals this
+    value, i.e. nobody appended since the caller read that version. The check
+    rides **inside the INSERT itself** (``INSERT ... SELECT ... WHERE (SELECT
+    MAX(ver) ...) = :expected``) so check and write are one atomic statement —
+    no TOCTOU window even against a writer that bypassed the advisory lock.
+    Returns ``1`` when written, ``0`` when stale (someone advanced the
+    version); the caller decides what a lost race means.
+
+    Without ``expected_current_ver`` the behavior is unchanged: always
+    returns ``1`` on success. A ``UniqueViolation`` on ``dedup_hash`` is
+    raised (not swallowed): because the version column is folded into the
+    hash, a collision means two writers slipped past the advisory lock — an
+    upstream bug worth surfacing loudly.
     """
     cls = type(obj)
     table = _table_name(cls)
     ver_col = version_field(cls)
     keys = key_fields(cls)
+    if expected_current_ver is not None and not ver_col:
+        raise ValueError(
+            f"{cls.__name__}: expected_current_ver requires a Version column"
+        )
 
     cols_map: dict[str, Any] = {c: getattr(obj, c) for c in cls.model_fields}
     key_tuple = tuple(getattr(obj, k) for k in keys)
@@ -174,8 +192,12 @@ async def insert_append(obj: Data) -> int:
             text("SELECT pg_advisory_xact_lock(:k)"),
             {"k": lock_key},
         )
-        if ver_col:
-            where = " AND ".join(f"{k} = :{k}" for k in keys)
+        where = " AND ".join(f"{k} = :{k}" for k in keys)
+        if expected_current_ver is not None:
+            # CAS path: the version to write is pinned to expected+1; whether
+            # expected still holds is judged by the INSERT's own WHERE below.
+            cols_map[ver_col] = expected_current_ver + 1
+        elif ver_col:
             r = await s.execute(
                 text(
                     f"SELECT COALESCE(MAX({ver_col}), 0) FROM {table} "
@@ -195,6 +217,19 @@ async def insert_append(obj: Data) -> int:
         jsonb_cols = _jsonb_columns(cls)
         cols = list(cols_map.keys())
         placeholders = ", ".join(_bind_value_sql(c, jsonb_cols) for c in cols)
+        if expected_current_ver is not None:
+            # Atomic check-and-insert: key columns are part of cols_map, so the
+            # subquery's :{k} binds reuse the same params (same values).
+            sql = (
+                f"INSERT INTO {table} ({', '.join(cols)}) "
+                f"SELECT {placeholders} "
+                f"WHERE (SELECT COALESCE(MAX({ver_col}), 0) FROM {table} "
+                f"WHERE {where}) = :_expected_ver RETURNING 1"
+            )
+            params = _encode_params(obj, cols_map, jsonb_cols)
+            params["_expected_ver"] = expected_current_ver
+            r = await s.execute(text(sql), params)
+            return len(r.fetchall())
         sql = (
             f"INSERT INTO {table} ({', '.join(cols)}) "
             f"VALUES ({placeholders})"

--- a/apps/agent-service/app/world/engine.py
+++ b/apps/agent-service/app/world/engine.py
@@ -82,7 +82,9 @@ from typing import Annotated
 from app.agent.context import AgentContext
 from app.agent.core import Agent, AgentConfig
 from app.agent.neutral import Message, Role
+from app.agent.sediment import build_world_fold_policy
 from app.agent.session import load_session
+from app.agent.session_fold import fold_session
 from app.agent.trace import collect_usage, make_session_id
 from app.data.queries.acts import list_recent_acts
 from app.data.queries.mailbox import renotify_unread
@@ -989,6 +991,23 @@ async def _run_world_round(tick: WorldTick, *, lane: str) -> None:
         lane=lane,
         advance_cursor_to=advance_cursor_to,
         materials_ingested_date=mark_ingested_date,
+    )
+
+    # transcript 沉淀折叠（沉淀 Task 2，spec 决策 4/5）：本轮写回已在 Agent.run 里
+    # durable 落定（两阶段解耦），这里在同一串行窗口（仍在 actor 锁内）做其后的独立
+    # 折叠步骤——达到阈值就把整卷压成推演者口吻的当天梗概 + marker 保全行（终点
+    # 游标随 marker 原样保全，游标补推不受折叠影响）。位置在收口（推进游标 / 标
+    # 底料）之后、**排下次醒之前**（codex T3 必改 1）：沉淀是一次离线 LLM 调用
+    # （最长 120s，硬超时见 app.agent.sediment），全程占着 actor 单飞锁——若先排
+    # self-wake，短 sleep（最短 60s）的自排会在折叠期间到达撞锁被吞（world 的
+    # 锁冲突一律吞掉、无 reschedule 保底）；fold 完成后才开始给下一轮自排计时，
+    # 撞锁窗口消失。fold_session 整段 fail-open（绝不抛），失败本版不折、下轮
+    # 再试。成本入账在沉淀回调内自带独立 collect_usage 作用域（actor =
+    # "world:sediment"），在上面本轮 collect_usage 之外调用——绝不混进 world 本体
+    # 已落账的 usage。
+    await fold_session(
+        session_id,
+        build_world_fold_policy(lane=lane, session_id=session_id, round_id=round_id),
     )
 
     # 循环收口后 emit 至多一条 self WorldTick（唤醒风暴命门）：sleep 工具把"下次几时

--- a/apps/agent-service/tests/domain/test_session_fold_pg.py
+++ b/apps/agent-service/tests/domain/test_session_fold_pg.py
@@ -1,0 +1,192 @@
+"""折叠机制 × PG 持久化 — 写回照常 + 折叠另写一版（真实 Postgres，testcontainers）.
+
+钉死两阶段解耦在存储层的形态：
+
+  * **默认无策略时 append_session 字节级行为不变**：存进 PG 的 transcript_json
+    必须逐字节等于现状序列化（``to_replay_dict`` + ``json.dumps(ensure_ascii=False)``）
+    ——折叠落地后 chat 等不带策略的调用方零感知。
+  * 折叠 = 写回之后的独立一版：fold 成功 → 新版本只剩单条折叠消息，旧版本
+    留作 durable 历史；fold 失败（回调炸）→ 不写新版、已写回的轮原样在。
+  * 重折叠经 PG 往返仍正确：旧沉淀 + 新轮重写、marker 代码并集。
+  * 硬上限（200 条 / 256KB）保留作兜底：折叠一直失败时 append 照样被 cap 住。
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+
+import pytest
+
+import app.nodes.life_wake as life_wake
+from app.agent.neutral import Message, Role
+from app.agent.session import (
+    TRANSCRIPT_MAX_MESSAGES,
+    append_session,
+    load_session,
+)
+from app.agent.session_fold import (
+    FOLD_TRIGGER_MESSAGES,
+    FoldPolicy,
+    fold_session,
+    is_fold_message,
+    split_fold_message,
+)
+from app.domain.session_transcript import SessionTranscript
+from app.runtime.persist import select_all_versions, select_latest
+from tests.runtime.conftest import migrate
+
+pytestmark = pytest.mark.integration
+
+_SID = "coe-x:akao:2026-06-10"
+
+
+@pytest.fixture
+async def session_db(test_db):
+    await migrate(SessionTranscript, test_db)
+    yield test_db
+
+
+def _life_round(i: int) -> list[Message]:
+    marker = life_wake._round_marker(f"rid-{i:03d}")
+    return [
+        Message(role=Role.USER, content=f"{marker}\n第 {i} 轮的感知。"),
+        Message(role=Role.ASSISTANT, content=f"第 {i} 轮的所想"),
+    ]
+
+
+async def _append_rounds(n_rounds: int, *, start: int = 0) -> list[Message]:
+    out: list[Message] = []
+    for i in range(start, start + n_rounds):
+        round_msgs = _life_round(i)
+        await append_session(_SID, round_msgs)
+        out.extend(round_msgs)
+    return out
+
+
+async def _stub_sediment(prior: str | None, rounds: list[Message]) -> str:
+    return "这一上午我过了 50 轮，记得每一件。"
+
+
+async def test_append_without_policy_is_byte_identical(session_db):
+    """不带折叠策略的写回，落进 PG 的字节与现状序列化逐字节一致。"""
+    msgs = _life_round(0) + _life_round(1)
+    await append_session(_SID, _life_round(0))
+    await append_session(_SID, _life_round(1))
+
+    row = await select_latest(SessionTranscript, {"session_id": _SID})
+    expected = json.dumps(
+        [m.to_replay_dict() for m in msgs], ensure_ascii=False
+    )
+    assert row.transcript_json == expected
+    # 只有两个 append 版本，没有任何折叠版本混进来
+    versions = await select_all_versions(SessionTranscript, {"session_id": _SID})
+    assert [v.ver for v in versions] == [1, 2]
+
+
+async def test_fold_writes_one_more_version_and_old_versions_retained(session_db):
+    await _append_rounds(FOLD_TRIGGER_MESSAGES // 2)  # 50 轮 = 100 条
+
+    assert await fold_session(_SID, FoldPolicy(write_sediment=_stub_sediment)) is True
+
+    versions = await select_all_versions(SessionTranscript, {"session_id": _SID})
+    assert len(versions) == FOLD_TRIGGER_MESSAGES // 2 + 1  # 写回各版 + 折叠一版
+
+    loaded = await load_session(_SID)
+    assert len(loaded) == 1
+    assert is_fold_message(loaded[0])
+    sediment, markers = split_fold_message(loaded[0])
+    assert sediment == "这一上午我过了 50 轮，记得每一件。"
+    # 经 PG 往返后 life 幂等扫描仍命中每一轮
+    for i in range(FOLD_TRIGGER_MESSAGES // 2):
+        assert life_wake._round_already_processed(loaded, f"rid-{i:03d}")
+    assert len(markers) == FOLD_TRIGGER_MESSAGES // 2
+
+
+async def test_fold_below_threshold_is_noop_on_pg(session_db):
+    await _append_rounds(2)
+    assert await fold_session(_SID, FoldPolicy(write_sediment=_stub_sediment)) is False
+    versions = await select_all_versions(SessionTranscript, {"session_id": _SID})
+    assert [v.ver for v in versions] == [1, 2]  # 没多写版本
+
+
+async def test_failed_fold_keeps_written_rounds_and_appends_continue(session_db):
+    """回调炸 → 不折不写；已写回的轮原样在；后续 append 照常续上。"""
+    written = await _append_rounds(FOLD_TRIGGER_MESSAGES // 2)
+
+    async def failing(prior: str | None, rounds: list[Message]) -> str:
+        raise RuntimeError("sediment agent down")
+
+    assert await fold_session(_SID, FoldPolicy(write_sediment=failing)) is False
+
+    loaded = await load_session(_SID)
+    assert [m.text() for m in loaded] == [m.text() for m in written]
+
+    await append_session(_SID, _life_round(999))
+    assert len(await load_session(_SID)) == len(written) + 2
+
+
+async def test_hard_cap_still_guards_when_fold_keeps_failing(session_db):
+    """折叠一直失败时，200 条硬上限仍兜底（带病也不无界膨胀）。"""
+    await _append_rounds(TRANSCRIPT_MAX_MESSAGES // 2 + 10)  # 220 条 > 200
+    loaded = await load_session(_SID)
+    assert len(loaded) <= TRANSCRIPT_MAX_MESSAGES
+
+
+async def test_concurrent_append_during_fold_aborts_replace(session_db, caplog):
+    """load 后、replace 前并发 append 一条 → replace 放弃、transcript 含新 append、无覆写。
+
+    版本 CAS（codex T3 必改 2）经真 PG 往返：fold 的 load 记下当时最新 ver，沉淀
+    LLM（这里用回调模拟其 120s 窗口内有人 append——单飞锁 TTL 过期、新一轮进入）
+    期间 transcript 版本前进；replace 的条件写入（同一条 SQL 校验 MAX(ver) ==
+    期望版本）失败 → 放弃本次折叠（fail-open），新 append 的轮原样在、没有任何
+    折叠版本混进来。
+    """
+    written = await _append_rounds(FOLD_TRIGGER_MESSAGES // 2)
+    racing_round = _life_round(777)
+
+    async def racing_sediment(prior: str | None, rounds: list[Message]) -> str:
+        # 模拟沉淀 LLM 期间锁过期、另一轮 append 进同一条 session
+        await append_session(_SID, racing_round)
+        return "基于过时整卷写出的沉淀"
+
+    with caplog.at_level(logging.WARNING):
+        assert (
+            await fold_session(_SID, FoldPolicy(write_sediment=racing_sediment))
+            is False
+        )
+
+    loaded = await load_session(_SID)
+    assert [m.text() for m in loaded] == [m.text() for m in written + racing_round], (
+        "并发 append 的轮必须原样在，stale 覆写必须被放弃"
+    )
+    assert not any(is_fold_message(m) for m in loaded), "不得有折叠版本落库"
+    # 没有多写任何版本：50 个 append + 并发那 1 个 append，无 fold 版本
+    versions = await select_all_versions(SessionTranscript, {"session_id": _SID})
+    assert [v.ver for v in versions] == list(
+        range(1, FOLD_TRIGGER_MESSAGES // 2 + 2)
+    )
+    assert any("fold" in r.message.lower() for r in caplog.records), "放弃不静默"
+
+
+async def test_refold_through_pg_unions_markers(session_db):
+    # 第一次折叠
+    await _append_rounds(FOLD_TRIGGER_MESSAGES // 2)
+    await fold_session(_SID, FoldPolicy(write_sediment=_stub_sediment))
+
+    # 折叠后新轮继续 append，攒到再次达阈值（1 条折叠 + 99 条新轮 ≥ 100 触发）
+    await _append_rounds(FOLD_TRIGGER_MESSAGES // 2, start=100)
+
+    async def rewrite(prior: str | None, rounds: list[Message]) -> str:
+        assert prior == "这一上午我过了 50 轮，记得每一件。"
+        return "整篇重写：上午 50 轮加下午 50 轮都在我心里。"
+
+    assert await fold_session(_SID, FoldPolicy(write_sediment=rewrite)) is True
+
+    loaded = await load_session(_SID)
+    assert len(loaded) == 1
+    sediment, markers = split_fold_message(loaded[0])
+    assert sediment == "整篇重写：上午 50 轮加下午 50 轮都在我心里。"
+    assert len(markers) == FOLD_TRIGGER_MESSAGES  # 旧 50 + 新 50，一条不丢
+    for i in list(range(50)) + list(range(100, 150)):
+        assert life_wake._round_already_processed(loaded, f"rid-{i:03d}")

--- a/apps/agent-service/tests/life/test_feed_whitelist.py
+++ b/apps/agent-service/tests/life/test_feed_whitelist.py
@@ -1,0 +1,110 @@
+"""life 感知白名单：哪些会话的聊天回灌进 life engine（spec Task 5）。
+
+成本止血：现在每条群消息都会唤醒一轮 life。收窄为只有 Dynamic Config
+``life_feed_chat_whitelist``（逗号分隔 common_conversation_id 列表）白名单内
+的群的消息进 life 成为她的经历；其他群只走 chat 被动回复路径。
+
+口径：
+- p2p 私聊不过滤（用户口径只针对"群"），且 p2p 短路时不消费配置
+- fail-closed：配置缺失/为空 → 所有群聊回灌全部跳过。配置系统挂了宁可她
+  暂时听不见群聊，也不能成本失控。
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from app.life import feed_whitelist as fw
+
+# ---------------------------------------------------------------------------
+# parse_whitelist：配置串 -> 白名单集合
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("", frozenset()),                          # 空串 -> 空白名单
+        ("   ", frozenset()),                       # 全空白 -> 空白名单
+        (",,", frozenset()),                        # 只有分隔符 -> 空白名单
+        ("c1", frozenset({"c1"})),                  # 单个 id
+        ("c1,c2", frozenset({"c1", "c2"})),         # 多个 id
+        (" c1 , c2 ,", frozenset({"c1", "c2"})),    # 带空格 / 尾逗号
+    ],
+)
+def test_parse_whitelist(raw: str, expected: frozenset[str]):
+    assert fw.parse_whitelist(raw) == expected
+
+
+# ---------------------------------------------------------------------------
+# should_feed_chat_to_life：白名单判定
+# ---------------------------------------------------------------------------
+
+
+def _patch_config(monkeypatch, value: str) -> list[str]:
+    """把 Dynamic Config 的 get 换成固定返回值，记录被读的 key。"""
+    calls: list[str] = []
+
+    def fake_get(key: str, *, default: str = "") -> str:
+        calls.append(key)
+        return value
+
+    monkeypatch.setattr(fw.dynamic_config, "get", fake_get)
+    return calls
+
+
+@pytest.mark.asyncio
+async def test_group_in_whitelist_feeds(monkeypatch):
+    calls = _patch_config(monkeypatch, "c1,c2")
+    assert await fw.should_feed_chat_to_life(chat_id="c1", is_p2p=False) is True
+    assert calls == [fw.LIFE_FEED_CHAT_WHITELIST_KEY]
+
+
+@pytest.mark.asyncio
+async def test_group_not_in_whitelist_skipped(monkeypatch, caplog):
+    """白名单非空、单纯不在名单内：正常挡下，**不**升 warning（info 在挡点打）。"""
+    _patch_config(monkeypatch, "c1,c2")
+    with caplog.at_level(logging.WARNING):
+        assert await fw.should_feed_chat_to_life(chat_id="c9", is_p2p=False) is False
+    assert caplog.records == [], "正常名单外挡下是预期行为，不该告警"
+
+
+@pytest.mark.asyncio
+async def test_empty_config_fail_closed_logs_warning(monkeypatch, caplog):
+    """配置缺失/为空 -> 所有群聊一律跳过（fail-closed），且必须 warning 可感知。
+
+    空白名单挡下回灌时升 warning（codex T3 小改）：fail-closed 把"配置丢失"和
+    "正常名单外"挡成同一个结果，配置系统挂了 / key 被误删若只有 info，止血会
+    无声变成"她永远听不见群聊"。
+    """
+    _patch_config(monkeypatch, "")
+    with caplog.at_level(logging.WARNING):
+        assert await fw.should_feed_chat_to_life(chat_id="c1", is_p2p=False) is False
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert any(
+        fw.LIFE_FEED_CHAT_WHITELIST_KEY in r.message for r in warnings
+    ), "空白名单挡下必须 warning 点名配置 key（配置丢失要可感知）"
+
+
+@pytest.mark.asyncio
+async def test_group_without_chat_id_skipped(monkeypatch):
+    """群聊但 chat_id 缺失：无法判定归属 -> 按 fail-closed 跳过。"""
+    _patch_config(monkeypatch, "c1")
+    assert await fw.should_feed_chat_to_life(chat_id=None, is_p2p=False) is False
+
+
+@pytest.mark.asyncio
+async def test_p2p_not_filtered_and_skips_config(monkeypatch):
+    """p2p 私聊不过滤：空配置下照样放行，且根本不消费 Dynamic Config。"""
+    calls = _patch_config(monkeypatch, "")
+    assert await fw.should_feed_chat_to_life(chat_id="c1", is_p2p=True) is True
+    assert calls == [], "p2p 短路不该读配置"
+
+
+@pytest.mark.asyncio
+async def test_whitelist_value_with_spaces_still_matches(monkeypatch):
+    """运维侧配置带空格（' c1 , c2 '）不影响命中。"""
+    _patch_config(monkeypatch, " c1 , c2 ")
+    assert await fw.should_feed_chat_to_life(chat_id="c2", is_p2p=False) is True

--- a/apps/agent-service/tests/life/test_review_evidence.py
+++ b/apps/agent-service/tests/life/test_review_evidence.py
@@ -1,0 +1,114 @@
+"""睡前回顾的意识流证据拼装 × 折叠 — 载荷段过滤、沉淀正文保留（铁律③）.
+
+``_transcript_evidence`` 按生活日窗口读两个自然日的 transcript。折叠落地后它会
+读到两种形态，拼证据的口径钉死为：
+
+  * **机制载荷过滤**：round marker 不是她的感知——折叠消息的 ``[fold-markers]``
+    载荷段、普通 stimulus 开头的 marker 行，都绝不能进回顾证据。
+  * **沉淀正文保留**：折叠消息上半段是她自己的记忆固化，照常进证据。
+  * 生活日窗口跨 04:00 两个 session，任一被折叠都同样成立。
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import app.nodes.life_wake as life_wake
+import app.world.engine as world_engine
+from app.agent.neutral import Message, Role
+from app.agent.session_fold import build_fold_message
+from app.life.review import _transcript_evidence
+
+_SEDIMENT = "上午我陪妹妹改了卷子，心里一直惦记着下午的雨。"
+_MARKERS = [
+    life_wake._round_marker("life-rid-001"),
+    world_engine._round_marker(
+        "world-rid-002",
+        end_created_at="2026-06-10T12:00:00+08:00",
+        end_act_id="9f3c2a1e-0000-5000-8000-000000000000",
+    ),
+]
+
+
+def _folded_history() -> list[Message]:
+    """折叠后的一天：单条折叠消息 + 折叠后续上的一轮新感知。"""
+    return [
+        build_fold_message(_SEDIMENT, _MARKERS),
+        Message(
+            role=Role.USER,
+            content=f"{life_wake._round_marker('life-rid-new')}\n现在是 18:00。窗外开始下雨了。",
+        ),
+        Message(role=Role.ASSISTANT, content="我去把阳台的衣服收进来"),
+    ]
+
+
+def _plain_history() -> list[Message]:
+    return [
+        Message(
+            role=Role.USER,
+            content=f"{life_wake._round_marker('life-rid-plain')}\n现在是 23:10。屋里很安静。",
+        ),
+        Message(role=Role.ASSISTANT, content="今天过得很满，准备睡了"),
+        Message(role=Role.TOOL, content="状态已更新", tool_call_id="c1"),
+    ]
+
+
+def test_sediment_kept_and_payload_filtered():
+    evidence = _transcript_evidence([("2026-06-10", _folded_history())])
+
+    # 沉淀正文是她的记忆，保留进证据
+    assert _SEDIMENT in evidence
+    # 机制载荷绝不进证据：载荷段标记行、两种 round marker 全部过滤
+    assert "[fold-markers]" not in evidence
+    assert "[transcript-fold]" not in evidence
+    assert "[life-round:" not in evidence
+    assert "[world-round:" not in evidence
+    # 折叠后续上的新轮照常进证据（marker 行被滤掉、正文在）
+    assert "窗外开始下雨了。" in evidence
+    assert "我去把阳台的衣服收进来" in evidence
+
+
+def test_plain_history_marker_line_filtered_but_text_kept():
+    """未折叠的普通 stimulus：开头的 marker 行同样不是她的感知，滤掉、正文保留。"""
+    evidence = _transcript_evidence([("2026-06-10", _plain_history())])
+    assert "[life-round:" not in evidence
+    assert "屋里很安静。" in evidence
+    assert "今天过得很满，准备睡了" in evidence
+    assert "状态已更新" not in evidence  # TOOL 结果照旧不进证据
+
+
+@pytest.mark.parametrize("folded_day", [0, 1])
+def test_cross_4am_window_either_session_folded(folded_day):
+    """生活日跨 04:00 两个自然日的 session，任一被折叠：沉淀保留、载荷过滤。"""
+    sessions = [
+        ("2026-06-10", _plain_history()),
+        ("2026-06-11", _plain_history()),
+    ]
+    sessions[folded_day] = (sessions[folded_day][0], _folded_history())
+
+    evidence = _transcript_evidence(sessions)
+    assert _SEDIMENT in evidence
+    assert "[fold-markers]" not in evidence
+    assert "[life-round:" not in evidence
+    assert "[world-round:" not in evidence
+    # 两个自然日的段都在（未折叠那天的正文也没丢）
+    assert "（2026-06-10 这个自然日）" in evidence
+    assert "（2026-06-11 这个自然日）" in evidence
+    assert "屋里很安静。" in evidence
+
+
+def test_marker_only_user_message_contributes_nothing():
+    """整条 USER 只剩 marker（理论边界）：滤掉后为空，不留空壳行。"""
+    history = [
+        Message(role=Role.USER, content=life_wake._round_marker("life-rid-only")),
+        Message(role=Role.ASSISTANT, content="随手记一笔"),
+    ]
+    evidence = _transcript_evidence([("2026-06-10", history)])
+    assert "[life-round:" not in evidence
+    assert "〔你当时感知到〕" not in evidence  # 空感知不该出现空前缀行
+    assert "随手记一笔" in evidence
+
+
+def test_empty_days_still_say_no_record():
+    evidence = _transcript_evidence([("2026-06-10", []), ("2026-06-11", [])])
+    assert "没有留下意识流记录" in evidence

--- a/apps/agent-service/tests/nodes/test_chat_node_life_feed_whitelist.py
+++ b/apps/agent-service/tests/nodes/test_chat_node_life_feed_whitelist.py
@@ -1,0 +1,118 @@
+"""chat 收口 → life 信箱回灌的白名单闸口（spec Task 5）。
+
+只有白名单内的群的对话回灌进 life（成为她的经历/唤醒 life 轮）；白名单外的群
+与空配置（fail-closed）一律跳过回灌。p2p 私聊不过滤。被挡的只是
+``deliver_event`` 这一处回灌——chat 即时回复 emit 照常，安全链不受影响。
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.domain.chat_dataflow import ChatRequest
+from app.life import feed_whitelist as fw
+from tests.nodes.test_chat_node_conversation_replay import _happy_path_mocks
+
+WL_CHAT = "019e820c-9134-7113-b8e2-ad4f3b926dde"
+
+
+def _patch_whitelist(monkeypatch, value: str) -> None:
+    """把 Dynamic Config 的白名单 key 钉成固定值（真解析逻辑照走）。"""
+
+    def fake_get(key: str, *, default: str = "") -> str:
+        assert key == fw.LIFE_FEED_CHAT_WHITELIST_KEY
+        return value
+
+    monkeypatch.setattr(fw.dynamic_config, "get", fake_get)
+
+
+def _capture_deliver(monkeypatch, cn) -> list[dict]:
+    delivered: list[dict] = []
+
+    async def fake_deliver(**kwargs):
+        delivered.append(kwargs)
+        return 1
+
+    monkeypatch.setattr(cn, "deliver_event", fake_deliver)
+    return delivered
+
+
+def _group_req(**overrides) -> ChatRequest:
+    base: dict = dict(
+        message_id="m1", persona_id="akao", session_id="s1",
+        chat_id=WL_CHAT, is_p2p=False, user_id="u1", lane="coe-t1",
+    )
+    base.update(overrides)
+    return ChatRequest(**base)
+
+
+@pytest.mark.asyncio
+async def test_group_in_whitelist_replays_to_life(monkeypatch):
+    """白名单内的群：聊完照常回灌一条 external event 进 persona 信箱。"""
+    from app.nodes import chat_node as cn
+
+    _happy_path_mocks(cn, monkeypatch)
+    monkeypatch.setenv("LANE", "coe-t1")
+    _patch_whitelist(monkeypatch, f"other-id,{WL_CHAT}")
+    delivered = _capture_deliver(monkeypatch, cn)
+
+    await cn.chat_node(_group_req())
+
+    assert len(delivered) == 1, "白名单内的群应照常回灌 life"
+    assert delivered[0]["persona_id"] == "akao"
+    assert delivered[0]["kind"] == "external"
+
+
+@pytest.mark.asyncio
+async def test_group_not_in_whitelist_skips_replay_but_reply_intact(monkeypatch):
+    """白名单外的群：不回灌 life（deliver_event 不被调），chat 回复照常 emit。"""
+    from app.nodes import chat_node as cn
+
+    _happy_path_mocks(cn, monkeypatch)
+    monkeypatch.setenv("LANE", "coe-t1")
+    _patch_whitelist(monkeypatch, "some-other-conversation-id")
+    delivered = _capture_deliver(monkeypatch, cn)
+
+    # 重新挂 emit 捕获回复段——挡回灌绝不能挡回复。
+    emitted: list = []
+
+    async def capture_emit(d):
+        emitted.append(d)
+
+    monkeypatch.setattr(cn, "emit", capture_emit)
+
+    await cn.chat_node(_group_req())
+
+    assert delivered == [], "白名单外的群不该回灌 life"
+    assert len(emitted) >= 1, "chat 回复路径必须不受白名单影响"
+    assert emitted[-1].is_last is True
+
+
+@pytest.mark.asyncio
+async def test_empty_whitelist_fail_closed_skips_all_groups(monkeypatch):
+    """空配置（缺失/没配）：所有群聊回灌全部跳过——fail-closed 成本止血。"""
+    from app.nodes import chat_node as cn
+
+    _happy_path_mocks(cn, monkeypatch)
+    monkeypatch.setenv("LANE", "coe-t1")
+    _patch_whitelist(monkeypatch, "")
+    delivered = _capture_deliver(monkeypatch, cn)
+
+    await cn.chat_node(_group_req())
+
+    assert delivered == [], "空白名单下任何群聊都不该回灌 life"
+
+
+@pytest.mark.asyncio
+async def test_p2p_not_filtered_even_with_empty_config(monkeypatch):
+    """p2p 私聊不过滤：空配置下私聊回灌照常进 life。"""
+    from app.nodes import chat_node as cn
+
+    _happy_path_mocks(cn, monkeypatch)
+    monkeypatch.setenv("LANE", "coe-t1")
+    _patch_whitelist(monkeypatch, "")
+    delivered = _capture_deliver(monkeypatch, cn)
+
+    await cn.chat_node(_group_req(is_p2p=True))
+
+    assert len(delivered) == 1, "p2p 不受白名单过滤"

--- a/apps/agent-service/tests/nodes/test_life_wake_fold.py
+++ b/apps/agent-service/tests/nodes/test_life_wake_fold.py
@@ -1,0 +1,384 @@
+"""life 轮收口的 transcript 沉淀折叠接线（沉淀 Task 2）.
+
+接线合同：``_run_life_round`` 在**全部 durable 收口之后**（标已读 / 排下次醒 / cd，
+仍在同一单飞锁串行窗口内）、睡前回顾之前，调 ``fold_session(session_id,
+build_life_fold_policy(...))``——本轮写回已在 ``Agent.run`` 里落定（两阶段解耦），
+折叠是其后的独立步骤；fold_session 整段 fail-open，折叠失败只 log、绝不影响轮。
+
+成本不嵌套污染（spec 决策 5 命门）：折叠调用点在本轮 ``collect_usage`` 作用域之外
+——沉淀的 token 落 ``{persona}:sediment`` 独立 actor，绝不算进 life 本体 actor。
+
+这些是节点编排测试：life / 沉淀两个 Agent.run 都打桩，验证接线位置与成本隔离，
+不验证 LLM 想得对。
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+
+import fakeredis.aioredis
+import pytest
+
+import app.agent.sediment as sediment_mod
+import app.agent.session_fold as fold_mod
+import app.nodes.life_wake as lw
+from app.agent.neutral import Message, Role
+from app.agent.session_fold import (
+    FOLD_TRIGGER_MESSAGES,
+    FoldPolicy,
+    split_fold_message,
+)
+from app.agent.trace import _accumulate_usage, make_session_id
+from app.domain.life_state import LifeState
+from app.domain.world_events import EventArrived, EventEnvelope
+from app.memory._persona import PersonaContext
+
+_LANE = "coe-t2"
+_PERSONA = "akao"
+_TODAY = "2026-06-10"
+_SID = make_session_id(_LANE, _PERSONA, _TODAY)
+
+
+@pytest.fixture(autouse=True)
+def fake_redis(monkeypatch):
+    import app.infra.redis as redis_mod
+
+    fake = fakeredis.aioredis.FakeRedis(decode_responses=True)
+    monkeypatch.setattr(redis_mod, "_redis", fake)
+    return fake
+
+
+@pytest.fixture(autouse=True)
+def frozen_now(monkeypatch):
+    """钉死 now = 2026-06-10 14:30 CST（午后普通一轮，不触发睡前回顾）。"""
+
+    class _FixedDateTime(_dt.datetime):
+        @classmethod
+        def now(cls, tz=None):
+            return cls(2026, 6, 10, 14, 30, tzinfo=tz)
+
+    monkeypatch.setattr(lw.cst_time, "datetime", _FixedDateTime)
+
+
+def _envelope(event_id="e1", summary="水壶在响"):
+    return EventEnvelope(
+        lane=_LANE,
+        persona_id=_PERSONA,
+        event_id=event_id,
+        kind="ambient",
+        source="world",
+        summary=summary,
+        occurred_at="2026-06-10T14:00:00+08:00",
+    )
+
+
+def _snapshot(**kwargs) -> LifeState:
+    base = {
+        "lane": _LANE,
+        "persona_id": _PERSONA,
+        "current_state": "在写作业",
+        "response_mood": "平静",
+        "activity_type": "study",
+        "observed_at": "2026-06-10T14:00:00+08:00",
+    }
+    base.update(kwargs)
+    return LifeState(**base)
+
+
+def _life_rounds(n_messages: int) -> list[Message]:
+    """凑 n 条折叠存储里的历史消息（带 life round marker，2 条/轮）。"""
+    out: list[Message] = []
+    i = 0
+    while len(out) + 2 <= n_messages:
+        out.append(
+            Message(
+                role=Role.USER,
+                content=f"[life-round:old-{i:03d}]\n现在是 12:{i:02d}。第 {i} 件动静。",
+            )
+        )
+        out.append(Message(role=Role.ASSISTANT, content=f"我想了想第 {i} 件事"))
+        i += 1
+    return out
+
+
+@pytest.fixture
+def patched(monkeypatch):
+    """stub 节点 IO（不碰真库），专测折叠接线机制。"""
+    state = {
+        "snapshot": _snapshot(),
+        "unread": [_envelope()],
+        "transcript": [],   # lw.load_session（turn 幂等查重读的那份）
+        "marked": [],
+        "costs": [],        # lw / sediment 两处 record_round_cost 的快照
+        "arc": None,
+    }
+
+    async def fake_find(*, lane, persona_id):
+        return state["snapshot"]
+
+    async def fake_unread(*, lane, persona_id):
+        return list(state["unread"])
+
+    async def fake_load_session(session_id, **kwargs):
+        return list(state["transcript"])
+
+    async def fake_mark(*, lane, persona_id, event_ids):
+        state["marked"].append(event_ids)
+
+    async def fake_load_persona(persona_id):
+        return PersonaContext(
+            persona_id=persona_id, display_name=persona_id, persona_lite="人设"
+        )
+
+    async def fake_review(**kwargs):
+        pass
+
+    async def fake_read_day_page(*, lane, persona_id, date):
+        return None
+
+    async def fake_arc(*, lane):
+        return state["arc"]
+
+    async def fake_record_round_cost(**kwargs):
+        state["costs"].append({**kwargs, "usage": dict(kwargs["usage"])})
+
+    import app.domain.arc_awareness as arc_mod
+
+    monkeypatch.setattr(arc_mod, "read_world_arc", fake_arc)
+    monkeypatch.setattr(lw, "find_life_state", fake_find)
+    monkeypatch.setattr(lw, "list_unread_events", fake_unread)
+    monkeypatch.setattr(lw, "mark_events_read", fake_mark)
+    monkeypatch.setattr(lw, "load_persona", fake_load_persona)
+    monkeypatch.setattr(lw, "load_session", fake_load_session)
+    monkeypatch.setattr(lw, "run_day_review", fake_review)
+    monkeypatch.setattr(lw, "read_day_page", fake_read_day_page)
+    monkeypatch.setattr(lw, "record_round_cost", fake_record_round_cost)
+    monkeypatch.setattr(sediment_mod, "record_round_cost", fake_record_round_cost)
+    monkeypatch.setattr(sediment_mod, "load_persona", fake_load_persona)
+    return state
+
+
+def _install_life_agent(monkeypatch, *, usage=None):
+    """life 本体 Agent 桩：可注入本轮 usage（进当前 collect_usage 作用域）。"""
+
+    class _FakeLifeAgent:
+        def __init__(self, cfg, *, tools=None, **kwargs):
+            pass
+
+        async def run(self, messages, *, prompt_vars=None, context=None,
+                      session_id=None, max_retries=2):
+            if usage is not None:
+                _accumulate_usage(usage)
+            return Message(role=Role.ASSISTANT, content="过我自己的一刻")
+
+    monkeypatch.setattr(lw, "Agent", _FakeLifeAgent)
+
+
+def _install_sediment_agent(monkeypatch, *, text="到此刻为止我记得这些。", usage=None,
+                            exc=None):
+    class _FakeSedimentAgent:
+        def __init__(self, cfg, *, tools=None, **kwargs):
+            pass
+
+        async def run(self, messages, *, prompt_vars=None, context=None,
+                      session_id=None, max_retries=2):
+            if usage is not None:
+                _accumulate_usage(usage)
+            if exc is not None:
+                raise exc
+            return Message(role=Role.ASSISTANT, content=text)
+
+    monkeypatch.setattr(sediment_mod, "Agent", _FakeSedimentAgent)
+
+
+@pytest.fixture
+def fold_store(monkeypatch):
+    """fold_session 的存取面（与 lw.load_session 的 turn 幂等查重读取面是两回事）。"""
+    store = {
+        "messages": _life_rounds(FOLD_TRIGGER_MESSAGES),
+        "ver": FOLD_TRIGGER_MESSAGES // 2,
+        "replaced": None,
+    }
+
+    async def fake_load(session_id):
+        return list(store["messages"]), store["ver"]
+
+    async def fake_replace(session_id, messages, *, expected_ver=None):
+        if expected_ver is not None and expected_ver != store["ver"]:
+            return False
+        store["replaced"] = list(messages)
+        store["ver"] += 1
+        return True
+
+    monkeypatch.setattr(fold_mod, "load_session_versioned", fake_load)
+    monkeypatch.setattr(fold_mod, "replace_session", fake_replace)
+    return store
+
+
+async def _wake():
+    await lw.life_wake_node(EventArrived(lane=_LANE, persona_id=_PERSONA))
+
+
+def _expected_round_id() -> str:
+    return lw._derive_life_round_id(
+        lane=_LANE,
+        persona_id=_PERSONA,
+        wake=EventArrived(lane=_LANE, persona_id=_PERSONA),
+        read_ids=["e1"],
+    )
+
+
+# ---------------------------------------------------------------------------
+# 接线位置：收口后调 fold_session，带正确的 session / 策略参数
+# ---------------------------------------------------------------------------
+
+
+async def test_round_close_folds_with_life_policy(patched, monkeypatch):
+    """收口后调 fold_session(本日 session, build_life_fold_policy(本轮参数))。"""
+    _install_life_agent(monkeypatch)
+
+    async def _dummy_writer(prior, rounds):
+        return "占位"
+
+    sentinel = FoldPolicy(write_sediment=_dummy_writer)
+    policy_calls: list[dict] = []
+
+    def fake_build(**kwargs):
+        policy_calls.append(kwargs)
+        return sentinel
+
+    fold_calls: list[tuple] = []
+
+    async def fake_fold(session_id, policy):
+        fold_calls.append((session_id, policy))
+        return False
+
+    monkeypatch.setattr(lw, "build_life_fold_policy", fake_build)
+    monkeypatch.setattr(lw, "fold_session", fake_fold)
+
+    await _wake()
+
+    assert fold_calls == [(_SID, sentinel)]
+    assert policy_calls == [
+        {
+            "lane": _LANE,
+            "persona_id": _PERSONA,
+            "session_id": _SID,
+            "round_id": _expected_round_id(),
+        }
+    ]
+
+
+async def test_fold_runs_after_mark_read_before_self_wake_and_review(
+    patched, monkeypatch
+):
+    """折叠在成本入账 + 标已读之后、**排下次醒之前**、睡前回顾之前。
+
+    fold 必须先于 fire_life_self_wake（codex T3 必改 1）：沉淀 LLM 最长 120s 仍
+    占着单飞锁，若先排 self-wake，短延迟的自排会在折叠期间到达撞锁——self tick
+    撞锁是直接被吞的（不像事件唤醒有 reschedule 保底）。fold 完成后才开始给
+    下一轮自排计时，窗口消失。
+    """
+    order: list[str] = []
+
+    async def fake_cost(**kwargs):
+        order.append("round_cost")
+
+    async def fake_mark(*, lane, persona_id, event_ids):
+        order.append("mark_read")
+
+    async def fake_fold(session_id, policy):
+        order.append("fold")
+        return False
+
+    async def fake_self_wake(*, lane, persona_id, self_wake):
+        order.append("self_wake")
+        return False
+
+    async def fake_review(**kwargs):
+        order.append("review")
+
+    monkeypatch.setattr(lw, "record_round_cost", fake_cost)
+    monkeypatch.setattr(lw, "mark_events_read", fake_mark)
+    monkeypatch.setattr(lw, "fold_session", fake_fold)
+    monkeypatch.setattr(lw, "fire_life_self_wake", fake_self_wake)
+    monkeypatch.setattr(lw, "run_day_review", fake_review)
+    patched["snapshot"] = _snapshot(activity_type="sleep", day_reviewed_date=None)
+    _install_life_agent(monkeypatch)
+
+    await _wake()
+
+    assert order == ["round_cost", "mark_read", "fold", "self_wake", "review"]
+
+
+async def test_turn_idempotent_skip_does_not_fold(patched, monkeypatch):
+    """同轮重投命中 turn 幂等 → 整段早返，不折叠（折叠等真跑过的轮收口再做）。"""
+    marker = lw._round_marker(_expected_round_id())
+    patched["transcript"] = [Message(role=Role.USER, content=f"{marker}\n上一次的本轮")]
+    fold_calls: list = []
+
+    async def fake_fold(session_id, policy):
+        fold_calls.append(session_id)
+        return False
+
+    monkeypatch.setattr(lw, "fold_session", fake_fold)
+    _install_life_agent(monkeypatch)
+
+    await _wake()
+
+    assert fold_calls == []
+    assert patched["marked"] == [], "幂等跳过的轮不收口（现状语义）"
+
+
+# ---------------------------------------------------------------------------
+# 成本不嵌套污染：沉淀 usage 绝不算进 life 本体 actor
+# ---------------------------------------------------------------------------
+
+
+async def test_sediment_usage_never_pollutes_life_actor(
+    patched, monkeypatch, fold_store
+):
+    """端到端（真 fold_session + 真沉淀回调）：两份成本各归各的 actor。"""
+    _install_life_agent(
+        monkeypatch, usage={"input": 1000, "output": 50, "total": 1050}
+    )
+    _install_sediment_agent(
+        monkeypatch,
+        text="到此刻为止我记得这些。",
+        usage={"input": 70, "output": 7, "total": 77},
+    )
+
+    await _wake()
+
+    by_actor = {c["actor"]: c for c in patched["costs"]}
+    assert by_actor[_PERSONA]["usage"]["input"] == 1000, (
+        "life 本体 actor 的 usage 不得混入沉淀的 70"
+    )
+    assert by_actor[_PERSONA]["usage"]["calls"] == 1
+    sed = by_actor[f"{_PERSONA}:sediment"]
+    assert sed["usage"]["input"] == 70
+    assert sed["lane"] == _LANE
+    assert sed["round_id"] == sediment_mod._sediment_round_id(
+        _SID, _expected_round_id()
+    )
+
+    # 折叠真落库：单条折叠消息 = 沉淀正文 + marker 逐行保全
+    assert fold_store["replaced"] is not None and len(fold_store["replaced"]) == 1
+    sediment, markers = split_fold_message(fold_store["replaced"][0])
+    assert sediment == "到此刻为止我记得这些。"
+    assert len(markers) == FOLD_TRIGGER_MESSAGES // 2
+
+
+async def test_sediment_failure_never_kills_the_round(
+    patched, monkeypatch, fold_store, caplog
+):
+    """沉淀失败 → 本轮收口照常（已标已读）、transcript 原样不动、只 warning 不抛。"""
+    _install_life_agent(monkeypatch)
+    _install_sediment_agent(monkeypatch, exc=RuntimeError("llm down"))
+
+    with caplog.at_level("WARNING"):
+        await _wake()  # 不抛
+
+    assert patched["marked"] == [["e1"]], "本轮 durable 收口在折叠之前已经完成"
+    assert fold_store["replaced"] is None, "折叠失败本版不折、原样不动"
+    assert any("fold" in r.message.lower() for r in caplog.records)

--- a/apps/agent-service/tests/runtime/test_bootstrap_dynamic_config.py
+++ b/apps/agent-service/tests/runtime/test_bootstrap_dynamic_config.py
@@ -1,0 +1,49 @@
+"""prepare_for_run 接线 Dynamic Config 的 lane provider（双入口共用路径）。
+
+agent-service 双入口（FastAPI ``app.main`` lifespan / worker
+``app.workers.runtime_entry``）都走 ``prepare_for_run``。Dynamic Config 是
+per-lane 解析的，必须在这条共用路径上接上进程级部署泳道
+（``current_deployment_lane``）——只挂 main.py 的话 worker 进程会永远读
+prod 配置（dual-entry footgun）。
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from inner_shared.dynamic_config import DynamicConfig, dynamic_config
+
+from app.runtime.bootstrap import prepare_for_run
+
+
+def test_set_lane_provider_drives_lane_resolution():
+    """DynamicConfig.set_lane_provider：provider 返回泳道则用之，None 退 prod。"""
+    cfg = DynamicConfig(paas_engine_url="http://example.invalid")
+    assert cfg._get_lane() == "prod"
+
+    cfg.set_lane_provider(lambda: "coe-x")
+    assert cfg._get_lane() == "coe-x"
+
+    cfg.set_lane_provider(lambda: None)
+    assert cfg._get_lane() == "prod"
+
+
+@pytest.mark.asyncio
+async def test_prepare_for_run_wires_dynamic_config_lane_provider(monkeypatch):
+    """prepare_for_run 后，全局 dynamic_config 按进程级部署泳道解析。
+
+    LANE=coe-* 时读 coe 泳道配置；LANE 未设（prod 部署）退回 "prod"。
+    """
+    with patch("app.runtime.bootstrap.load_dataflow_graph", MagicMock()), \
+         patch(
+             "app.runtime.delayed_trigger.register_runtime_trigger_wire",
+             MagicMock(),
+         ):
+        await prepare_for_run("agent-service")
+
+    monkeypatch.setenv("LANE", "coe-feedwl")
+    assert dynamic_config._get_lane() == "coe-feedwl"
+
+    monkeypatch.delenv("LANE", raising=False)
+    assert dynamic_config._get_lane() == "prod"

--- a/apps/agent-service/tests/unit/agent/test_sediment.py
+++ b/apps/agent-service/tests/unit/agent/test_sediment.py
@@ -1,0 +1,408 @@
+"""沉淀 agent 契约 — 折叠占位由真沉淀填充（沉淀 Task 2，spec 决策 4/5）.
+
+:mod:`app.agent.session_fold` 定义了 ``SedimentWriter`` 回调契约；本文件钉死它的
+两个实现（:mod:`app.agent.sediment`）的机制层硬约束：
+
+  * 两口吻各自走对 prompt id：life=``life_sediment``、world=``world_sediment``，
+    都是 offline-model、无会话（run 不传 session_id）、无工具、max_retries=1；
+  * prompt_vars 契约：life=={persona_name, persona_lite}（与 life_day_review 同款薄
+    契约）、world=={}（零 vars）；
+  * 证据拼装：单条 user 消息——现实此刻 + 旧沉淀（首折如实说没有）+ 被折叠轮的
+    USER/ASSISTANT 文本（TOOL 机械确认不进、round marker 摘干净、条目全量不截断）；
+  * 成本独立入账：collect_usage 包住沉淀调用、record_round_cost(actor=
+    ``{persona}:sediment`` / ``world:sediment``)，round_id 从 (session_id, 触发轮
+    round_id) 派生幂等；
+  * 失败语义：LLM 抛错 / 硬超时（asyncio.wait_for）/ 空产出都向上抛——交给
+    fold_session fail-open（本版不折、transcript 原样不动）。
+
+写什么口吻、留什么细节由沉淀 agent 自己判断（写作纪律在 langfuse prompt 层）；
+这里没有内容检测器（赤尾宪法）。
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+import app.agent.sediment as sediment_mod
+import app.agent.session_fold as fold_mod
+from app.agent.neutral import Message, Role
+from app.agent.sediment import (
+    SEDIMENT_TIMEOUT_SECONDS,
+    build_life_fold_policy,
+    build_world_fold_policy,
+)
+from app.agent.session_fold import (
+    FOLD_TRIGGER_MESSAGES,
+    fold_session,
+    split_fold_message,
+)
+from app.agent.trace import _accumulate_usage
+from app.memory._persona import PersonaContext
+
+_LANE = "coe-t2"
+_PERSONA = "akao"
+_SID = "coe-t2:akao:2026-06-11"
+_ROUND = "life-round-abc"
+
+
+def _life_rounds(n_rounds: int) -> list[Message]:
+    """凑 n 轮 life：带 round marker 的 USER stimulus + ASSISTANT 所想。"""
+    out: list[Message] = []
+    for i in range(n_rounds):
+        out.append(
+            Message(
+                role=Role.USER,
+                content=f"[life-round:rid-{i:03d}]\n现在是 12:{i:02d}。你感知到第 {i} 件动静。",
+            )
+        )
+        out.append(Message(role=Role.ASSISTANT, content=f"我想了想第 {i} 件事"))
+    return out
+
+
+@pytest.fixture(autouse=True)
+def _stub_persona(monkeypatch):
+    """load_persona 打桩（沉淀的 prompt_vars 从这取 persona_name / persona_lite）。"""
+
+    async def fake_load_persona(persona_id):
+        return PersonaContext(
+            persona_id=persona_id, display_name="某姐姐", persona_lite="人设速写"
+        )
+
+    monkeypatch.setattr(sediment_mod, "load_persona", fake_load_persona)
+
+
+@pytest.fixture(autouse=True)
+def cost_records(monkeypatch):
+    """record_round_cost 打桩：快照 usage（dict 会被复用，记当时值）。"""
+    costs: list[dict] = []
+
+    async def fake_record_round_cost(**kwargs):
+        costs.append({**kwargs, "usage": dict(kwargs["usage"])})
+
+    monkeypatch.setattr(sediment_mod, "record_round_cost", fake_record_round_cost)
+    return costs
+
+
+def _install_agent(
+    monkeypatch,
+    *,
+    text="她口吻的当天回忆。",
+    usage=None,
+    exc=None,
+    delay=0.0,
+):
+    """把沉淀模块的 ``Agent`` 换成记录调用参数的桩，返回 captured。"""
+    captured: dict = {"runs": []}
+
+    class _FakeAgent:
+        def __init__(self, cfg, *, tools=None, **kwargs):
+            captured["cfg"] = cfg
+            captured["tools"] = tools
+
+        async def run(
+            self, messages, *, prompt_vars=None, context=None, session_id=None,
+            max_retries=2,
+        ):
+            captured["runs"].append(
+                {
+                    "messages": messages,
+                    "prompt_vars": prompt_vars,
+                    "context": context,
+                    "session_id": session_id,
+                    "max_retries": max_retries,
+                }
+            )
+            if delay:
+                await asyncio.sleep(delay)
+            if usage is not None:
+                _accumulate_usage(usage)
+            if exc is not None:
+                raise exc
+            return Message(role=Role.ASSISTANT, content=text)
+
+    monkeypatch.setattr(sediment_mod, "Agent", _FakeAgent)
+    return captured
+
+
+def _life_writer():
+    return build_life_fold_policy(
+        lane=_LANE, persona_id=_PERSONA, session_id=_SID, round_id=_ROUND
+    ).write_sediment
+
+
+def _world_writer():
+    return build_world_fold_policy(
+        lane=_LANE, session_id=_SID, round_id=_ROUND
+    ).write_sediment
+
+
+def _user_blob(captured) -> str:
+    run = captured["runs"][-1]
+    assert len(run["messages"]) == 1, "沉淀输入必须是单条 user 消息（一次喂全）"
+    assert run["messages"][0].role == Role.USER
+    return run["messages"][0].text()
+
+
+# ---------------------------------------------------------------------------
+# 两口吻各自走对 prompt id + 调用契约（无会话 / 无工具 / max_retries=1）
+# ---------------------------------------------------------------------------
+
+
+def test_life_config_pins_prompt_id_and_offline_model():
+    assert sediment_mod._LIFE_SEDIMENT_CFG.prompt_id == "life_sediment"
+    assert sediment_mod._LIFE_SEDIMENT_CFG.model_id == "offline-model"
+
+
+def test_world_config_pins_prompt_id_and_offline_model():
+    assert sediment_mod._WORLD_SEDIMENT_CFG.prompt_id == "world_sediment"
+    assert sediment_mod._WORLD_SEDIMENT_CFG.model_id == "offline-model"
+
+
+async def test_life_writer_uses_life_config(monkeypatch):
+    captured = _install_agent(monkeypatch)
+    await _life_writer()(None, _life_rounds(2))
+    assert captured["cfg"] is sediment_mod._LIFE_SEDIMENT_CFG
+
+
+async def test_world_writer_uses_world_config(monkeypatch):
+    captured = _install_agent(monkeypatch)
+    await _world_writer()(None, _life_rounds(2))
+    assert captured["cfg"] is sediment_mod._WORLD_SEDIMENT_CFG
+
+
+async def test_life_prompt_vars_contract(monkeypatch):
+    """life prompt_vars 契约 == {persona_name, persona_lite}（薄契约，同 life_day_review）。"""
+    captured = _install_agent(monkeypatch)
+    await _life_writer()(None, _life_rounds(2))
+    assert captured["runs"][-1]["prompt_vars"] == {
+        "persona_name": "某姐姐",
+        "persona_lite": "人设速写",
+    }
+
+
+async def test_world_prompt_vars_contract_is_empty(monkeypatch):
+    """world prompt_vars 契约 == {}（零 vars）。"""
+    captured = _install_agent(monkeypatch)
+    await _world_writer()(None, _life_rounds(2))
+    assert captured["runs"][-1]["prompt_vars"] == {}
+
+
+async def test_writer_is_sessionless_toolless_max_retries_one(monkeypatch):
+    """无会话（run 不传 session_id——绝不把沉淀写回它正要折叠的 transcript）、无工具、max_retries=1。"""
+    captured = _install_agent(monkeypatch)
+    await _life_writer()(None, _life_rounds(2))
+    run = captured["runs"][-1]
+    assert run["session_id"] is None
+    assert run["max_retries"] == 1
+    assert not captured["tools"], "沉淀 agent 无工具（一次 LLM 调用整篇重写）"
+    # langfuse 归组：context.session_id 只做 trace 标签（不续接）
+    assert run["context"].session_id == _SID
+    assert run["context"].persona_id == _PERSONA
+
+
+# ---------------------------------------------------------------------------
+# 证据拼装：现实此刻 / 首折 vs 重折叠 / 条目全量不截断 / marker 与 TOOL 不进
+# ---------------------------------------------------------------------------
+
+
+async def test_first_fold_says_no_prior_sediment(monkeypatch):
+    """首折（prior=None）→ 如实说还没有旧沉淀，不冒充。"""
+    captured = _install_agent(monkeypatch)
+    await _life_writer()(None, _life_rounds(2))
+    blob = _user_blob(captured)
+    assert "第一次沉淀" in blob
+    assert "【现实此刻】" in blob
+
+
+async def test_refold_passes_prior_sediment_through(monkeypatch):
+    """重折叠（prior 非 None）→ 旧沉淀全文透传进证据、首折占位语缺席。"""
+    captured = _install_agent(monkeypatch)
+    await _life_writer()("上午我帮妹妹讲了题。", _life_rounds(2))
+    blob = _user_blob(captured)
+    assert "上午我帮妹妹讲了题。" in blob
+    assert "第一次沉淀" not in blob
+
+
+async def test_evidence_keeps_every_entry_without_truncation(monkeypatch):
+    """被折叠轮逐条进证据（条目控制、绝不字符截断）；marker 摘干净；TOOL 不进。"""
+    rounds = _life_rounds(30)
+    rounds.append(Message(role=Role.TOOL, content="状态已更新", tool_call_id="c1"))
+    captured = _install_agent(monkeypatch)
+    await _life_writer()(None, rounds)
+    blob = _user_blob(captured)
+    for i in range(30):
+        assert f"你感知到第 {i} 件动静。" in blob
+        assert f"我想了想第 {i} 件事" in blob
+    assert "[life-round:" not in blob, "round marker 是机制载荷，绝不喂给沉淀 agent"
+    assert "状态已更新" not in blob, "TOOL 机械确认不是她的经历，不进证据"
+
+
+async def test_world_evidence_uses_deliberation_labels(monkeypatch):
+    """world 证据用推演口吻的标签（输入 / 推演），不是 life 的感知口吻。"""
+    captured = _install_agent(monkeypatch)
+    await _world_writer()(
+        None,
+        [
+            Message(
+                role=Role.USER,
+                content="[world-round:r1|end:-]\n【现实此刻】中午，推演这批动作。",
+            ),
+            Message(role=Role.ASSISTANT, content="世界往前流了一格"),
+        ],
+    )
+    blob = _user_blob(captured)
+    assert "推演这批动作。" in blob
+    assert "世界往前流了一格" in blob
+    assert "[world-round:" not in blob
+    assert "〔当时给你的输入〕" in blob
+    assert "〔你当时的推演〕" in blob
+
+
+async def test_life_evidence_uses_her_perception_labels(monkeypatch):
+    captured = _install_agent(monkeypatch)
+    await _life_writer()(None, _life_rounds(1))
+    blob = _user_blob(captured)
+    assert "〔你当时感知到〕" in blob
+    assert "〔你当时想着 / 说做了〕" in blob
+
+
+async def test_writer_returns_sediment_text(monkeypatch):
+    _install_agent(monkeypatch, text="  到此刻为止我记得这些。  ")
+    sediment = await _life_writer()(None, _life_rounds(2))
+    assert sediment == "到此刻为止我记得这些。"
+
+
+def test_instructions_have_no_plot_facts_or_digits():
+    """两份代码侧 instruction 零剧情事实、零数字（写作纪律在 langfuse prompt 层）。"""
+    for instruction in (
+        sediment_mod.life_sediment_instruction(),
+        sediment_mod.world_sediment_instruction(),
+    ):
+        assert "高考" not in instruction
+        for name in ("千凪", "赤尾", "绫奈", "chinagi", "akao", "ayana"):
+            assert name not in instruction
+        assert not any(ch.isdigit() for ch in instruction)
+
+
+# ---------------------------------------------------------------------------
+# 成本：独立 actor + (session_id, 触发轮) 派生幂等 round_id
+# ---------------------------------------------------------------------------
+
+
+async def test_life_cost_lands_on_sediment_actor(monkeypatch, cost_records):
+    _install_agent(
+        monkeypatch, usage={"input": 70, "output": 7, "total": 77}
+    )
+    await _life_writer()(None, _life_rounds(2))
+    assert len(cost_records) == 1
+    rec = cost_records[0]
+    assert rec["lane"] == _LANE
+    assert rec["actor"] == f"{_PERSONA}:sediment"
+    assert rec["round_id"] == sediment_mod._sediment_round_id(_SID, _ROUND)
+    assert rec["usage"]["input"] == 70
+    assert rec["usage"]["calls"] == 1
+
+
+async def test_world_cost_lands_on_world_sediment_actor(monkeypatch, cost_records):
+    _install_agent(monkeypatch, usage={"input": 5, "output": 5, "total": 10})
+    await _world_writer()(None, _life_rounds(2))
+    assert cost_records[-1]["actor"] == "world:sediment"
+
+
+def test_sediment_round_id_is_idempotent_per_trigger_round():
+    """同 (session_id, 触发轮) → 同 round_id（重投不重复计成本）；触发轮变 → 变。"""
+    a = sediment_mod._sediment_round_id(_SID, _ROUND)
+    assert a == sediment_mod._sediment_round_id(_SID, _ROUND)
+    assert a != sediment_mod._sediment_round_id(_SID, "another-round")
+    assert a != sediment_mod._sediment_round_id("other-session", _ROUND)
+
+
+# ---------------------------------------------------------------------------
+# 失败语义：抛错 / 超时 / 空产出都向上抛（交给 fold_session fail-open）
+# ---------------------------------------------------------------------------
+
+
+async def test_llm_failure_propagates_and_skips_cost(monkeypatch, cost_records):
+    _install_agent(monkeypatch, exc=RuntimeError("llm down"))
+    with pytest.raises(RuntimeError):
+        await _life_writer()(None, _life_rounds(2))
+    assert cost_records == []
+
+
+async def test_hard_timeout_raises_timeout_error(monkeypatch, cost_records):
+    """硬超时（asyncio.wait_for 包 LLM 调用）→ TimeoutError 向上抛、不记成本。"""
+    _install_agent(monkeypatch, delay=5.0)
+    monkeypatch.setattr(sediment_mod, "SEDIMENT_TIMEOUT_SECONDS", 0.05)
+    with pytest.raises(TimeoutError):
+        await _life_writer()(None, _life_rounds(2))
+    assert cost_records == []
+
+
+def test_timeout_far_below_engine_lock_ttl():
+    """硬超时远小于 life / world 单飞锁 TTL（600s）——折叠绝不把锁拖到过期。"""
+    assert SEDIMENT_TIMEOUT_SECONDS * 2 <= 600
+
+
+async def test_empty_output_raises_but_records_cost(monkeypatch, cost_records):
+    """空产出 = 折出来会失忆 → 抛错走 fail-open；token 真烧了，成本照记。"""
+    _install_agent(monkeypatch, text="   \n  ", usage={"input": 9, "output": 0, "total": 9})
+    with pytest.raises(ValueError):
+        await _life_writer()(None, _life_rounds(2))
+    assert len(cost_records) == 1, "run 正常返回过，token 真烧了，成本照记"
+
+
+# ---------------------------------------------------------------------------
+# 与 fold_session 的端到端：成功折叠落库 / 失败 fail-open 原样不动
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def fold_store(monkeypatch):
+    store = {
+        "messages": _life_rounds(FOLD_TRIGGER_MESSAGES // 2),
+        "ver": FOLD_TRIGGER_MESSAGES // 2,
+        "replaced": None,
+    }
+
+    async def fake_load(session_id):
+        return list(store["messages"]), store["ver"]
+
+    async def fake_replace(session_id, messages, *, expected_ver=None):
+        if expected_ver is not None and expected_ver != store["ver"]:
+            return False
+        store["replaced"] = list(messages)
+        store["ver"] += 1
+        return True
+
+    monkeypatch.setattr(fold_mod, "load_session_versioned", fake_load)
+    monkeypatch.setattr(fold_mod, "replace_session", fake_replace)
+    return store
+
+
+async def test_fold_session_with_life_policy_folds_and_persists(
+    monkeypatch, fold_store
+):
+    _install_agent(monkeypatch, text="到此刻为止，我记得今天帮妹妹讲了题。")
+    policy = build_life_fold_policy(
+        lane=_LANE, persona_id=_PERSONA, session_id=_SID, round_id=_ROUND
+    )
+
+    assert await fold_session(_SID, policy) is True
+
+    assert fold_store["replaced"] is not None and len(fold_store["replaced"]) == 1
+    sediment, markers = split_fold_message(fold_store["replaced"][0])
+    assert sediment == "到此刻为止，我记得今天帮妹妹讲了题。"
+    assert len(markers) == FOLD_TRIGGER_MESSAGES // 2, "被折叠各轮 marker 逐行保全"
+
+
+async def test_fold_session_fails_open_when_sediment_fails(monkeypatch, fold_store):
+    """沉淀失败 → 本版不折、transcript 原样不动（已写回的轮不受影响）。"""
+    _install_agent(monkeypatch, exc=RuntimeError("llm down"))
+    policy = build_life_fold_policy(
+        lane=_LANE, persona_id=_PERSONA, session_id=_SID, round_id=_ROUND
+    )
+
+    assert await fold_session(_SID, policy) is False
+    assert fold_store["replaced"] is None

--- a/apps/agent-service/tests/unit/agent/test_session_fold.py
+++ b/apps/agent-service/tests/unit/agent/test_session_fold.py
@@ -1,0 +1,438 @@
+"""折叠机制纯逻辑层契约 — transcript 到阈值整卷压成一条合成 USER 消息 (沉淀 Task 1).
+
+钉死 spec 决策 3/4/5 的机制边界（表驱动）：
+
+  * 阈值：100 条触发 / 99 条不触发；策略 None = 完全不折叠（连 load 都不做）。
+  * 折叠产物 = **单条合成 USER 消息**，上半沉淀正文 + 尾部机制载荷段，两段由
+    固定标记行（``[transcript-fold]`` / ``[fold-markers]``）可靠切分。
+  * marker 保全（铁律①③）：被折叠各轮的完整 round marker 字符串逐行进载荷段——
+    life / world 两套现有幂等扫描 / 游标解析函数**直接调用**断言折叠后仍命中。
+  * 重折叠：旧沉淀 + 新轮交回调整篇重写；marker 由**代码做并集**（绝不经回调）。
+  * fail-open：回调抛错 / 超时 = 本版不折、transcript 原样不动。
+  * 铁律②：marker 字符串不得混进沉淀正文——build 时净化 + warning。
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+
+import pytest
+
+import app.agent.session_fold as fold_mod
+import app.nodes.life_wake as life_wake
+import app.world.engine as world_engine
+from app.agent.neutral import Message, Role
+from app.agent.session_fold import (
+    FOLD_HEADER,
+    FOLD_MARKERS_HEADER,
+    FOLD_TRIGGER_MESSAGES,
+    FoldPolicy,
+    build_fold_message,
+    extract_round_markers,
+    fold_session,
+    is_fold_message,
+    split_fold_message,
+    strip_round_markers,
+)
+
+_SID = "coe-x:akao:2026-06-10"
+
+_WORLD_END_CREATED = "2026-06-10T12:00:00+08:00"
+_WORLD_END_ACT = str(uuid.uuid5(uuid.NAMESPACE_DNS, "act-seed"))
+
+
+def _life_round(i: int) -> list[Message]:
+    """一轮 life：带 round marker 的 USER stimulus + ASSISTANT 所想。"""
+    marker = life_wake._round_marker(f"life-rid-{i:03d}")
+    return [
+        Message(role=Role.USER, content=f"{marker}\n现在是 12:{i:02d}。你感知到第 {i} 件动静。"),
+        Message(role=Role.ASSISTANT, content=f"我想了想第 {i} 件事"),
+    ]
+
+
+def _world_round(i: int) -> list[Message]:
+    """一轮 world：带「round_id + 终点游标」marker 的 USER stimulus + ASSISTANT。"""
+    marker = world_engine._round_marker(
+        f"world-rid-{i:03d}",
+        end_created_at=_WORLD_END_CREATED,
+        end_act_id=_WORLD_END_ACT,
+    )
+    return [
+        Message(role=Role.USER, content=f"{marker}\n【现实此刻】12:{i:02d}，推演这批动作。"),
+        Message(role=Role.ASSISTANT, content=f"世界第 {i} 轮往前流了一格"),
+    ]
+
+
+def _rounds(n_messages: int) -> list[Message]:
+    """凑出恰好 ``n_messages`` 条的 life 轮序列（2 条/轮，奇数补一条 ASSISTANT）。"""
+    out: list[Message] = []
+    i = 0
+    while len(out) + 2 <= n_messages:
+        out.extend(_life_round(i))
+        i += 1
+    if len(out) < n_messages:
+        out.append(Message(role=Role.ASSISTANT, content="补一条尾巴"))
+    return out
+
+
+class _FakeStore:
+    """fold_session 的假存储：记录 load / replace 调用 + ver CAS 语义，替代 PG IO。
+
+    版本语义对齐真存储：load 返回 (messages, 当前 ver)；replace 带 expected_ver
+    时做 CAS——期间 ver 前进（有人 append）则放弃写入、返回 False。
+    """
+
+    def __init__(self, messages: list[Message]):
+        self.messages = list(messages)
+        self.ver = 1 if messages else 0
+        self.load_calls = 0
+        self.replaced: list[Message] | None = None
+
+    async def load(self, session_id: str) -> tuple[list[Message], int]:
+        self.load_calls += 1
+        return list(self.messages), self.ver
+
+    async def append(self, messages: list[Message]) -> None:
+        """模拟并发 append（锁过期后另一轮写入）：ver 前进。"""
+        self.messages = self.messages + list(messages)
+        self.ver += 1
+
+    async def replace(
+        self,
+        session_id: str,
+        messages: list[Message],
+        *,
+        expected_ver: int | None = None,
+    ) -> bool:
+        if expected_ver is not None and expected_ver != self.ver:
+            return False
+        self.replaced = list(messages)
+        self.messages = list(messages)
+        self.ver += 1
+        return True
+
+
+@pytest.fixture
+def store(monkeypatch):
+    """把 session_fold 的存取面换成假存储（默认空 transcript，测试自己塞）。"""
+    fake = _FakeStore([])
+    monkeypatch.setattr(fold_mod, "load_session_versioned", fake.load)
+    monkeypatch.setattr(fold_mod, "replace_session", fake.replace)
+    return fake
+
+
+async def _stub_sediment(prior: str | None, rounds: list[Message]) -> str:
+    return "今天上午我帮妹妹讲了题，又把房间收拾了一遍。"
+
+
+# ---------------------------------------------------------------------------
+# 阈值与默认关闭
+# ---------------------------------------------------------------------------
+
+
+async def test_no_policy_means_no_fold_at_all(store):
+    """策略 None = 完全不折叠：不 load、不写、返回 False（chat 等调用方零感知）。"""
+    store.messages = _rounds(FOLD_TRIGGER_MESSAGES + 10)
+    assert await fold_session(_SID, None) is False
+    assert store.load_calls == 0
+    assert store.replaced is None
+
+
+@pytest.mark.parametrize(
+    ("n_messages", "expect_fold"),
+    [
+        (FOLD_TRIGGER_MESSAGES - 1, False),  # 99 条不触发
+        (FOLD_TRIGGER_MESSAGES, True),  # 100 条触发
+        (FOLD_TRIGGER_MESSAGES + 30, True),  # 超过也触发
+    ],
+)
+async def test_fold_triggers_at_threshold(store, n_messages, expect_fold):
+    store.messages = _rounds(n_messages)
+    calls: list[tuple[str | None, int]] = []
+
+    async def writer(prior: str | None, rounds: list[Message]) -> str:
+        calls.append((prior, len(rounds)))
+        return "沉淀正文"
+
+    folded = await fold_session(_SID, FoldPolicy(write_sediment=writer))
+    assert folded is expect_fold
+    if expect_fold:
+        assert store.replaced is not None and len(store.replaced) == 1
+        assert calls == [(None, n_messages)]  # 首折：无旧沉淀、整卷进回调
+    else:
+        assert store.replaced is None
+        assert calls == []  # 不到阈值不烧回调
+
+
+# ---------------------------------------------------------------------------
+# 折叠产物：单条 USER 消息、两段可靠切分
+# ---------------------------------------------------------------------------
+
+
+async def test_fold_product_is_single_user_message_with_two_sections(store):
+    store.messages = _rounds(FOLD_TRIGGER_MESSAGES)
+    await fold_session(_SID, FoldPolicy(write_sediment=_stub_sediment))
+
+    assert store.replaced is not None and len(store.replaced) == 1
+    folded = store.replaced[0]
+    assert folded.role == Role.USER
+    assert is_fold_message(folded)
+
+    sediment, markers = split_fold_message(folded)
+    assert sediment == "今天上午我帮妹妹讲了题，又把房间收拾了一遍。"
+    # 载荷段 = 被折叠各轮的完整 marker 字符串，逐行、保序
+    expected = [life_wake._round_marker(f"life-rid-{i:03d}") for i in range(50)]
+    assert markers == expected
+
+
+def test_is_fold_message_gates_role_and_header():
+    fold = build_fold_message("沉淀", ["[life-round:x]"])
+    assert is_fold_message(fold) is True
+    # 普通 USER stimulus（哪怕含 marker）不是折叠消息
+    assert is_fold_message(_life_round(0)[0]) is False
+    # 同样文本但 ASSISTANT role：不是（两套扫描都只看 USER，折叠产物必须是 USER）
+    impostor = Message(role=Role.ASSISTANT, content=fold.text())
+    assert is_fold_message(impostor) is False
+
+
+def test_build_then_split_roundtrip_with_empty_markers():
+    """没有任何 marker 的卷（理论边界）也能 build / split 回来。"""
+    fold = build_fold_message("只有沉淀没有载荷", [])
+    sediment, markers = split_fold_message(fold)
+    assert sediment == "只有沉淀没有载荷"
+    assert markers == []
+
+
+def test_split_non_fold_message_raises():
+    with pytest.raises(ValueError):
+        split_fold_message(Message(role=Role.USER, content="普通消息"))
+
+
+# ---------------------------------------------------------------------------
+# marker 保全：现有 life / world 扫描函数对折叠后 transcript 仍命中（铁律③前半）
+# ---------------------------------------------------------------------------
+
+
+async def test_life_idempotent_scan_still_hits_after_fold(store):
+    store.messages = _rounds(FOLD_TRIGGER_MESSAGES)
+    await fold_session(_SID, FoldPolicy(write_sediment=_stub_sediment))
+    folded_history = store.replaced
+
+    # 直接调 life 的现有扫描：被折叠的每一轮都仍判「已处理」
+    for i in range(50):
+        assert life_wake._round_already_processed(folded_history, f"life-rid-{i:03d}")
+    # 没出现过的轮仍判未处理（不误伤）
+    assert not life_wake._round_already_processed(folded_history, "life-rid-999")
+
+
+async def test_world_scan_and_cursor_parse_still_work_after_fold(store):
+    rounds = _world_round(0) + _world_round(1) + _rounds(FOLD_TRIGGER_MESSAGES - 4)
+    store.messages = rounds
+    await fold_session(_SID, FoldPolicy(write_sediment=_stub_sediment))
+    folded_history = store.replaced
+
+    # 直接调 world 的现有函数：命中 + 从 marker 解析出终点游标
+    assert world_engine._round_in_history(folded_history, "world-rid-001")
+    assert world_engine._round_already_processed(folded_history, "world-rid-001") == (
+        _WORLD_END_CREATED,
+        _WORLD_END_ACT,
+    )
+    assert not world_engine._round_in_history(folded_history, "world-rid-999")
+
+
+async def test_world_empty_batch_marker_survives_fold(store):
+    """空批次 marker（``end:-``）也保全：命中但无终点游标（与折叠前语义一致）。"""
+    empty_marker = world_engine._round_marker(
+        "world-rid-empty", end_created_at=None, end_act_id=None
+    )
+    store.messages = [
+        Message(role=Role.USER, content=f"{empty_marker}\n例行看一眼世界。"),
+        Message(role=Role.ASSISTANT, content="世界安静流动"),
+    ] + _rounds(FOLD_TRIGGER_MESSAGES - 2)
+    await fold_session(_SID, FoldPolicy(write_sediment=_stub_sediment))
+    folded_history = store.replaced
+
+    assert world_engine._round_in_history(folded_history, "world-rid-empty")
+    assert world_engine._round_already_processed(folded_history, "world-rid-empty") is None
+
+
+def test_extract_round_markers_only_scans_user_messages():
+    """marker 印在 USER stimulus 里；ASSISTANT 复述的 marker 不算（对齐两套扫描的口径）。"""
+    msgs = [
+        Message(role=Role.USER, content="[life-round:u1]\n现在是中午。"),
+        Message(role=Role.ASSISTANT, content="我看到 [life-round:echo] 这行字"),
+        Message(role=Role.TOOL, content="[life-round:tool]", tool_call_id="c1"),
+    ]
+    assert extract_round_markers(msgs) == ["[life-round:u1]"]
+
+
+# ---------------------------------------------------------------------------
+# 重折叠：旧沉淀 + 新轮整篇重写；marker 由代码并集（绝不经回调）
+# ---------------------------------------------------------------------------
+
+
+async def test_refold_unions_markers_in_code_not_via_callback(store):
+    old_markers = ["[life-round:old-1]", "[world-round:old-2|end:-]"]
+    old_fold = build_fold_message("旧沉淀：上午的事。", old_markers)
+    new_rounds = _rounds(FOLD_TRIGGER_MESSAGES - 1)
+    store.messages = [old_fold] + new_rounds
+
+    seen: list[tuple[str | None, list[Message]]] = []
+
+    async def writer(prior: str | None, rounds: list[Message]) -> str:
+        seen.append((prior, rounds))
+        return "重写后的整篇沉淀（不含任何 marker）"
+
+    assert await fold_session(_SID, FoldPolicy(write_sediment=writer)) is True
+
+    # 回调拿到的是：旧沉淀正文 + 新轮消息（不含旧折叠消息本身、不含 marker 载荷职责）
+    assert len(seen) == 1
+    prior, rounds = seen[0]
+    assert prior == "旧沉淀：上午的事。"
+    assert rounds == new_rounds
+
+    # marker 并集由代码做：回调输出零 marker，载荷段仍是 旧∪新、保序去重
+    sediment, markers = split_fold_message(store.replaced[0])
+    assert sediment == "重写后的整篇沉淀（不含任何 marker）"
+    new_markers = extract_round_markers(new_rounds)
+    assert markers == old_markers + new_markers
+
+
+async def test_refold_dedups_duplicate_markers(store):
+    """同一 marker 既在旧载荷又在新轮里（防御性场景）：并集只留一份。"""
+    dup = "[life-round:dup-1]"
+    old_fold = build_fold_message("旧沉淀", [dup, "[life-round:old-2]"])
+    new_rounds = [
+        Message(role=Role.USER, content=f"{dup}\n重投的同一轮"),
+        Message(role=Role.ASSISTANT, content="想了想"),
+    ] + _rounds(FOLD_TRIGGER_MESSAGES - 3)
+    store.messages = [old_fold] + new_rounds
+
+    await fold_session(_SID, FoldPolicy(write_sediment=_stub_sediment))
+    _, markers = split_fold_message(store.replaced[0])
+    assert markers.count(dup) == 1
+    assert markers[:2] == [dup, "[life-round:old-2]"]
+
+
+# ---------------------------------------------------------------------------
+# fail-open：回调失败 = 本版不折、transcript 原样不动
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("exc", [RuntimeError("llm down"), TimeoutError()])
+async def test_callback_failure_fails_open(store, caplog, exc):
+    before = _rounds(FOLD_TRIGGER_MESSAGES)
+    store.messages = before
+
+    async def failing(prior: str | None, rounds: list[Message]) -> str:
+        raise exc
+
+    with caplog.at_level(logging.WARNING):
+        assert await fold_session(_SID, FoldPolicy(write_sediment=failing)) is False
+    assert store.replaced is None  # 没写任何新版本
+    assert store.messages == before  # 原样不动
+    assert any("fold" in r.message.lower() for r in caplog.records)  # 不静默
+
+
+async def test_store_failure_fails_open(store, caplog, monkeypatch):
+    """写回失败同样 fail-open（折叠是写回之后的独立步骤，绝不影响已落定的轮）。"""
+    store.messages = _rounds(FOLD_TRIGGER_MESSAGES)
+
+    async def broken_replace(
+        session_id: str, messages: list[Message], *, expected_ver: int | None = None
+    ) -> bool:
+        raise RuntimeError("pg down")
+
+    monkeypatch.setattr(fold_mod, "replace_session", broken_replace)
+    with caplog.at_level(logging.WARNING):
+        assert await fold_session(_SID, FoldPolicy(write_sediment=_stub_sediment)) is False
+
+
+# ---------------------------------------------------------------------------
+# 版本 CAS：load 后、replace 前有人 append（锁过期）→ 放弃本次折叠，不覆写
+# ---------------------------------------------------------------------------
+
+
+async def test_concurrent_append_during_sediment_abandons_fold(store, caplog):
+    """沉淀 LLM 期间 ver 前进（并发 append）→ replace CAS 放弃、原样不动、warning。
+
+    场景（codex T3 必改 2）：单飞锁 TTL 600s 不续租，本体轮 + 沉淀超 600s 时锁
+    过期、新一轮进入并 append；旧 fold 的整卷覆写若照常落库会把新 append 吞掉。
+    乐观并发：load 时记 ver，写入校验 ver 未变；变了 = 放弃本次折叠（fail-open，
+    下次到阈值再折），新 append 一条不丢。
+    """
+    before = _rounds(FOLD_TRIGGER_MESSAGES)
+    store.messages = before
+
+    async def racing_writer(prior: str | None, rounds: list[Message]) -> str:
+        # 沉淀 LLM 还在跑，另一轮（锁过期后进入）append 了新消息
+        await store.append(_life_round(999))
+        return "基于过时整卷写出的沉淀"
+
+    with caplog.at_level(logging.WARNING):
+        assert (
+            await fold_session(_SID, FoldPolicy(write_sediment=racing_writer)) is False
+        )
+
+    assert store.replaced is None, "stale 覆写必须被放弃"
+    assert store.messages == before + _life_round(999), "并发 append 一条不丢"
+    assert any("fold" in r.message.lower() for r in caplog.records), "放弃不静默"
+
+
+# ---------------------------------------------------------------------------
+# 铁律②：marker 不得混进沉淀正文 —— build 时净化
+# ---------------------------------------------------------------------------
+
+
+def test_build_sanitizes_markers_out_of_sediment(caplog):
+    dirty = (
+        "上午我写了作业。\n"
+        "[life-round:leaked]\n"
+        f"{FOLD_MARKERS_HEADER}\n"
+        "中午吃了面，[world-round:leak2|end:-] 然后睡了会儿。"
+    )
+    with caplog.at_level(logging.WARNING):
+        fold = build_fold_message(dirty, ["[life-round:real]"])
+    sediment, markers = split_fold_message(fold)
+    assert "[life-round:leaked]" not in sediment
+    assert "[world-round:" not in sediment
+    assert FOLD_MARKERS_HEADER not in sediment
+    assert "上午我写了作业。" in sediment
+    assert "中午吃了面，" in sediment and "然后睡了会儿。" in sediment
+    assert markers == ["[life-round:real]"]  # 载荷段不受净化影响
+    assert any("sediment" in r.message.lower() for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# strip_round_markers：回顾证据过滤用的纯函数
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        # marker 独占一行：整行删
+        ("[life-round:abc]\n现在是中午。", "现在是中午。"),
+        # marker 混在行内：只摘掉 marker、其余保留
+        ("开头 [world-round:r|end:-] 结尾", "开头  结尾"),
+        # 无 marker：原样
+        ("纯感知文本\n第二行", "纯感知文本\n第二行"),
+        # 多个 marker 都摘
+        ("[life-round:a]\n[world-round:b|end:-]\n正文", "正文"),
+    ],
+)
+def test_strip_round_markers(text, expected):
+    assert strip_round_markers(text) == expected
+
+
+def test_fold_header_lines_are_machine_constants():
+    """两个段标记是固定行级常量（Task 2 的沉淀 agent 与读取方都按它识别）。"""
+    fold = build_fold_message("正文", ["[life-round:x]"])
+    text = fold.text()
+    lines = text.split("\n")
+    assert lines[0] == FOLD_HEADER
+    assert FOLD_MARKERS_HEADER in lines
+    # 载荷段在尾部：markers 紧跟在最后一个 FOLD_MARKERS_HEADER 行之后
+    sep_at = len(lines) - 1 - lines[::-1].index(FOLD_MARKERS_HEADER)
+    assert lines[sep_at + 1 :] == ["[life-round:x]"]

--- a/apps/agent-service/tests/world/test_world_engine_fold.py
+++ b/apps/agent-service/tests/world/test_world_engine_fold.py
@@ -1,0 +1,316 @@
+"""world 轮收口的 transcript 沉淀折叠接线（沉淀 Task 2）.
+
+接线合同：``_run_world_round`` 在**成功收口之后**（推进游标 / 标底料 / 排下次醒，
+仍在同一 actor 锁串行窗口内）调 ``fold_session(session_id,
+build_world_fold_policy(...))``——本轮写回已在 ``Agent.run`` 里落定（两阶段解耦），
+折叠是其后的独立步骤；fold_session 整段 fail-open，折叠失败只 log、绝不影响轮。
+
+成本不嵌套污染（spec 决策 5 命门）：折叠调用点在本轮 ``collect_usage`` 作用域之外
+——沉淀的 token 落 ``world:sediment`` 独立 actor，绝不算进 world 本体 actor。
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+import fakeredis.aioredis
+import pytest
+
+import app.agent.sediment as sediment_mod
+import app.agent.session_fold as fold_mod
+import app.world.engine as engine_mod
+from app.agent.neutral import Message, Role
+from app.agent.session_fold import (
+    FOLD_TRIGGER_MESSAGES,
+    FoldPolicy,
+    split_fold_message,
+)
+from app.agent.trace import _accumulate_usage, make_session_id
+from app.world.engine import WorldTick, world_tick
+
+_LANE = "coe-t2"
+
+
+def _today() -> str:
+    return datetime.now(engine_mod._CST).strftime("%Y-%m-%d")
+
+
+def _sid() -> str:
+    return make_session_id(_LANE, "world", _today())
+
+
+@pytest.fixture(autouse=True)
+def _fake_redis(monkeypatch):
+    import app.capabilities.redis as cap_mod
+    import app.infra.redis as redis_mod
+
+    fake = fakeredis.aioredis.FakeRedis(decode_responses=True)
+    monkeypatch.setattr(redis_mod, "_redis", fake)
+    monkeypatch.setattr(cap_mod, "_singleton", None)
+
+
+@pytest.fixture(autouse=True)
+def _stub_engine_io(monkeypatch):
+    """stub world 节点的 IO（不碰真库），专测折叠接线机制。"""
+    state = {
+        "close_calls": [],
+        "costs": [],   # engine / sediment 两处 record_round_cost 的快照
+    }
+
+    async def fake_read_world_state(*, lane):
+        from app.world.state import WorldState
+
+        return WorldState(
+            lane=lane,
+            world_time="2026-06-10T06:30:00+08:00",
+            detail="清晨厨房有了动静。",
+        )
+
+    async def fake_renotify_unread(*, lane):
+        return 0
+
+    async def fake_list_recent_acts(*, lane, cursor_created_at, cursor_act_id, limit):
+        return []
+
+    async def fake_record_world_round_close(
+        *, lane, advance_cursor_to, materials_ingested_date
+    ):
+        state["close_calls"].append(
+            {"lane": lane, "advance_cursor_to": advance_cursor_to}
+        )
+
+    async def fake_find_daily_materials(*, lane, date):
+        return None
+
+    async def fake_read_world_arc(*, lane):
+        return None
+
+    async def fake_run_arc_reflection(**kwargs):
+        pass
+
+    async def fake_load_session(session_id):
+        return []
+
+    async def fake_record_round_cost(**kwargs):
+        state["costs"].append({**kwargs, "usage": dict(kwargs["usage"])})
+
+    monkeypatch.setattr(engine_mod, "read_world_state", fake_read_world_state)
+    monkeypatch.setattr(engine_mod, "renotify_unread", fake_renotify_unread)
+    monkeypatch.setattr(engine_mod, "list_recent_acts", fake_list_recent_acts)
+    monkeypatch.setattr(
+        engine_mod, "record_world_round_close", fake_record_world_round_close
+    )
+    monkeypatch.setattr(engine_mod, "find_daily_materials", fake_find_daily_materials)
+    monkeypatch.setattr(engine_mod, "read_world_arc", fake_read_world_arc)
+    monkeypatch.setattr(engine_mod, "run_arc_reflection", fake_run_arc_reflection)
+    monkeypatch.setattr(engine_mod, "load_session", fake_load_session)
+    monkeypatch.setattr(engine_mod, "record_round_cost", fake_record_round_cost)
+    monkeypatch.setattr(sediment_mod, "record_round_cost", fake_record_round_cost)
+    return state
+
+
+def _install_world_agent(monkeypatch, *, usage=None):
+    """world 本体 Agent 桩：记录 context（拿本轮 round_id 用）、可注入本轮 usage。"""
+    captured: dict = {}
+
+    class _FakeWorldAgent:
+        def __init__(self, cfg, *, tools=None, **kwargs):
+            pass
+
+        async def run(self, messages, *, prompt_vars=None, context=None,
+                      session_id=None, max_retries=2):
+            captured["context"] = context
+            captured["session_id"] = session_id
+            if usage is not None:
+                _accumulate_usage(usage)
+            return Message(role=Role.ASSISTANT, content="世界往前流了一格")
+
+    monkeypatch.setattr(engine_mod, "Agent", _FakeWorldAgent)
+    return captured
+
+
+def _install_sediment_agent(monkeypatch, *, text="到此刻为止世界这样流过。",
+                            usage=None, exc=None):
+    captured: dict = {}
+
+    class _FakeSedimentAgent:
+        def __init__(self, cfg, *, tools=None, **kwargs):
+            captured["cfg"] = cfg
+
+        async def run(self, messages, *, prompt_vars=None, context=None,
+                      session_id=None, max_retries=2):
+            captured["prompt_vars"] = prompt_vars
+            if usage is not None:
+                _accumulate_usage(usage)
+            if exc is not None:
+                raise exc
+            return Message(role=Role.ASSISTANT, content=text)
+
+    monkeypatch.setattr(sediment_mod, "Agent", _FakeSedimentAgent)
+    return captured
+
+
+@pytest.fixture
+def fold_store(monkeypatch):
+    """fold_session 的存取面：默认塞满阈值的历史（旧轮 marker 用与本轮无关的 rid）。"""
+    messages: list[Message] = []
+    i = 0
+    while len(messages) + 2 <= FOLD_TRIGGER_MESSAGES:
+        messages.append(
+            Message(
+                role=Role.USER,
+                content=f"[world-round:old-{i:03d}|end:-]\n【现实此刻】12:{i:02d}，看一眼世界。",
+            )
+        )
+        messages.append(Message(role=Role.ASSISTANT, content=f"第 {i} 轮的世界叙述"))
+        i += 1
+    store = {"messages": messages, "ver": len(messages) // 2, "replaced": None}
+
+    async def fake_load(session_id):
+        return list(store["messages"]), store["ver"]
+
+    async def fake_replace(session_id, messages, *, expected_ver=None):
+        if expected_ver is not None and expected_ver != store["ver"]:
+            return False
+        store["replaced"] = list(messages)
+        store["ver"] += 1
+        return True
+
+    monkeypatch.setattr(fold_mod, "load_session_versioned", fake_load)
+    monkeypatch.setattr(fold_mod, "replace_session", fake_replace)
+    return store
+
+
+async def _tick():
+    await world_tick(WorldTick(lane=_LANE, reason="heartbeat"))
+
+
+# ---------------------------------------------------------------------------
+# 接线位置：成功收口之后调 fold_session，带正确的 session / 策略参数
+# ---------------------------------------------------------------------------
+
+
+async def test_round_close_folds_with_world_policy(_stub_engine_io, monkeypatch):
+    """收口后调 fold_session(world 当日 session, build_world_fold_policy(本轮参数))。"""
+    world_captured = _install_world_agent(monkeypatch)
+
+    async def _dummy_writer(prior, rounds):
+        return "占位"
+
+    sentinel = FoldPolicy(write_sediment=_dummy_writer)
+    policy_calls: list[dict] = []
+
+    def fake_build(**kwargs):
+        policy_calls.append(kwargs)
+        return sentinel
+
+    fold_calls: list[tuple] = []
+
+    async def fake_fold(session_id, policy):
+        fold_calls.append((session_id, policy))
+        return False
+
+    monkeypatch.setattr(engine_mod, "build_world_fold_policy", fake_build)
+    monkeypatch.setattr(engine_mod, "fold_session", fake_fold)
+
+    await _tick()
+
+    round_id = world_captured["context"].features["world_round_id"]
+    assert fold_calls == [(_sid(), sentinel)]
+    assert policy_calls == [
+        {"lane": _LANE, "session_id": _sid(), "round_id": round_id}
+    ]
+
+
+async def test_fold_runs_after_round_close_before_self_wake(
+    _stub_engine_io, monkeypatch
+):
+    """折叠在成本入账 + 收口（推进游标）之后、**排下次醒之前**。
+
+    fold 必须先于 fire_self_wake（codex T3 必改 1）：沉淀 LLM 最长 120s 仍占着
+    actor 单飞锁，若先排 self-wake，短延迟（最短 60s）的自排会在折叠期间到达
+    撞锁被吞。fold 完成后才开始给下一轮自排计时，窗口消失。
+    """
+    order: list[str] = []
+
+    async def fake_cost(**kwargs):
+        order.append("round_cost")
+
+    async def fake_close(*, lane, advance_cursor_to, materials_ingested_date):
+        order.append("round_close")
+
+    async def fake_fold(session_id, policy):
+        order.append("fold")
+        return False
+
+    async def fake_self_wake(*, lane, self_wake):
+        order.append("self_wake")
+        return False
+
+    monkeypatch.setattr(engine_mod, "record_round_cost", fake_cost)
+    monkeypatch.setattr(engine_mod, "record_world_round_close", fake_close)
+    monkeypatch.setattr(engine_mod, "fold_session", fake_fold)
+    monkeypatch.setattr(engine_mod, "fire_self_wake", fake_self_wake)
+    _install_world_agent(monkeypatch)
+
+    await _tick()
+
+    assert order == ["round_cost", "round_close", "fold", "self_wake"]
+
+
+# ---------------------------------------------------------------------------
+# 成本不嵌套污染：沉淀 usage 绝不算进 world 本体 actor
+# ---------------------------------------------------------------------------
+
+
+async def test_sediment_usage_never_pollutes_world_actor(
+    _stub_engine_io, monkeypatch, fold_store
+):
+    """端到端（真 fold_session + 真沉淀回调）：两份成本各归各的 actor。"""
+    world_captured = _install_world_agent(
+        monkeypatch, usage={"input": 2000, "output": 80, "total": 2080}
+    )
+    sed_captured = _install_sediment_agent(
+        monkeypatch,
+        text="到此刻为止世界这样流过。",
+        usage={"input": 70, "output": 7, "total": 77},
+    )
+
+    await _tick()
+
+    costs = _stub_engine_io["costs"]
+    by_actor = {c["actor"]: c for c in costs}
+    assert by_actor["world"]["usage"]["input"] == 2000, (
+        "world 本体 actor 的 usage 不得混入沉淀的 70"
+    )
+    assert by_actor["world"]["usage"]["calls"] == 1
+    sed = by_actor["world:sediment"]
+    assert sed["usage"]["input"] == 70
+    assert sed["lane"] == _LANE
+    round_id = world_captured["context"].features["world_round_id"]
+    assert sed["round_id"] == sediment_mod._sediment_round_id(_sid(), round_id)
+
+    # world 口吻：零 prompt_vars + world_sediment 配置
+    assert sed_captured["prompt_vars"] == {}
+    assert sed_captured["cfg"] is sediment_mod._WORLD_SEDIMENT_CFG
+
+    # 折叠真落库：单条折叠消息 = 沉淀正文 + 旧轮 marker 逐行保全
+    assert fold_store["replaced"] is not None and len(fold_store["replaced"]) == 1
+    sediment, markers = split_fold_message(fold_store["replaced"][0])
+    assert sediment == "到此刻为止世界这样流过。"
+    assert len(markers) == FOLD_TRIGGER_MESSAGES // 2
+
+
+async def test_sediment_failure_never_kills_world_round(
+    _stub_engine_io, monkeypatch, fold_store, caplog
+):
+    """沉淀失败 → 本轮收口照常（已推进收口）、transcript 原样不动、只 warning 不抛。"""
+    _install_world_agent(monkeypatch)
+    _install_sediment_agent(monkeypatch, exc=RuntimeError("llm down"))
+
+    with caplog.at_level("WARNING"):
+        await _tick()  # 不抛
+
+    assert len(_stub_engine_io["close_calls"]) == 1, "收口在折叠之前已经完成"
+    assert fold_store["replaced"] is None, "折叠失败本版不折、原样不动"
+    assert any("fold" in r.message.lower() for r in caplog.records)

--- a/packages/py-shared/inner_shared/dynamic_config.py
+++ b/packages/py-shared/inner_shared/dynamic_config.py
@@ -43,6 +43,16 @@ class DynamicConfig:
         self._cache: dict[str, tuple[dict[str, dict[str, str]], float]] = {}
         self._lock = threading.Lock()
 
+    def set_lane_provider(
+        self, lane_provider: Callable[[], str | None]
+    ) -> None:
+        """设置 lane provider（进程启动时调用一次）。
+
+        provider 返回 None / 空串时退回 "prod"——与各 app 的
+        ``current_deployment_lane()``（prod 部署返回 None）口径天然对齐。
+        """
+        self._lane_provider = lane_provider
+
     def _get_lane(self) -> str:
         if self._lane_provider:
             lane = self._lane_provider()


### PR DESCRIPTION
## Summary

- Transcript sedimentation: at 100 messages the day's scroll is rewritten into a single message — the character's own recollection (world gets a simulator digest) — with all round markers preserved verbatim so turn idempotency and the world act cursor are untouched. Fold is fail-open with a 120s timeout and version-CAS against concurrent appends; the 200-message hard cap stays as backstop. Day one on prod hit that cap within 4.5h (akao: 110 rounds), silently forgetting the morning and busting the prompt cache every round.
- Life feed whitelist: the chat→life mailbox backfeed is gated by dynamic config `life_feed_chat_whitelist` (fail-closed when empty, p2p bypasses). Group chatter outside the whitelist no longer wakes the life engine; chat replies are unaffected.
- codex T1 (3 must-fixes) + T3 (2 adopted, 1 rejected with reason) applied; 1886 tests passed (+87 over baseline), incl. real-PG fold/CAS/idempotency cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
