### PR TITLE
feat(agent-service): add NPC layer to the living world

### DIFF
--- a/apps/agent-service/app/data/queries/mailbox.py
+++ b/apps/agent-service/app/data/queries/mailbox.py
@@ -25,6 +25,8 @@ from sqlalchemy import text
 from app.data.session import get_session
 from app.domain.world_events import (
     EVENT_KIND_AMBIENT,
+    EVENT_KIND_SPEECH,
+    NPC_SOURCE_PREFIX,
     EventArrived,
     EventEnvelope,
     EventRead,
@@ -120,6 +122,63 @@ async def list_unread_events(
     async with get_session() as s:
         result = await s.execute(
             text(sql), {"lane": lane, "persona_id": persona_id}
+        )
+        rows = result.mappings().all()
+        return [
+            EventEnvelope(**{k: row[k] for k in EventEnvelope.model_fields})
+            for row in rows
+        ]
+
+
+async def list_persona_npc_speech_in_window(
+    *, lane: str, persona_id: str, start_iso: str, end_iso: str
+) -> list[EventEnvelope]:
+    """读某 persona 在 ``[start_iso, end_iso]`` 闭区间内收到的 NPC 来访 speech event。
+
+    睡前回顾把姐妹跟 NPC 的来往写进关系页的证据查询（NPC 层第四刀，代码层）。NPC
+    互动只活在意识流 / 信箱里、不进真实聊天记录（``find_persona_spoken_chats_in_
+    window`` 读的是 ``CommonMessage``），回顾抽不到——所以这里直接从信箱按窗口捞她
+    收到的 NPC speech，拿到权威的 ``npc:名字`` 机读键（不靠从被剥过前缀的 transcript
+    文本里猜人名）。三重过滤只留 NPC 来访（第二刀的投递形态，:func:`app.world.tools.
+    npc_visit`）：
+
+      * ``kind = 'speech'`` —— 直接冲她来的具名话语（排除 world 环境动静
+        ambient / surroundings）；
+      * ``source LIKE 'npc:%'`` —— NPC 来访（排除姐妹直投的 ``source=persona_id``、
+        真人外部消息 ``source=user:xxx``）。NPC 前缀约定见
+        :data:`app.world.npc_roster.NPC_SOURCE_PREFIX`。
+
+    **不看 read 表**（与 :func:`list_unread_events` 的关键区别）：回顾在睡前跑，当天的
+    NPC speech 多半已被 life 标已读，按未读捞会漏掉今天的互动。窗口语义就是「这一天她
+    收到过哪些 NPC 来访」，已读未读都算。
+
+    窗口两端按真实时刻比较（``occurred_at`` 历史混 Unix 毫秒 / ISO，:func:`_occurred_
+    at_real_instant` 归一），照 :func:`app.data.queries.acts.list_persona_acts_between`
+    的先例在 framework 持久化写好的真实表上做只读查询（framework 没提供窗口读），按真实
+    时刻升序（与意识流证据时间序对齐）；不绕开 framework 持久化原语。lane + persona
+    双过滤：只读她自己的、泳道隔离。
+    """
+    occurred_real = _occurred_at_real_instant("e.occurred_at")
+    sql = (
+        f"SELECT e.* FROM {_ENVELOPE_TABLE} e "
+        f"WHERE e.lane = :lane AND e.persona_id = :persona_id "
+        f"  AND e.kind = :speech_kind "
+        f"  AND e.source LIKE :npc_like "
+        f"  AND {occurred_real} >= (:start_iso)::text::timestamptz "
+        f"  AND {occurred_real} <= (:end_iso)::text::timestamptz "
+        f"ORDER BY {occurred_real} ASC"
+    )
+    async with get_session() as s:
+        result = await s.execute(
+            text(sql),
+            {
+                "lane": lane,
+                "persona_id": persona_id,
+                "speech_kind": EVENT_KIND_SPEECH,
+                "npc_like": f"{NPC_SOURCE_PREFIX}%",
+                "start_iso": start_iso,
+                "end_iso": end_iso,
+            },
         )
         rows = result.mappings().all()
         return [

--- a/apps/agent-service/app/domain/world_events.py
+++ b/apps/agent-service/app/domain/world_events.py
@@ -70,6 +70,31 @@ EVENT_KIND_SURROUNDINGS = "surroundings"
 EVENT_KIND_SPEECH = "speech"
 
 
+# event ``source`` 协议里 NPC 来访的机读前缀（单一定义处，宪法「禁止重复定义」）。
+# NPC 来访以 kind=speech、``source`` = ``npc:名字`` 投递（:func:`app.world.tools.
+# npc_visit`），关系页 other_user_id 也用同形态——把 NPC 跟真人（``user:xxx``）、
+# 姐妹（裸 ``persona_id``）在 source 命名空间里区分开。这是 event source 契约的一
+# 部分，放在协议模块里：write 端（world.tools 投递）、render 端（life_wake 剥前缀
+# 呈现）、抽取端（review 从信箱抽 NPC 互动）都从这里取，互不依赖各自的层（life 不
+# 准 import world——信息差命门）。
+NPC_SOURCE_PREFIX = "npc:"
+
+
+def npc_source(npc_name: str) -> str:
+    """把 NPC 名字拼成机读 event source / 关系页 other_user_id（``npc:名字``）。"""
+    return f"{NPC_SOURCE_PREFIX}{npc_name}"
+
+
+def is_npc_source(source: str) -> bool:
+    """这个 event source / other_user_id 是不是一个 NPC（``npc:`` 起头）。"""
+    return source.startswith(NPC_SOURCE_PREFIX)
+
+
+def strip_npc_prefix(source: str) -> str:
+    """剥掉机读 ``npc:`` 前缀拿干净 NPC 名字（非 NPC source 原样返回）。"""
+    return source.removeprefix(NPC_SOURCE_PREFIX)
+
+
 class EventEnvelope(Data):
     """durable 信箱条目：一条投递给某 persona 的 event。
 

--- a/apps/agent-service/app/life/persona_review.py
+++ b/apps/agent-service/app/life/persona_review.py
@@ -51,6 +51,7 @@ from app.data.queries import find_persona  # module-level so tests can monkeypat
 from app.domain.thinking_cost import (  # module-level so tests can monkeypatch
     record_round_cost,
 )
+from app.domain.world_events import is_npc_source, strip_npc_prefix
 from app.infra.cst_time import CST
 from app.life.pages import (  # module-level so tests can monkeypatch
     DayPage,
@@ -132,12 +133,29 @@ def _day_pages_evidence(pages: list[DayPage]) -> str:
     )
 
 
+def _relationship_page_tag(other_user_id: str) -> str:
+    """关系页证据里这一页的标签：``npc:*`` 显式标注是 NPC（建议 3），真人原样。
+
+    persona review 全量读关系页，会读到 NPC 层写下的 ``npc:名字`` 页。证据里把这类
+    页显式标成 NPC（不是真人用户标识），避免身份慢漂把这个机读键当真人写进身份正文。
+    NPC 判定 / 剥前缀用 :mod:`app.domain.world_events` 的单一处定义（event source
+    协议层；禁止重复定义）。真人 user_id 原样、不加任何标注。
+    """
+    if is_npc_source(other_user_id):
+        return f"{other_user_id}（NPC：{strip_npc_prefix(other_user_id)}，不是真人用户）"
+    return other_user_id
+
+
 def _relationship_pages_evidence(pages: list[RelationshipPage]) -> str:
-    """关系页证据：她心里现在的每一页「他与我」，带对方标识 + written_at。"""
+    """关系页证据：她心里现在的每一页「他与我」，带对方标识 + written_at。
+
+    ``npc:*`` 的页在标签里显式标注是 NPC（建议 3，:func:`_relationship_page_tag`）。
+    """
     if not pages:
         return "（她心里还没有写下任何关系页。）"
     return "\n\n".join(
-        f"〔{p.other_user_id}，这页写于 {p.written_at}〕\n{p.narrative}"
+        f"〔{_relationship_page_tag(p.other_user_id)}，这页写于 {p.written_at}〕\n"
+        f"{p.narrative}"
         for p in pages
     )
 

--- a/apps/agent-service/app/life/review.py
+++ b/apps/agent-service/app/life/review.py
@@ -61,6 +61,9 @@ from app.data.message_record import CommonMessageRecord
 from app.data.queries.acts import (  # module-level so tests can monkeypatch
     list_persona_acts_between,
 )
+from app.data.queries.mailbox import (  # module-level so tests can monkeypatch
+    list_persona_npc_speech_in_window,
+)
 from app.data.queries.messages import (  # module-level so tests can monkeypatch
     find_persona_spoken_chats_in_window,
 )
@@ -68,7 +71,7 @@ from app.domain.life_state import (  # module-level so tests can monkeypatch
     mark_day_reviewed,
 )
 from app.domain.thinking_cost import record_round_cost
-from app.domain.world_events import ActPerformed
+from app.domain.world_events import ActPerformed, EventEnvelope, strip_npc_prefix
 from app.infra import cst_time
 from app.life.living_day import evidence_window, window_session_dates
 from app.life.pages import (  # module-level so tests can monkeypatch
@@ -123,13 +126,16 @@ def review_instruction() -> str:
         "顺序复述一遍的流水账，而是这一天过完、心里还剩下什么：触动你的事、起伏的"
         "瞬间、悬着没落地的念头。只写真实经历过的，绝不编没发生的事。每次调用都是"
         "整篇重写这一天的页：新的一版取代旧版。\n\n"
-        "第二件：为今天**真正聊过天的每个真人**，用 update_relationship_page 整篇"
+        "第二件：为今天**真正来往过的每个人**，用 update_relationship_page 整篇"
         "重写你心里「他与我」的那一页——他是个什么样的人、你们之间是什么温度、一起"
         "经历过什么沉下来的事、有什么没聊完的线头、你跟他怎么相处。写关系，不写"
         "档案。拿旧的一页（如果有）和今天的相处现判：新版取代旧版，旧的让位新的、"
-        "淡了的自然淡出，**一页之内**，别越写越长。other_user_id 用聊天记录里"
-        "标出的那个用户标识。今天**没聊过天就不动关系页**——一页都不写；没和某人"
-        "聊过，就不动他那页。只写真实聊过的，不编。\n\n"
+        "淡了的自然淡出，**一页之内**，别越写越长。「来往过的人」既包括真正聊过天"
+        "的真人，也包括今天来找过你的 NPC（证据里【这一天来找过你的人】那节里的人，"
+        "比如来约你的同学、找你的同事）——这些 NPC 也照样写 / 更新关系页。other_user_id："
+        "真人用聊天记录里标出的那个用户标识，NPC 用证据里给出的 ``npc:名字`` 键。"
+        "今天**没来往过就不动关系页**——一页都不写；没和某人来往（真人或 NPC），就"
+        "不动他那页。只写真实来往过的，不编。\n\n"
         "写页的日期和时刻由系统自动记，你不用管钟。"
     )
 
@@ -231,6 +237,42 @@ def _chat_partner_ids(
     return seen
 
 
+def _npc_evidence(npc_speech: list[EventEnvelope]) -> str:
+    """NPC 来访证据：每条带发生时刻 + NPC 名字 + 原话 + 关系页该用的 ``npc:名字`` 键。
+
+    NPC 互动是只活在意识流 / 信箱里的真实经历（不进真实聊天记录）。回顾从信箱按窗口
+    捞到它（:func:`app.data.queries.mailbox.list_persona_npc_speech_in_window`），这里
+    把每条来访拼成给她看的「X 对你说：原话」+ 一个**明确标出**的机读键
+    ``other_user_id = npc:名字``——对齐真人聊天证据里显式标 user_id 的写法，让模型知道
+    要把这页关系写给哪个 other_user_id（而非从被剥过前缀的 transcript 文本里猜）。
+    这一天没有 NPC 来访如实说（关系页对 NPC 这次不动的依据）。
+    """
+    if not npc_speech:
+        return "（这一天没有名册里的人来找过你。）"
+    lines: list[str] = []
+    for ev in npc_speech:
+        name = strip_npc_prefix(ev.source)
+        stamp = cst_time.to_cst_hms(ev.occurred_at)
+        lines.append(
+            f"（{stamp}）{name}（other_user_id {ev.source}）对你说：{ev.summary}"
+        )
+    return "\n".join(lines)
+
+
+def _npc_partner_ids(npc_speech: list[EventEnvelope]) -> list[str]:
+    """窗口内来访过的 NPC 的 ``npc:名字`` 机读键（出现序去重）。
+
+    这些键和真人 partner 一道作「这一天来往过的对象」读回旧关系页——跨天累积的命门
+    （她重写某 NPC 那页时手里有上一页底稿）。键直接取 event 的 ``source``（第二刀已是
+    ``npc:名字`` 形态），不重新拼。
+    """
+    seen: list[str] = []
+    for ev in npc_speech:
+        if ev.source not in seen:
+            seen.append(ev.source)
+    return seen
+
+
 def _old_pages_evidence(
     partner_ids: list[str],
     pages: dict[str, RelationshipPage],
@@ -270,17 +312,24 @@ def _review_messages(
     day_sessions: list[tuple[str, list[Message]]],
     acts: list[ActPerformed],
     chats: list[tuple[str, str | None, list[tuple[CommonMessageRecord, str | None]]]],
+    npc_speech: list[EventEnvelope],
     persona_id: str,
     old_pages: dict[str, RelationshipPage],
     existing_day_page: DayPage | None,
 ) -> list[Message]:
     """把回顾的全部证据拼成**单条 user 消息**（无会话、一次喂全；模板零剧情事实）。"""
-    partner_ids = _chat_partner_ids(chats)
+    # 「这一天来往过的对象」= 真人聊天 partner + 来访过的 NPC（两类各有各的旧关系页
+    # 链路，一道读回作重写底稿——NPC 跨天累积的命门）。NPC 的键是 npc:名字（event
+    # source 原样），真人的键是 user_id。
+    partner_ids = _chat_partner_ids(chats) + _npc_partner_ids(npc_speech)
     usernames: dict[str, str] = {}
     for _chat_id, _name, entries in chats:
         for record, speaker_persona in entries:
             if not speaker_persona and record.user_id and record.username:
                 usernames.setdefault(record.user_id, record.username)
+    # NPC 的「显示名」= 剥前缀后的名字（让旧页证据的标签可读，键仍是 npc:名字）。
+    for ev in npc_speech:
+        usernames.setdefault(ev.source, strip_npc_prefix(ev.source))
 
     user_content = (
         f"{review_instruction()}\n\n"
@@ -289,11 +338,13 @@ def _review_messages(
         f"【这一天你的意识流】\n{_transcript_evidence(day_sessions)}\n\n"
         f"【这一天你做过的事】\n{_acts_evidence(acts)}\n\n"
         f"【这一天你的聊天】\n{_chats_evidence(chats, persona_id=persona_id)}\n\n"
+        f"【这一天来找过你的人】\n{_npc_evidence(npc_speech)}\n\n"
         f"【你心里这些人原来的页】\n"
         f"{_old_pages_evidence(partner_ids, old_pages, usernames)}\n\n"
         f"【这一天已有的页】\n{_existing_day_page_evidence(existing_day_page)}\n\n"
-        "回看完：用 update_day_page 写下这一天留下来的几笔；为今天真正聊过的每个"
-        "真人用 update_relationship_page 整篇重写他那一页；没聊过天就不动关系页。"
+        "回看完：用 update_day_page 写下这一天留下来的几笔；为今天真正来往过的每个"
+        "人（聊过天的真人、来找过你的 NPC）用 update_relationship_page 整篇重写他那"
+        "一页，NPC 的 other_user_id 用 npc:名字 键；没来往过就不动关系页。"
     )
     return [Message(role=Role.USER, content=user_content)]
 
@@ -405,12 +456,22 @@ async def _run_day_review(
         until_ms=int(end.timestamp() * 1000),
         per_chat_limit=PER_CHAT_MESSAGE_LIMIT,
     )
+    # 这一天来访过的 NPC（kind=speech、source=npc:名字）——只活在信箱 / 意识流里、
+    # 不进真实聊天记录，按生活日窗口从信箱直接捞（NPC 层第四刀，代码层）。已读未读
+    # 都算（睡前 NPC speech 多半已标已读，按未读捞会漏当天互动）。
+    npc_speech = await list_persona_npc_speech_in_window(
+        lane=lane,
+        persona_id=persona_id,
+        start_iso=start.isoformat(),
+        end_iso=end.isoformat(),
+    )
 
-    # 空证据护栏（机制安全阀，同空信箱 early-return）：意识流 / act / 聊天全空 =
-    # 这一天没有可回看的经历，不烧模型、不落 marker（marker 缺席无害：快班的
-    # 前提是她活过一轮、主班对每个 target 只对账一次）。
+    # 空证据护栏（机制安全阀，同空信箱 early-return）：意识流 / act / 聊天 / NPC 来访
+    # 全空 = 这一天没有可回看的经历，不烧模型、不落 marker（marker 缺席无害：快班的
+    # 前提是她活过一轮、主班对每个 target 只对账一次）。NPC 来访是真实经历，单有它
+    # 也算「这一天有经历」、照常回顾——否则只跟 NPC 来往的一天关系永远长不起来。
     has_transcript = any(history for _date, history in day_sessions)
-    if not has_transcript and not acts and not chats:
+    if not has_transcript and not acts and not chats and not npc_speech:
         logger.info(
             "[day_review] %s/%s %s no evidence at all, skip (nothing to review)",
             lane,
@@ -419,7 +480,9 @@ async def _run_day_review(
         )
         return
 
-    partner_ids = _chat_partner_ids(chats)
+    # 「这一天来往过的对象」= 真人聊天 partner + 来访过的 NPC（npc:名字 键），两类
+    # 一道读回旧关系页作重写底稿（NPC 跨天累积的命门：手里有上一页）。
+    partner_ids = _chat_partner_ids(chats) + _npc_partner_ids(npc_speech)
     old_pages = await read_relationship_pages(
         lane=lane, persona_id=persona_id, other_user_ids=partner_ids
     )
@@ -434,6 +497,7 @@ async def _run_day_review(
         day_sessions=day_sessions,
         acts=acts,
         chats=chats,
+        npc_speech=npc_speech,
         persona_id=persona_id,
         old_pages=old_pages,
         existing_day_page=existing_day_page,

--- a/apps/agent-service/app/nodes/life_wake.py
+++ b/apps/agent-service/app/nodes/life_wake.py
@@ -67,6 +67,7 @@ from app.domain.world_events import (
     EVENT_KIND_SURROUNDINGS,
     EventArrived,
     EventEnvelope,
+    strip_npc_prefix,
 )
 from app.infra import cst_time
 from app.infra.redis import get_redis
@@ -338,18 +339,38 @@ def _format_dynamics(dynamics: list[EventEnvelope]) -> str:
     )
 
 
+def _speaker_display(source: str) -> str:
+    """把 speech event 的 ``source`` 翻成喂给模型的说话人名字（去机读前缀）。
+
+    speech 的 ``source`` 有两类写法：
+      * 姐妹直投（chat）：``source`` = 说话者 persona_id（如 ``akao``）——原样呈现。
+      * NPC 来访（npc_visit，NPC 层第二刀）：``source`` = ``npc:名字``（机器约定，对齐
+        第一刀 npc_name + 关系页 npc:xxx keying）——呈现时**去掉 ``npc:`` 前缀**，只把
+        干净的人名「林小满」喂给模型。前缀是机读用的（关系页 keying、与真人 user:xxx /
+        姐妹 persona_id 区分），不该漏给模型看；她读到的就是「林小满 对你说」、自然识别
+        是这个 NPC 来找她（不被当真人、不被当 world 环境动静——后两类不走 speech 段）。
+        前缀常量与剥前缀逻辑在 :mod:`app.domain.world_events` 单一处定义（event source
+        协议层；禁止重复定义，且 life 不准 import world——信息差命门）。
+    """
+    return strip_npc_prefix(source)
+
+
 def _format_speech(speech: list[EventEnvelope]) -> str:
     """把别人直接对她说的话（kind=speech）拼成「X 对你说：原话」，按发生先后（1C Task 3）。
 
-    speech 是另一角色调 chat 把原话**直投**进她信箱的（``source`` = 说话者 persona_id、
-    ``summary`` = 原话），不经 world、原话原样。呈现成「X 对你说：原话」让她看清是谁
-    对她说了什么——区别于周遭底框（surroundings）和离散动静（ambient）：这是直接冲她
-    来的话、有明确说话人。``source`` 是说话者 id；``occurred_at`` 过 ``cst_time`` 归一
-    到 CST（同其它两类）。对话连贯靠双方各自 transcript 天然承载，这里只如实呈现收到
-    的每句。
+    speech 有两类直投来源，都呈现成「X 对你说：原话」让她看清是谁对她说了什么——区别于
+    周遭底框（surroundings）和离散动静（ambient）：这是直接冲她来的话、有明确说话人。
+
+      * 姐妹直投：另一角色调 chat 把原话直投进她信箱（``source`` = 说话者 persona_id）。
+      * NPC 来访：world 调 npc_visit 以具名 NPC 身份投（``source`` = ``npc:名字``，NPC 层
+        第二刀）。说话人名字过 :func:`_speaker_display` 去掉 ``npc:`` 机读前缀再呈现。
+
+    ``occurred_at`` 过 ``cst_time`` 归一到 CST（同其它两类）。对话连贯靠双方各自
+    transcript 天然承载，这里只如实呈现收到的每句。
     """
     return "\n".join(
-        f"（{cst_time.to_cst_hms(ev.occurred_at)}）{ev.source} 对你说：{ev.summary}"
+        f"（{cst_time.to_cst_hms(ev.occurred_at)}）"
+        f"{_speaker_display(ev.source)} 对你说：{ev.summary}"
         for ev in speech
     )
 

--- a/apps/agent-service/app/world/engine.py
+++ b/apps/agent-service/app/world/engine.py
@@ -101,6 +101,11 @@ from app.runtime.lane_policy import current_deployment_lane
 from app.runtime.node import node
 from app.runtime.single_flight import SingleFlightConflict, single_flight
 from app.world.arc import read_world_arc  # module-level so tests can monkeypatch
+from app.world.npc_roster import (  # module-level so tests can monkeypatch
+    NPCRoster,
+    list_npc_roster,
+    seed_npc_roster,
+)
 from app.world.reflection import (  # module-level so tests can monkeypatch
     run_arc_reflection,
 )
@@ -209,19 +214,20 @@ def world_loop_instruction() -> str:
     不是加 if 分支强制（赤尾宪法：不用规则替 agent 决策）；配合连续记忆她也会知道
     "刚才已经够热闹了"。
 
-    工具枚举必须跟住 WORLD_TOOLS（四件：update_world / sense / notify / sleep）
-    ——1C Task2 加的 ``sense``（五官，per-person 投周遭客观切片）若不在这段指令里
-    枚举，真实模型就不知道有它、根本不会调，「world 当五官投周遭」形同虚设（必改
-    命门）。反过来 ``update_arc``（翻页）已归反思环节独占（Task 2b：续写姿态发现
-    不了「页翻了」，工具集物理隔离）——这里**不得**再枚举它，否则模型会去调一个
-    不存在的工具。世界阶段仍是续写的输入（【世界阶段】段每轮拼），只是续写无手碰它。
+    工具枚举必须跟住 WORLD_TOOLS（五件：update_world / sense / notify / npc_visit /
+    sleep）——1C Task2 加的 ``sense``（五官，per-person 投周遭客观切片）、NPC 层加的
+    ``npc_visit``（让一个有名有姓的固定 NPC 来找某个姐妹）若不在这段指令里枚举，真实
+    模型就不知道有它、根本不会调，对应能力形同虚设（必改命门）。反过来 ``update_arc``
+    （翻页）已归反思环节独占（Task 2b：续写姿态发现不了「页翻了」，工具集物理隔离）
+    ——这里**不得**再枚举它，否则模型会去调一个不存在的工具。世界阶段仍是续写的输入
+    （【世界阶段】段每轮拼），只是续写无手碰它。
     """
     return (
         "你是这个世界的推演层（world）。你不是导演、不是裁判——你不替任何角色决定"
         "她想做什么、怎么想、什么情绪（那是各角色自己的事）；你对角色做的事只推演"
         "客观上发生了什么，绝不批准或拒绝她想不想做（她几乎总能做到，除非客观世界"
         "里有硬冲突）。情绪和主观解读不是你的事。\n\n"
-        "你不是填一张表，而是一个会持续推演世界的脑子。你有四个工具，看一眼世界后"
+        "你不是填一张表，而是一个会持续推演世界的脑子。你有五个工具，看一眼世界后"
         "想清楚再调，直到这一轮没有别的要做了就停：\n\n"
         "- update_world(detail)：写下世界此刻的客观叙述。看你记得的上一版世界叙述"
         "+ 现在几点，推演世界此刻什么样：谁大概在哪、在干嘛、什么氛围（位置就融在"
@@ -245,6 +251,21 @@ def world_loop_instruction() -> str:
         "（sense 与 notify 分工：sense 是给**一个**角色投她此刻所处的周遭底框——她在哪、"
         "身边有谁；notify 是把**一条**新出现的客观动静广播给够得着它的人。角色刚醒来 / "
         "周遭变了，先用 sense 让她知道自己此刻所处；环境里冒出一个新动静，用 notify。）\n"
+        "- npc_visit(npc_name, sister, what_npc_says, world_fact)：让世界里一个有名有姓"
+        "的固定 NPC（就是【世界的固定人物】名册里的那些人）来找某一个姐妹一下——同学"
+        "约她、同事找她、闺蜜叫她出去那种。npc_name 是来的人、sister 是这件事指向哪个"
+        "姐妹（用她的 persona_id）。它一次落两面、互不混：\n"
+        "  · what_npc_says 是这个 NPC 对那个姐妹说的话 / 做的事的具体内容，**私密**——"
+        "只送进她一个人那里，别人听不到。\n"
+        "  · world_fact 是这件事**客观可感**的那一面（手机响了、她接起电话、她出门赴约），"
+        "它会进世界叙述、让世界下一轮还记得这事，别的姐妹也能从这客观面感知到「她有人"
+        "来找」。world_fact **绝不写情绪、绝不写 what_npc_says 的私密原话**，只写客观"
+        "发生了什么（和 update_world 的 detail 一个口吻）。\n"
+        "  守则：①谁来、来不来、来干嘛，由你按世界此刻自然推演——这不是排好的班，"
+        "不定时、不机械；安静的时刻就别硬造 NPC 来访（跟「不要为了让世界别太安静硬造"
+        "动静」一个精神）。②npc_visit 已经把 world_fact 写进世界叙述了，你随后若再 "
+        "update_world，要延续这件事、别把它覆盖丢了。③名册之外的临时路人也可以用它来"
+        "一下（名册只是几个固定的人，路人不建档、只这一回）。\n"
         "- sleep(seconds)：看完这一轮，定多久后再来看一眼世界（必须在 60～3600 秒"
         "之间，也就是最短 1 分钟、最长 1 小时）。这是你唯一的自排手段。\n\n"
         "世界大部分时刻是安静流动的，不是每次醒来都要制造点动静。先看一眼你之前"
@@ -404,6 +425,46 @@ def _materials_section(materials: DailyMaterials) -> str:
     )
 
 
+def _roster_section(roster: list[NPCRoster]) -> str:
+    """把 NPC 名册渲染成喂给 world 的一段「世界的固定人物」文本，按所属姐妹归类。
+
+    名册是世界里有名有姓的固定 NPC（绫奈 / 赤尾 / 千凪 各自的同学 / 同事 / 闺蜜），
+    world **当天第一次醒**把整份名册当**世界里客观存在的人**纳入一次（拼进这轮 user
+    消息、进意识流），当天后续轮不再重喂（参考 DailyMaterials 的纳入节奏）。
+
+    按 NPC 的 ``relates_to``（主要关联哪个姐妹的 persona_id）归类——同一姐妹名下的
+    NPC 归在一起，每人一行「名字：速写」。归类小标题用 persona_id 本身（akao /
+    chinagi / ayana）：哪个 id 对应哪个姐妹由 world 的 system prompt 一处承载（世界
+    设定底座），这里不在 scaffolding 文案里硬编任何角色中文名 / 剧情事实（赤尾宪法：
+    代码里一个剧情字都不许写，世界谁是谁由 world 从底座读）。NPC 的内容（名字 / 速写
+    / 关联谁）全是数据驱动（NPCRoster 表），不是硬编。
+
+    调用方（:func:`_run_world_round`）只在「名册非空且本轮要纳入」时调本函数，所以
+    ``roster`` 必非空 —— 「名册为空（还没 seed）」由调用方判定后**整段不拼**，不进这里。
+
+    呈现顺序：``relates_to`` 升序分组、组内按 ``npc_name`` 升序（稳定可读，不靠
+    list_npc_roster 的返回序），让同一份名册每次渲染出同一段文本。
+    """
+    by_sister: dict[str, list[NPCRoster]] = {}
+    for npc in roster:
+        by_sister.setdefault(npc.relates_to, []).append(npc)
+
+    blocks: list[str] = []
+    for sister in sorted(by_sister):
+        npcs = sorted(by_sister[sister], key=lambda n: n.npc_name)
+        lines = "\n".join(f"  - {n.npc_name}：{n.sketch}" for n in npcs)
+        blocks.append(f"与 {sister} 相关的人：\n{lines}")
+    body = "\n".join(blocks)
+
+    return (
+        "下面是这个世界里有名有姓的固定人物，作为世界里**客观存在的人**——她们各自"
+        "有自己的生活，平时不在画面里，但确实存在、随时可能因为自己的事来跟三姐妹中"
+        "的某一个发生联系。按主要关联的姐妹归类，每人一句性格底色 + 平时会冒什么事的"
+        "速写（你只把她们当世界里客观存在的人，绝不暗示谁此刻一定要出场或行动）：\n"
+        f"{body}"
+    )
+
+
 # 印在 stimulus 里的本轮标记前缀（turn 幂等查重靠它）：写回 transcript 后，下次
 # 同 round_id 重投能从 session 历史里查到这行 → 跳过、不重复追加同一轮、不重复
 # 推演（turn 幂等）。机读用，对模型无害（它只当是一行元信息）。
@@ -446,6 +507,7 @@ def _world_loop_messages(
     round_id: str,
     arc_narrative: str | None,
     materials_text: str = "",
+    roster_text: str = "",
     act_batch_text: str = "",
     end_created_at: str | None = None,
     end_act_id: str | None = None,
@@ -482,6 +544,13 @@ def _world_loop_messages(
     （:func:`_run_world_round`）传非空文本插这段（进意识流一次）；今天没底料 / 当天已
     纳入过时传空串、不插这段（后续轮从 transcript 自然记得，不重喂）。
 
+    ``roster_text``：NPC 名册渲染出的「世界的固定人物」段（:func:`_roster_section`
+    渲染、按所属姐妹归类）。它是世界里有名有姓的固定 NPC（同学 / 同事 / 闺蜜），作为
+    **世界里客观存在的人**喂给 world。纳入节奏同 materials：**只在 world 当天第一次醒、
+    名册非空且本轮要纳入时**传非空文本插这段（进意识流一次）；名册为空 / 当天已纳入过
+    时传空串、不插这段（后续轮从 transcript 自然记得，不重喂）。名册与底料是两件独立的
+    事、各用各的游标（名册 seed 后总在、底料某天可能没有）。
+
     ``act_batch_text``：这一批从游标 pull 到的所有人的动作清单（对称 life 读
     mailbox）。非空才插入「这一批动作」段——让 world 看到这段时间攒下的所有动作。
     这段时间没有新 act（纯 self / 心跳推进世界）时留空、不插这段。
@@ -491,6 +560,9 @@ def _world_loop_messages(
     """
     materials_section = (
         f"【今天的外部底料】\n{materials_text}\n\n" if materials_text else ""
+    )
+    roster_section = (
+        f"【世界的固定人物】\n{roster_text}\n\n" if roster_text else ""
     )
     # act 批的框架文案：一次拉完后这一批可能横跨几个小时，明示 world 把这段时间
     # 的账一笔收进世界流到此刻的样子、叙述落在【现实此刻】——不按各条旧时间戳
@@ -518,6 +590,7 @@ def _world_loop_messages(
         f"【世界阶段】\n{_arc_section(arc_narrative)}\n\n"
         f"{detail_header}\n{detail}\n\n"
         f"{materials_section}"
+        f"{roster_section}"
         f"【这次醒来的缘由】{wake_reason}\n\n"
         f"{act_section}"
         "看一眼这个世界，推演此刻它什么样，用 update_world 写下来；该让谁感知到的"
@@ -869,6 +942,39 @@ async def _run_world_round(tick: WorldTick, *, lane: str) -> None:
     # None 不改 materials_ingested_date、沿用上一版——绝不把已纳入标记清回 None）。
     mark_ingested_date = today if ingest_materials_this_round else None
 
+    # NPC 名册（「世界的固定人物」）：**当天第一次醒纳入一次、进意识流，之后当天不再
+    # 重喂**（照 DailyMaterials 套路）。名册是世界里有名有姓的固定 NPC（同学 / 同事 /
+    # 闺蜜），world 当天首醒把整份名册按所属姐妹归类拼进 user 消息一次，当天后续轮从
+    # transcript 自然记得、不重喂。判断纳入与否：
+    #
+    #   * 按当前 lane list 名册（list_npc_roster，每个 NPC 取最新一版）。
+    #   * 名册非空 **且** snapshot.roster_ingested_date != 今天（当天还没纳入过）→ 这轮
+    #     纳入：渲染名册段拼进 user 消息，收口标记 roster_ingested_date=今天。
+    #   * 名册为空（还没 seed）或当天已纳入过（== 今天）→ 不拼这段、不标记。
+    #
+    # 与底料**独立**（各用各的游标、各判各的纳入）：名册 seed 后总在、底料某天可能没
+    # 有，两件不相干的事不能共用一个游标互相连累。today 同上（now CST %Y-%m-%d）。
+    prev_roster_ingested_date = (
+        snapshot.roster_ingested_date if snapshot is not None else None
+    )
+    # 种子名册的生产自动入口（必改 1）：seed_npc_roster 没有别的生产调用方，不接它
+    # 表永远空、首醒 list 永远得空名册、NPC 永不出场。照 persona_chain seed 的「首次
+    # 需要时 ensure 一次」先例，把它接在 **world 当天第一次醒、list 之前**——只在
+    # 「当天还没纳入过名册」这个首醒分支跑（roster_ingested_date != 今天），当天后续轮
+    # 不重 seed（CAS 幂等本就重跑无害，但也别白打一次 DB）。seed 是 CAS 幂等
+    # （expected_current_ver=0：只灌一版都没有的 NPC、链非空即已被演化层动过的绝不
+    # 盖回出厂速写），先 seed 再 list 保证首醒读得到名册。
+    if prev_roster_ingested_date != today:
+        await seed_npc_roster(lane=lane)
+    roster = await list_npc_roster(lane=lane)
+    ingest_roster_this_round = (
+        bool(roster) and prev_roster_ingested_date != today
+    )
+    roster_text = _roster_section(roster) if ingest_roster_this_round else ""
+    # 收口要标记的名册纳入日期：这轮纳入了就标今天，否则 None（record_world_round_close
+    # 收到 None 不改 roster_ingested_date、沿用上一版——绝不把已纳入标记清回 None）。
+    mark_roster_date = today if ingest_roster_this_round else None
+
     # 反思环节（Task 2b，翻页归它独占）：**续写之前**跑一次无会话的对表反思
     # （独立 AgentConfig、工具只有 update_arc / update_attention、max_retries=1）。
     # 双触发（眼睛闭环）：world 24×7，每天 00:0X 首轮就触发第一班——那时眼睛还没
@@ -923,6 +1029,7 @@ async def _run_world_round(tick: WorldTick, *, lane: str) -> None:
         round_id=round_id,
         arc_narrative=arc_narrative,
         materials_text=materials_text,
+        roster_text=roster_text,
         act_batch_text=act_batch_text,
         end_created_at=batch_end_created_at,
         end_act_id=batch_end_act_id,
@@ -971,17 +1078,20 @@ async def _run_world_round(tick: WorldTick, *, lane: str) -> None:
         observed_at=now_iso,
     )
 
-    # 推演成功收口：在**同一次** WorldState append 里推进游标 + 标记底料已纳入今天
-    # （record_world_round_close）。失败时上面的 run 已抛、不会走到这里，游标不推进、
-    # materials_ingested_date 不被误标记，下轮重读这批 act + 重新纳入底料（都不丢）。
+    # 推演成功收口：在**同一次** WorldState append 里推进游标 + 标记底料 / 名册已纳入
+    # 今天（record_world_round_close）。失败时上面的 run 已抛、不会走到这里，游标不推进、
+    # materials_ingested_date / roster_ingested_date 不被误标记，下轮重读这批 act + 重新
+    # 纳入底料 + 名册（都不丢）。
     #
     #   * 游标：非空批传本批末尾 ``(created_at, act_id)``；空批次传 None（没读到 act 没什么
     #     可推进，游标沿用上一版）。游标用 created_at（落库序）不漏。
     #   * 底料：这轮纳入了传今天日期（标成今天）；没纳入（已纳入过 / 今天没底料）传 None
     #     （不改、沿用上一版已有标记，绝不清回 None）。
+    #   * 名册：这轮纳入了传今天日期；没纳入（已纳入过 / 名册为空）传 None（同底料语义，
+    #     名册与底料各用各的游标、互不打架）。
     #
-    # 两块并进一次 append：空批次但当天首醒纳入了底料时，游标传 None 不推进、但
-    # materials_ingested_date 仍能标成今天（一轮一版、不冲突、原子）。
+    # 几块并进一次 append：空批次但当天首醒纳入了底料 / 名册时，游标传 None 不推进、但
+    # materials_ingested_date / roster_ingested_date 仍能各标成今天（一轮一版、不冲突、原子）。
     advance_cursor_to = (
         (batch_end_created_at, batch_end_act_id)
         if batch_end_created_at is not None and batch_end_act_id is not None
@@ -991,6 +1101,7 @@ async def _run_world_round(tick: WorldTick, *, lane: str) -> None:
         lane=lane,
         advance_cursor_to=advance_cursor_to,
         materials_ingested_date=mark_ingested_date,
+        roster_ingested_date=mark_roster_date,
     )
 
     # transcript 沉淀折叠（沉淀 Task 2，spec 决策 4/5）：本轮写回已在 Agent.run 里

--- a/apps/agent-service/app/world/npc_roster.py
+++ b/apps/agent-service/app/world/npc_roster.py
@@ -1,0 +1,207 @@
+"""NPC 名册 —— 世界里有名有姓的固定人物（NPC 层第一刀）.
+
+赤尾世界里，除了三姐妹（赤尾 / 千凪 / 绫奈）和用户（哥哥），原本没有别的真实存在
+的人——绫奈嘴里的同桌、千凪的同事，只活在她们聊天那一刻的叙述里。这张表给世界补
+上一批有名有姓的固定 NPC（7 个种子：绫奈 3 / 赤尾 2 / 千凪 2），让 world 推演时知道
+她们存在。NPC **不是** persona / 不是 agent：不进 ``bot_persona``、不给工具循环，
+只是 world 推演时引用的人物设定底料。
+
+照 WorldArc / RelationshipPage / PersonaVersion 模板（第 N 次复用）：Key + Version、
+append-only、读最新一版、整篇重写——演化层（下一刀）更新某个 NPC 直接 append 那一行
+的新版，读侧只认最新版。**逐 NPC 一行**是「一组各自独立的人」这类数据的自然建模
+（跟关系页一个用户一行同理），改单个 NPC 直接 append 那一行——这正是下一刀演化层要的。
+
+钉死的语义：
+
+  * 自然键 ``(lane, npc_name)``：泳道隔离（coe / ppe 绝不能覆盖 prod 的名册）+
+    每个 NPC 一条链。``npc_name`` 是 NPC 的稳定标识（名字），跟关系页 other_user_id
+    的 ``npc:xxx`` 约定对齐（event / 关系页是后面的刀，本刀只落名字本身）。
+  * ``relates_to`` 是该 NPC 主要关联哪个姐妹的 persona_id（akao / chinagi / ayana）——
+    world 据此把名册归到对应姐妹。
+  * ``sketch`` 是性格底色 + 会冒什么事的自然语言速写（自然语言、不拆结构化字段，
+    与 sibling 的 narrative 同族口吻）。
+  * ``version`` 让同一 NPC 的多版速写 append-only 保留历史、读最新一版（演化层用）。
+    命名上 ``npc_name`` / ``relates_to`` / ``sketch`` / ``version`` 都不撞 migrator
+    保留列（id / created_at / updated_at / dedup_hash），无需另起时刻字段（本刀不记
+    NPC 的写入时刻——它不像页 / 阶段那样要按时间游标读，演化层若需要再加）。
+
+写入走 framework 的 ``insert_append``（Version 自增），读最新走 ``select_latest``；
+list 一个 lane 全部 NPC 是 framework 没提供的只读查询，照 acts.py / day_page_exists /
+list_relationship_pages 的先例在 framework 持久化写好的真实表上直接 SELECT
+（DISTINCT ON 每人取最新一版）——不绕开 framework 持久化原语。
+
+seed：7 个种子 NPC 一次性灌库，逐 NPC 幂等（:func:`seed_npc_roster`，CAS
+expected_current_ver=0，照 :func:`app.life.persona_chain.seed_persona_chain` 的
+先例）——重跑无害、并发双跑也只落一行、链非空（已被演化层动过）的 NPC 绝不被出厂
+速写盖回。
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Annotated
+
+from sqlalchemy import text
+
+from app.data.session import get_session
+from app.runtime.data import Data, Key, Version
+from app.runtime.migrator import _table_name
+from app.runtime.persist import insert_append, select_latest
+
+
+class NPCRoster(Data):
+    """世界里一个有名有姓的固定 NPC 的设定速写（一版）.
+
+    自然键 ``(lane, npc_name)``：泳道隔离 + 每个 NPC 一条链。``relates_to`` 是该
+    NPC 主要关联哪个姐妹的 persona_id（akao / chinagi / ayana），world 据此归类。
+    ``sketch`` 是性格底色 + 会冒什么事的自然语言速写（整篇重写、不拆结构化字段）。
+    ``version`` 让同一 NPC 的多版速写 append-only 保留历史、读最新一版（演化层用）。
+    """
+
+    lane: Annotated[str, Key]
+    npc_name: Annotated[str, Key]   # NPC 的稳定标识（名字，对齐关系页 npc:xxx 约定）
+    relates_to: str                 # 主要关联的姐妹 persona_id（akao / chinagi / ayana）
+    sketch: str                     # 性格底色 + 会冒什么事的自然语言速写
+    version: Annotated[int, Version] = 0
+
+
+@dataclass(frozen=True)
+class NPCSeed:
+    """一个种子 NPC 的骨架（名字 + 关联姐妹 + 速写）——seed 灌库用。"""
+
+    npc_name: str
+    relates_to: str
+    sketch: str
+
+
+# 7 个种子 NPC（绫奈 3 / 赤尾 2 / 千凪 2），Claude 编骨架（spec 决策 5，用户已授权）。
+# 演化交给 world + 后续演化层；路人 world 即兴长不建档、不进这张表（spec non-goals）。
+NPC_SEEDS: tuple[NPCSeed, ...] = (
+    # 绫奈（14，初中生）——
+    NPCSeed(
+        npc_name="林小满",
+        relates_to="ayana",
+        sketch=(
+            "同桌兼死党，同岁。比绫奈稳、像小大人，会照顾爱慌的她，自己也藏着小心事。"
+            "会冒：约周末、考前互打气、闹小别扭又和好。"
+        ),
+    ),
+    NPCSeed(
+        npc_name="顾舟",
+        relates_to="ayana",
+        sketch=(
+            "班长，认真严肃，总“盯着”爱走神画画的绫奈，其实是另一种照顾。"
+            "会冒：催交作业、收作业较劲、小组活动分一起。"
+        ),
+    ),
+    NPCSeed(
+        npc_name="沈乐",
+        relates_to="ayana",
+        sketch=(
+            "同班开心果 / 小活宝，爱起哄带头闹。"
+            "会冒：课间拉她胡闹、起哄她糗事、约人放学买奶茶。"
+        ),
+    ),
+    # 赤尾（18，刚高考完）——
+    NPCSeed(
+        npc_name="陈鹿",
+        relates_to="akao",
+        sketch=(
+            "高中闺蜜，一起熬过高三，毒舌互怼但最懂彼此。"
+            "会冒：约出去浪、互相打击式关心、一起盯分数线焦虑暑假。"
+        ),
+    ),
+    NPCSeed(
+        npc_name="池夏",
+        relates_to="akao",
+        sketch=(
+            "高中死党（女生），大大咧咧、组局王。"
+            "会冒：撺掇赤尾出去浪 / 开黑、转沙雕东西、考完一起疯。"
+        ),
+    ),
+    # 千凪（24，上班）——
+    NPCSeed(
+        npc_name="许念",
+        relates_to="chinagi",
+        sketch=(
+            "同部门同事兼朋友，职场互相照应。"
+            "会冒：下班约饭、吐槽工作、周末小聚、找千凪这个“靠谱的人”倒苦水。"
+        ),
+    ),
+    NPCSeed(
+        npc_name="苏晴",
+        relates_to="chinagi",
+        sketch=(
+            "大学室友兼多年闺蜜，各自工作但常联系。是千凪能卸下“大姐”担子放松的人。"
+            "会冒：深夜聊心事、约周末见面。"
+        ),
+    ),
+)
+
+
+async def write_npc(
+    *, lane: str, npc_name: str, relates_to: str, sketch: str
+) -> None:
+    """append 一版 NPC 速写（演化层对这个 NPC 整篇重写）。
+
+    durable 语义同 write_world_arc / write_persona_version：append 新版本、无 dedup。
+    重跑可能再 append 一次语义相同的版本——无害，读侧只认最新版，版本链留痕。
+    """
+    await insert_append(
+        NPCRoster(
+            lane=lane,
+            npc_name=npc_name,
+            relates_to=relates_to,
+            sketch=sketch,
+        )
+    )
+
+
+async def read_npc(*, lane: str, npc_name: str) -> NPCRoster | None:
+    """读某泳道某 NPC 最新一版速写，没有返回 None（名册里没这个人）。"""
+    return await select_latest(NPCRoster, {"lane": lane, "npc_name": npc_name})
+
+
+async def list_npc_roster(*, lane: str) -> list[NPCRoster]:
+    """list 某泳道全部 NPC（每个 NPC 只取最新一版），空名册返回空表。
+
+    world 当天首轮把整份名册 list 出来、按 relates_to 归到对应姐妹、拼成「世界的
+    固定人物」一段纳入推演（engine 调用方）。照 list_relationship_pages 的先例在
+    framework 持久化写好的真实表上做只读 SELECT（DISTINCT ON 每人取最新一版）；
+    写入仍走 ``insert_append``，不绕开 framework 持久化原语。
+    """
+    sql = (
+        f"SELECT DISTINCT ON (npc_name) * "
+        f"FROM {_table_name(NPCRoster)} "
+        f"WHERE lane = :lane "
+        f"ORDER BY npc_name ASC, version DESC"
+    )
+    async with get_session() as s:
+        r = await s.execute(text(sql), {"lane": lane})
+        return [
+            NPCRoster(**{k: row[k] for k in NPCRoster.model_fields})
+            for row in r.mappings()
+        ]
+
+
+async def seed_npc_roster(*, lane: str) -> int:
+    """把 7 个种子 NPC 灌进指定 lane，逐 NPC 幂等。返回真正写入的条数。
+
+    每个 NPC 靠 ``insert_append`` 的 CAS（``expected_current_ver=0``：只有该 NPC
+    链上 MAX(version)=0 即一版都没有时才插入），检查和写入是同一条原子语句——重跑
+    无害、并发双跑也只落一行、链非空（已被演化层动过）的 NPC 绝不被出厂速写盖回。
+    照 :func:`app.life.persona_chain.seed_persona_chain` 的先例。
+    """
+    inserted = 0
+    for seed in NPC_SEEDS:
+        n = await insert_append(
+            NPCRoster(
+                lane=lane,
+                npc_name=seed.npc_name,
+                relates_to=seed.relates_to,
+                sketch=seed.sketch,
+            ),
+            expected_current_ver=0,
+        )
+        inserted += n
+    return inserted

--- a/apps/agent-service/app/world/state.py
+++ b/apps/agent-service/app/world/state.py
@@ -77,6 +77,15 @@ class WorldState(Data):
     # 只落 arc_reflected_date、不碰本字段。同样成功才落、失败同日重试。nullable +
     # additive migrate（对齐 arc_reflected_date），默认 None 不撞 migrator 保留列。
     arc_materials_reflected_date: str | None = None
+    # 已纳入「世界的固定人物」名册的那一天（CST `YYYY-MM-DD`，NPC 层第一刀）。world
+    # 当天第一次醒、名册非空且这个字段 != 今天时，把整份 NPCRoster 名册（按所属姐妹
+    # 归类的速写）当公共背景纳入一次、进意识流 transcript；纳入那轮收口把这个字段标成
+    # 今天，当天后续轮次（== 今天）不再重喂；跨到第二天（!= 今天）再重新纳入一次。
+    # 与 materials_ingested_date **独立**（名册 seed 后总在、底料某天可能没有——两件
+    # 不相干的事，各用各的游标）。nullable：从没纳入过（首轮 / 冷启）时为 None，与
+    # "任何今天"都不相等、首醒就纳入。additive nullable migrate（对齐
+    # materials_ingested_date），默认 None 不撞 migrator 保留列。
+    roster_ingested_date: str | None = None
     version: Annotated[int, Version] = 0
 
 
@@ -106,6 +115,9 @@ async def write_world_state(*, lane: str, world_time: str, detail: str) -> None:
             ),
             arc_materials_reflected_date=(
                 prev.arc_materials_reflected_date if prev is not None else None
+            ),
+            roster_ingested_date=(
+                prev.roster_ingested_date if prev is not None else None
             ),
         )
     )
@@ -142,6 +154,7 @@ async def set_next_wake_at(*, lane: str, next_wake_at: str) -> None:
             materials_ingested_date=snapshot.materials_ingested_date,
             arc_reflected_date=snapshot.arc_reflected_date,
             arc_materials_reflected_date=snapshot.arc_materials_reflected_date,
+            roster_ingested_date=snapshot.roster_ingested_date,
         )
     )
 
@@ -173,6 +186,7 @@ async def advance_act_cursor(*, lane: str, created_at: str, act_id: str) -> None
             materials_ingested_date=snapshot.materials_ingested_date,
             arc_reflected_date=snapshot.arc_reflected_date,
             arc_materials_reflected_date=snapshot.arc_materials_reflected_date,
+            roster_ingested_date=snapshot.roster_ingested_date,
         )
     )
 
