### PR TITLE
perf(media-sync): batch tagger submissions

### DIFF
--- a/apps/media-sync-worker/.env.example
+++ b/apps/media-sync-worker/.env.example
@@ -66,7 +66,8 @@ TAGGER_TRIGGER_ENABLED=false
 TAGGER_ENTRY_URL=http://tagger-entry.internal:8000
 TAGGER_API_TOKEN=your_tagger_caller_token_here
 TAGGER_CALLBACK_URL=http://media-sync-worker/internal/tagger/callback
-TAGGER_SUBMIT_BATCH_SIZE=1
+# 每个 tagger task 合并提交的图片数。设为 4 可让 tagger-entry 对 4 张图做一次 batch 推理。
+TAGGER_SUBMIT_BATCH_SIZE=4
 TAGGER_SUBMIT_TIMEOUT_MS=10000
 TAGGER_SUBMIT_RETRIES=2
 TAGGER_TRIGGER_WORKER_IDLE_DELAY_MS=5000

--- a/apps/media-sync-worker/README.md
+++ b/apps/media-sync-worker/README.md
@@ -48,6 +48,7 @@ Tagger 结果存储例外：打标结果写入本地 Mongo，复用 channel-serv
 - `TAGGER_RESULT_MONGO_*`：本地 tagger 结果 Mongo 配置，必须和旧 `MONGO_*` 分开。
 - `TAGGER_TRIGGER_ENABLED`：开启下载后写入 tagger outbox，由后台 worker 自动提交 tagger，默认关闭。
 - `TAGGER_ENTRY_URL` / `TAGGER_API_TOKEN`：tagger entry 调用地址和 caller token。
+- `TAGGER_SUBMIT_BATCH_SIZE`：每个 tagger task 合并提交的图片数，默认 `1`；线上可设为 `4` 让 tagger-entry 对多图做一次 batch 推理。
 - `TAGGER_TRIGGER_WORKER_IDLE_DELAY_MS` / `TAGGER_TRIGGER_RETRY_DELAY_MS` / `TAGGER_TRIGGER_PROCESSING_TIMEOUT_MS` / `TAGGER_TRIGGER_MAX_ATTEMPTS`：tagger outbox worker 轮询、重试和 processing 超时配置。
 - `TAGGER_CALLBACK_URL` / `TAGGER_CALLBACK_AUTH_TOKEN`：tagger-service 回调地址和回调鉴权 token。
 - `TAGGER_CALLBACK_SERVER_ENABLED` / `TAGGER_CALLBACK_PORT`：开启 worker 内部 HTTP callback 入口及端口。

