### PR TITLE
fix(agent-service): chat yesterday-page injection bounded to before current living day

### DIFF
--- a/apps/agent-service/app/life/pages.py
+++ b/apps/agent-service/app/life/pages.py
@@ -106,9 +106,9 @@ async def day_page_exists(*, lane: str, persona_id: str, date: str) -> bool:
     清晨对账班「那天回顾过没有」的权威口径（2026-06-12 prod 事故修复）：单字段
     marker（LifeState.day_reviewed_date）会被清晨回笼觉的快班推前到新生活日，
     回答不了按天的问题——按天的事实只在这张表里。框架 ``select_latest`` 取的是
-    整行页全文，这里只要存在性，照 :func:`read_latest_day_page` 的先例在
-    framework 持久化写好的真实表上做一个只读 EXISTS 查询；写入仍走
-    ``insert_append``，不绕开 framework 持久化原语。
+    整行页全文，这里只要存在性，照 acts.py 的先例在 framework 持久化写好的
+    真实表上做一个只读 EXISTS 查询；写入仍走 ``insert_append``，不绕开
+    framework 持久化原语。
     """
     sql = (
         f"SELECT 1 FROM {_table_name(DayPage)} "
@@ -122,43 +122,19 @@ async def day_page_exists(*, lane: str, persona_id: str, date: str) -> bool:
         return r.first() is not None
 
 
-async def read_latest_day_page(*, lane: str, persona_id: str) -> DayPage | None:
-    """跨日期取她最近写下的一页昨天：date 最大那条链的最新一版，没有返回 None。
-
-    chat / life 注入的读口——注入侧只关心「她最近一次睡前回顾写下了什么」，不
-    关心具体哪个生活日（她病了一天没回顾，次日聊天该读到的就是前一页）。框架
-    ``select_latest`` 是「全 key 取最新一版」语义（必须给 date），这里要的是
-    「跨 date 的最新」——照 acts.py 的先例，在 framework 持久化写好的真实表上
-    做一个它没提供的只读查询；写入仍走 ``insert_append``，不绕开 framework
-    持久化原语。``date`` 是 YYYY-MM-DD 文本、字典序即时间序：按 date 降序、
-    version 降序取第一行即可（同日多版时取对账班重写后的最新一版）。
-    """
-    sql = (
-        f"SELECT * FROM {_table_name(DayPage)} "
-        f"WHERE lane = :lane AND persona_id = :persona_id "
-        f"ORDER BY date DESC, version DESC LIMIT 1"
-    )
-    async with get_session() as s:
-        r = await s.execute(text(sql), {"lane": lane, "persona_id": persona_id})
-        row = r.mappings().first()
-        if not row:
-            return None
-        return DayPage(**{k: row[k] for k in DayPage.model_fields})
-
-
 async def read_day_page_before(
     *, lane: str, persona_id: str, before_date: str
 ) -> DayPage | None:
     """取日期**严格早于** ``before_date`` 的最新一版昨天页，没有返回 None。
 
