### PR TITLE
feat(media-sync): inject pixiv auth from Dynamic Config

### DIFF
--- a/apps/media-sync-worker/src/pixiv/auth.test.ts
+++ b/apps/media-sync-worker/src/pixiv/auth.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'bun:test';
+import {
+  readPixivAuth,
+  PIXIV_COOKIE_KEY,
+  PIXIV_USER_AGENT_KEY,
+  PIXIV_SEC_CH_UA_KEY,
+} from './auth';
+
+// 假 DynamicConfig：按预置 map 返回值，缺失返回 ''（与真实 SDK 的 get 默认一致）。
+function fakeConfig(map: Record<string, string>) {
+  return {
+    get: async (key: string): Promise<string> => map[key] ?? '',
+  } as any;
+}
+
+describe('readPixivAuth：从 Dynamic Config 读 pixiv 鉴权字段', () => {
+  it('三项都配了：返回完整 pixiv_auth', async () => {
+    const auth = await readPixivAuth(
+      fakeConfig({
+        [PIXIV_COOKIE_KEY]: 'ck',
+        [PIXIV_USER_AGENT_KEY]: 'ua',
+        [PIXIV_SEC_CH_UA_KEY]: 'sec',
+      }),
+    );
+    expect(auth).toEqual({ cookie: 'ck', user_agent: 'ua', sec_ch_ua: 'sec' });
+  });
+
+  it('只配了 cookie：只返回非空字段（空的交给 server 逐字段回退）', async () => {
+    const auth = await readPixivAuth(fakeConfig({ [PIXIV_COOKIE_KEY]: 'ck' }));
+    expect(auth).toEqual({ cookie: 'ck' });
+  });
+
+  it('三项都没配：返回 undefined（worker 不带 pixiv_auth，server 全量回退 Redis）', async () => {
+    const auth = await readPixivAuth(fakeConfig({}));
+    expect(auth).toBeUndefined();
+  });
+});

--- a/apps/media-sync-worker/src/pixiv/auth.ts
+++ b/apps/media-sync-worker/src/pixiv/auth.ts
@@ -1,0 +1,37 @@
+import { DynamicConfig } from "@inner/shared";
+import type { PixivAuth } from "@inner/pixiv-client";
+
+// pixiv 鉴权字段在 Dynamic Config 里的 key（两仓共享契约的内网侧来源）。
+export const PIXIV_COOKIE_KEY = "pixiv_cookie";
+export const PIXIV_USER_AGENT_KEY = "pixiv_user_agent";
+export const PIXIV_SEC_CH_UA_KEY = "pixiv_sec_ch_ua";
+
+/**
+ * 从 Dynamic Config 读 pixiv 鉴权字段（cookie / user-agent / sec-ch-ua）。
+ * 只放非空字段；三项都空时返回 undefined —— 此时 worker 不带 pixiv_auth，
+ * chiwei_bot_server 全量回退读自己的 Redis（Dynamic Config 还没配时的零回归路径）。
+ */
+export async function readPixivAuth(
+  config: DynamicConfig,
+): Promise<PixivAuth | undefined> {
+  const [cookie, userAgent, secChUa] = await Promise.all([
+    config.get(PIXIV_COOKIE_KEY),
+    config.get(PIXIV_USER_AGENT_KEY),
+    config.get(PIXIV_SEC_CH_UA_KEY),
+  ]);
+
+  const auth: PixivAuth = {};
+  if (cookie) auth.cookie = cookie;
+  if (userAgent) auth.user_agent = userAgent;
+  if (secChUa) auth.sec_ch_ua = secChUa;
+
+  return Object.keys(auth).length > 0 ? auth : undefined;
+}
+
+// 生产单例：DynamicConfig 自带 10s 缓存，cron 无 per-request context、默认读 prod lane。
+const dynamicConfig = new DynamicConfig();
+
+/** 给 PixivClient 的 authProvider 用。 */
+export function getPixivAuth(): Promise<PixivAuth | undefined> {
+  return readPixivAuth(dynamicConfig);
+}