@@ -182,25 +196,30 @@ async def record_world_round_close(
     lane: str,
     advance_cursor_to: tuple[str, str] | None,
     materials_ingested_date: str | None,
+    roster_ingested_date: str | None = None,
 ) -> None:
     """world 一轮成功推演收口：在**同一次** WorldState append 里推进 act 游标 + 标记
-    底料已纳入今天。
+    底料已纳入今天 + 标记名册已纳入今天。
 
-    一轮收口本有两件互不相干的调度状态要落：act 消费游标推进、以及「今天的外部底料」
-    是否在这轮被纳入（纳入了就把日期标成今天，当天后续轮不再重喂）。它们都改 WorldState，
-    若各写一版会多出冗余快照、还可能彼此覆盖（后写的读到前写之前的快照、把对方的改动
-    丢掉）。所以并进一次 append：读最新一版，按入参选择性地改这两块、其余字段（world_time
-    / detail / next_wake_at / 另一块没改的）原样沿用，append 一版，原子、幂等。
+    一轮收口本有几件互不相干的调度状态要落：act 消费游标推进、「今天的外部底料」是否
+    在这轮被纳入、「世界的固定人物」名册是否在这轮被纳入（纳入了就把对应日期标成今天，
+    当天后续轮不再重喂）。它们都改 WorldState，若各写一版会多出冗余快照、还可能彼此
+    覆盖（后写的读到前写之前的快照、把对方的改动丢掉）。所以并进一次 append：读最新一版，
+    按入参选择性地改这几块、其余字段（world_time / detail / next_wake_at / 没改的标记）
+    原样沿用，append 一版，原子、幂等。
 
       * ``advance_cursor_to``：``(created_at, act_id)`` —— 本批末尾游标。非空批传它、把
         游标推进过去；**空批次传 None** —— 没读到 act 没什么可推进，游标沿用上一版。
       * ``materials_ingested_date``：今天的日期串 —— 这轮纳入了底料就传它，标成今天；
         **没纳入（已纳入过 / 今天没底料）传 None** —— 不改，沿用上一版已有标记（绝不把
         已纳入标记清回 None，否则当天会反复重喂）。
+      * ``roster_ingested_date``：今天的日期串 —— 这轮纳入了 NPC 名册就传它，标成今天；
+        **没纳入（已纳入过 / 名册为空）传 None** —— 不改，沿用上一版（同 materials 的
+        语义；名册与底料各用各的游标、互不打架）。
 
     崩溃语义命门：本函数只在 ``Agent.run`` 成功返回后（engine 收口）才调。run 中途抛
-    时它根本不会被调到，游标不推进、materials_ingested_date 不被误标记——下轮重醒重读
-    这批 act、重新纳入底料（act 与底料都不丢）。
+    时它根本不会被调到，游标不推进、materials_ingested_date / roster_ingested_date 不被
+    误标记——下轮重醒重读这批 act、重新纳入底料 + 名册（act / 底料 / 名册都不丢）。
 
     冷启容错（对齐 :func:`advance_act_cursor`）：还没有任何 WorldState 快照时无可承载
     收口状态的快照，安全跳过——这种情形本就没消费到 act、世界叙述统一由 update_world
@@ -229,6 +248,11 @@ async def record_world_round_close(
             ),
             arc_reflected_date=snapshot.arc_reflected_date,
             arc_materials_reflected_date=snapshot.arc_materials_reflected_date,
+            roster_ingested_date=(
+                roster_ingested_date
+                if roster_ingested_date is not None
+                else snapshot.roster_ingested_date
+            ),
         )
     )
 
@@ -288,5 +312,6 @@ async def mark_arc_reflected(
                 if materials_date is not None
                 else snapshot.arc_materials_reflected_date
             ),
+            roster_ingested_date=snapshot.roster_ingested_date,
         )
     )

--- a/apps/agent-service/app/world/tools.py
+++ b/apps/agent-service/app/world/tools.py
@@ -67,12 +67,21 @@ from app.agent.runtime_context import get_context
 from app.agent.tooling import tool
 from app.agent.tools._common import get_or_create_counter, tool_error
 from app.data.queries.mailbox import deliver_event
-from app.domain.world_events import EVENT_KIND_AMBIENT, EVENT_KIND_SURROUNDINGS
+from app.domain.world_events import (
+    EVENT_KIND_AMBIENT,
+    EVENT_KIND_SPEECH,
+    EVENT_KIND_SURROUNDINGS,
+    npc_source,
+)
 from app.infra import cst_time
 from app.runtime.emit import emit_delayed  # module-level so tests can monkeypatch
 from app.world.arc import write_world_arc
 from app.world.attention import write_world_attention
-from app.world.state import set_next_wake_at, write_world_state
+from app.world.state import (
+    read_world_state,
+    set_next_wake_at,
+    write_world_state,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -100,11 +109,19 @@ _EVENT_ID_NS = uuid.UUID("6f1c8b2a-5e7d-4c3a-9f0b-1d2e3a4b5c6d")
 # （两类是不同语义的 event）。
 _SURROUNDINGS_EVENT_ID_NS = uuid.UUID("9a3d7c1e-2b4f-4e6a-8c0d-7f1a2b3c4d5e")
 
+# NPC 来访（npc_visit）的 event_id 派生命名空间：与 notify / sense 都分开，让同样文字
+# 的「NPC 对你说的话」「动静」「周遭切片」派生出不同 id、不在 deliver_event 幂等里互相
+# 吞掉（三类是不同语义的 event）。
+_NPC_EVENT_ID_NS = uuid.UUID("3c5b8e1d-4a2f-4d6c-9e7b-0a1f2c3d4e5f")
+
 WORLD_NOTIFY_EVENTS = get_or_create_counter(
     "world_notify_events_total", "world notify 投递的 event 计数", ["status"]
 )
 WORLD_SENSE_EVENTS = get_or_create_counter(
     "world_sense_events_total", "world sense 投递的周遭切片计数", ["status"]
+)
+WORLD_NPC_VISIT_EVENTS = get_or_create_counter(
+    "world_npc_visit_events_total", "world npc_visit 投递的 NPC 来访 event 计数", ["status"]
 )
 WORLD_SLEEP_REJECTED = get_or_create_counter(
     "world_sleep_rejected_total", "world sleep 超出 60s~1h 上下限被拒次数", []
@@ -143,6 +160,42 @@ def derive_surroundings_event_id(
     return uuid.uuid5(
         _SURROUNDINGS_EVENT_ID_NS,
         f"{lane}\x1f{recipient}\x1f{surroundings}\x1f{round_id}",
+    ).hex
+
+
+def derive_npc_event_id(
+    *,
+    lane: str,
+    npc_name: str,
+    sister: str,
+    what_npc_says: str,
+    world_fact: str,
+    round_id: str,
+) -> str:
+    """确定性派生一件 NPC 来访的 id：同 (lane, npc, sister, 话, world_fact, round_id) 同 id。
+
+    NPC event 是 durable 写（投信箱），整轮 ``Agent.run`` retry 会重放它。派生源绑
+    触发源（轮 id + 哪个 NPC + 指向哪个姐妹 + 说的话 + 这件事的世界事实），让重放投
+    同一条 event，``deliver_event`` 按 (lane, persona, event_id) 幂等去重、不重复投
+    ——与 notify / sense 的 round_id 幂等做法同一套（不另搞）。
+
+    派生源里四个命门各自防一类误吞：
+
+      * ``npc_name``：同一轮林小满找绫奈、顾舟找绫奈是两件独立 event（不同 NPC）。
+      * ``sister``：林小满分别找绫奈和找赤尾也是两件（不同收件人，理论上 world
+        可一轮推多件）。
+      * ``what_npc_says``：她说的不一样自然是两件事。
+      * ``world_fact``（codex 必改 3）：同一姐妹、同一 NPC、同一轮、同一句话但
+        **不同 world_fact** 是两件客观上不一样的来访（先发消息约、过一会儿又来
+        电话敲定，恰好那句话措辞相同）——不纳入它，第二件会撞同一 id 被幂等当
+        重放吞掉。纳入它让不同事不撞、同事（整轮重放：四样全同）仍幂等。
+
+    独立命名空间（``_NPC_EVENT_ID_NS``）让同文字的 NPC 话 / 动静 / 周遭切片不撞。
+    """
+    return uuid.uuid5(
+        _NPC_EVENT_ID_NS,
+        f"{lane}\x1f{npc_name}\x1f{sister}\x1f{what_npc_says}"
+        f"\x1f{world_fact}\x1f{round_id}",
     ).hex
 
 
@@ -386,6 +439,114 @@ async def sense(recipient: str, surroundings: str) -> str:
 
 
 @tool
+@tool_error("投递 NPC 来访失败")
+async def npc_visit(
+    npc_name: str, sister: str, what_npc_says: str, world_fact: str
+) -> str:
+    """让一个有名有姓的固定 NPC（同学 / 同事 / 闺蜜）来找某个姐妹一次。
+
+    世界里那些有名有姓的人（名册里那几位）各自有自己的生活，平时不在画面里，但会因为
+    自己的事来跟三姐妹中的某一个发生联系——同桌约绫奈周末、同事找千凪吐槽。当你推演到
+    此刻某个 NPC 真会来找某个姐妹时，用这条工具把这件事落下来。它一次做两件事，保证
+    「收件人收到」和「世界记得」不分叉：
+
+      * ``what_npc_says`` 直接送进**那一个姐妹**的耳朵里——她下次醒来会读到「{npc_name}
+        对你说：……」，据此自然反应。这是这个 NPC 直接对她说的话、原话原样。
+      * ``world_fact`` 同步写进世界此刻的叙述里（追加在你记得的上一版世界叙述之后），
+        让世界记住「这件事发生过」——你下一轮还记得、别的姐妹也可能从客观面感知到
+        （比如绫奈在客厅接了个电话，旁边的人听得到这通电话）。
+
+    分两段写的道理：``what_npc_says`` 是只有收件人听得到的那句话（私人的、冲她来的），
+    ``world_fact`` 是这件事**客观可感**的那一面（手机响了、她接起电话、她出门赴约）——
+    后者绝不写情绪 / 主观解读，只写客观发生了什么（和 update_world 的 detail 同口吻）。
+
+    NPC 该不该来、来做什么，全由你按世界此刻推演决定——没人催你每轮造个 NPC 出来，
+    世界大部分时刻她们都在各自的生活里、不来打扰。即兴的路人（名册里没有的）你也可以
+    用这条工具让他来一次，路人不建档、只这一下。
+
+    **一致性语义（codex 必改 2，给维护者看，不给模型看）：** 留世界（write_world_state）
+    与投信箱（deliver_event）是两次独立 durable 写、**非事务**——framework 持久化原语
+    （insert_append / insert_idempotent）各自开自己的 ``get_session``、各自提交，不接受
+    注入 session，要把两写拢进一个事务得改 framework 持久化 API 的契约（牵动所有 Data
+    写入方），代价远大于收益，故不做。退而求其次按「先写世界、后投信箱」排序：world
+    detail 是世界权威，崩在两写之间的残留是收件人**偶发漏收一次来访**，危害小于反过来
+    「收件人反应了但世界不记得」（世界状态与别的姐妹的感知会分叉）。这是 best-effort 残
+    留：deliver 失败会 **log error（绝不静默吞）**、并把异常交给 @tool_error 路由给模型，
+    世界层那段叙述已落、下次不补投（不重要到值得补偿）。
+
+    整轮重放安全：world 的 ``Agent.run`` 用 ``max_retries=1``（engine 收口处关掉整轮
+    重放），所以这条 write_world_state 的 append **不会**被整轮 retry 重放成重复追加；
+    模型在同一轮里手动重复调本工具，则靠 ``derive_npc_event_id`` 的确定性 id + deliver
+    幂等去重（投信箱不重，世界叙述的重复追加靠 world 自己 prompt 守，不上机制强制——
+    一轮里怎么写 detail 是 world 自己的事，赤尾哲学不在代码里强制 world 的决策；这条
+    靠 world_loop_instruction 守则②的 prompt 引导）。
+
+    Args:
+        npc_name: 来访的 NPC 名字（如「林小满」；名册里的固定人物或你即兴的路人）。
+        sister: 这件事指向哪个姐妹（persona_id：akao / chinagi / ayana）。
+        what_npc_says: 这个 NPC 直接对她说的话（原话，进她耳朵里）。
+        world_fact: 这件事客观可感的那一面（追加进世界叙述，让世界记得；只写客观）。
+
+    Returns:
+        一句确认文本。
+    """
+    lane, round_id = _world_round()
+
+    event_id = derive_npc_event_id(
+        lane=lane,
+        npc_name=npc_name,
+        sister=sister,
+        what_npc_says=what_npc_says,
+        world_fact=world_fact,
+        round_id=round_id,
+    )
+    # occurred_at 跟现实走，由代码填（客观时间不让模型编，同 notify / sense）。
+    now = cst_time.now_cst_iso()
+
+    # 世界留痕（codex 必改：收件人信箱 + 世界层不分叉）。投信箱**之前**先把这件事
+    # 同步写进世界叙述：读上一版 detail、把 world_fact 追加进去 append 一版。这一步
+    # 由工具自己做、不靠模型另调 update_world 自觉——机制层保证「世界记得这件事」。
+    # 冷启动（还没有上一版世界叙述）时 world_fact 直接作为新 detail。
+    prev = await read_world_state(lane=lane)
+    if prev is not None and prev.detail:
+        new_detail = f"{prev.detail}\n{world_fact}"
+    else:
+        new_detail = world_fact
+    await write_world_state(lane=lane, world_time=now, detail=new_detail)
+
+    # 投进那一个姐妹的信箱：kind=speech（有具名说话人、原话直投，对齐 chat 直投的
+    # speech 语义）、source=`npc:名字`（机器约定，对齐第一刀 npc_name + 关系页 npc:xxx；
+    # 区别于真人的 user:xxx / kind=external、也区别于 world 环境动静的 ambient）。
+    # 非事务的 best-effort 残留（codex 必改 2）：世界叙述上面已落，这步投信箱失败要
+    # **log error（绝不静默）**、记下哪个 NPC 投给谁失败，再把异常交给 @tool_error
+    # 路由给模型——世界层那段已落、收件人偶发漏收一次，危害小于反过来（详见 docstring）。
+    try:
+        await deliver_event(
+            lane=lane,
+            persona_id=sister,
+            event_id=event_id,
+            summary=what_npc_says,
+            occurred_at=now,
+            kind=EVENT_KIND_SPEECH,
+            source=npc_source(npc_name),
+        )
+    except Exception:
+        WORLD_NPC_VISIT_EVENTS.labels(status="deliver_failed").inc()
+        logger.error(
+            "[npc_visit] %s 来访 %s 已写进世界叙述、但投信箱失败（best-effort 残留："
+            "世界记得这事、收件人这次漏收）lane=%s event_id=%s",
+            npc_name,
+            sister,
+            lane,
+            event_id,
+            exc_info=True,
+        )
+        raise
+    WORLD_NPC_VISIT_EVENTS.labels(status="delivered").inc()
+    return f"{npc_name} 来找了 {sister}，已送到她耳朵里、也记进了世界"
+
+
+@tool
 @tool_error("安排下次醒来失败")
 async def sleep(
     seconds: Annotated[
@@ -465,9 +626,11 @@ async def fire_self_wake(*, lane: str, self_wake: dict) -> bool:
     return True
 
 
-# 续写工具集（四件）：顺着流往前推。update_arc **不在这里**——翻页归反思环节独占
-# （工具集物理隔离：续写无手碰世界阶段）。
-WORLD_TOOLS = [notify, update_world, sense, sleep]
+# 续写工具集（五件）：顺着流往前推。npc_visit 让 world 以具名 NPC 身份投一件指向某
+# 姐妹的 event（speech、source=npc:名字）、同步把这件事追加进世界叙述（收件人信箱 +
+# 世界层不分叉）。update_arc **不在这里**——翻页归反思环节独占（工具集物理隔离：续写
+# 无手碰世界阶段）。
+WORLD_TOOLS = [notify, update_world, sense, npc_visit, sleep]
 
 # 反思工具集（两件）：对表翻页 + 留关注。反思环节（app.world.reflection）每日一次、
 # 无会话，工具只有 update_arc / update_attention——反思无手碰 detail / notify /

--- a/apps/agent-service/tests/domain/test_event_mailbox.py
+++ b/apps/agent-service/tests/domain/test_event_mailbox.py
@@ -21,6 +21,7 @@ import pytest
 
 from app.data.queries.mailbox import (
     deliver_event,
+    list_persona_npc_speech_in_window,
     list_personas_with_unread,
     list_unread_events,
     mark_events_read,
@@ -316,6 +317,100 @@ async def test_unread_mixed_format_ordered_by_real_instant(mailbox_db):
     assert [e.event_id for e in unread] == ["iso_early", "unix_mid", "iso_late"], (
         "混格式必须按真实时刻排序——Unix 毫秒不能因字符串以 1 开头就被排到 ISO 前面"
     )
+
+
+@pytest.mark.integration
+async def test_npc_speech_in_window_reads_only_npc_speech(mailbox_db):
+    """睡前回顾的 NPC 互动证据查询：只捞本生活日窗口内、投给她的 NPC speech event。
+
+    NPC 层第四刀（代码层）的命门——回顾要从信箱里拿到权威的 ``npc:名字`` 机读键
+    （而非从被剥过前缀的 transcript 文本里猜）。所以这条查询按窗口 + kind=speech +
+    source 以 ``npc:`` 起头三重过滤，**只**返回 NPC 来访：
+
+      * world 环境动静（kind=ambient / surroundings、source=world）排除；
+      * 姐妹直投（kind=speech、source=persona_id 如 akao）排除——那是真姐妹，不是 NPC；
+      * 真人外部消息（source=user:xxx）排除。
+
+    已读 / 未读都要捞回：回顾在睡前跑，当天的 NPC speech 多半已被 life 标已读了，
+    按未读捞会漏掉今天的互动（这是与 list_unread_events 的关键区别——它是窗口读、
+    不看 read 表）。
+    """
+    # 窗口：2026-06-10 全天（CST）
+    start_iso = "2026-06-10T04:00:00+08:00"
+    end_iso = "2026-06-10T23:30:00+08:00"
+
+    # 1) 窗口内的 NPC 来访（要捞回）——且已被标已读，验证窗口读不看 read 表
+    await deliver_event(
+        lane="coe-t1", persona_id="ayana", event_id="npc-1",
+        kind="speech", source="npc:林小满",
+        summary="绫奈周末一起去图书馆复习好不好？",
+        occurred_at="2026-06-10T16:30:00+08:00",
+    )
+    await mark_events_read(lane="coe-t1", persona_id="ayana", event_ids=["npc-1"])
+
+    # 2) 姐妹直投 speech（source=persona_id）——不是 NPC，排除
+    await deliver_event(
+        lane="coe-t1", persona_id="ayana", event_id="sis-1",
+        kind="speech", source="akao",
+        summary="绫奈在写作业吗",
+        occurred_at="2026-06-10T17:00:00+08:00",
+    )
+    # 3) world 环境动静——排除
+    await deliver_event(
+        lane="coe-t1", persona_id="ayana", event_id="amb-1",
+        kind="ambient", source="world",
+        summary="窗外开始下雨",
+        occurred_at="2026-06-10T18:00:00+08:00",
+    )
+    # 4) 窗口外的 NPC 来访（前一天）——排除
+    await deliver_event(
+        lane="coe-t1", persona_id="ayana", event_id="npc-old",
+        kind="speech", source="npc:林小满",
+        summary="昨天的事",
+        occurred_at="2026-06-09T16:30:00+08:00",
+    )
+    # 5) 投给别的姐妹的 NPC 来访——persona 隔离，排除
+    await deliver_event(
+        lane="coe-t1", persona_id="akao", event_id="npc-other",
+        kind="speech", source="npc:陈鹿",
+        summary="给赤尾的",
+        occurred_at="2026-06-10T16:30:00+08:00",
+    )
+
+    events = await list_persona_npc_speech_in_window(
+        lane="coe-t1", persona_id="ayana", start_iso=start_iso, end_iso=end_iso
+    )
+
+    assert [e.event_id for e in events] == ["npc-1"], (
+        "只捞窗口内、投给 ayana 的 NPC speech（已读也算）；姐妹直投 / 环境动静 / "
+        "窗口外 / 别人的都排除"
+    )
+    assert events[0].source == "npc:林小满", "source 原样保留，回顾据它取 npc:名字 键"
+    assert events[0].summary == "绫奈周末一起去图书馆复习好不好？"
+
+
+@pytest.mark.integration
+async def test_npc_speech_in_window_ordered_by_real_instant(mailbox_db):
+    """多次 NPC 来访按真实时刻升序（与意识流证据时间序对齐）。"""
+    start_iso = "2026-06-10T04:00:00+08:00"
+    end_iso = "2026-06-10T23:30:00+08:00"
+
+    await deliver_event(
+        lane="coe-t1", persona_id="ayana", event_id="late",
+        kind="speech", source="npc:林小满", summary="后说的",
+        occurred_at="2026-06-10T18:00:00+08:00",
+    )
+    await deliver_event(
+        lane="coe-t1", persona_id="ayana", event_id="early",
+        kind="speech", source="npc:沈乐", summary="先说的",
+        occurred_at="2026-06-10T10:00:00+08:00",
+    )
+
+    events = await list_persona_npc_speech_in_window(
+        lane="coe-t1", persona_id="ayana", start_iso=start_iso, end_iso=end_iso
+    )
+
+    assert [e.event_id for e in events] == ["early", "late"]
 
 
 @pytest.mark.integration

--- a/apps/agent-service/tests/integration/test_world_life_closed_loop.py
+++ b/apps/agent-service/tests/integration/test_world_life_closed_loop.py
@@ -59,6 +59,7 @@ from app.world.engine import (
     WorldTick,
     world_tick,
 )
+from app.world.npc_roster import NPCRoster
 from app.world.state import WorldState, read_world_state
 from tests.runtime.conftest import migrate
 
@@ -77,6 +78,20 @@ def _notify(recipients: list[str], observation: str) -> tuple[str, dict]:
 
 def _sense(recipient: str, surroundings: str) -> tuple[str, dict]:
     return ("sense", {"recipient": recipient, "surroundings": surroundings})
+
+
+def _npc_visit(
+    npc_name: str, sister: str, what_npc_says: str, world_fact: str
+) -> tuple[str, dict]:
+    return (
+        "npc_visit",
+        {
+            "npc_name": npc_name,
+            "sister": sister,
+            "what_npc_says": what_npc_says,
+            "world_fact": world_fact,
+        },
+    )
 
 
 def _sleep(seconds: int) -> tuple[str, dict]:
@@ -139,6 +154,10 @@ async def world_db(test_db):
     # world 每轮按 (lane, 今天) 查当天外部底料（engine 的 find_daily_materials 真打
     # 这张表）——不建它，闭环里每个 world_tick 都死在 UndefinedTableError。
     await migrate(DailyMaterials, test_db)
+    # world 每轮 list NPC 名册（engine 的 list_npc_roster 真打这张表，NPC 层第一刀）
+    # ——不建它，闭环里每个 world_tick 都死在 UndefinedTableError（即便名册为空也要
+    # 表存在才能 SELECT 出空表）。
+    await migrate(NPCRoster, test_db)
     # 睡前回顾的两张页（昨天页 + 关系页）。当前闭环还没接回顾触发（Task 2 接线），
     # 先把表建齐——接上后 life 轮收口会真打它们，缺表同样死 UndefinedTableError。
     await migrate(DayPage, test_db)
@@ -437,6 +456,73 @@ async def test_info_gap_notify_only_reaches_recipients(world_db, _agent_run, mon
     akao_unread = await list_unread_events(lane=lane, persona_id="akao")
     assert [e.summary for e in chinagi_unread] == ["厨房飘来煎蛋的香味"]
     assert akao_unread == []
+
+
+@pytest.mark.integration
+async def test_npc_visit_end_to_end_mailbox_and_world_layer(
+    world_db, _stub_persona, _agent_run, monkeypatch
+):
+    """NPC 层第二刀机制层端到端（真 PG，不靠模型自发）：world 调 npc_visit 一次，断言三条.
+
+    构造一轮 world 推演里调一次 ``npc_visit``（林小满来找绫奈），全程走真实工具 + 真实
+    持久化，验证 spec Task 2 的三条机制：
+
+      ① 投进对应姐妹信箱、带 NPC 来源标识：绫奈信箱里这条 event 的 ``source`` 是
+         ``npc:林小满``、``kind`` 是 speech —— 既不是真人（user:xxx / external）、也不是
+         world 环境动静（ambient）。
+      ② 对应姐妹 list_unread_events 拿得到、且 life 侧能识别出 NPC 来源（speech 段
+         「林小满 对你说」、机读前缀 npc: 不漏给模型）。
+      ③ 同一件事同步留在世界层：同轮 world detail 含这件 NPC 事实（收件人感知 + 世界
+         状态不分叉）。
+
+    全程没有让模型「自发」决定投——脚本里直接编排 npc_visit 这一步，证的是机制能力
+    （Task 2 不负责让 world 愿意投，那是第三刀 prompt 的事）。
+    """
+    lane = "coe-npc"
+    _world_llm(
+        _agent_run,
+        [
+            [
+                _update_world("午后。ayana 在客厅写作业，akao 在房间，chinagi 在厨房。"),
+                _npc_visit(
+                    npc_name="林小满",
+                    sister="ayana",
+                    what_npc_says="绫奈周末有空吗？一起去图书馆复习吧。",
+                    world_fact="ayana 的手机响了，是林小满发来的消息。",
+                ),
+                _sleep(600),
+            ],
+        ],
+    )
+
+    await world_tick(WorldTick(lane=lane, reason="heartbeat"))
+
+    # ① + ② 投进绫奈信箱、带 NPC 来源标识，list_unread 拿得到
+    ayana_unread = await list_unread_events(lane=lane, persona_id="ayana")
+    assert len(ayana_unread) == 1
+    npc_ev = ayana_unread[0]
+    assert npc_ev.source == "npc:林小满", "NPC event 来源必须是 npc:名字（不是真人 / 不是 world）"
+    assert npc_ev.kind == "speech", "NPC event 是 speech（有具名说话人）、不是 ambient 环境动静"
+    assert npc_ev.summary == "绫奈周末有空吗？一起去图书馆复习吧。"
+    # NPC event 没误投给别的姐妹（指向单个收件人）
+    assert await list_unread_events(lane=lane, persona_id="akao") == []
+    assert await list_unread_events(lane=lane, persona_id="chinagi") == []
+
+    # ② life 侧识别 NPC 来源：绫奈被唤醒，stimulus 呈现「林小满 对你说」、不漏 npc: 前缀
+    _agent_run.life_round = []  # 看一眼即可，不需要她做什么
+    await lw.life_wake_node(EventArrived(lane=lane, persona_id="ayana"))
+    life_blob = _agent_run.life_calls[-1]["messages_text"]
+    assert "林小满 对你说" in life_blob, "life 应把 NPC speech 呈现成「林小满 对你说」"
+    assert "绫奈周末有空吗？一起去图书馆复习吧。" in life_blob
+    assert "npc:林小满" not in life_blob, "npc: 机读前缀不该漏进喂给模型的 stimulus"
+
+    # ③ 同一件事同步留世界层：同轮 world detail 含这件 NPC 事实（不分叉）
+    snap = await read_world_state(lane=lane)
+    assert snap is not None
+    assert "林小满" in snap.detail
+    assert "ayana 的手机响了，是林小满发来的消息。" in snap.detail
+    # 不丢同轮 update_world 写的上一段叙述（追加而非覆盖）
+    assert "ayana 在客厅写作业" in snap.detail
 
 
 @pytest.mark.integration

--- a/apps/agent-service/tests/life/test_day_review.py
+++ b/apps/agent-service/tests/life/test_day_review.py
@@ -127,12 +127,14 @@ def stub_io(monkeypatch):
         },
         "acts": [_act()],
         "chats": [_chat_block()],
+        "npc_events": [],
         "rel_pages": {},
         "day_page": None,
         "marks": [],
         "costs": [],
         "act_windows": [],
         "chat_windows": [],
+        "npc_windows": [],
         "session_loads": [],
         "page_lookups": [],
     }
@@ -157,6 +159,12 @@ def stub_io(monkeypatch):
             }
         )
         return list(state["chats"])
+
+    async def fake_npc_speech(*, lane, persona_id, start_iso, end_iso):
+        state["npc_windows"].append(
+            {"lane": lane, "persona_id": persona_id, "start": start_iso, "end": end_iso}
+        )
+        return list(state["npc_events"])
 
     async def fake_rel_pages(*, lane, persona_id, other_user_ids):
         state["page_lookups"].append(list(other_user_ids))
@@ -187,6 +195,9 @@ def stub_io(monkeypatch):
     monkeypatch.setattr(review_mod, "load_session", fake_load_session)
     monkeypatch.setattr(review_mod, "list_persona_acts_between", fake_acts)
     monkeypatch.setattr(review_mod, "find_persona_spoken_chats_in_window", fake_chats)
+    monkeypatch.setattr(
+        review_mod, "list_persona_npc_speech_in_window", fake_npc_speech
+    )
     monkeypatch.setattr(review_mod, "read_relationship_pages", fake_rel_pages)
     monkeypatch.setattr(review_mod, "read_day_page", fake_day_page)
     monkeypatch.setattr(review_mod, "day_page_exists", fake_day_page_exists)
@@ -897,6 +908,31 @@ def test_review_instruction_has_no_hardcoded_plot_facts():
     for name in ("千凪", "赤尾", "绫奈", "chinagi", "akao", "ayana"):
         assert name not in instruction
     assert not any(ch.isdigit() for ch in instruction)
+
+
+def test_review_instruction_covers_npc_relationship_pages():
+    """第三刀 prompt 收口：关系页那句要从「只认真人」扩到也涵盖来访过的 NPC。
+
+    第四刀（代码层）已让回顾把 NPC 来访摆进证据、给出 ``npc:名字`` 机读键并读回旧
+    NPC 关系页。但任务指令那句若还只说「真正聊过天的每个真人」，模型可能只给真人
+    写关系页、把证据里的 NPC 互动晾着——NPC 关系跨天长不起来。所以 instruction 必须：
+
+      * 提到来找过她的 NPC（证据里【这一天来找过你的人】那节）也照样写 / 更新关系页；
+      * 明确 NPC 那页的 other_user_id 就用证据里给出的 ``npc:名字`` 键；
+      * 保持现有克制：没来往过的人（真人或 NPC）一律不动关系页。
+    """
+    instruction = review_mod.review_instruction()
+    # NPC 也要写关系页（指令不能只认真人）
+    assert "NPC" in instruction, "关系页指令应扩到涵盖来访过的 NPC"
+    assert "来找过" in instruction, (
+        "应引用证据里【这一天来找过你的人】那节的来访 NPC"
+    )
+    # NPC 那页的 other_user_id 用 npc:名字 机读键
+    assert "npc:" in instruction, "NPC 关系页的 other_user_id 应用 npc:名字 机读键"
+    # 仍守克制：没来往就不动（真人或 NPC 一律）
+    assert "没" in instruction and ("来往" in instruction or "聊" in instruction), (
+        "应保持「没来往过就不动关系页」的克制（真人或 NPC 一律）"
+    )
 
 
 @pytest.mark.asyncio

--- a/apps/agent-service/tests/life/test_persona_review.py
+++ b/apps/agent-service/tests/life/test_persona_review.py
@@ -846,6 +846,36 @@ async def test_evidence_includes_relationship_pages(stub_io, monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_evidence_marks_npc_relationship_pages(stub_io, monkeypatch):
+    """关系页里 ``npc:*`` 的页要在证据里**显式标注是 NPC**（codex 建议 3）。
+
+    persona review 全量读关系页（list_relationship_pages），会读到 NPC 层写下的
+    ``npc:名字`` 关系页。喂给模型的证据若把 ``npc:林小满`` 和真人 user_id 一视同仁，
+    模型可能把这个 NPC 标识慢慢漂当成真人写进身份正文（身份慢漂误当真人）。所以
+    NPC 页的证据要带一个明确「这是 NPC、不是真人用户」的标注。
+    """
+    stub_io["rel_pages"] = [
+        _rel_page(
+            other_user_id="npc:林小满",
+            narrative="她是绫奈的同桌，总在她慌的时候稳住她。",
+        ),
+        _rel_page(other_user_id="user-1", narrative="哥哥常来群里找我。"),
+    ]
+    captured = _mock_run(monkeypatch, stub_io)
+
+    await _review()
+
+    blob = _blob(captured)
+    # NPC 页内容仍在
+    assert "她是绫奈的同桌" in blob
+    assert "npc:林小满" in blob
+    # 且明确标了「NPC」，让模型知道这不是真人标识
+    assert "NPC" in blob, "npc:* 关系页的证据必须显式标注是 NPC（不是真人用户标识）"
+    # 真人页不受影响、不被误标 NPC
+    assert "哥哥常来群里找我。" in blob
+
+
+@pytest.mark.asyncio
 async def test_evidence_no_relationship_pages_says_so(stub_io, monkeypatch):
     """还没有任何关系页 → 如实说，不冒充。"""
     stub_io["rel_pages"] = []

--- a/apps/agent-service/tests/life/test_review_npc.py
+++ b/apps/agent-service/tests/life/test_review_npc.py
@@ -1,0 +1,392 @@
+"""睡前回顾把 NPC 互动纳入关系页生成链路 — NPC 层第四刀（代码层）.
+
+第二刀让 world 以具名 NPC 身份投 speech event（kind=speech、source=`npc:名字`）
+进姐妹信箱；life 把它渲染进当轮 USER stimulus、落进意识流 transcript。但睡前回顾
+原本只从**真实聊天记录**（``find_persona_spoken_chats_in_window``）抽 other_user_id，
+NPC 互动只活在意识流 / 信箱里、抽不到——所以姐妹跟 NPC 反复来往出来的关系无法跨天
+长进 RelationshipPage。
+
+第四刀（代码层）让回顾能从信箱里读到本生活日窗口内投给她的 NPC speech event
+（kind=speech、source 以 `npc:` 起头），由此：
+
+  * 拿到权威的 ``npc:名字`` 机读键（不靠从 transcript 文本里猜被剥过前缀的人名）；
+  * 把这些 NPC 当成「这一天来往过的对象」，和真人 partner 一道读回旧关系页作证据
+    （跨天累积的命门：她重写 NPC 那页时手里有上一页底稿）；
+  * 把 NPC 互动 + 它的 ``npc:名字`` 键明明白白摆进证据里，让模型知道该用哪个
+    other_user_id 写这页（对齐真人证据里显式标 user_id 的写法）。
+
+「也给 NPC 写关系页」的**指令措辞**（instruction / 模板里那句「真正聊过天的每个
+真人」）是第三刀 prompt 的事，本刀不碰——本刀只让**代码层有能力**抽取 / 喂回 NPC
+关系证据。这些测试钉死代码层能力，不测 prompt 鼓励措辞。
+
+写入 / 读回链路本就接受任意 other_user_id 字符串（RelationshipPage 的 Key 是
+str、读写无「只要真人」过滤），所以 `npc:名字` 关系页的写入与读回不需要新代码——
+命门只在「回顾的抽取对象」这一处把 NPC 纳进来。
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+
+import fakeredis.aioredis
+import pytest
+
+import app.life.review as review_mod
+from app.agent.neutral import Message, Role
+from app.agent.trace import make_session_id
+from app.data.message_record import CommonMessageRecord
+from app.domain.world_events import ActPerformed, EventEnvelope
+from app.life.pages import DayPage, RelationshipPage
+
+_CST = timezone(timedelta(hours=8))
+
+_NOW = datetime(2026, 6, 10, 23, 30, 0, tzinfo=_CST)
+_TARGET = "2026-06-10"
+_LANE = "coe-t2"
+_PERSONA = "ayana"
+
+
+@pytest.fixture(autouse=True)
+def fake_redis(monkeypatch):
+    import app.infra.redis as redis_mod
+
+    fake = fakeredis.aioredis.FakeRedis(decode_responses=True)
+    monkeypatch.setattr(redis_mod, "_redis", fake)
+    return fake
+
+
+def _act(description="我把书桌收拾了一遍", occurred_at="2026-06-10T20:15:00+08:00"):
+    return ActPerformed(
+        lane=_LANE,
+        act_id="act-1",
+        persona_id=_PERSONA,
+        description=description,
+        occurred_at=occurred_at,
+    )
+
+
+def _npc_event(
+    *,
+    npc_name="林小满",
+    summary="绫奈周末一起去图书馆复习好不好？",
+    occurred_at="2026-06-10T16:30:00+08:00",
+    event_id=None,
+) -> EventEnvelope:
+    """一条投给绫奈的 NPC speech event（kind=speech、source=`npc:名字`，第二刀形态）。"""
+    return EventEnvelope(
+        lane=_LANE,
+        persona_id=_PERSONA,
+        event_id=event_id or f"npc-{npc_name}-{occurred_at}",
+        kind="speech",
+        source=f"npc:{npc_name}",
+        summary=summary,
+        occurred_at=occurred_at,
+    )
+
+
+@pytest.fixture(autouse=True)
+def stub_io(monkeypatch):
+    """stub 回顾本体的全部 IO，专测 NPC 抽取 / 喂回编排，不碰真库。"""
+    state = {
+        "sessions": {
+            make_session_id(_LANE, _PERSONA, "2026-06-10"): [
+                Message(role=Role.USER, content="现在是 16:35。林小满 对你说：周末一起去图书馆复习好不好？"),
+                Message(role=Role.ASSISTANT, content="好呀，那约周六上午！"),
+            ],
+            make_session_id(_LANE, _PERSONA, "2026-06-11"): [],
+        },
+        "acts": [_act()],
+        "chats": [],
+        "npc_events": [],
+        "rel_pages": {},
+        "day_page": None,
+        "marks": [],
+        "costs": [],
+        "page_lookups": [],
+        "npc_windows": [],
+    }
+
+    async def fake_load_session(session_id):
+        return list(state["sessions"].get(session_id, []))
+
+    async def fake_acts(*, lane, persona_id, start_iso, end_iso):
+        return list(state["acts"])
+
+    async def fake_chats(*, persona_id, since_ms, until_ms, per_chat_limit):
+        return list(state["chats"])
+
+    async def fake_npc_speech(*, lane, persona_id, start_iso, end_iso):
+        state["npc_windows"].append(
+            {"lane": lane, "persona_id": persona_id, "start": start_iso, "end": end_iso}
+        )
+        return list(state["npc_events"])
+
+    async def fake_rel_pages(*, lane, persona_id, other_user_ids):
+        state["page_lookups"].append(list(other_user_ids))
+        return {
+            k: v for k, v in state["rel_pages"].items() if k in other_user_ids
+        }
+
+    async def fake_day_page(*, lane, persona_id, date):
+        return state["day_page"]
+
+    async def fake_day_page_exists(*, lane, persona_id, date):
+        return state["day_page"] is not None
+
+    async def fake_mark(*, lane, persona_id, date):
+        state["marks"].append({"lane": lane, "persona_id": persona_id, "date": date})
+
+    async def fake_cost(**kwargs):
+        state["costs"].append(kwargs)
+
+    async def fake_load_persona(persona_id):
+        from app.memory._persona import PersonaContext
+
+        return PersonaContext(
+            persona_id=persona_id, display_name="她自己", persona_lite="一段人设"
+        )
+
+    monkeypatch.setattr(review_mod, "load_session", fake_load_session)
+    monkeypatch.setattr(review_mod, "list_persona_acts_between", fake_acts)
+    monkeypatch.setattr(review_mod, "find_persona_spoken_chats_in_window", fake_chats)
+    monkeypatch.setattr(
+        review_mod, "list_persona_npc_speech_in_window", fake_npc_speech
+    )
+    monkeypatch.setattr(review_mod, "read_relationship_pages", fake_rel_pages)
+    monkeypatch.setattr(review_mod, "read_day_page", fake_day_page)
+    monkeypatch.setattr(review_mod, "day_page_exists", fake_day_page_exists)
+    monkeypatch.setattr(review_mod, "mark_day_reviewed", fake_mark)
+    monkeypatch.setattr(review_mod, "record_round_cost", fake_cost)
+    monkeypatch.setattr(review_mod, "load_persona", fake_load_persona)
+    return state
+
+
+def _written_page() -> DayPage:
+    return DayPage(
+        lane=_LANE,
+        persona_id=_PERSONA,
+        date=_TARGET,
+        narrative="这一天留下来的几笔。",
+        written_at=_NOW.isoformat(),
+    )
+
+
+def _mock_run(monkeypatch, stub_io):
+    captured: dict = {}
+
+    async def fake_run(
+        self, messages, *, prompt_vars=None, context=None, session_id=None,
+        max_retries=2,
+    ):
+        captured["messages"] = messages
+        captured["context"] = context
+        stub_io["day_page"] = _written_page()
+        return Message(role=Role.ASSISTANT, content="")
+
+    monkeypatch.setattr(review_mod.Agent, "run", fake_run)
+    return captured
+
+
+async def _review(**overrides):
+    kwargs = {
+        "lane": _LANE,
+        "persona_id": _PERSONA,
+        "target_date": _TARGET,
+        "now": _NOW,
+        "trace_session_id": "sess-1",
+        "trigger": "sleep",
+    }
+    kwargs.update(overrides)
+    await review_mod.run_day_review(**kwargs)
+
+
+def _blob(captured) -> str:
+    return "".join(m.text() for m in captured["messages"])
+
+
+# ---------------------------------------------------------------------------
+# NPC speech 读取窗口：和 act 同一个生活日窗口
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_npc_speech_query_receives_living_day_window(stub_io, monkeypatch):
+    """NPC speech 查询接的是生活日窗口 [target 04:00 CST, 触发时刻]（同 act 口径）。"""
+    stub_io["npc_events"] = [_npc_event()]
+    _mock_run(monkeypatch, stub_io)
+
+    await _review()
+
+    win = stub_io["npc_windows"][0]
+    assert win["lane"] == _LANE and win["persona_id"] == _PERSONA
+    assert win["start"] == "2026-06-10T04:00:00+08:00"
+    assert win["end"] == _NOW.isoformat()
+
+
+# ---------------------------------------------------------------------------
+# NPC 互动进证据：带 npc:名字 机读键，让模型知道写哪个 other_user_id
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_npc_interaction_surfaced_with_machine_key(stub_io, monkeypatch):
+    """这一天来访过的 NPC：原话 + ``npc:名字`` 机读键明确进证据（对齐真人证据标 user_id）。"""
+    stub_io["npc_events"] = [
+        _npc_event(npc_name="林小满", summary="绫奈周末一起去图书馆复习好不好？")
+    ]
+    captured = _mock_run(monkeypatch, stub_io)
+
+    await _review()
+
+    blob = _blob(captured)
+    assert "林小满" in blob, "NPC 名字要出现在证据里"
+    assert "周末一起去图书馆复习" in blob, "NPC 原话要进证据"
+    assert "npc:林小满" in blob, (
+        "关系页要写给 npc:林小满，证据里必须明确给出这个机读键——"
+        "不让模型从被剥过前缀的 transcript 文本里猜"
+    )
+
+
+@pytest.mark.asyncio
+async def test_no_npc_interaction_says_so(stub_io, monkeypatch):
+    """这一天没有 NPC 来访 → 证据如实说，不冒充。
+
+    检查范围限在【这一天来找过你的人】这节**证据**里——任务指令本身（第三刀收口）
+    会讲到 NPC 那页的 other_user_id 用 ``npc:名字`` 键这个约定，instruction 文本里
+    出现 ``npc:`` 是正常的；这里要钉的是「没人来访时证据里不冒充 npc 键」，所以只看
+    证据节、不看整段 blob（否则会把合法的指令措辞误判成冒充）。
+    """
+    stub_io["npc_events"] = []
+    captured = _mock_run(monkeypatch, stub_io)
+
+    await _review()
+
+    blob = _blob(captured)
+    # 切出【这一天来找过你的人】这节**证据**（到下一个【段标题前）。指令措辞里也会
+    # 引用这个段名（讲 NPC 关系页的约定），所以用 rsplit 取**最后一次**出现的那处
+    # ——那才是真正的证据节标题（指令在前、证据在后）。
+    marker = "【这一天来找过你的人】"
+    assert marker in blob, "证据应有【这一天来找过你的人】这节"
+    after = blob.rsplit(marker, 1)[1]
+    npc_section = after.split("【", 1)[0]
+    assert "npc:" not in npc_section, "没 NPC 互动时这节证据里不该硬塞 npc 键"
+    assert "没有名册里的人来找过你" in npc_section, "没 NPC 来访应如实说，不冒充"
+
+
+# ---------------------------------------------------------------------------
+# 跨天累积命门：NPC 的旧关系页和真人一道读回作证据
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_npc_old_relationship_page_read_back_as_evidence(stub_io, monkeypatch):
+    """跨天累积命门：来访过的 NPC 的旧关系页（npc:名字 键）和真人 partner 一道读回。"""
+    stub_io["npc_events"] = [_npc_event(npc_name="林小满")]
+    stub_io["rel_pages"] = {
+        "npc:林小满": RelationshipPage(
+            lane=_LANE,
+            persona_id=_PERSONA,
+            other_user_id="npc:林小满",
+            narrative="她是我同桌，总能在我慌的时候稳住我。",
+            written_at="2026-06-09T23:40:00+08:00",
+        )
+    }
+    captured = _mock_run(monkeypatch, stub_io)
+
+    await _review()
+
+    # 旧 NPC 关系页确实被请求读回了（other_user_ids 含 npc:林小满）
+    assert any("npc:林小满" in ids for ids in stub_io["page_lookups"]), (
+        "NPC 必须被纳入「读回旧关系页」的对象集，否则她重写时手里没有上一页、无法跨天累积"
+    )
+    # 而且读回的旧页全文进了证据（重写底稿）
+    blob = _blob(captured)
+    assert "她是我同桌" in blob, "NPC 旧关系页全文必须作为重写底稿进证据"
+    assert "2026-06-09T23:40:00+08:00" in blob, "NPC 旧关系页必须带 written_at 标注"
+
+
+@pytest.mark.asyncio
+async def test_npc_and_human_partners_both_read_back(stub_io, monkeypatch):
+    """真人 partner 与 NPC partner 都纳入读回对象集（两类不互相挤掉）。"""
+
+    def _msg(text, user_id, username, role="user"):
+        return CommonMessageRecord(
+            message_id="m",
+            user_id=user_id,
+            username=username,
+            content=json.dumps({"v": 2, "text": text, "items": []}, ensure_ascii=False),
+            role=role,
+            root_message_id="m",
+            reply_message_id=None,
+            chat_id="chat-a",
+            chat_type="group",
+            create_time=1781190000000,
+        )
+
+    stub_io["chats"] = [
+        (
+            "chat-a",
+            "一家人",
+            [(_msg("哥哥来消息了", "user-1", "哥哥"), None)],
+        )
+    ]
+    stub_io["npc_events"] = [_npc_event(npc_name="林小满")]
+    _mock_run(monkeypatch, stub_io)
+
+    await _review()
+
+    all_looked_up = {oid for ids in stub_io["page_lookups"] for oid in ids}
+    assert "user-1" in all_looked_up, "真人 partner 仍要读回"
+    assert "npc:林小满" in all_looked_up, "NPC partner 也要读回"
+
+
+@pytest.mark.asyncio
+async def test_same_npc_visiting_twice_deduped(stub_io, monkeypatch):
+    """同一 NPC 一天来访多次 → 读回对象集里只出现一次（去重，同真人 partner 口径）。"""
+    stub_io["npc_events"] = [
+        _npc_event(
+            npc_name="林小满",
+            summary="第一次：周末一起复习？",
+            occurred_at="2026-06-10T16:30:00+08:00",
+            event_id="n1",
+        ),
+        _npc_event(
+            npc_name="林小满",
+            summary="第二次：那约周六上午吧",
+            occurred_at="2026-06-10T18:00:00+08:00",
+            event_id="n2",
+        ),
+    ]
+    _mock_run(monkeypatch, stub_io)
+
+    await _review()
+
+    all_looked_up = [oid for ids in stub_io["page_lookups"] for oid in ids]
+    assert all_looked_up.count("npc:林小满") == 1, "同一 NPC 多次来访只读回一次旧页"
+
+
+# ---------------------------------------------------------------------------
+# 空证据护栏：只有 NPC 互动也算「这一天有经历」、照常跑
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_only_npc_interaction_still_reviews(stub_io, monkeypatch):
+    """意识流 / act / 真人聊天全空、但有 NPC 来访 → 仍算这一天有经历，照常回顾。
+
+    NPC 互动是真实经历的一部分；空证据护栏不能把「只有 NPC 来访的一天」误判成
+    「没有可回看的经历」而跳过——否则 NPC 关系永远长不起来。
+    """
+    stub_io["sessions"] = {}
+    stub_io["acts"] = []
+    stub_io["chats"] = []
+    stub_io["npc_events"] = [_npc_event(npc_name="林小满")]
+    captured = _mock_run(monkeypatch, stub_io)
+
+    await _review()
+
+    assert "messages" in captured, "只有 NPC 来访的一天也要回顾，不被空证据护栏跳过"
+    assert stub_io["marks"] == [
+        {"lane": _LANE, "persona_id": _PERSONA, "date": _TARGET}
+    ]

