### PR TITLE
feat(agent-service): add no_reply terminal tool

### DIFF
--- a/apps/agent-service/app/agent/core.py
+++ b/apps/agent-service/app/agent/core.py
@@ -66,6 +66,7 @@ from app.agent.neutral import (
     Message,
     Role,
     StreamChunk,
+    ToolCall,
     ToolDef,
     ToolResult,
 )
@@ -307,6 +308,8 @@ def _record_tool_output(span: Any, result: ToolResult) -> None:
 # Hand-written ReAct loops (module-level so they can be de-risked in isolation)
 # ---------------------------------------------------------------------------
 
+_TERMINAL_TOOL_NAMES = {"no_reply"}
+
 
 def _tooldefs(tools: list[Tool]) -> list[ToolDef] | None:
     """Project neutral Tools to the ToolDefs the model sees, or None if empty."""
@@ -342,6 +345,11 @@ def _normalise_tool_result(result: ToolResult) -> ToolResult:
     # dict (incl. tool_error outcome) or any other JSON-able value → string
     text = json.dumps(content, ensure_ascii=False, default=str)
     return ToolResult(tool_call_id=result.tool_call_id, content=text)
+
+
+def _is_terminal_tool_call(call: ToolCall) -> bool:
+    """Whether a tool call intentionally ends the current agent turn."""
+    return call.name in _TERMINAL_TOOL_NAMES
 
 
 async def _run_loop(
@@ -405,6 +413,11 @@ async def _run_loop(
             convo.append(tool_msg)
             if transcript_sink is not None:
                 transcript_sink.append(tool_msg)
+            if _is_terminal_tool_call(call):
+                final = Message(role=Role.ASSISTANT, content="")
+                if transcript_sink is not None:
+                    transcript_sink.append(final)
+                return final
 
     # recursion limit hit: return the last assistant message we have.
     return last if last is not None else Message(role=Role.ASSISTANT, content="")
@@ -496,6 +509,10 @@ async def _stream_loop(
             if transcript_sink is not None:
                 transcript_sink.append(tool_msg)
             yield StreamChunk(tool_result=result)
+            if _is_terminal_tool_call(call):
+                if transcript_sink is not None:
+                    transcript_sink.append(Message(role=Role.ASSISTANT, content=""))
+                return
 
 
 @contextmanager

--- a/apps/agent-service/app/agent/tools/__init__.py
+++ b/apps/agent-service/app/agent/tools/__init__.py
@@ -9,6 +9,7 @@ Exports two tool lists:
 from app.agent.tools.delegation import deep_research
 from app.agent.tools.image import generate_image, read_images
 from app.agent.tools.image_search import search_images
+from app.agent.tools.no_reply import no_reply
 from app.agent.tools.sandbox import sandbox_bash
 from app.agent.tools.search import search_web
 from app.agent.tools.skill import load_skill
@@ -27,6 +28,7 @@ ALL_TOOLS = [
     deep_research,
     load_skill,
     sandbox_bash,
+    no_reply,
 ]
 
 __all__ = [
@@ -40,4 +42,5 @@ __all__ = [
     "deep_research",
     "load_skill",
     "sandbox_bash",
+    "no_reply",
 ]

--- a/apps/agent-service/app/agent/tools/no_reply.py
+++ b/apps/agent-service/app/agent/tools/no_reply.py
@@ -1,0 +1,15 @@
+"""Main-chat tool for intentionally ending a turn without replying."""
+
+from __future__ import annotations
+
+from app.agent.tooling import tool
+
+
+@tool
+async def no_reply() -> str:
+    """不回复用户，直接结束本轮对话。
+
+    当你不想回复、不喜欢这个话题、想拒绝接话，或遇到骚扰、无意义刷屏、
+    钓鱼式逼回应、政治敏感话题时，调用这个工具。调用前后都不要输出任何文字。
+    """
+    return "本轮不回复。"

--- a/apps/agent-service/tests/unit/agent/test_react_loop.py
+++ b/apps/agent-service/tests/unit/agent/test_react_loop.py
@@ -23,8 +23,6 @@ from contextlib import contextmanager
 from unittest.mock import MagicMock
 
 import pytest
-from openai import APITimeoutError
-from pydantic import BaseModel
 
 from app.agent.client import ModelClient
 from app.agent.context import AgentContext
@@ -140,6 +138,12 @@ async def blocks_tool(x: str) -> list:
     ]
 
 
+@tool
+async def no_reply() -> str:
+    """End the turn without sending any reply."""
+    return "ok"
+
+
 # ---------------------------------------------------------------------------
 # Helpers to import the loop functions under test
 # ---------------------------------------------------------------------------
@@ -198,6 +202,25 @@ class TestRunLoop:
         tool_msg = next(m for m in second_msgs if m.role == Role.TOOL)
         assert tool_msg.tool_call_id == "c1"
         assert tool_msg.text() == "echoed:x"
+
+    async def test_no_reply_tool_ends_without_second_model_call(self):
+        _run_loop, _ = _import_loops()
+        call = ToolCall(id="c1", name="no_reply", arguments={})
+        fake = FakeModelClient(
+            complete_script=[
+                Message(role=Role.ASSISTANT, content="", tool_calls=[call]),
+                Message(role=Role.ASSISTANT, content="should not run"),
+            ]
+        )
+        result = await _run_loop(
+            fake,
+            messages=[Message(role=Role.USER, content="go")],
+            tools=[no_reply, echo_tool],
+            context=None,
+            recursion_limit=12,
+        )
+        assert result.text() == ""
+        assert len(fake.complete_calls) == 1
 
     async def test_parallel_tool_calls_all_dispatched(self):
         _run_loop, _ = _import_loops()
@@ -399,6 +422,29 @@ class TestStreamLoop:
         assert any(c.tool_call is not None for c in out)
         assert any(c.tool_result is not None for c in out)
         assert "".join(c.text or "" for c in out) == "final"
+
+    async def test_no_reply_tool_stream_ends_without_text_or_second_model_call(self):
+        _, _stream_loop = _import_loops()
+        call = ToolCall(id="c1", name="no_reply", arguments={})
+        fake = FakeModelClient(
+            stream_script=[
+                [StreamChunk(tool_call=call), StreamChunk(finish_reason="tool_calls")],
+                [StreamChunk(text="should not stream"), StreamChunk(finish_reason="stop")],
+            ]
+        )
+        out = []
+        async for chunk in _stream_loop(
+            fake,
+            messages=[Message(role=Role.USER, content="go")],
+            tools=[no_reply, echo_tool],
+            context=None,
+            recursion_limit=12,
+        ):
+            out.append(chunk)
+        assert len(fake.stream_calls) == 1
+        assert any(c.tool_call is not None for c in out)
+        assert any(c.tool_result is not None for c in out)
+        assert "".join(c.text or "" for c in out) == ""
 
     async def test_no_tool_calls_does_not_loop(self):
         _, _stream_loop = _import_loops()

--- a/apps/agent-service/tests/unit/agent/tools/test_tool_sets.py
+++ b/apps/agent-service/tests/unit/agent/tools/test_tool_sets.py
@@ -4,12 +4,21 @@
 def test_main_agent_keeps_supported_main_tools():
     from app.agent.tools import ALL_TOOLS
     from app.agent.tools.delegation import deep_research
+    from app.agent.tools.no_reply import no_reply
     from app.agent.tools.sandbox import sandbox_bash
     from app.agent.tools.skill import load_skill
 
     assert deep_research in ALL_TOOLS
     assert load_skill in ALL_TOOLS
     assert sandbox_bash in ALL_TOOLS
+    assert no_reply in ALL_TOOLS
+
+
+def test_no_reply_is_main_only_tool():
+    from app.agent.tools import ALL_TOOLS, BASE_TOOLS
+
+    assert "no_reply" not in {t.definition.name for t in BASE_TOOLS}
+    assert "no_reply" in {t.definition.name for t in ALL_TOOLS}
 
 
 def test_chat_toolsets_drop_legacy_rag_tools():


### PR DESCRIPTION
## Summary
- add a real `no_reply` tool to the main chat toolset only
- make the ReAct run/stream loops end the current turn when `no_reply` is called
- cover non-streaming, streaming, and toolset registration behavior

## Prompt coordination
- Langfuse production was not changed for this PR
- test prompt label prepared separately: `ppe-refuse-topics`

## Verification
- `uv run pytest tests/unit/agent/test_react_loop.py tests/unit/agent/tools/test_tool_sets.py`
- `uv run ruff check app/agent/core.py app/agent/tools/__init__.py app/agent/tools/no_reply.py tests/unit/agent/test_react_loop.py tests/unit/agent/tools/test_tool_sets.py`