-    life 注入「她最近一页昨天」的读口（2026-06-12 事故修复的配套口径）：清晨
-    回笼觉的快班会给**当前生活日**写下凌晨的短页，跨日取最新
-    （:func:`read_latest_day_page`）会把它错当「上一页日子」；按单字段 marker
-    （LifeState.day_reviewed_date）取又会被回笼觉推前 / 对账班回拨。这里只认
-    日期：严格早于当前生活日（``before_date`` 由调用方按 living_day 口径算好
-    传入）的最新一版才是「昨天」。照 :func:`read_latest_day_page` 的先例做
-    framework 没提供的只读查询；``date`` 是 YYYY-MM-DD 文本、字典序即时间序，
-    按 date 降序、version 降序取第一行（同日多版取重写后的最新一版）。
+    life 与 chat 注入「她最近一页昨天」的统一读口（2026-06-12 事故修复的配套
+    口径）：清晨回笼觉的快班会给**当前生活日**写下凌晨的短页，跨日取最新会把
+    它错当「上一页日子」；按单字段 marker（LifeState.day_reviewed_date）取又
+    会被回笼觉推前 / 对账班回拨。这里只认日期：严格早于当前生活日
+    （``before_date`` 由调用方按 living_day 口径算好传入）的最新一版才是
+    「昨天」。照 acts.py 的先例做 framework 没提供的只读查询；``date`` 是
+    YYYY-MM-DD 文本、字典序即时间序，按 date 降序、version 降序取第一行
+    （同日多版取重写后的最新一版）。
     """
     sql = (
         f"SELECT * FROM {_table_name(DayPage)} "

--- a/apps/agent-service/app/memory/context.py
+++ b/apps/agent-service/app/memory/context.py
@@ -13,9 +13,11 @@ Sections, in order:
      alike). No trigger user / no page / read failure → absent, no
      placeholder (spec decision 6).
   4. Latest day page (only when it exists) — the most recent "yesterday"
-     she wrote at bedtime review, whatever life-day it covers. The
-     written_at stamp goes into the frame so she knows how old the memory
-     is. No page / read failure → absent.
+     she wrote at bedtime review, dated strictly before the current living
+     day (an early-morning nap review writes a stub page for *today*; that
+     stub must not pose as yesterday — same boundary as the life-side
+     injection). The written_at stamp goes into the frame so she knows how
+     old the memory is. No page / read failure → absent.
   5. Life snapshot — where she is, what she's doing, how she feels *right now*,
      read straight from the life engine's LifeState. This is the main subject:
      the 赤尾 talking to a real person is the 赤尾 living this moment.
@@ -34,7 +36,9 @@ import logging
 
 from app.domain.arc_awareness import render_arc_awareness
 from app.domain.life_state import find_life_state
-from app.life.pages import read_latest_day_page, read_relationship_page
+from app.infra.cst_time import now_cst
+from app.life.living_day import living_day
+from app.life.pages import read_day_page_before, read_relationship_page
 from app.runtime.lane_policy import current_deployment_lane
 
 logger = logging.getLogger(__name__)
@@ -116,14 +120,22 @@ async def _build_relationship_section(
 
 
 async def _build_yesterday_section(persona_id: str) -> str:
-    """她最近一页昨天：跨日期取最新（哪个生活日不重要，最近写下的那页才是）。
+    """她最近一页昨天：日期**严格早于当前生活日**的最新一版（与 life 侧同口径）。
+
+    跨日取最新不行：清晨回笼觉的快班会给**当前生活日**写下凌晨短页，下午聊天
+    会把它错当「你的昨天」注进来（2026-06-12 真实群聊 trace 实证）。上界按
+    生活日（04:00 晨界）算——熬夜聊到凌晨两点，「昨天」仍是前一个生活日之前。
 
     无页（冷启动：她还没有昨天可忆）/ narrative 空白 / 读失败 → 返回 ""，
     整段缺席不补占位，失败兜底同 _build_relationship_section。
     """
     try:
         lane = current_deployment_lane() or "prod"
-        page = await read_latest_day_page(lane=lane, persona_id=persona_id)
+        page = await read_day_page_before(
+            lane=lane,
+            persona_id=persona_id,
+            before_date=living_day(now_cst()),
+        )
     except Exception as e:
         logger.warning("[%s] Failed to read latest day page: %s", persona_id, e)
         return ""