--- a/apps/agent-service/tests/nodes/test_life_wake.py
+++ b/apps/agent-service/tests/nodes/test_life_wake.py
@@ -861,6 +861,40 @@ async def test_speech_rendered_separately_from_surroundings_and_dynamics(
 
 
 @pytest.mark.asyncio
+async def test_npc_speech_rendered_with_clean_name_not_machine_prefix(
+    patched, monkeypatch
+):
+    """NPC 来访（source=npc:名字、kind=speech）→ stimulus 呈现「林小满 对你说：原话」。
+
+    NPC 层第二刀：world 以具名 NPC 身份投的 event，source 在信箱里是机器约定
+    ``npc:林小满``（对齐第一刀 npc_name + 关系页 npc:xxx），但喂给模型时要呈现成干净
+    的人名「林小满 对你说：…」——``npc:`` 是机读前缀（关系页 keying 用），不该漏给模型
+    看。她据此识别「是 NPC 林小满来找我」：不被当真人（真人是 user:xxx / kind=external、
+    走离散动静段）、也不被当 world 环境动静（ambient）。
+    """
+    patched["unread"] = [
+        _envelope(
+            "npc1",
+            "绫奈周末有空吗？一起去图书馆吧。",
+            kind=EVENT_KIND_SPEECH,
+            source="npc:林小满",
+            persona_id="ayana",
+        ),
+    ]
+    _FakeAgent.install(monkeypatch, script=None)
+
+    await lw.life_wake_node(EventArrived(lane="coe-t3", persona_id="ayana"))
+
+    msg_blob = "".join(m.text() for m in _FakeAgent.last_run()["messages"])
+    # 原话原样进 stimulus
+    assert "绫奈周末有空吗？一起去图书馆吧。" in msg_blob
+    # 呈现成「林小满 对你说」（speech 段，不混进离散动静 / 周遭底框）
+    assert "林小满 对你说" in msg_blob
+    # 机读前缀 npc: 不漏给模型
+    assert "npc:林小满" not in msg_blob, "npc: 机读前缀不该出现在喂给模型的 stimulus 里"
+
+
+@pytest.mark.asyncio
 async def test_acts_when_model_calls_it(patched, monkeypatch):
     """模型在循环里调 act → 落 ActPerformed，per-act id 从本轮 base act_id 派生。"""
     patched["unread"] = [_envelope("e1", "天亮了")]

--- a/apps/agent-service/tests/world/test_npc_roster.py
+++ b/apps/agent-service/tests/world/test_npc_roster.py
@@ -1,0 +1,263 @@
+"""NPC 名册（NPCRoster）— 世界里有名有姓的固定人物（NPC 层第一刀）.
+
+world 推演时除了三姐妹和用户，还能看到一份「世界的固定人物」名册——7 个 NPC
+（绫奈 3 / 赤尾 2 / 千凪 2），每个 NPC 一行。照 WorldArc / RelationshipPage 模板
+（lane keyed + 多 Key + Version、append-only、读最新一版、整篇重写——演化层更新某个
+NPC 直接 append 那一行的新版）。
+
+钉死的语义（docstring 层契约，本文件断言数据层行为）：
+
+  * 自然键 ``(lane, npc_name)``：泳道隔离（coe / ppe 绝不能覆盖 prod 的名册）+
+    每个 NPC 一条链。``npc_name`` 是 NPC 的稳定标识（名字），跟关系页 other_user_id
+    的 ``npc:xxx`` 约定对齐（本刀只落名字，event / 关系页是后面的刀）。
+  * ``relates_to`` 是该 NPC 主要关联哪个姐妹的 persona_id（akao / chinagi / ayana），
+    world 据此把名册归到对应姐妹。
+  * ``sketch`` 是性格底色 + 会冒什么事的自然语言速写（不拆结构化字段）。
+  * ``version`` 让演化层更新某个 NPC 时 append 新版、读最新一版（与 sibling 同模板）。
+  * seed：7 个种子 NPC 一次性灌库，逐 NPC 幂等（CAS expected_current_ver=0，
+    重跑无害、并发双跑也只落一行），照 :func:`seed_persona_chain` 的先例。
+
+持久化用真实 Postgres（testcontainers）——版本链 / 多 Key / 隔离的正确性全在
+"能不能 append 进去、能不能按 (lane, name) 读回、list 一个 lane 全部 NPC、seed
+能否端到端落库"，mock pg 等于什么都没测。
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.world.npc_roster import (
+    NPC_SEEDS,
+    NPCRoster,
+    list_npc_roster,
+    read_npc,
+    seed_npc_roster,
+    write_npc,
+)
+from tests.runtime.conftest import migrate
+
+
+@pytest.fixture
+async def roster_db(test_db):
+    await migrate(NPCRoster, test_db)
+    yield test_db
+
+
+# ---------------------------------------------------------------------------
+# Data 骨架（泳道隔离 + 自然键 + 不撞框架保留列）
+# ---------------------------------------------------------------------------
+
+
+def test_npc_roster_key_is_lane_and_name():
+    """名册自然键 = (lane, npc_name)：泳道隔离 + 每个 NPC 一条链。"""
+    from app.runtime.data import key_fields
+
+    assert set(key_fields(NPCRoster)) == {"lane", "npc_name"}
+
+
+def test_npc_roster_has_version_for_evolution():
+    """名册带 Version：演化层更新某个 NPC 时 append 新版、读最新一版。"""
+    from app.runtime.data import version_field
+
+    assert version_field(NPCRoster) == "version"
+
+
+def test_npc_roster_fields_avoid_framework_reserved_columns():
+    """字段名不撞框架保留列（id / created_at / updated_at / dedup_hash）。
+
+    三步检查第①步：字段名绝不撞 migrator 保留列（否则建表 / migrate 会冲突）。
+    """
+    reserved = {"id", "created_at", "updated_at", "dedup_hash"}
+    assert not reserved & set(NPCRoster.model_fields)
+    # 业务字段齐全（relates_to 归类 + sketch 速写）。
+    assert "relates_to" in NPCRoster.model_fields
+    assert "sketch" in NPCRoster.model_fields
+
+
+def test_npc_roster_table_name_is_data_npc_roster():
+    """表名 = data_npc_roster（framework 命名约定：data_ + snake_case 类名）。"""
+    from app.runtime.migrator import _table_name
+
+    assert _table_name(NPCRoster) == "data_npc_roster"
+
+
+# ---------------------------------------------------------------------------
+# 种子名册：7 个 NPC（绫奈 3 / 赤尾 2 / 千凪 2），按所属姐妹归类
+# ---------------------------------------------------------------------------
+
+
+def test_npc_seeds_count_and_distribution():
+    """7 个种子：绫奈(ayana) 3 个、赤尾(akao) 2 个、千凪(chinagi) 2 个。"""
+    assert len(NPC_SEEDS) == 7
+    by_sister: dict[str, int] = {}
+    for s in NPC_SEEDS:
+        by_sister[s.relates_to] = by_sister.get(s.relates_to, 0) + 1
+    assert by_sister == {"ayana": 3, "akao": 2, "chinagi": 2}
+
+
+def test_npc_seeds_relates_to_only_three_sisters():
+    """relates_to 取值只能是三姐妹之一（akao / chinagi / ayana）。"""
+    assert {s.relates_to for s in NPC_SEEDS} <= {"akao", "chinagi", "ayana"}
+
+
+def test_npc_seeds_names_unique_and_expected():
+    """7 个种子名字唯一、且就是 spec 钉死的 7 个。"""
+    names = [s.npc_name for s in NPC_SEEDS]
+    assert len(set(names)) == 7
+    assert set(names) == {
+        "林小满",
+        "顾舟",
+        "沈乐",
+        "陈鹿",
+        "池夏",
+        "许念",
+        "苏晴",
+    }
+
+
+def test_npc_seeds_have_nonempty_sketch():
+    """每个种子都有非空速写（性格底色 + 会冒什么事）。"""
+    for s in NPC_SEEDS:
+        assert s.sketch.strip(), f"{s.npc_name} 必须有非空速写"
+
+
+# ---------------------------------------------------------------------------
+# 真 PG 端到端（写 / 读 / list / 版本链 / 隔离）— 三步检查第③步
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+async def test_write_then_read_npc(roster_db):
+    """写一个 NPC → 按 (lane, npc_name) 读回最新（端到端 schema 能建、能读写）。"""
+    await write_npc(
+        lane="coe-t1",
+        npc_name="林小满",
+        relates_to="ayana",
+        sketch="同桌兼死党，会照顾爱慌的绫奈。",
+    )
+
+    npc = await read_npc(lane="coe-t1", npc_name="林小满")
+    assert npc is not None
+    assert npc.relates_to == "ayana"
+    assert "同桌" in npc.sketch
+
+
+@pytest.mark.integration
+async def test_read_npc_cold_start_returns_none(roster_db):
+    """没写过的 NPC 读回 None（名册里没这个人）。"""
+    assert await read_npc(lane="coe-t1", npc_name="查无此人") is None
+
+
+@pytest.mark.integration
+async def test_npc_rewrite_appends_versions_and_reads_latest(roster_db):
+    """同一个 NPC 整篇重写：版本递增、历史保留、读侧只认最新一版（演化层用）。"""
+    from app.runtime.persist import select_all_versions
+
+    keys = {"lane": "coe-t1", "npc_name": "林小满"}
+    await write_npc(**keys, relates_to="ayana", sketch="第一版：刚转学来的同桌。")
+    await write_npc(**keys, relates_to="ayana", sketch="第二版：成了无话不谈的死党。")
+
+    versions = await select_all_versions(NPCRoster, keys)
+    assert [n.version for n in versions] == [1, 2], (
+        "名册是 append-only 版本链：版本逐次递增、旧版保留"
+    )
+    latest = await read_npc(**keys)
+    assert latest.sketch == "第二版：成了无话不谈的死党。"
+
+
+@pytest.mark.integration
+async def test_list_npc_roster_returns_latest_per_npc(roster_db):
+    """list 一个 lane 全部 NPC：每个 NPC 只取最新一版；空名册返回空表。"""
+    assert await list_npc_roster(lane="coe-t1") == []
+
+    await write_npc(
+        lane="coe-t1", npc_name="林小满", relates_to="ayana", sketch="旧版。"
+    )
+    await write_npc(
+        lane="coe-t1", npc_name="林小满", relates_to="ayana", sketch="新版。"
+    )
+    await write_npc(
+        lane="coe-t1", npc_name="许念", relates_to="chinagi", sketch="同事。"
+    )
+
+    roster = await list_npc_roster(lane="coe-t1")
+    by_name = {n.npc_name: n for n in roster}
+    assert set(by_name) == {"林小满", "许念"}
+    assert by_name["林小满"].sketch == "新版。", "每个 NPC 只取最新一版"
+
+
+@pytest.mark.integration
+async def test_npc_roster_lane_isolation(roster_db):
+    """泳道隔离：coe 的名册绝不覆盖 / 泄露到 prod。"""
+    await write_npc(
+        lane="coe-t1", npc_name="林小满", relates_to="ayana", sketch="coe 的一个人。"
+    )
+
+    assert await read_npc(lane="prod", npc_name="林小满") is None
+    assert await list_npc_roster(lane="prod") == []
+
+
+# ---------------------------------------------------------------------------
+# seed：7 个种子端到端落库（逐 NPC 幂等、泳道隔离）— 三步检查第③步
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+async def test_seed_writes_all_seven_npcs(roster_db):
+    """seed 把 7 个种子全部落进指定 lane，list 能读回全 7 个。"""
+    await seed_npc_roster(lane="coe-t1")
+
+    roster = await list_npc_roster(lane="coe-t1")
+    assert len(roster) == 7
+    assert {n.npc_name for n in roster} == {s.npc_name for s in NPC_SEEDS}
+    # 内容对齐种子（relates_to / sketch 落对）。
+    by_name = {n.npc_name: n for n in roster}
+    for s in NPC_SEEDS:
+        assert by_name[s.npc_name].relates_to == s.relates_to
+        assert by_name[s.npc_name].sketch == s.sketch
+
+
+@pytest.mark.integration
+async def test_seed_is_idempotent_per_npc(roster_db):
+    """seed 重跑无害：逐 NPC CAS 幂等，第二次跑不再 append 新版（版本不涨）。"""
+    from app.runtime.persist import select_all_versions
+
+    await seed_npc_roster(lane="coe-t1")
+    await seed_npc_roster(lane="coe-t1")
+
+    # 每个 NPC 仍只有一版（seed 第二次零操作，不 append v2）。
+    for s in NPC_SEEDS:
+        versions = await select_all_versions(
+            NPCRoster, {"lane": "coe-t1", "npc_name": s.npc_name}
+        )
+        assert [n.version for n in versions] == [1], (
+            f"{s.npc_name} seed 重跑应幂等、不 append 新版，实际 {[n.version for n in versions]}"
+        )
+
+
+@pytest.mark.integration
+async def test_seed_does_not_overwrite_evolved_npc(roster_db):
+    """seed 对已演化（链非空）的 NPC 零操作：不把演化后的版本盖回出厂速写。"""
+    # 演化层先把林小满 append 了一版（链非空）。
+    await write_npc(
+        lane="coe-t1",
+        npc_name="林小满",
+        relates_to="ayana",
+        sketch="演化后的速写，绝不该被 seed 盖回。",
+    )
+
+    await seed_npc_roster(lane="coe-t1")
+
+    latest = await read_npc(lane="coe-t1", npc_name="林小满")
+    assert latest.sketch == "演化后的速写，绝不该被 seed 盖回。", (
+        "seed 是 CAS 幂等（仅链空时灌）：链非空的 NPC 绝不被出厂速写盖回"
+    )
+
+
+@pytest.mark.integration
+async def test_seed_lane_isolation(roster_db):
+    """seed 指定 lane：只落进该 lane，绝不污染别的泳道。"""
+    await seed_npc_roster(lane="coe-t1")
+
+    assert await list_npc_roster(lane="prod") == []
+    assert await list_npc_roster(lane="coe-other") == []

--- a/apps/agent-service/tests/world/test_world_engine.py
+++ b/apps/agent-service/tests/world/test_world_engine.py
@@ -115,17 +115,18 @@ def _stub_state(monkeypatch):
     close_calls: list[dict] = []
 
     async def fake_record_world_round_close(
-        *, lane, advance_cursor_to, materials_ingested_date
+        *, lane, advance_cursor_to, materials_ingested_date, roster_ingested_date=None
     ):
         # 正常成功收口走这个统一收口：既推游标（advance_cursor_to 非 None 时）又标记
-        # 底料已纳入（materials_ingested_date 非 None 时），一次 append。这里只记录调用，
-        # 同时把"推进游标"那部分镜像进 _test_cursor_calls，保持旧用例（断言游标推进）
+        # 底料 / 名册已纳入（对应日期非 None 时），一次 append。这里只记录调用，同时
+        # 把"推进游标"那部分镜像进 _test_cursor_calls，保持旧用例（断言游标推进）
         # 不动——它们仍能断言"游标推到本批末尾"。
         close_calls.append(
             {
                 "lane": lane,
                 "advance_cursor_to": advance_cursor_to,
                 "materials_ingested_date": materials_ingested_date,
+                "roster_ingested_date": roster_ingested_date,
             }
         )
         if advance_cursor_to is not None:
@@ -153,6 +154,24 @@ def _stub_state(monkeypatch):
         arc_reads.append(lane)
         return None
 
+    roster_reads: list[str] = []
+
+    async def fake_list_npc_roster(*, lane):
+        # 默认名册为空（[] = 还没 seed）：需要断言名册段的用例自己覆写这个桩
+        # （monkeypatch.setattr engine_mod.list_npc_roster）。
+        roster_reads.append(lane)
+        return []
+
+    seed_calls: list[str] = []
+
+    async def fake_seed_npc_roster(*, lane):
+        # 种子名册的生产自动入口（必改 1）每天首醒会调一次 seed（默认快照
+        # roster_ingested_date=None → 视作首醒），真打 PG 的 CAS insert。专测引擎机制
+        # 的用例不关心 seed 本身，统一打成 no-op，让单测无库也安静。需要断言 seed
+        # 行为的用例自己覆写这个桩（monkeypatch.setattr engine_mod.seed_npc_roster）。
+        seed_calls.append(lane)
+        return 0
+
     reflect_calls: list[dict] = []
 
     async def fake_run_arc_reflection(**kwargs):
@@ -161,7 +180,25 @@ def _stub_state(monkeypatch):
         # 自己覆写这个桩（monkeypatch.setattr engine_mod.run_arc_reflection）。
         reflect_calls.append(kwargs)
 
+    # 收口后两步旁路（记成本 + transcript 沉淀折叠）都会真打 PG（record_round_cost
+    # 落 thinking token、fold_session 读 session transcript），它们各自 fail-open（只
+    # log warning 不抛），所以**不打桩也不会让用例 fail**——但每轮都对真库发一次连接
+    # 尝试（无库环境徒增噪声 + 慢）。专测引擎机制的用例不关心成本 / 折叠，统一在这里
+    # 打成 no-op，让单测边界干净、无库也安静（codex 建议 2）。需要断言成本 / 折叠行为
+    # 的用例自己覆写这两个桩。
+    cost_calls: list[dict] = []
+
+    async def fake_record_round_cost(**kwargs):
+        cost_calls.append(kwargs)
+
+    fold_calls: list[str] = []
+
+    async def fake_fold_session(session_id, policy):
+        fold_calls.append(session_id)
+
     monkeypatch.setattr(engine_mod, "run_arc_reflection", fake_run_arc_reflection)
+    monkeypatch.setattr(engine_mod, "record_round_cost", fake_record_round_cost)
+    monkeypatch.setattr(engine_mod, "fold_session", fake_fold_session)
     monkeypatch.setattr(engine_mod, "read_world_state", fake_read_world_state)
     monkeypatch.setattr(engine_mod, "renotify_unread", fake_renotify_unread)
     monkeypatch.setattr(engine_mod, "list_recent_acts", fake_list_recent_acts)
@@ -173,10 +210,16 @@ def _stub_state(monkeypatch):
         engine_mod, "find_daily_materials", fake_find_daily_materials
     )
     monkeypatch.setattr(engine_mod, "read_world_arc", fake_read_world_arc)
+    monkeypatch.setattr(engine_mod, "list_npc_roster", fake_list_npc_roster)
+    monkeypatch.setattr(engine_mod, "seed_npc_roster", fake_seed_npc_roster)
 
     engine_mod._test_materials_calls = materials_calls  # type: ignore[attr-defined]
     engine_mod._test_arc_reads = arc_reads  # type: ignore[attr-defined]
+    engine_mod._test_roster_reads = roster_reads  # type: ignore[attr-defined]
     engine_mod._test_reflect_calls = reflect_calls  # type: ignore[attr-defined]
+    engine_mod._test_cost_calls = cost_calls  # type: ignore[attr-defined]
+    engine_mod._test_fold_calls = fold_calls  # type: ignore[attr-defined]
+    engine_mod._test_seed_calls = seed_calls  # type: ignore[attr-defined]
 
     engine_mod._test_renotify_calls = renotify_calls  # type: ignore[attr-defined]
     engine_mod._test_cursor_calls = cursor_calls  # type: ignore[attr-defined]
@@ -1448,16 +1491,16 @@ async def test_placeholder_snapshot_gate_behaves_like_cold_start(monkeypatch):
 async def test_world_instruction_does_not_enumerate_update_arc():
     """续写指令**不再**枚举 update_arc——翻页归反思独占（工具集物理隔离的 prompt 面）。
 
-    续写工具回到四个（notify / update_world / sense / sleep）。世界阶段仍是续写的输入
-    （【世界阶段】段保留），但续写无手碰世界阶段：指令里不能再有 update_arc 的使用
-    指令，否则模型会去调一个不存在的工具。
+    续写工具是五个（notify / update_world / sense / npc_visit / sleep）。世界阶段仍是
+    续写的输入（【世界阶段】段保留），但续写无手碰世界阶段：指令里不能再有 update_arc
+    的使用指令，否则模型会去调一个不存在的工具。
     """
     instruction = engine_mod.world_loop_instruction()
     assert "update_arc" not in instruction, (
         "续写指令不得枚举 update_arc（翻页已归反思环节独占）"
     )
-    assert "五个工具" not in instruction, "续写工具已回到四个，指令不能再写「五个工具」"
-    assert "四个工具" in instruction, "工具清单应明确是四个（update_arc 已移出）"
+    assert "六个工具" not in instruction, "续写工具是五个，指令不能再写「六个工具」"
+    assert "五个工具" in instruction, "工具清单应明确是五个（update_arc 已移出，含 npc_visit）"
 
 
 # ---------------------------------------------------------------------------
@@ -2100,8 +2143,8 @@ async def test_world_instruction_enumerates_sense_tool():
     instruction = engine_mod.world_loop_instruction()
     assert "sense" in instruction, "循环指令必须枚举 sense 工具（否则模型不会调它）"
     assert "三个工具" not in instruction, "工具早已不止三个，指令不能再写「三个工具」"
-    assert "四个工具" in instruction, (
-        "工具清单应明确是四个（含 sense；update_arc 已归反思环节）"
+    assert "五个工具" in instruction, (
+        "工具清单应明确是五个（含 sense / npc_visit；update_arc 已归反思环节）"
     )
     # sense 是逐角色（per-person）投周遭客观切片：引导逐角色 + 信息差
     assert ("逐角色" in instruction) or ("每个角色" in instruction) or ("单个" in instruction), (
@@ -2114,6 +2157,37 @@ async def test_world_instruction_enumerates_sense_tool():
     assert ("周遭" in instruction) or ("身边" in instruction), (
         "sense 引导应说明投的是她此刻的周遭客观切片"
     )
+
+
+@pytest.mark.asyncio
+async def test_world_instruction_enumerates_npc_visit_tool():
+    """必改：world_loop_instruction 必须把 NPC 层的 npc_visit 枚举进工具清单。
+
+    npc_visit 让 world 以具名 NPC 身份投一件指向某姐妹的 event（同学约她、同事找她
+    那种）。但循环指令若不枚举它，真实模型就不知道有这个工具、根本不会调 —— NPC 层
+    「world 推具名 NPC 来撞姐妹」形同虚设。所以指令必须：
+
+      * 明确枚举 npc_visit 工具（按名字）+ 它的两个内容参数 what_npc_says / world_fact；
+      * 钉死 world_fact 是客观可感那一面、**绝不写情绪 / 绝不写 what_npc_says 的私密
+        原话**（与 sense / notify 的客观投影口吻一致）；
+      * 守「引导而非强制」的口吻：谁来 / 来不来 / 来干嘛由 world 按世界此刻自然推演、
+        不定时不机械，安静时不硬造 NPC 来访；
+      * 提醒 npc_visit 已把 world_fact 写进世界叙述，随后 update_world 要延续别覆盖丢；
+      * 说明名册之外的临时路人也可以用它来一下。
+    """
+    instruction = engine_mod.world_loop_instruction()
+    assert "npc_visit" in instruction, "循环指令必须枚举 npc_visit 工具（否则模型不会调它）"
+    assert "what_npc_says" in instruction, "npc_visit 段应枚举 what_npc_says 参数"
+    assert "world_fact" in instruction, "npc_visit 段应枚举 world_fact 参数"
+    # world_fact 客观、绝不写情绪、绝不写私密原话
+    assert ("情绪" in instruction), "world_fact 守则应钉死绝不写情绪"
+    # 引导而非强制：自然推演、不定时不机械、安静别硬造
+    assert ("自然" in instruction) or ("推演" in instruction), (
+        "npc_visit 守则应是「由 world 自然推演」的引导口吻"
+    )
+    assert ("硬造" in instruction), "npc_visit 守则应说安静时别硬造 NPC 来访"
+    # 路人也能用它来一下（名册只是固定的几个人）
+    assert ("路人" in instruction), "npc_visit 段应说明名册之外的临时路人也可以用它"
 
 
 @pytest.mark.asyncio
@@ -2140,6 +2214,11 @@ async def test_world_loop_messages_carry_no_household_rhythm():
     ``household_rhythm()`` 就是重复的两处真相。撤掉后喂给循环的 user 消息里既不该有
     「作息节律」这个段标题，也不该出现节律里写死的客观坐标（千凪早起 / 赤尾睡到
     下午 / 绫奈上学）。
+
+    npc_visit 段同理：它讲「让一个固定 NPC 来找某个姐妹」这个工具的用法，``sister``
+    参数指向哪个姐妹用 persona_id，但**具体哪个 id 对应谁由 system prompt 一处承载**
+    —— 续写指令里不得硬编 akao / chinagi / ayana 这些 id 或三姐妹中文名（否则又成
+    两处真相）。
     """
     from app.world.engine import _world_loop_messages
 
@@ -2215,10 +2294,11 @@ async def test_world_instruction_has_no_world_setting():
             f"USER 层指令不该描述世界设定（谁是谁）：{setting!r}"
         )
     assert "作息" not in instruction, "USER 层指令不该描述作息（归 system 一处）"