--- a/apps/media-sync-worker/src/tagger/trigger.test.ts
+++ b/apps/media-sync-worker/src/tagger/trigger.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'bun:test';
-import { triggerTaggerForPixivAddr, type TriggerTaggerDeps } from './trigger';
+import { triggerTaggerForPixivAddr, triggerTaggerForPixivAddrs, type TriggerTaggerDeps } from './trigger';
 import type { MinioSyncForTaggerResult } from '../storage/syncPage';
 
 class FakeSubmitClient {
@@ -118,5 +118,98 @@ describe('triggerTaggerForPixivAddr', () => {
 
         expect(result).toEqual({ status: 'submit_failed', objectName: 'a.jpg', error: 'entry busy' });
         expect((d.repository as FakeRepo).failed).toEqual([{ paths: ['a.jpg'], error: 'entry busy' }]);
+    });
+});
+
+describe('triggerTaggerForPixivAddrs', () => {
+    it('submits all synced MinIO basenames as one tagger task', async () => {
+        const submitClient = new FakeSubmitClient();
+        const repository = new FakeRepo();
+        const syncResults: Record<string, MinioSyncForTaggerResult> = {
+            'a.jpg': {
+                status: 'synced',
+                pixivAddr: 'a.jpg',
+                ossKey: 'pixiv_img_v2/20260605/a.jpg',
+                objectName: 'a.jpg',
+            },
+            'b.jpg': {
+                status: 'synced',
+                pixivAddr: 'b.jpg',
+                ossKey: 'pixiv_img_v2/20260605/b.jpg',
+                objectName: 'b.jpg',
+            },
+        };
+
+        const result = await triggerTaggerForPixivAddrs(['a.jpg', 'b.jpg'], {
+            syncPixivToMinio: async (pixivAddr) => syncResults[pixivAddr],
+            submitClient,
+            repository,
+            callbackUrl: 'http://media-sync-worker/internal/tagger/callback',
+        });
+
+        expect(result).toEqual({
+            status: 'submitted',
+            taskId: 'task-1',
+            items: [
+                { pixivAddr: 'a.jpg', objectName: 'a.jpg' },
+                { pixivAddr: 'b.jpg', objectName: 'b.jpg' },
+            ],
+            skipped: [],
+        });
+        expect(submitClient.calls).toEqual([
+            {
+                paths: ['a.jpg', 'b.jpg'],
+                callbackUrl: 'http://media-sync-worker/internal/tagger/callback',
+            },
+        ]);
+        expect(repository.submitted).toEqual([{ taskId: 'task-1', paths: ['a.jpg', 'b.jpg'] }]);
+    });
+
+    it('submits ready images and returns skipped images for retry handling', async () => {
+        const submitClient = new FakeSubmitClient();
+        const repository = new FakeRepo();
+        const syncResults: Record<string, MinioSyncForTaggerResult> = {
+            'a.jpg': {
+                status: 'synced',
+                pixivAddr: 'a.jpg',
+                ossKey: 'pixiv_img_v2/20260605/a.jpg',
+                objectName: 'a.jpg',
+            },
+            'b.jpg': {
+                status: 'timeout',
+                pixivAddr: 'b.jpg',
+                ossKey: 'pixiv_img_v2/20260605/b.jpg',
+                objectName: 'b.jpg',
+                timeoutMs: 30000,
+            },
+        };
+
+        const result = await triggerTaggerForPixivAddrs(['a.jpg', 'b.jpg'], {
+            syncPixivToMinio: async (pixivAddr) => syncResults[pixivAddr],
+            submitClient,
+            repository,
+            callbackUrl: 'http://media-sync-worker/internal/tagger/callback',
+        });
+
+        expect(result).toEqual({
+            status: 'submitted',
+            taskId: 'task-1',
+            items: [{ pixivAddr: 'a.jpg', objectName: 'a.jpg' }],
+            skipped: [
+                {
+                    pixivAddr: 'b.jpg',
+                    reason: 'timeout',
+                    ossKey: 'pixiv_img_v2/20260605/b.jpg',
+                    objectName: 'b.jpg',
+                    timeoutMs: 30000,
+                },
+            ],
+        });
+        expect(submitClient.calls).toEqual([
+            {
+                paths: ['a.jpg'],
+                callbackUrl: 'http://media-sync-worker/internal/tagger/callback',
+            },
+        ]);
     });
 });

--- a/apps/media-sync-worker/src/tagger/trigger.ts
+++ b/apps/media-sync-worker/src/tagger/trigger.ts
@@ -25,6 +25,34 @@ export type TriggerTaggerResult =
     | { status: 'submitted'; taskId: string; objectName: string }
     | { status: 'submit_failed'; objectName: string; error: string };
 