--- a/apps/media-sync-worker/src/pixiv/pixiv.ts
+++ b/apps/media-sync-worker/src/pixiv/pixiv.ts
@@ -2,6 +2,7 @@ import { PixivClient, createPixivClient, FollowerInfo, IllustrationPageDetail } 
 import redisClient from "../redis/redisClient";
 import { GetIllustInfoBody } from "../service/types";
 import { cacheProxy } from "../utils/cache";
+import { getPixivAuth } from "./auth";
 
 // 创建 Pixiv 客户端实例
 const pixivClient = createPixivClient({
@@ -9,6 +10,7 @@ const pixivClient = createPixivClient({
   httpSecret: process.env.HTTP_SECRET || process.env.PROXY_HTTP_SECRET || '',
   defaultUserId: '35384654',
   getVersion: async () => redisClient.get("version"),
+  authProvider: getPixivAuth,
 });
 
 /**

--- a/apps/media-sync-worker/src/pixiv/pixivProxy.ts
+++ b/apps/media-sync-worker/src/pixiv/pixivProxy.ts
@@ -1,10 +1,12 @@
 // Re-export from @inner/pixiv-client for backward compatibility
 import { createPixivClient } from "@inner/pixiv-client";
+import { getPixivAuth } from "./auth";
 
 // 创建 Pixiv 客户端实例
 const pixivClient = createPixivClient({
   proxyHost: process.env.PIXIV_PROXY_HOST || 'http://www.yuanzhi.xyz',
   httpSecret: process.env.HTTP_SECRET || process.env.PROXY_HTTP_SECRET || '',
+  authProvider: getPixivAuth,
 });
 
 /**

--- a/docs/plan/media-sync-internal-deps.md
+++ b/docs/plan/media-sync-internal-deps.md
@@ -1,0 +1,62 @@
+# pixiv 鉴权字段注入迁内网（走 Dynamic Config）
+
+## Problem
+
+pixiv 的会话凭证（`cookie`/`user-agent`/`sec-ch-ua`）现在存在公网服务 chiwei_bot_server（`www.yuanzhi.xyz`）的 Redis 里，由它的 `/api/v2/proxy`（图片下载走同一 `buildHeaders`）在请求 pixiv.net 时注入。凭证存在外网、归它的 JWT `setting` 模块管，轮换和管控都在内网够不着的地方。
+
+## Goal
+
+pixiv 鉴权字段改由内网 Dynamic Config 持有，内网 media-sync-worker 运行时读出、随 proxy / 下载请求带给 chiwei_bot_server，server 把调用方带入的鉴权头转发给 pixiv.net。轮换 cookie 只需改 Dynamic Config，不再碰公网服务的 Redis。
+
+## Non-goals
+
+- 不做更大范围的 media sync 收口——image-store 业务逻辑内化到 worker、channel-server 发图功能去留、`img_map`/`trans_map` Mongo 迁内网、瘦下载契约（download 改成只存 OSS）等，全部"可再议"，不在本次（见文末）。
+- 不动对象存储（仍阿里云 OSS），不改 download 的存储/写库/去重逻辑——本次只改它和 proxy 的"鉴权头从哪来"。
+- 不强行下线 chiwei_bot_server 的 `setting` 模块或它 Redis 里的 cookie——本次只让 proxy/download 优先用调用方带入的鉴权头，Redis 作为过渡期回退。
+
+## Key design decisions
+
+- **鉴权头由调用方带入、server 转发，Redis 降级为逐字段回退**：chiwei_bot_server 的 `buildHeaders` 对 `cookie`/`user-agent`/`sec-ch-ua` **逐字段**判断——带入且非空就用带入值，缺失或空串则回退读自己 Redis。关键：`DynamicConfig.get()` 拉取失败 / 缺 key 时返回空串，必须当"未带入"处理、回退 Redis，**绝不把空 header 发给 pixiv**（"headers 对象存在"不等于三项凭证有效）。保留 Redis 回退而非一刀切，是为过渡期零回归——老调用方不带头仍走旧逻辑，这也天然是回滚路径。内网注入稳定后 Redis 来源可另行退役（属"可再议"）。
+- **鉴权字段走 Dynamic Config，不走 env/ConfigBundle**：cookie 是需要频繁轮换的业务级会话凭证，Dynamic Config 运行时可改、10s 生效，契合轮换诉求；env/ConfigBundle 改一次要重新部署，不合适。按 bezhai 指定走 dynamic-config（这偏离仓库"密钥走部署时配置"的默认，随之的约束见 Data & deployment impact）。
+- **跨仓契约字段钉死（两仓共享，不留"实现时定"）**：请求体新增可选对象 `pixiv_auth: { cookie?, user_agent?, sec_ch_ua? }`（`/api/v2/proxy` 与下载接口都加）；Dynamic Config 三个 key 为 `pixiv_cookie` / `pixiv_user_agent` / `pixiv_sec_ch_ua`。两仓独立改、字段名即契约，必须先钉死。新增字段属于被签名 body（现有 X-Token = sha256(salt + JSON.stringify(body) + secret)），client 签名与 server guard 看同一 body，故加字段不破坏鉴权——前提是 server 在 guard 前不剥离 / 重写 body。
+- **注入点只在 media-sync-worker**：worker 是唯一直接调 `/api/v2/proxy` 和下载接口的内网消费方（channel-server 只用 image-store 列表、不直接调 proxy）。所以本次只在 worker 侧读 Dynamic Config 并注入，channel-server 不动。
+
+## Caller coverage
+
+chiwei_bot_server `/api/v2/proxy` 与图片下载接口的内网调用方（grep 自 `apps/**` `packages/**`）：
+
+- `pixivProxy`（→ `/api/v2/proxy`）→ media-sync-worker 的 getFollowersByTag / getAuthorArtwork / getTagArtwork / getIllustInfo / getIllustPageDetail（pixiv.ts，被 dailyDownload / consumeService 用）。**改**：请求体带上鉴权头。
+- `downloadContent`（→ 图片下载，走同一 `buildHeaders`）→ media-sync-worker `getContent`（consumeService 下载每页时）。**改**：请求体带上鉴权头。
+- channel-server：只用 `getPixivImages` / `reportLarkUpload`（image-store 接口，不经 `buildHeaders`），**不受影响**。
+
+涉及改动的契约层：`packages/pixiv-client` 的 `pixivProxy` 与 `downloadContent` 增加可选鉴权头入参并放进发往 server 的 body；media-sync-worker 调用处从 Dynamic Config 读值后传入。
+
+## Data & deployment impact
+
+- **新 Dynamic Config keys**：`pixiv_cookie` / `pixiv_user_agent` / `pixiv_sec_ch_ua`（见 Key design decisions）。**上线前置**：先在 Dynamic Config 配好这三项、并把现有值从 chiwei_bot_server Redis 取出灌入。
+- **凭证进 Dynamic Config 的取舍与约束**：按 bezhai 指定 cookie 走 Dynamic Config，偏离仓库"密钥走部署时配置"的默认，随之必须满足：(a) **严禁日志打印鉴权头**——现 `proxy.service.ts` 有 `console.log('headers', headers)` 会泄露 cookie，本次必须去掉 / 脱敏；(b) worker 是 cron、无 per-request context，`DynamicConfig` 默认读 `prod` lane——cookie 是单一 pixiv 账号、跨 lane 同值，读 prod 可接受（若要按部署 lane 取值则显式传 laneProvider）。
+- **过渡期维持 Redis 初值**：回滚路径依赖公网 Redis 里的旧 cookie 仍有效，cutover 验证稳定前必须继续维护 Redis 里的凭证、不能清。
+- **worker 读 Dynamic Config**：复用 `@inner/shared` 的 `DynamicConfig`（默认连 `paas-engine:8080`、10s 缓存）。worker 是内网 k3s 进程，可达 paas-engine。
+- **跨仓上线顺序（关键）**：① 先上"proxy/download 优先用带入头、缺失回退 Redis"的 chiwei_bot_server（兼容变更：老 worker 不带头仍走 Redis，零回归）→ ② 在 Dynamic Config 配好三个字段初值 → ③ 再上带注入的 worker。**回滚**：worker 回退到不带头版本，server 自动回退读 Redis，无需协同回滚。
+- **部署中断**：部署 media-sync-worker 会中断正在跑的下载消费循环；上线前确认无在跑的批量下载。
+- 两仓改动（monorepo + chiwei_bot_server），非 PG / 不涉 ops-db、不涉 Langfuse。
+
+## Tasks
+
+1. **chiwei_bot_server：proxy/download 接受调用方鉴权头**（仓库：chiwei_bot_server）
+   - **Goal**：proxy 与下载接口的请求体接受可选 `pixiv_auth`，`buildHeaders` 逐字段优先用带入值、缺失或空回退 Redis。注意下载接口比 proxy 多一层 DTO/service（`DownloadImageDto → downloadImage → proxyRequestBuffer`），鉴权字段必须一路透传到 `buildHeaders`、不能在这层被丢；同时去掉会泄露 cookie 的 header 日志。proxy 的"GET 转发"本质与 download 的存储逻辑都不变。
+   - **Deliverable**：chiwei_bot_server proxy + download 模块改造 + 与 monorepo 约定的 `pixiv_auth` 请求体字段。
+   - **Verification**：带 `pixiv_auth` 请求 proxy 与下载，server 都用带入头打 pixiv.net 成功（不是 Redis）；不带或字段为空时逐字段回退 Redis、行为与现状一致（零回归）；日志不再出现 cookie。
+
+2. **media-sync-worker：从 Dynamic Config 读鉴权字段并注入**（仓库：monorepo）
+   - **Goal**：worker 调 proxy/下载前从 Dynamic Config 读 pixiv 三个鉴权字段，经 pixiv-client 随请求带给 server；`packages/pixiv-client` 的 `pixivProxy`/`downloadContent` 增加鉴权头入参。
+   - **Deliverable**：pixiv-client 鉴权头入参 + worker 读 Dynamic Config 并注入的链路。
+   - **Verification**：跑一次下载/元数据抓取，server 端收到 worker 带入的鉴权头并请求 pixiv 成功；在 Dynamic Config 改 cookie 后（≤10s）新请求用新值，不再依赖 server Redis 里的旧值。
+
+## 可再议（非本次，仅记录探查结论，未承诺 scope）
+
+下面是"media sync 链路收口"更大范围的探查结论，本次不做，留待另议：
+
+- chiwei_bot_server 的 image-store 业务逻辑（去重、`img_map`/`trans_map` 写入、列表查询、飞书上传回填）收口进内网 media-sync-worker，让 server 只剩 proxy 透传 + 瘦下载（下字节 + 存 OSS + 返回 key）。
+- channel-server 的发图功能（`发图`/`换一批`/`查看详情`/每日推图）去留——若收口则交互式发图无法保留（飞书事件只进 channel-server），需产品取舍。
+- `img_map`/`trans_map`/`download_task` 这份 `chiwei` 库当前在阿里云外网、worker 与 chiwei_bot_server 共用，迁内网是有状态 owner 切换，需单独的 cutover 与回滚方案。

--- a/packages/pixiv-client/src/client.test.ts
+++ b/packages/pixiv-client/src/client.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it, mock } from 'bun:test';
+import { PixivClient } from './client';
+
+// 注入一个假的 axios 风格 httpClient：记录每次 post 的 body，返回同时满足
+// pixivProxy（{error,body}）与 downloadContent（{code,msg}）两种调用的响应壳。
+function makeMockHttp() {
+    const calls: Array<{ url: string; body: any }> = [];
+    const post = mock(async (url: string, body: any) => {
+        calls.push({ url, body });
+        return { data: { error: false, body: {}, code: 0, msg: 'ok' } };
+    });
+    return { post, calls };
+}
+
+const AUTH = { cookie: 'ck', user_agent: 'ua', sec_ch_ua: 'sec' };
+
+describe('PixivClient 鉴权头注入（pixiv_auth）', () => {
+    it('pixivProxy：authProvider 有值时把 pixiv_auth 放进请求体', async () => {
+        const http = makeMockHttp();
+        const client = new PixivClient(
+            { proxyHost: 'http://srv', httpSecret: 's', authProvider: async () => AUTH },
+            http as any,
+        );
+
+        await client.pixivProxy('https://www.pixiv.net/ajax/x', 'ref', { lang: 'zh' });
+
+        expect(http.calls).toHaveLength(1);
+        expect(http.calls[0].url).toBe('http://srv/api/v2/proxy');
+        expect(http.calls[0].body.referer).toBe('ref');
+        expect(http.calls[0].body.url).toContain('https://www.pixiv.net/ajax/x');
+        expect(http.calls[0].body.pixiv_auth).toEqual(AUTH);
+    });
+
+    it('pixivProxy：没有 authProvider 时不带 pixiv_auth 字段', async () => {
+        const http = makeMockHttp();
+        const client = new PixivClient(
+            { proxyHost: 'http://srv', httpSecret: 's' },
+            http as any,
+        );
+
+        await client.pixivProxy('https://www.pixiv.net/ajax/x', 'ref');
+
+        expect(http.calls[0].body.pixiv_auth).toBeUndefined();
+    });
+
+    it('downloadContent：authProvider 有值时 pixiv_url 与 pixiv_auth 同在请求体', async () => {
+        const http = makeMockHttp();
+        const client = new PixivClient(
+            { proxyHost: 'http://srv', httpSecret: 's', authProvider: async () => AUTH },
+            http as any,
+        );
+
+        await client.downloadContent('https://i.pximg.net/img_p0.png');
+
+        expect(http.calls[0].url).toBe('http://srv/api/v2/image-store/download');
+        expect(http.calls[0].body.pixiv_url).toBe('https://i.pximg.net/img_p0.png');
+        expect(http.calls[0].body.pixiv_auth).toEqual(AUTH);
+    });
+
+    it('authProvider 返回 undefined 时不带 pixiv_auth（交由 server 回退 Redis）', async () => {
+        const http = makeMockHttp();
+        const client = new PixivClient(
+            { proxyHost: 'http://srv', httpSecret: 's', authProvider: async () => undefined },
+            http as any,
+        );
+
+        await client.downloadContent('https://i.pximg.net/img_p0.png');
+
+        expect(http.calls[0].body.pixiv_auth).toBeUndefined();
+    });
+});

--- a/packages/pixiv-client/src/client.ts
+++ b/packages/pixiv-client/src/client.ts
@@ -5,6 +5,7 @@ import {
     createDefaultPixivConfig,
     PixivGenericResponse,
     PixivProxyRequestBody,
+    PixivAuth,
     BaseResponse,
     PaginationResponse,
     ImageForLark,
@@ -49,6 +50,11 @@ export class PixivClient {
             url: baseUrl,
             referer: referer,
         };
+
+        const auth = await this.config.authProvider?.();
+        if (auth) {
+            reqBody.pixiv_auth = auth;
+        }
 
         return await sendAuthenticatedRequest<T>(
             `${this.config.proxyHost}/api/v2/proxy`,
@@ -210,7 +216,12 @@ export class PixivClient {
      * 下载 Pixiv 图片内容
      */
     async downloadContent(pixivUrl: string): Promise<void> {
-        const reqBody = { pixiv_url: pixivUrl };
+        const reqBody: { pixiv_url: string; pixiv_auth?: PixivAuth } = { pixiv_url: pixivUrl };
+
+        const auth = await this.config.authProvider?.();
+        if (auth) {
+            reqBody.pixiv_auth = auth;
+        }
 
         const response = await sendAuthenticatedRequest<BaseResponse<void>>(
             `${this.config.proxyHost}/api/v2/image-store/download`,

--- a/packages/pixiv-client/src/index.ts
+++ b/packages/pixiv-client/src/index.ts
@@ -11,6 +11,7 @@ export type {
     // Pixiv API types
     PixivGenericResponse,
     PixivProxyRequestBody,
+    PixivAuth,
     FollowerInfo,
     FollowerBody,
     AuthorArtworkResponseBody,

--- a/packages/pixiv-client/src/types.ts
+++ b/packages/pixiv-client/src/types.ts
@@ -158,12 +158,23 @@ export interface UploadLarkResp {
 }
 
 /**
+ * pixiv 鉴权头：随 proxy / 下载请求带给 server，由 server 转发给 pixiv.net。
+ * 字段缺失或为空时，server 端逐字段回退读自己的 Redis（过渡期兼容）。
+ */
+export interface PixivAuth {
+    cookie?: string;
+    user_agent?: string;
+    sec_ch_ua?: string;
+}
+
+/**
  * Pixiv 代理请求体
  */
 export interface PixivProxyRequestBody {
     url: string;
     referer: string;
     debug?: boolean;
+    pixiv_auth?: PixivAuth;
 }
 
 /**
@@ -178,6 +189,11 @@ export interface PixivClientConfig {
     defaultUserId?: string;
     /** 获取版本号的函数（用于 API 请求） */
     getVersion?: () => Promise<string | null>;
+    /**
+     * 运行时提供 pixiv 鉴权头（cookie/user-agent/sec-ch-ua），随 proxy / 下载请求
+     * 带给 server 转发给 pixiv.net。返回 undefined 时不带 pixiv_auth，server 回退读 Redis。
+     */
+    authProvider?: () => Promise<PixivAuth | undefined>;
 }
 
 /**


### PR DESCRIPTION
## What

`media-sync-worker` now reads pixiv auth (cookie / user-agent / sec-ch-ua) from Dynamic Config (keys `pixiv_cookie` / `pixiv_user_agent` / `pixiv_sec_ch_ua`) and passes them as `pixiv_auth` in the proxy / download request bodies sent to `chiwei_bot_server`.

## Why

Move the pixiv credential source from the public `chiwei_bot_server`'s own Redis to internal Dynamic Config. Rotating the cookie now only touches Dynamic Config and never the public service.

## Cross-repo coordination

This is the worker half. The `chiwei_bot_server` half is already deployed: its `buildHeaders` uses the caller-provided `pixiv_auth` per field and falls back to its own Redis when a field is missing or empty. The three Dynamic Config keys are already seeded in the prod lane.

## Zero-regression

When the Dynamic Config keys are empty the worker sends no `pixiv_auth` and the server keeps reading its own Redis — identical to current behavior. Deploying this worker is what actually starts using the internal credentials; the server + config side is already in place.

## Verification

- monorepo: `bun test` 7 pass (pixiv-client `client.test` + worker `auth.test`); `tsc --noEmit` OK for `pixiv-client` and `media-sync-worker`.
- chiwei_bot_server: `proxy.service.spec.ts` 5 pass (per-field fallback); `tsc --noEmit` OK.
- Signature safety: `ServerAuthGuard` re-stringifies `req.body` to verify the X-Token; adding `pixiv_auth` preserves the signature because JSON key order is stable and existing multi-field bodies (url/referer/debug) already work under the same mechanism.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