-    # 仍是四工具行动指令（含 1C 新增的 sense 五官；update_arc 归反思）
+    # 仍是五工具行动指令（含 1C 新增的 sense 五官 + NPC 层的 npc_visit；update_arc 归反思）
     assert ("notify" in instruction) and ("update_world" in instruction)
     assert "update_arc" not in instruction
     assert "sense" in instruction
+    assert "npc_visit" in instruction
     assert "sleep" in instruction
 
 
@@ -2384,3 +2464,357 @@ async def test_world_cost_record_failure_does_not_fail_round(monkeypatch):
     assert engine_mod._test_cursor_calls == [
         {"lane": "coe-t2", "created_at": "c1", "act_id": "a1"}
     ], "记成本失败不该阻断游标推进"
+
+
+# ---------------------------------------------------------------------------
+# NPC 名册（NPC 层第一刀）：world 当天第一次醒把「世界的固定人物」名册纳入一次、
+# 进意识流，之后当天不再重喂（照 DailyMaterials 套路，但用独立的 roster 游标）。
+#
+# 今天名册非空 **且** WorldState.roster_ingested_date != 今天 → 纳入一次（拼进这轮
+# user 消息，按 relates_to 归到对应姐妹），收口标记 roster_ingested_date=今天；当天
+# 后续轮次（已纳入）不再重喂；名册为空（还没 seed）→ 不拼这段、不标记；纳入那轮崩溃
+# → 不误标记。
+# ---------------------------------------------------------------------------
+
+
+def _npc(*, lane="coe-t2", npc_name, relates_to, sketch, version=1):
+    """构造一条 NPCRoster（world list 出来的名册一行）。"""
+    from app.world.npc_roster import NPCRoster
+
+    return NPCRoster(
+        lane=lane,
+        npc_name=npc_name,
+        relates_to=relates_to,
+        sketch=sketch,
+        version=version,
+    )
+
+
+def _seed_roster(lane="coe-t2"):
+    """构造一份小名册（覆盖三姐妹各至少一个，验证按 relates_to 归类）。"""
+    return [
+        _npc(lane=lane, npc_name="林小满", relates_to="ayana", sketch="同桌兼死党。"),
+        _npc(lane=lane, npc_name="陈鹿", relates_to="akao", sketch="高中闺蜜。"),
+        _npc(lane=lane, npc_name="许念", relates_to="chinagi", sketch="同部门同事。"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_first_wake_today_with_roster_ingests_and_marks(monkeypatch):
+    """① 当天第一次醒、名册非空、未纳入 → 名册速写进 user 消息，且收口标记 roster_ingested_date=今天。"""
+    from app.infra import cst_time
+
+    today = cst_time.now_cst().strftime("%Y-%m-%d")
+    _snapshot_with(monkeypatch, roster_ingested_date=None)
+
+    async def roster(*, lane):
+        return _seed_roster(lane)
+
+    monkeypatch.setattr(engine_mod, "list_npc_roster", roster)
+    captured = _mock_run(monkeypatch)
+
+    await world_tick(WorldTick(lane="coe-t2", reason="heartbeat"))
+
+    blob = "".join(m.text() for m in captured["messages"])
+    assert "同桌兼死党。" in blob, "当天首醒名册非空应把速写纳入 world 的 USER 消息"
+    assert "高中闺蜜。" in blob
+    assert "同部门同事。" in blob
+
+    # 收口把 roster_ingested_date 标成今天（并进统一收口的同一次 append）。
+    assert engine_mod._test_close_calls, "纳入那轮收口必须走 record_world_round_close"
+    last = engine_mod._test_close_calls[-1]
+    assert last["roster_ingested_date"] == today, (
+        f"纳入那轮收口必须把 roster_ingested_date 标成今天 {today}，实际 {last}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_roster_section_groups_by_relates_to(monkeypatch):
+    """名册段按 relates_to 归到对应姐妹（同一姐妹的 NPC 归在她名下）。"""
+    _snapshot_with(monkeypatch, roster_ingested_date=None)
+
+    async def roster(*, lane):
+        return [
+            _npc(lane=lane, npc_name="林小满", relates_to="ayana", sketch="绫奈的同桌。"),
+            _npc(lane=lane, npc_name="顾舟", relates_to="ayana", sketch="绫奈的班长。"),
+            _npc(lane=lane, npc_name="许念", relates_to="chinagi", sketch="千凪的同事。"),
+        ]
+
+    monkeypatch.setattr(engine_mod, "list_npc_roster", roster)
+    captured = _mock_run(monkeypatch)
+
+    await world_tick(WorldTick(lane="coe-t2", reason="heartbeat"))
+
+    blob = "".join(m.text() for m in captured["messages"])
+    # 名字 + 速写都出现（归类是 by relates_to，呈现里至少要能看到这些人）。
+    for name in ("林小满", "顾舟", "许念"):
+        assert name in blob, f"名册段必须含 NPC 名字 {name}"
+    # 归类锚点：三姐妹的名字/标识出现在名册段（按 relates_to 分组的小标题）。
+    assert ("绫奈" in blob) or ("ayana" in blob), "名册段应按所属姐妹归类（绫奈/ayana）"
+    assert ("千凪" in blob) or ("chinagi" in blob), "名册段应按所属姐妹归类（千凪/chinagi）"
+
+
+@pytest.mark.asyncio
+async def test_first_wake_queries_roster_for_current_lane(monkeypatch):
+    """未纳入时按当前 lane list 名册（泳道隔离）。"""
+    _snapshot_with(monkeypatch, roster_ingested_date=None)
+
+    calls: list[str] = []
+
+    async def roster(*, lane):
+        calls.append(lane)
+        return _seed_roster(lane)
+
+    monkeypatch.setattr(engine_mod, "list_npc_roster", roster)
+    _mock_run(monkeypatch)
+
+    await world_tick(WorldTick(lane="coe-t2", reason="heartbeat"))
+
+    assert calls == ["coe-t2"], f"未纳入时必须按当前 lane list 名册，实际 {calls}"
+
+
+@pytest.mark.asyncio
+async def test_second_wake_same_day_does_not_refeed_roster(monkeypatch):
+    """② 同一天第二次醒（已纳入）→ 名册不再进 user 消息（不重喂）。"""
+    from app.infra import cst_time
+
+    today = cst_time.now_cst().strftime("%Y-%m-%d")
+    _snapshot_with(monkeypatch, roster_ingested_date=today)
+
+    secret_sketch = "这串只在名册速写里出现的死党标记"
+
+    async def roster(*, lane):
+        return [
+            _npc(lane=lane, npc_name="林小满", relates_to="ayana", sketch=secret_sketch),
+        ]
+
+    monkeypatch.setattr(engine_mod, "list_npc_roster", roster)
+    captured = _mock_run(monkeypatch)
+
+    await world_tick(WorldTick(lane="coe-t2", reason="heartbeat"))
+
+    blob = "".join(m.text() for m in captured["messages"])
+    assert secret_sketch not in blob, "当天已纳入过名册，第二次醒不该再把速写重喂"
+    # 不能用「【世界的固定人物】」这个段标题判定——它也出现在 npc_visit 工具指令里
+    # （讲「名册里的那些人」）。改判**纳入段的引导句**（_roster_section 渲染的那句、
+    # 只在喂入的名册段里出现、不在指令里）：没拼名册段它就不在 blob。
+    assert "下面是这个世界里有名有姓的固定人物" not in blob, (
+        "已纳入当天不再拼名册段（不重喂）"
+    )
+    # 收口不再标记（传 None，不重标）。
+    assert engine_mod._test_close_calls, "收口仍应走 record_world_round_close"
+    assert engine_mod._test_close_calls[-1]["roster_ingested_date"] is None, (
+        "已纳入当天收口不再标记 roster_ingested_date（传 None）"
+    )
+
+
+@pytest.mark.asyncio
+async def test_new_day_reingests_roster(monkeypatch):
+    """③ 跨到第二天（roster_ingested_date 是昨天）→ 重新纳入一次。"""
+    from app.infra import cst_time
+
+    today = cst_time.now_cst().strftime("%Y-%m-%d")
+    _snapshot_with(monkeypatch, roster_ingested_date="2000-01-01")
+
+    async def roster(*, lane):
+        return _seed_roster(lane)
+
+    monkeypatch.setattr(engine_mod, "list_npc_roster", roster)
+    captured = _mock_run(monkeypatch)
+
+    await world_tick(WorldTick(lane="coe-t2", reason="heartbeat"))
+
+    blob = "".join(m.text() for m in captured["messages"])
+    assert "同桌兼死党。" in blob, "跨天应重新纳入名册一次"
+    assert engine_mod._test_close_calls[-1]["roster_ingested_date"] == today, (
+        "跨天重新纳入那轮收口应把 roster_ingested_date 标成今天（不是昨天）"
+    )
+
+
+@pytest.mark.asyncio
+async def test_empty_roster_does_not_feed_or_mark(monkeypatch):
+    """④ 名册为空（还没 seed）→ 不拼名册段、不标记。"""
+    _snapshot_with(monkeypatch, roster_ingested_date=None)
+
+    async def empty_roster(*, lane):
+        return []
+
+    monkeypatch.setattr(engine_mod, "list_npc_roster", empty_roster)
+    captured = _mock_run(monkeypatch)
+
+    await world_tick(WorldTick(lane="coe-t2", reason="heartbeat"))
+
+    blob = "".join(m.text() for m in captured["messages"])
+    # 同上：判纳入段的引导句（只在喂入的名册段里、不在 npc_visit 指令里），不判段标题。
+    assert "下面是这个世界里有名有姓的固定人物" not in blob, "名册为空时不该拼名册段"
+    assert engine_mod._test_close_calls[-1]["roster_ingested_date"] is None, (
+        "名册为空时收口不该标记 roster_ingested_date"
+    )
+
+
+@pytest.mark.asyncio
+async def test_ingest_round_crash_does_not_mark_roster(monkeypatch):
+    """⑤ 纳入那轮崩溃（run 抛）→ 收口不执行，roster_ingested_date 不被误标记成已纳入。"""
+    _snapshot_with(monkeypatch, roster_ingested_date=None)
+
+    async def roster(*, lane):
+        return _seed_roster(lane)
+
+    async def boom_run(self, messages, *, prompt_vars=None, context=None,
+                       session_id=None, max_retries=2):
+        raise RuntimeError("model boom during roster ingest round")
+
+    monkeypatch.setattr(engine_mod, "list_npc_roster", roster)
+    monkeypatch.setattr(engine_mod.Agent, "run", boom_run)
+
+    with pytest.raises(RuntimeError):
+        await world_tick(WorldTick(lane="coe-t2", reason="heartbeat"))
+
+    assert engine_mod._test_close_calls == [], (
+        "纳入那轮崩溃时收口绝不该执行（roster_ingested_date 不被误标记）"
+    )
+
+
+@pytest.mark.asyncio
+async def test_roster_independent_of_materials_ingest(monkeypatch):
+    """名册与底料独立：今天没底料但名册非空 → 仍纳入名册（不被「无底料」连累）。"""
+    from app.infra import cst_time
+
+    today = cst_time.now_cst().strftime("%Y-%m-%d")
+    _snapshot_with(monkeypatch, roster_ingested_date=None, materials_ingested_date=None)
+
+    async def roster(*, lane):
+        return _seed_roster(lane)
+
+    async def no_materials(*, lane, date):
+        return None
+
+    monkeypatch.setattr(engine_mod, "list_npc_roster", roster)
+    monkeypatch.setattr(engine_mod, "find_daily_materials", no_materials)
+    captured = _mock_run(monkeypatch)
+
+    await world_tick(WorldTick(lane="coe-t2", reason="heartbeat"))
+
+    blob = "".join(m.text() for m in captured["messages"])
+    assert "同桌兼死党。" in blob, "今天没底料不该影响名册纳入（两件独立的事）"
+    assert "【今天的外部底料】" not in blob, "今天没底料不拼底料段"
+    last = engine_mod._test_close_calls[-1]
+    assert last["roster_ingested_date"] == today, "名册纳入照常标记"
+    assert last["materials_ingested_date"] is None, "没底料不标记底料"
+
+
+@pytest.mark.asyncio
+async def test_first_wake_today_seeds_roster_before_listing(monkeypatch):
+    """必改 1：当天第一次醒，纳入名册**之前**先 ensure seed 一次（生产自动入口）。
+
+    seed_npc_roster 原本只在测试里被手动调用、没有任何生产入口——表会一直空、首醒
+    list 永远得空名册、NPC 永不出场。这里给它接的自动入口是「world 当天第一次醒、
+    list 名册之前 ensure seed」（CAS 幂等、链非空不覆盖）。本测试钉：① 首醒那轮 seed
+    被调（按当前 lane）；② seed 在 list 之前发生（先灌再读，否则读到空表）。
+    """
+    _snapshot_with(monkeypatch, roster_ingested_date=None)
+
+    order: list[str] = []
+    seed_calls: list[str] = []
+
+    async def fake_seed(*, lane):
+        seed_calls.append(lane)
+        order.append("seed")
+        return 7
+
+    async def fake_list(*, lane):
+        order.append("list")
+        return _seed_roster(lane)
+
+    monkeypatch.setattr(engine_mod, "seed_npc_roster", fake_seed)
+    monkeypatch.setattr(engine_mod, "list_npc_roster", fake_list)
+    _mock_run(monkeypatch)
+
+    await world_tick(WorldTick(lane="coe-t2", reason="heartbeat"))
+
+    assert seed_calls == ["coe-t2"], (
+        f"当天首醒必须按当前 lane ensure seed 一次，实际 {seed_calls}"
+    )
+    assert order.index("seed") < order.index("list"), (
+        "seed 必须在 list 之前（先灌名册再读，否则首醒读到空表、NPC 永不出场）"
+    )
+
+
+@pytest.mark.asyncio
+async def test_first_wake_empty_lane_seeds_then_npcs_show_up(monkeypatch):
+    """必改 1 端到端意图：首醒前 seed 让原本空的名册有了人、当轮就纳入推演。
+
+    用真实 seed_npc_roster（不打桩），但 list 在 seed 后返回种子名册——证「seed 接进
+    首醒分支」让首醒读得到名册、拼进 user 消息。这是「seed 没接入生产路径」这条致命
+    缺陷修复后的正向证据：不再依赖测试手动 seed。
+    """
+    _snapshot_with(monkeypatch, roster_ingested_date=None)
+
+    seeded: dict = {"done": False}
+
+    async def fake_seed(*, lane):
+        seeded["done"] = True
+        return 7
+
+    async def fake_list(*, lane):
+        # seed 跑过后名册才有人（模拟 CAS seed 把 7 个种子灌进空表）。
+        return _seed_roster(lane) if seeded["done"] else []
+
+    monkeypatch.setattr(engine_mod, "seed_npc_roster", fake_seed)
+    monkeypatch.setattr(engine_mod, "list_npc_roster", fake_list)
+    captured = _mock_run(monkeypatch)
+
+    await world_tick(WorldTick(lane="coe-t2", reason="heartbeat"))
+
+    blob = "".join(m.text() for m in captured["messages"])
+    assert "下面是这个世界里有名有姓的固定人物" in blob, (
+        "首醒 seed 后名册有人、当轮就该纳入推演（修复前永远空、NPC 不出场）"
+    )
+    assert "同桌兼死党。" in blob
+
+
+@pytest.mark.asyncio
+async def test_second_wake_same_day_does_not_reseed_roster(monkeypatch):
+    """必改 1：当天已纳入过（第二次醒）→ 不再 seed（seed 不进每轮热路径）。
+
+    seed 只该在「首醒纳入名册」那个分支跑一次，不能每轮都调（哪怕 CAS 幂等也别白打
+    一次 DB）。当天已纳入（roster_ingested_date == 今天）时既不纳入名册、也不 seed。
+    """
+    from app.infra import cst_time
+
+    today = cst_time.now_cst().strftime("%Y-%m-%d")
+    _snapshot_with(monkeypatch, roster_ingested_date=today)
+
+    seed_calls: list[str] = []
+
+    async def fake_seed(*, lane):
+        seed_calls.append(lane)
+        return 0
+
+    monkeypatch.setattr(engine_mod, "seed_npc_roster", fake_seed)
+    _mock_run(monkeypatch)
+
+    await world_tick(WorldTick(lane="coe-t2", reason="heartbeat"))
+
+    assert seed_calls == [], (
+        f"当天已纳入过名册（第二次醒）不该再 seed（不进每轮热路径），实际 {seed_calls}"
+    )
+
+
+def test_render_roster_section_groups_by_sister():
+    """渲染器：把名册按 relates_to 归到对应姐妹、拼成「世界的固定人物」一段。"""
+    from app.world.engine import _roster_section
+
+    roster = [
+        _npc(npc_name="林小满", relates_to="ayana", sketch="绫奈的同桌。"),
+        _npc(npc_name="顾舟", relates_to="ayana", sketch="绫奈的班长。"),
+        _npc(npc_name="陈鹿", relates_to="akao", sketch="赤尾的闺蜜。"),
+    ]
+    section = _roster_section(roster)
+    # 名字 + 速写都在
+    for s in ("林小满", "绫奈的同桌。", "顾舟", "陈鹿", "赤尾的闺蜜。"):
+        assert s in section, f"名册段必须含 {s}"
+    # 同一姐妹的 NPC 归在一起（绫奈名下两人在赤尾名下那人之前/之后成块出现）。
+    # 至少验证按姐妹分组（出现姐妹的归类锚点）。
+    assert ("绫奈" in section) or ("ayana" in section)
+    assert ("赤尾" in section) or ("akao" in section)

--- a/apps/agent-service/tests/world/test_world_engine_fold.py
+++ b/apps/agent-service/tests/world/test_world_engine_fold.py
@@ -73,7 +73,7 @@ def _stub_engine_io(monkeypatch):
         return []
 
     async def fake_record_world_round_close(
-        *, lane, advance_cursor_to, materials_ingested_date
+        *, lane, advance_cursor_to, materials_ingested_date, roster_ingested_date=None
     ):
         state["close_calls"].append(
             {"lane": lane, "advance_cursor_to": advance_cursor_to}
@@ -84,6 +84,13 @@ def _stub_engine_io(monkeypatch):
 
     async def fake_read_world_arc(*, lane):
         return None
+
+    async def fake_list_npc_roster(*, lane):
+        return []
+
+    async def fake_seed_npc_roster(*, lane):
+        # 当天首醒会 ensure seed 名册（必改 1 的生产自动入口）；stub no-op 不碰真库。
+        return 0
 
     async def fake_run_arc_reflection(**kwargs):
         pass
@@ -102,6 +109,8 @@ def _stub_engine_io(monkeypatch):
     )
     monkeypatch.setattr(engine_mod, "find_daily_materials", fake_find_daily_materials)
     monkeypatch.setattr(engine_mod, "read_world_arc", fake_read_world_arc)
+    monkeypatch.setattr(engine_mod, "list_npc_roster", fake_list_npc_roster)
+    monkeypatch.setattr(engine_mod, "seed_npc_roster", fake_seed_npc_roster)
     monkeypatch.setattr(engine_mod, "run_arc_reflection", fake_run_arc_reflection)
     monkeypatch.setattr(engine_mod, "load_session", fake_load_session)
     monkeypatch.setattr(engine_mod, "record_round_cost", fake_record_round_cost)
@@ -236,7 +245,9 @@ async def test_fold_runs_after_round_close_before_self_wake(
     async def fake_cost(**kwargs):
         order.append("round_cost")
 
-    async def fake_close(*, lane, advance_cursor_to, materials_ingested_date):
+    async def fake_close(
+        *, lane, advance_cursor_to, materials_ingested_date, roster_ingested_date=None
+    ):
         order.append("round_close")
 
     async def fake_fold(session_id, policy):

--- a/apps/agent-service/tests/world/test_world_self_wake_gate.py
+++ b/apps/agent-service/tests/world/test_world_self_wake_gate.py
@@ -87,9 +87,9 @@ def _stub_io(monkeypatch):
         return None
 
     async def fake_record_world_round_close(
-        *, lane, advance_cursor_to, materials_ingested_date
+        *, lane, advance_cursor_to, materials_ingested_date, roster_ingested_date=None
     ):
-        # gate 放行的轮收口走统一收口（推游标 + 标记底料）；stub 成 no-op（不碰真库）。
+        # gate 放行的轮收口走统一收口（推游标 + 标记底料 / 名册）；stub 成 no-op（不碰真库）。
         return None
 
     async def fake_find_daily_materials(*, lane, date):
@@ -99,6 +99,15 @@ def _stub_io(monkeypatch):
     async def fake_read_world_arc(*, lane):
         # gate 放行的轮会读最新世界阶段；这里 stub 成 None（阶段空白，不碰真库）。
         return None
+
+    async def fake_list_npc_roster(*, lane):
+        # gate 放行的轮会 list NPC 名册；这里 stub 成空表（还没 seed，不碰真库）。
+        return []
+
+    async def fake_seed_npc_roster(*, lane):
+        # gate 放行的轮当天首醒会 ensure seed 名册（必改 1 的生产自动入口），真打
+        # PG 的 CAS insert；这里 stub 成 no-op（不碰真库）。
+        return 0
 
     monkeypatch.setattr(engine_mod, "renotify_unread", fake_renotify_unread)
     monkeypatch.setattr(engine_mod, "list_recent_acts", fake_list_recent_acts)
@@ -110,6 +119,8 @@ def _stub_io(monkeypatch):
         engine_mod, "find_daily_materials", fake_find_daily_materials
     )
     monkeypatch.setattr(engine_mod, "read_world_arc", fake_read_world_arc)
+    monkeypatch.setattr(engine_mod, "list_npc_roster", fake_list_npc_roster)
+    monkeypatch.setattr(engine_mod, "seed_npc_roster", fake_seed_npc_roster)
 
 
 def _stub_state(monkeypatch, snapshot: WorldState | None):

--- a/apps/agent-service/tests/world/test_world_state.py
+++ b/apps/agent-service/tests/world/test_world_state.py
@@ -742,3 +742,209 @@ async def test_record_world_round_close_preserves_arc_materials_reflected_date(w
         "record_world_round_close 不该冲掉 arc_materials_reflected_date（否则每轮"
         "收口都把第二班标记打回 None、当天反复重跑带底料反思）"
     )
+
+
+# ---------------------------------------------------------------------------
+# roster_ingested_date —— NPC 层第一刀：world「当天第一次醒纳入 NPC 名册一次」的收口标记
+#
+# world 当天第一次醒把「世界的固定人物」名册拼进意识流一次（照 DailyMaterials 套路），
+# 收口时把 roster_ingested_date 标成今天；之后当天后续轮次从 transcript 自然记得、不
+# 重喂。名册与底料是两件独立的事（名册 seed 后总在、底料某天可能没有），所以是**独立
+# 的游标**（不复用 materials_ingested_date）。同 materials_ingested_date 的教训：所有
+# 其他 WorldState 写入点都必须保留这个新字段，否则任何一轮收口都把它冲回 None、当天
+# 反复重喂名册。
+# ---------------------------------------------------------------------------
+
+
+def test_worldstate_has_nullable_roster_ingested_date():
+    """WorldState 多一个 roster_ingested_date 字段，nullable，默认 None（从没纳入过）。"""
+    assert "roster_ingested_date" in WorldState.model_fields
+    snap = WorldState(lane="x", world_time="t", detail="d")
+    assert snap.roster_ingested_date is None
+
+
+@pytest.mark.integration
+async def test_roster_ingested_date_defaults_null_and_insert_roundtrips(world_db):
+    """write_world_state 不带 roster_ingested_date → 列存 NULL（additive nullable 列）。"""
+    await write_world_state(
+        lane="coe-t2",
+        world_time="2026-06-08T06:30:00+08:00",
+        detail="清晨。",
+    )
+    snap = await read_world_state(lane="coe-t2")
+    assert snap is not None
+    assert snap.roster_ingested_date is None, "从没纳入过名册时该字段为 None"
+
+
+@pytest.mark.integration
+async def test_record_world_round_close_marks_roster_and_advances_cursor(world_db):
+    """收口：同一次 append 既推进游标、又标记名册已纳入今天（原子、一版）。"""
+    await write_world_state(lane="coe-t2", world_time="t0", detail="d0")
+
+    await record_world_round_close(
+        lane="coe-t2",
+        advance_cursor_to=("2026-06-08T08:05:00+08:00", "a5"),
+        materials_ingested_date=None,
+        roster_ingested_date="2026-06-08",
+    )
+
+    snap = await read_world_state(lane="coe-t2")
+    assert snap is not None
+    assert snap.act_cursor_created_at == "2026-06-08T08:05:00+08:00"
+    assert snap.roster_ingested_date == "2026-06-08"
+    assert snap.detail == "d0"
+
+
+@pytest.mark.integration
+async def test_record_world_round_close_marks_roster_on_empty_batch(world_db):
+    """空批次（没新 act 但当天首醒纳入了名册）→ 不推游标、但标记名册已纳入。"""
+    await write_world_state(lane="coe-t2", world_time="t0", detail="d0")
+    await advance_act_cursor(
+        lane="coe-t2", created_at="2026-06-08T07:00:00+08:00", act_id="prev"
+    )
+
+    await record_world_round_close(
+        lane="coe-t2",
+        advance_cursor_to=None,
+        materials_ingested_date=None,
+        roster_ingested_date="2026-06-08",
+    )
+
+    snap = await read_world_state(lane="coe-t2")
+    assert snap is not None
+    assert snap.act_cursor_created_at == "2026-06-08T07:00:00+08:00"
+    assert snap.roster_ingested_date == "2026-06-08"
+
+
+@pytest.mark.integration
+async def test_record_world_round_close_roster_none_preserves_existing(world_db):
+    """当天已纳入过名册 → roster_ingested_date 传 None：不改它、绝不清回 None。"""
+    await write_world_state(lane="coe-t2", world_time="t0", detail="d0")
+    await record_world_round_close(
+        lane="coe-t2",
+        advance_cursor_to=None,
+        materials_ingested_date=None,
+        roster_ingested_date="2026-06-08",
+    )
+
+    await record_world_round_close(
+        lane="coe-t2",
+        advance_cursor_to=("2026-06-08T09:00:00+08:00", "a9"),
+        materials_ingested_date=None,
+        roster_ingested_date=None,
+    )
+
+    snap = await read_world_state(lane="coe-t2")
+    assert snap is not None
+    assert snap.act_cursor_act_id == "a9"
+    assert snap.roster_ingested_date == "2026-06-08", (
+        "roster_ingested_date 传 None 时该保留已有值，不能被清回 None"
+    )
+
+
+@pytest.mark.integration
+async def test_roster_and_materials_ingested_dates_are_independent(world_db):
+    """名册游标与底料游标互不打架：能各标各的（名册标了、底料没标，反之亦然）。"""
+    await write_world_state(lane="coe-t2", world_time="t0", detail="d0")
+
+    # 这轮只纳入了名册（今天没底料）。
+    await record_world_round_close(
+        lane="coe-t2",
+        advance_cursor_to=None,
+        materials_ingested_date=None,
+        roster_ingested_date="2026-06-08",
+    )
+    snap = await read_world_state(lane="coe-t2")
+    assert snap.roster_ingested_date == "2026-06-08"
+    assert snap.materials_ingested_date is None, "名册纳入不该误标底料"
+
+    # 之后底料落地、这轮纳入底料（名册当天已纳入、不重标）。
+    await record_world_round_close(
+        lane="coe-t2",
+        advance_cursor_to=None,
+        materials_ingested_date="2026-06-08",
+        roster_ingested_date=None,
+    )
+    snap = await read_world_state(lane="coe-t2")
+    assert snap.materials_ingested_date == "2026-06-08"
+    assert snap.roster_ingested_date == "2026-06-08", "底料纳入不该冲掉名册标记"
+
+
+@pytest.mark.integration
+async def test_write_world_state_preserves_roster_ingested_date(world_db):
+    """update_world 改叙述不冲掉名册纳入标记。"""
+    await write_world_state(lane="coe-t2", world_time="t0", detail="d0")
+    await record_world_round_close(
+        lane="coe-t2",
+        advance_cursor_to=None,
+        materials_ingested_date=None,
+        roster_ingested_date="2026-06-08",
+    )
+
+    await write_world_state(lane="coe-t2", world_time="t1", detail="新叙述")
+
+    snap = await read_world_state(lane="coe-t2")
+    assert snap.roster_ingested_date == "2026-06-08", (
+        "update_world 不该冲掉 roster_ingested_date（否则当天反复重喂名册）"
+    )
+
+
+@pytest.mark.integration
+async def test_set_next_wake_at_preserves_roster_ingested_date(world_db):
+    """排下次醒（set_next_wake_at）不冲掉名册纳入标记。"""
+    await write_world_state(lane="coe-t2", world_time="t0", detail="d0")
+    await record_world_round_close(
+        lane="coe-t2",
+        advance_cursor_to=None,
+        materials_ingested_date=None,
+        roster_ingested_date="2026-06-08",
+    )
+
+    await set_next_wake_at(lane="coe-t2", next_wake_at="2026-06-08T11:00:00+08:00")
+
+    snap = await read_world_state(lane="coe-t2")
+    assert snap.roster_ingested_date == "2026-06-08", (
+        "set_next_wake_at 不该冲掉 roster_ingested_date"
+    )
+
+
+@pytest.mark.integration
+async def test_advance_act_cursor_preserves_roster_ingested_date(world_db):
+    """推进 act 游标不冲掉名册纳入标记。"""
+    await write_world_state(lane="coe-t2", world_time="t0", detail="d0")
+    await record_world_round_close(
+        lane="coe-t2",
+        advance_cursor_to=None,
+        materials_ingested_date=None,
+        roster_ingested_date="2026-06-08",
+    )
+
+    await advance_act_cursor(
+        lane="coe-t2", created_at="2026-06-08T09:00:00+08:00", act_id="a9"
+    )
+
+    snap = await read_world_state(lane="coe-t2")
+    assert snap.roster_ingested_date == "2026-06-08", (
+        "advance_act_cursor 不该冲掉 roster_ingested_date"
+    )
+
+
+@pytest.mark.integration
+async def test_mark_arc_reflected_preserves_roster_ingested_date(world_db):
+    """反思落标（mark_arc_reflected）不冲掉名册纳入标记。"""
+    from app.world.state import mark_arc_reflected
+
+    await write_world_state(lane="coe-t2", world_time="t0", detail="d0")
+    await record_world_round_close(
+        lane="coe-t2",
+        advance_cursor_to=None,
+        materials_ingested_date=None,
+        roster_ingested_date="2026-06-08",
+    )
+
+    await mark_arc_reflected(lane="coe-t2", date="2026-06-08")
+
+    snap = await read_world_state(lane="coe-t2")
+    assert snap.roster_ingested_date == "2026-06-08", (
+        "mark_arc_reflected 不该冲掉 roster_ingested_date"
+    )

--- a/apps/agent-service/tests/world/test_world_tools.py
+++ b/apps/agent-service/tests/world/test_world_tools.py
@@ -29,8 +29,10 @@ from app.world.tools import (
     WORLD_SLEEP_MAX_SECONDS,
     WORLD_SLEEP_MIN_SECONDS,
     derive_event_id,
+    derive_npc_event_id,
     derive_surroundings_event_id,
     notify,
+    npc_visit,
     sense,
     sleep,
     update_arc,
@@ -71,6 +73,20 @@ def _stub_handlers(monkeypatch):
     async def fake_write_world_state(*, lane, world_time, detail):
         world_writes.append({"lane": lane, "world_time": world_time, "detail": detail})
 
+    # npc_visit 把 NPC 这件事同步留进世界层时，先 read_world_state 读上一版叙述、再
+    # 把这件事追加进去——所以测试要桩一个 prev 叙述供它读。默认给一版非空叙述，个别
+    # 用例自行覆盖（如冷启动无快照场景）。
+    world_snapshot: dict = {"detail": "午后客厅很安静，赤尾在房间，绫奈在客厅写作业。"}
+
+    class _FakeSnapshot:
+        def __init__(self, detail: str):
+            self.detail = detail
+
+    async def fake_read_world_state(*, lane):
+        if world_snapshot.get("detail") is None:
+            return None
+        return _FakeSnapshot(world_snapshot["detail"])
+
     arc_writes: list[dict] = []
 
     async def fake_write_world_arc(*, lane, narrative, turned_at):
@@ -80,10 +96,12 @@ def _stub_handlers(monkeypatch):
 
     monkeypatch.setattr(tools_mod, "deliver_event", fake_deliver_event)
     monkeypatch.setattr(tools_mod, "write_world_state", fake_write_world_state)
+    monkeypatch.setattr(tools_mod, "read_world_state", fake_read_world_state)
     monkeypatch.setattr(tools_mod, "write_world_arc", fake_write_world_arc)
 
     tools_mod._test_delivered = delivered  # type: ignore[attr-defined]
     tools_mod._test_world_writes = world_writes  # type: ignore[attr-defined]
+    tools_mod._test_world_snapshot = world_snapshot  # type: ignore[attr-defined]
     tools_mod._test_arc_writes = arc_writes  # type: ignore[attr-defined]
     # sleep 不直接 emit_delayed（它把待办 self-wake 记进 round state、由 engine
     # 收口后 emit），这个空列表只用来断言"tool 层没有任何直接 self-wake 发生"。
@@ -445,6 +463,232 @@ async def test_sense_in_world_tools():
 
 
 # ---------------------------------------------------------------------------
+# npc_visit — NPC 层第二刀：world 以具名 NPC 身份投一件指向某姐妹的 event
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_npc_visit_delivers_speech_to_sister_with_npc_source(_ctx):
+    """① 投进对应姐妹信箱：source 是 `npc:名字`、kind=speech、summary 是 NPC 说的话。
+
+    NPC（林小满）来找绫奈这件事，把 NPC 说的话投进绫奈信箱。机制层硬约束：
+      * source = ``npc:林小满``（对齐第一刀 npc_name + 关系页 npc:xxx 约定）——
+        既不是真实用户（真人是 user:xxx / kind=external）、也不是 world 环境动静
+        （ambient）。
+      * kind = speech（有具名说话人、原话直投），life 侧 _format_speech 据此识别。
+      * summary = NPC 对她说的话（绫奈醒来读到的就是这句）。
+    """
+    with agent_context(_ctx):
+        await npc_visit.invoke(
+            {
+                "npc_name": "林小满",
+                "sister": "ayana",
+                "what_npc_says": "绫奈周末有空吗？一起去图书馆吧。",
+                "world_fact": "绫奈的手机响了，是林小满发来的消息。",
+            }
+        )
+
+    assert len(tools_mod._test_delivered) == 1
+    d = tools_mod._test_delivered[0]
+    assert d["persona_id"] == "ayana"
+    assert d["source"] == "npc:林小满"
+    assert d["kind"] == "speech"
+    assert d["summary"] == "绫奈周末有空吗？一起去图书馆吧。"
+    assert d["lane"] == "coe-t2"
+
+
+@pytest.mark.asyncio
+async def test_npc_visit_writes_same_fact_to_world_layer(_ctx):
+    """② 同一件事同步留在世界层（codex 必改）：world detail 含这件 NPC 事实。
+
+    NPC event 不能只投进收件人信箱——同一件事必须同步写进 world detail，否则 world
+    下一轮不记得、别的姐妹感知不到、世界状态与收件人感知分叉。机制层保证：投递工具
+    **自己**在同一次调用里 write_world_state 把 world_fact 追加进世界叙述（不靠模型
+    另调 update_world 自觉）。
+    """
+    with agent_context(_ctx):
+        await npc_visit.invoke(
+            {
+                "npc_name": "林小满",
+                "sister": "ayana",
+                "what_npc_says": "绫奈周末有空吗？",
+                "world_fact": "绫奈的手机响了，是林小满发来的消息。",
+            }
+        )
+
+    # 工具自己落了一版世界叙述（不依赖模型另调 update_world）
+    assert len(tools_mod._test_world_writes) == 1
+    w = tools_mod._test_world_writes[0]
+    assert w["lane"] == "coe-t2"
+    # 这件 NPC 事实进了 detail
+    assert "林小满" in w["detail"]
+    assert "绫奈的手机响了，是林小满发来的消息。" in w["detail"]
+    # 不丢上一版叙述（在它基础上追加，世界不被这条 NPC 事实覆盖掉）
+    assert "午后客厅很安静" in w["detail"]
+    # world_time 由工具体自填现实 CST（不让模型编）
+    assert "+08:00" in w["world_time"]
+
+
+@pytest.mark.asyncio
+async def test_npc_visit_cold_start_no_prior_detail(_ctx):
+    """冷启动（还没有上一版世界叙述）也能投：detail 就是这件 NPC 事实本身。
+
+    read_world_state 返回 None（首版还没快照）时，world_fact 直接作为新 detail 落，
+    不拼 None、不炸。投递照常发生。
+    """
+    tools_mod._test_world_snapshot["detail"] = None  # type: ignore[attr-defined]
+
+    with agent_context(_ctx):
+        await npc_visit.invoke(
+            {
+                "npc_name": "许念",
+                "sister": "chinagi",
+                "what_npc_says": "下班一起吃饭？",
+                "world_fact": "千凪的手机震了一下，是许念约饭。",
+            }
+        )
+
+    assert len(tools_mod._test_delivered) == 1
+    assert tools_mod._test_delivered[0]["source"] == "npc:许念"
+    assert len(tools_mod._test_world_writes) == 1
+    assert (
+        tools_mod._test_world_writes[0]["detail"]
+        == "千凪的手机震了一下，是许念约饭。"
+    )
+
+
+@pytest.mark.asyncio
+async def test_npc_visit_logs_error_when_deliver_fails_after_world_write(
+    _ctx, monkeypatch, caplog
+):
+    """deliver 失败（世界已写、信箱没投）→ log error（no silent）+ 世界写仍在（codex 必改 2）。
+
+    npc_visit 非事务：先写世界（world detail 是世界权威）、后投信箱。崩在中间的残留
+    是收件人偶发漏收一次来访，危害小于反过来。但 deliver 失败绝不能静默吞掉——必须
+    log error 留痕，运维能看到「世界记了这事但收件人没收到」。这里桩 deliver_event
+    抛错、走真实工具入口（@tool_error 把异常路由成给模型的 ToolOutcomeError），断言：
+    ① 世界层那段叙述已落（先写世界）；② npc_visit 在投递失败时 log 了 error。
+    """
+
+    async def boom_deliver(**kwargs):
+        raise RuntimeError("mailbox down")
+
+    monkeypatch.setattr(tools_mod, "deliver_event", boom_deliver)
+
+    with caplog.at_level("ERROR"):
+        with agent_context(_ctx):
+            await npc_visit.invoke(
+                {
+                    "npc_name": "林小满",
+                    "sister": "ayana",
+                    "what_npc_says": "周末一起去图书馆吧。",
+                    "world_fact": "绫奈的手机响了，是林小满发来的消息。",
+                }
+            )
+
+    # ① 世界层已写（先写世界、后投信箱）
+    assert len(tools_mod._test_world_writes) == 1
+    assert "林小满" in tools_mod._test_world_writes[0]["detail"]
+    # ② npc_visit 自己在投递失败处 log 了 error（no silent）——来自 npc_visit 模块、
+    #    含哪个 NPC 投给谁（区别于 @tool_error 的通用兜底日志）。
+    assert any(
+        rec.levelname == "ERROR"
+        and rec.name == tools_mod.logger.name
+        and "林小满" in rec.getMessage()
+        and "ayana" in rec.getMessage()
+        for rec in caplog.records
+    ), "deliver 失败必须由 npc_visit log error（记下哪个 NPC 投给谁失败）"
+
+
+@pytest.mark.asyncio
+async def test_npc_visit_event_id_idempotent_per_round(_ctx):
+    """同一 (lane, npc, sister, 话, round_id) 派生同一 event_id —— 整轮重放幂等命门。
+
+    Agent.run 整轮 retry 会重放 durable 工具，NPC event 是 durable 写——派生 id 绑
+    触发源（轮 + NPC + 收件人 + 话），重放投同一条 event，deliver_event 按
+    (lane, persona, event_id) 幂等去重，不重复投。
+    """
+    args = {
+        "npc_name": "林小满",
+        "sister": "ayana",
+        "what_npc_says": "周末一起去图书馆吧。",
+        "world_fact": "绫奈的手机响了。",
+    }
+    with agent_context(_ctx):
+        await npc_visit.invoke(args)
+    first = tools_mod._test_delivered[0]["event_id"]
+
+    tools_mod._test_delivered.clear()
+    with agent_context(_ctx):
+        await npc_visit.invoke(args)
+    second = tools_mod._test_delivered[0]["event_id"]
+    assert second == first, "同输入重放应派生同一 event_id（deliver_event 幂等去重）"
+
+
+def test_npc_visit_event_id_differs_per_npc_and_sister():
+    """不同 NPC / 不同收件人 → 不同 event_id（两件独立的 NPC 来访不互相吞掉）。"""
+    base = {
+        "lane": "coe-t2",
+        "what_npc_says": "一样的话",
+        "world_fact": "一样的世界事实",
+        "round_id": "r",
+    }
+    id_a = derive_npc_event_id(npc_name="林小满", sister="ayana", **base)
+    id_diff_npc = derive_npc_event_id(npc_name="顾舟", sister="ayana", **base)
+    id_diff_sister = derive_npc_event_id(npc_name="林小满", sister="akao", **base)
+    assert id_a != id_diff_npc
+    assert id_a != id_diff_sister
+
+
+def test_npc_visit_event_id_differs_per_world_fact():
+    """同 NPC / 同姐妹 / 同话、但 world_fact 不同 → 不同 event_id（codex 必改 3）。
+
+    幂等区分太窄会误吞：同一姐妹、同一 NPC、同一轮、同一句 what_npc_says 但是
+    **不同 world_fact**（同桌先发消息约图书馆、过一会儿又来电话敲定时间，两件客观
+    上不一样的来访恰好那句话措辞相同），若派生源不含 world_fact 会撞同一 id、被
+    deliver_event 幂等当重放吞掉第二件。把 world_fact 纳入派生源让不同事不撞。
+    """
+    base = {
+        "lane": "coe-t2",
+        "npc_name": "林小满",
+        "sister": "ayana",
+        "what_npc_says": "一样的话",
+        "round_id": "r",
+    }
+    id_msg = derive_npc_event_id(world_fact="绫奈的手机响了，是林小满的消息。", **base)
+    id_call = derive_npc_event_id(world_fact="绫奈接起电话，是林小满打来的。", **base)
+    assert id_msg != id_call, (
+        "同话不同 world_fact 是两件独立来访，不能派生同一 id 被幂等吞掉"
+    )
+
+
+def test_npc_visit_event_id_distinct_from_notify_and_sense():
+    """NPC speech 的 event_id 命名空间与 notify / sense 不撞（同文字也不互相幂等吞）。
+
+    NPC 来访（speech）、动静（ambient）、周遭切片（surroundings）是三类不同 event，
+    即便文字偶然相同也不能因派生命名空间重叠在 deliver_event 幂等里互相覆盖。
+    """
+    npc_id = derive_npc_event_id(
+        lane="coe-t2", npc_name="林小满", sister="ayana",
+        what_npc_says="同一句话", world_fact="同一句话", round_id="r",
+    )
+    notify_id = derive_event_id(lane="coe-t2", observation="同一句话", round_id="r")
+    sense_id = derive_surroundings_event_id(
+        lane="coe-t2", recipient="ayana", surroundings="同一句话", round_id="r"
+    )
+    assert npc_id != notify_id
+    assert npc_id != sense_id
+
+
+@pytest.mark.asyncio
+async def test_npc_visit_in_world_tools():
+    """npc_visit 是 world 续写工具集的一员（WORLD_TOOLS 含 npc_visit）。"""
+    from app.world.tools import WORLD_TOOLS
+
+    assert npc_visit in WORLD_TOOLS
+
+
+# ---------------------------------------------------------------------------
 # sleep — 1A 完全不动（保留原行为）
 # ---------------------------------------------------------------------------
 
@@ -522,14 +766,15 @@ async def test_sleep_under_floor_returns_error_no_pending_wake(_ctx):
 # ---------------------------------------------------------------------------
 
 
-def test_world_tools_are_notify_update_world_sense_sleep():
-    """WORLD_TOOLS = [notify, update_world, sense, sleep]（续写四工具）。
+def test_world_tools_are_notify_update_world_sense_npc_visit_sleep():
+    """WORLD_TOOLS = [notify, update_world, sense, npc_visit, sleep]（续写五工具）。
 
     没有 move_persona / emit_event（旧导演范式）。sense 是 1C 加的「投周遭客观切片
     给单个角色」的五官工具，与 notify（广播一条动静给够得着的多人）分工不同。
-    update_arc（世界阶段的「翻页」工具）**不在这里**——翻页归独立的反思环节独占
-    （WORLD_REFLECT_TOOLS），续写与反思靠工具集物理隔离互不干扰。
+    npc_visit 是 NPC 层第二刀加的「以具名 NPC 身份投一件指向某姐妹的 event + 同步留
+    世界层」的工具。update_arc（世界阶段的「翻页」工具）**不在这里**——翻页归独立的
+    反思环节独占（WORLD_REFLECT_TOOLS），续写与反思靠工具集物理隔离互不干扰。
     """
     from app.world.tools import WORLD_TOOLS
 
-    assert WORLD_TOOLS == [notify, update_world, sense, sleep]
+    assert WORLD_TOOLS == [notify, update_world, sense, npc_visit, sleep]


### PR DESCRIPTION
## What

Introduces an NPC layer to the living world. The sisters' world held no one but the three of them and the owner — classmates and colleagues only lived in chat narration and never reached back. This gives the world named, recurring NPCs (plus walk-on strangers) that the world *deliberates* into reaching out to a sister.

## How (4 cuts)

1. **NPCRoster** table (one row per NPC, (lane, npc_name) keyed), seeded with 7 fixed NPCs (3 for ayana, 2 for akao, 2 for chinagi). The world reads the roster into deliberation on the day's first wake (its own ingest cursor, once per day); seed is CAS-idempotent on first wake.
2. **npc_visit** world tool: an NPC reaches out to one sister as a speech event (source=npc:NAME). The public-facing fact is written into the world narrative in the same call, so the world stays consistent with the recipient (not just the mailbox); private words go only to the recipient.
3. **Day review** picks NPC visits from the mailbox by living-day window and grows per-NPC relationship pages (npc:NAME reuses RelationshipPage, no schema change).
4. **Prompts**: world loop instruction lists npc_visit; day review covers NPCs; world_deliberate system prompt gets an NPC-world section telling the world these people exist and to let them reach out naturally — never on a schedule.

## Verification

- Full suite 1775 passed (non-integration) + integration (real-PG end-to-end seed/list/ingest, npc_visit delivery + world-layer write, relationship pages).
- codex T3: 3 must-fix + 3 suggestions all applied.
- coe-npc lane: deployed clean; world first wake seeded 7 NPCs and ingested the roster into deliberation (roster_ingested_date set); deliberation quality high.

## Not yet observed in coe

Whether the world *naturally* emits an NPC visit (prompt-steered, intermittent) — better observed on prod's live world. Will watch on prod: an NPC showing up naturally (tune world_deliberate if not) and cost/frequency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)