+export interface TriggerSubmittedItem {
+    pixivAddr: string;
+    objectName: string;
+}
+
+export type TriggerTaggerBatchResult =
+    | {
+        status: 'submitted';
+        taskId: string;
+        items: TriggerSubmittedItem[];
+        skipped: TriggerSkippedItem[];
+    }
+    | {
+        status: 'submit_failed';
+        items: TriggerSubmittedItem[];
+        error: string;
+        skipped: TriggerSkippedItem[];
+    }
+    | {
+        status: 'empty';
+        skipped: TriggerSkippedItem[];
+    };
+
+export type TriggerSkippedItem = {
+    pixivAddr: string;
+    reason: Exclude<MinioSyncForTaggerResult['status'], 'synced'>;
+} & TriggerSkipDetails;
+
 interface TriggerSkipDetails {
     objectName?: string;
     ossKey?: string;
@@ -36,40 +64,84 @@ export async function triggerTaggerForPixivAddr(
     pixivAddr: string,
     deps: TriggerTaggerDeps
 ): Promise<TriggerTaggerResult> {
-    const syncResult = await deps.syncPixivToMinio(pixivAddr);
-    if (syncResult.status !== 'synced') {
+    const batchResult = await triggerTaggerForPixivAddrs([pixivAddr], deps);
+    if (batchResult.status === 'submitted') {
         return {
-            status: 'skipped',
-            reason: syncResult.status,
-            ...skipDetails(syncResult),
+            status: 'submitted',
+            taskId: batchResult.taskId,
+            objectName: batchResult.items[0].objectName,
+        };
+    }
+    if (batchResult.status === 'submit_failed') {
+        return {
+            status: 'submit_failed',
+            objectName: batchResult.items[0].objectName,
+            error: batchResult.error,
         };
     }
 
-    const objectName = syncResult.objectName;
+    const { pixivAddr: _pixivAddr, ...skipped } = batchResult.skipped[0];
+    return {
+        status: 'skipped',
+        ...skipped,
+    };
+}
+
+export async function triggerTaggerForPixivAddrs(
+    pixivAddrs: string[],
+    deps: TriggerTaggerDeps
+): Promise<TriggerTaggerBatchResult> {
+    const items: TriggerSubmittedItem[] = [];
+    const skipped: TriggerSkippedItem[] = [];
+
+    const syncResults = await Promise.all(pixivAddrs.map(async (pixivAddr) => ({
+        pixivAddr,
+        syncResult: await deps.syncPixivToMinio(pixivAddr),
+    })));
+
+    for (const { pixivAddr, syncResult } of syncResults) {
+        if (syncResult.status !== 'synced') {
+            skipped.push({
+                pixivAddr,
+                reason: syncResult.status,
+                ...skipDetails(syncResult),
+            });
+            continue;
+        }
+        items.push({ pixivAddr, objectName: syncResult.objectName });
+    }
+
+    if (items.length === 0) {
+        return { status: 'empty', skipped };
+    }
+
+    const objectNames = items.map((item) => item.objectName);
     try {
         const submitResult = await deps.submitClient.submit({
-            paths: [objectName],
+            paths: objectNames,
             callbackUrl: deps.callbackUrl,
         });
         await deps.repository.markSubmitted({
             taskId: submitResult.taskId,
-            paths: [objectName],
+            paths: objectNames,
         });
         return {
             status: 'submitted',
             taskId: submitResult.taskId,
-            objectName,
+            items,
+            skipped,
         };
     } catch (err) {
         const error = err instanceof Error ? err.message : String(err);
         await deps.repository.markSubmitFailed({
-            paths: [objectName],
+            paths: objectNames,
             error,
         });
         return {
             status: 'submit_failed',
-            objectName,
+            items,
             error,
+            skipped,
         };
     }
 }

--- a/apps/media-sync-worker/src/tagger/triggerWorker.test.ts
+++ b/apps/media-sync-worker/src/tagger/triggerWorker.test.ts
@@ -75,29 +75,29 @@ function doc(pixivAddr: string, attempts = 0): TaggerImageResultDocument {
 }
 
 describe('processTaggerTriggerBatch', () => {
-    it('submits due queued images from the background worker', async () => {
+    it('submits due queued images as one tagger batch from the background worker', async () => {
         const repository = new FakeRepository();
         const submitClient = new FakeSubmitClient();
-        repository.docs = [doc('a.jpg')];
+        repository.docs = [doc('a.jpg'), doc('b.jpg')];
 
         const processed = await processTaggerTriggerBatch({
             repository: repository as any,
             submitClient: submitClient as any,
             config,
-            syncPixivToMinio: async (): Promise<MinioSyncForTaggerResult> => ({
+            syncPixivToMinio: async (pixivAddr): Promise<MinioSyncForTaggerResult> => ({
                 status: 'synced',
-                pixivAddr: 'a.jpg',
-                ossKey: 'pixiv_img_v2/20260605/a.jpg',
-                objectName: 'a.jpg',
+                pixivAddr,
+                ossKey: `pixiv_img_v2/20260605/${pixivAddr}`,
+                objectName: pixivAddr,
             }),
         });
 
-        expect(processed).toBe(1);
-        expect(repository.claimed).toEqual(['a.jpg']);
+        expect(processed).toBe(2);
+        expect(repository.claimed).toEqual(['a.jpg', 'b.jpg']);
         expect(submitClient.calls).toEqual([
-            { paths: ['a.jpg'], callbackUrl: 'http://media-sync-worker/internal/tagger/callback' },
+            { paths: ['a.jpg', 'b.jpg'], callbackUrl: 'http://media-sync-worker/internal/tagger/callback' },
         ]);
-        expect(repository.submitted).toEqual([{ taskId: 'task-1', paths: ['a.jpg'] }]);
+        expect(repository.submitted).toEqual([{ taskId: 'task-1', paths: ['a.jpg', 'b.jpg'] }]);
         expect(repository.retries).toEqual([]);
     });
 
@@ -124,6 +124,43 @@ describe('processTaggerTriggerBatch', () => {
         expect(repository.retries[0].path).toBe('a.jpg');
         expect(repository.retries[0].attempts).toBe(2);
         expect(repository.retries[0].error).toContain('reason=timeout');
+    });
+
+    it('submits synced images while retrying skipped images in the same batch', async () => {
+        const repository = new FakeRepository();
+        const submitClient = new FakeSubmitClient();
+        repository.docs = [doc('a.jpg'), doc('b.jpg', 1)];
+
+        await processTaggerTriggerBatch({
+            repository: repository as any,
+            submitClient: submitClient as any,
+            config,
+            syncPixivToMinio: async (pixivAddr): Promise<MinioSyncForTaggerResult> => {
+                if (pixivAddr === 'b.jpg') {
+                    return {
+                        status: 'timeout',
+                        pixivAddr,
+                        ossKey: 'pixiv_img_v2/20260605/b.jpg',
+                        objectName: 'b.jpg',
+                        timeoutMs: 30000,
+                    };
+                }
+                return {
+                    status: 'synced',
+                    pixivAddr,
+                    ossKey: 'pixiv_img_v2/20260605/a.jpg',
+                    objectName: 'a.jpg',
+                };
+            },
+        });
+
+        expect(submitClient.calls).toEqual([
+            { paths: ['a.jpg'], callbackUrl: 'http://media-sync-worker/internal/tagger/callback' },
+        ]);
+        expect(repository.submitted).toEqual([{ taskId: 'task-1', paths: ['a.jpg'] }]);
+        expect(repository.retries).toHaveLength(1);
+        expect(repository.retries[0].path).toBe('b.jpg');
+        expect(repository.retries[0].attempts).toBe(2);
     });
 
     it('does not submit when another worker has already claimed the image', async () => {

--- a/apps/media-sync-worker/src/tagger/triggerWorker.ts
+++ b/apps/media-sync-worker/src/tagger/triggerWorker.ts
@@ -1,6 +1,9 @@
 import { syncPixivToMinioForTagger, type MinioSyncForTaggerResult } from '../storage/syncPage';
 import type { TaggerSubmitClient } from './submitClient';
-import { triggerTaggerForPixivAddr, type TriggerTaggerResult } from './trigger';
+import {
+    triggerTaggerForPixivAddrs,
+    type TriggerSkippedItem,
+} from './trigger';
 import type { TaggerTriggerConfig } from './config';
 import type { TaggerResultRepository } from './resultRepository';
 import type { TaggerImageResultDocument } from './types';
@@ -56,13 +59,23 @@ export async function processTaggerTriggerBatch(deps: TaggerTriggerWorkerDeps): 
         limit: deps.config.batchSize,
         processingTimeoutMs: deps.config.processingTimeoutMs,
     });
+    const claimedDocs: TaggerImageResultDocument[] = [];
     for (const doc of docs) {
-        await processOne(doc, deps);
+        const claimedDoc = await claimOne(doc, deps);
+        if (claimedDoc) {
+            claimedDocs.push(claimedDoc);
+        }
+    }
+    if (claimedDocs.length > 0) {
+        await processClaimedBatch(claimedDocs, deps);
     }
     return docs.length;
 }
 
-async function processOne(doc: TaggerImageResultDocument, deps: TaggerTriggerWorkerDeps): Promise<void> {
+async function claimOne(
+    doc: TaggerImageResultDocument,
+    deps: TaggerTriggerWorkerDeps
+): Promise<TaggerImageResultDocument | null> {
     const path = doc.pixiv_addr;
     const claimedDoc = await deps.repository.claimDueTriggerImage({
         path,
@@ -70,10 +83,16 @@ async function processOne(doc: TaggerImageResultDocument, deps: TaggerTriggerWor
     });
     if (!claimedDoc) {
         console.log(`Tagger trigger claim skipped: pixiv_addr=${path}`);
-        return;
+        return null;
     }
+    return claimedDoc;
+}
 
-    const result = await triggerTaggerForPixivAddr(path, {
+async function processClaimedBatch(
+    docs: TaggerImageResultDocument[],
+    deps: TaggerTriggerWorkerDeps
+): Promise<void> {
+    const result = await triggerTaggerForPixivAddrs(docs.map((doc) => doc.pixiv_addr), {
         syncPixivToMinio: deps.syncPixivToMinio ?? syncPixivToMinioForTagger,
         submitClient: deps.submitClient,
         repository: deps.repository,
@@ -81,13 +100,35 @@ async function processOne(doc: TaggerImageResultDocument, deps: TaggerTriggerWor
     });
 
     if (result.status === 'submitted') {
-        console.log(`Tagger trigger submitted: pixiv_addr=${path} object_name=${result.objectName} task_id=${result.taskId}`);
-        return;
+        for (const item of result.items) {
+            console.log(
+                `Tagger trigger submitted: pixiv_addr=${item.pixivAddr} object_name=${item.objectName} task_id=${result.taskId} batch_size=${result.items.length}`
+            );
+        }
+    } else if (result.status === 'submit_failed') {
+        console.warn(
+            `Tagger trigger submit failed: paths=${result.items.map((item) => item.objectName).join(',')} error=${result.error}`
+        );
     }
 
-    const attempts = (claimedDoc.attempts ?? 0) + 1;
-    const error = formatTriggerError(result);
-    if (attempts >= deps.config.maxAttempts || (result.status === 'skipped' && result.reason === 'disabled')) {
+    for (const skipped of result.skipped) {
+        const doc = docs.find((item) => item.pixiv_addr === skipped.pixivAddr);
+        if (!doc) {
+            continue;
+        }
+        await handleSkipped(doc, skipped, deps);
+    }
+}
+
+async function handleSkipped(
+    doc: TaggerImageResultDocument,
+    skipped: TriggerSkippedItem,
+    deps: TaggerTriggerWorkerDeps
+): Promise<void> {
+    const path = doc.pixiv_addr;
+    const attempts = (doc.attempts ?? 0) + 1;
+    const error = formatSkippedError(skipped);
+    if (attempts >= deps.config.maxAttempts || skipped.reason === 'disabled') {
         await deps.repository.markSubmitFailed({ paths: [path], error });
         console.warn(`Tagger trigger exhausted: pixiv_addr=${path} attempts=${attempts} error=${error}`);
         return;
@@ -105,10 +146,7 @@ async function processOne(doc: TaggerImageResultDocument, deps: TaggerTriggerWor
     );
 }
 
-function formatTriggerError(result: Exclude<TriggerTaggerResult, { status: 'submitted' }>): string {
-    if (result.status === 'submit_failed') {
-        return result.error;
-    }
+function formatSkippedError(result: TriggerSkippedItem): string {
     const details = [
         `reason=${result.reason}`,
         result.objectName ? `object_name=${result.objectName}` : '',


### PR DESCRIPTION
## Summary
- batch claimed tagger outbox images into one tagger task instead of submitting one task per image
- keep per-image retry handling for MinIO sync skips while still submitting ready images
- document TAGGER_SUBMIT_BATCH_SIZE=4 as the production tuning knob

## Verification
- bun test apps/media-sync-worker/src/tagger/trigger.test.ts apps/media-sync-worker/src/tagger/triggerWorker.test.ts
- bun run --cwd apps/media-sync-worker check
- bun run --cwd apps/media-sync-worker test
- git diff --check

## Notes
This opens batching at the media-sync submit layer. It does not add multiple tagger-entry workers, because the Qwen runner is still serialized behind one vLLM instance.