--- a/apps/agent-service/tests/life/test_life_pages.py
+++ b/apps/agent-service/tests/life/test_life_pages.py
@@ -28,7 +28,6 @@ from app.life.pages import (
     day_page_exists,
     read_day_page,
     read_day_page_before,
-    read_latest_day_page,
     read_relationship_page,
     read_relationship_pages,
     write_day_page,
@@ -237,86 +236,8 @@ async def test_day_page_exists_lane_and_persona_isolation(pages_db):
 
 
 # ---------------------------------------------------------------------------
-# 最近一页昨天：跨日期取最新（chat / life 注入的读口）
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.integration
-async def test_read_latest_day_page_picks_newest_date(pages_db):
-    """跨日期取最新：多个生活日各有页时，返回 date 最大那天的页。"""
-    await write_day_page(
-        lane="coe-t1",
-        persona_id="akao",
-        date="2026-06-09",
-        narrative="六月九日的几笔。",
-        written_at="2026-06-09T23:40:00+08:00",
-    )
-    await write_day_page(
-        lane="coe-t1",
-        persona_id="akao",
-        date="2026-06-10",
-        narrative="六月十日的几笔。",
-        written_at="2026-06-10T23:40:00+08:00",
-    )
-
-    latest = await read_latest_day_page(lane="coe-t1", persona_id="akao")
-    assert latest is not None
-    assert latest.date == "2026-06-10"
-    assert latest.narrative == "六月十日的几笔。"
-
-
-@pytest.mark.integration
-async def test_read_latest_day_page_takes_latest_version_of_that_date(pages_db):
-    """最新生活日有多版（快班写过、对账班重写）→ 取该日版本最新的一版。"""
-    keys = {"lane": "coe-t1", "persona_id": "akao", "date": "2026-06-10"}
-    await write_day_page(
-        lane="coe-t1",
-        persona_id="akao",
-        date="2026-06-09",
-        narrative="前一天的页。",
-        written_at="2026-06-09T23:40:00+08:00",
-    )
-    await write_day_page(
-        **keys,
-        narrative="第一版：快班写的。",
-        written_at="2026-06-10T23:40:00+08:00",
-    )
-    await write_day_page(
-        **keys,
-        narrative="第二版：对账班重写的。",
-        written_at="2026-06-11T05:00:00+08:00",
-    )
-
-    latest = await read_latest_day_page(lane="coe-t1", persona_id="akao")
-    assert latest is not None
-    assert latest.date == "2026-06-10"
-    assert latest.version == 2
-    assert latest.narrative == "第二版：对账班重写的。"
-
-
-@pytest.mark.integration
-async def test_read_latest_day_page_cold_start_returns_none(pages_db):
-    """一页都没有（冷启动：她还没有昨天可忆）→ None，不补占位。"""
-    assert await read_latest_day_page(lane="coe-t1", persona_id="akao") is None
-
-
-@pytest.mark.integration
-async def test_read_latest_day_page_lane_and_persona_isolation(pages_db):
-    """泳道与 persona 隔离：别的泳道 / 别的姐妹的昨天页绝不串读。"""
-    await write_day_page(
-        lane="coe-t1",
-        persona_id="akao",
-        date="2026-06-10",
-        narrative="赤尾的页。",
-        written_at="2026-06-10T23:40:00+08:00",
-    )
-
-    assert await read_latest_day_page(lane="prod", persona_id="akao") is None
-    assert await read_latest_day_page(lane="coe-t1", persona_id="ayana") is None
-
-
-# ---------------------------------------------------------------------------
-# 严格早于某生活日的最近一页：life 注入「她最近一页昨天」的读口（事故修复）
+# 严格早于某生活日的最近一页：life / chat 注入「她最近一页昨天」的统一读口
+# （事故修复）
 # ---------------------------------------------------------------------------
 
 

--- a/apps/agent-service/tests/unit/memory/test_context.py
+++ b/apps/agent-service/tests/unit/memory/test_context.py
@@ -42,9 +42,9 @@ def _no_relationship_page():
 
 
 def _no_day_page():
-    """Stub the latest-day-page read to None so unit tests stay DB-free."""
+    """Stub the day-page read to None so unit tests stay DB-free."""
     return patch(
-        "app.memory.context.read_latest_day_page",
+        "app.memory.context.read_day_page_before",
         new=AsyncMock(return_value=None),
     )
 
@@ -425,7 +425,7 @@ def _rel_read(page):
 
 def _day_read(page):
     return patch(
-        "app.memory.context.read_latest_day_page",
+        "app.memory.context.read_day_page_before",
         new=AsyncMock(return_value=page),
     )
 
@@ -541,7 +541,16 @@ async def test_relationship_section_absent_when_no_page():
 
 @pytest.mark.asyncio
 async def test_latest_day_page_injected():
-    """有最近一页昨天 → 注入【你的昨天】段：页全文 + written_at 时间标注。"""
+    """有最近一页昨天 → 注入【你的昨天】段：页全文 + written_at 时间标注。
+
+    读口必须是 read_day_page_before（严格早于当前生活日，与 life 侧 #260 同
+    口径）：清晨回笼觉的快班会给**当前生活日**写下凌晨短页，跨日取最新会把它
+    错当「昨天」注进下午的聊天（2026-06-12 真实群聊 trace 实证过）。
+    """
+    from datetime import datetime
+
+    from app.infra.cst_time import CST
+
     narrative = "考完最后一门，走出考场的时候腿是软的。"
     read = AsyncMock(return_value=_day_page(narrative))
     with (
@@ -550,9 +559,13 @@ async def test_latest_day_page_injected():
             new=AsyncMock(return_value="你此刻在散步"),
         ),
         patch("app.memory.context.current_deployment_lane", return_value=None),
+        patch(
+            "app.memory.context.now_cst",
+            return_value=datetime(2026, 6, 12, 17, 0, tzinfo=CST),
+        ),
         _no_arc(),
         _no_relationship_page(),
-        patch("app.memory.context.read_latest_day_page", new=read),
+        patch("app.memory.context.read_day_page_before", new=read),
     ):
         out = await build_inner_context(
             chat_id="oc_a", chat_type="p2p",
@@ -564,8 +577,44 @@ async def test_latest_day_page_injected():
     assert narrative in out, "昨天页全文必须原样进 inner_context"
     assert "这页写于" in out
     assert "2026-06-10T23:40:00+08:00" in out
-    assert read.await_args.kwargs == {"lane": "prod", "persona_id": "chiwei"}, (
-        "最近一页昨天按 (lane, persona) 跨日期取最新，lane 口径 prod 归一"
+    assert read.await_args.kwargs == {
+        "lane": "prod",
+        "persona_id": "chiwei",
+        "before_date": "2026-06-12",
+    }, "昨天页只认日期严格早于当前生活日的最新一版，lane 口径 prod 归一"
+
+
+@pytest.mark.asyncio
+async def test_day_page_boundary_follows_living_day_not_calendar_day():
+    """凌晨 02:00 聊天：当前生活日还是前一天（04:00 边界），before_date 必须
+    跟生活日口径走——熬夜聊天时「昨天」不能被日历日切走。"""
+    from datetime import datetime
+
+    from app.infra.cst_time import CST
+
+    read = AsyncMock(return_value=None)
+    with (
+        patch(
+            "app.memory.context._build_life_state",
+            new=AsyncMock(return_value="你此刻在散步"),
+        ),
+        patch("app.memory.context.current_deployment_lane", return_value=None),
+        patch(
+            "app.memory.context.now_cst",
+            return_value=datetime(2026, 6, 13, 2, 0, tzinfo=CST),
+        ),
+        _no_arc(),
+        _no_relationship_page(),
+        patch("app.memory.context.read_day_page_before", new=read),
+    ):
+        await build_inner_context(
+            chat_id="oc_a", chat_type="p2p",
+            user_ids=["u1"], trigger_user_id="u1",
+            trigger_username="浩南", persona_id="chiwei",
+        )
+
+    assert read.await_args.kwargs["before_date"] == "2026-06-12", (
+        "06-13 凌晨 2 点仍属生活日 06-12，「昨天」的上界应是 06-12 而非 06-13"
     )
 
 
@@ -692,7 +741,7 @@ async def test_page_read_errors_do_not_collapse_inner_context():
             new=AsyncMock(side_effect=RuntimeError("db down")),
         ),
         patch(
-            "app.memory.context.read_latest_day_page",
+            "app.memory.context.read_day_page_before",
             new=AsyncMock(side_effect=RuntimeError("db down")),
         ),
     ):


### PR DESCRIPTION
## Summary

A real prod group-chat trace today (`886b21d1…`, 17:51) showed chat injecting akao's 06:06 morning-nap stub page as 【你的昨天】 — the chat-side reader still picked the latest day page **across dates**, lacking the strictly-before-current-living-day bound that #260 gave the life-side injection.

- `_build_yesterday_section` now reads via `read_day_page_before(before_date=living_day(now_cst()))` — an early-morning stub written for *today* never poses as yesterday, and a 2am chat still resolves "yesterday" by the living-day 04:00 boundary (not the calendar day).
- `read_latest_day_page` lost its last caller → deleted with its 4 PG tests (`read_day_page_before`'s PG tests cover the same behaviors: newest-date pick, version supersede, cold start, lane/persona isolation).

## Validation
- TDD: contract tests written red first (reader swap + `before_date` boundary incl. the 2am living-day case), then green
- Full agent-service suite: **1903 passed, 3 skipped, 0 failed**
- grep `read_latest_day_page` → zero residual outside its own history
- No codex review: applies the exact semantics codex itself adjudicated in #260 (must-fix 2) to the second call site, plus dead-code removal

🤖 Generated with [Claude Code](https://claude.com/claude-code)