### PR TITLE
fix: proactive persona role + group reply ingest

### DIFF
--- a/apps/agent-service/app/data/queries/messages.py
+++ b/apps/agent-service/app/data/queries/messages.py
@@ -38,6 +38,44 @@ __all__ = [
 ]
 
 
+def _bot_config_persona():
+    """assistant 行经 ``bot_config(bot_name → persona_id)`` 兜底取发言 persona。
+
+    proactive 出站行真实落库形态是 ``response_id=NULL`` 且**没有**
+    ``common_agent_response`` 行（worker 口径：proactive session_id=null → responseId
+    不挂、不写 agent_response），所以单靠 ``response_id → common_agent_response.session_id``
+    join 必拿 None —— 那会让 proactive 行被判成 persona=None，下游误判为真人输入（串味）。
+    bot_name → persona 是它在真实链路里唯一能拿到的归属来源。
+
+    ``bot_config`` 由 channel-server 管理、不在 agent-service 的 SQLAlchemy 模型里
+    （见 ``models.py`` 顶注、``resolve_persona_id`` 同样裸表读它），用相关标量子查询读
+    裸表：``bot_name = common_message.bot_name`` 与外层 ``common_message`` 关联，只取
+    ``is_active`` 的映射。
+
+    **承重红线（codex 必改 1）**：子查询额外 correlate 外层 ``role = 'assistant'``。
+    channel-server 给真人 ``role='user'`` 行**也写 bot_name``（storeLarkInboundMessage
+    给 inbound user 行落 bot_name=botName、claim 时再写），裸 ``bot_name`` 子查询会对
+    user 行也命中、把真人话错归成某 persona——查询合同被串脏。human-chat 路径下游
+    ``is_self`` 第一个条件就是 ``role == 'assistant'`` 遮住不炸，但睡前回顾路径
+    （``find_persona_spoken_chats_in_window`` → ``review``）**直接用 persona 分"她说的
+    vs 用户说的"、没有 role gate**，会把真人话当成她自己说的。加 role 限定让外层非
+    assistant 行（user / 其它）→ 子查询无命中 → 返回 NULL。assistant proactive 出站行
+    （``response_id=NULL``、无 agent_response）仍经 bot_name → persona 兜底拿到归属。
+    """
+    return (
+        select(text("persona_id"))
+        .select_from(text("bot_config"))
+        .where(
+            text(
+                "bot_name = common_message.bot_name AND is_active = true "
+                "AND common_message.role = 'assistant'"
+            )
+        )
+        .limit(1)
+        .scalar_subquery()
+    )
+
+
 def _uuid(value: str | UUID | None) -> UUID | None:
     if value is None:
         return None
@@ -319,24 +357,11 @@ async def find_recent_chat_messages(
     if chat_uuid is None:
         return []
 
-    # bot_config 兜底：assistant 行 response_id 取不到 persona 时（proactive 出站行
-    # response_id=NULL），按它的 bot_name 在 bot_config 里查 persona。bot_config 不是
-    # agent-service 的映射模型（channel-server 管），用相关标量子查询读裸表（同
-    # resolve_persona_id）。只对有 bot_name 的行有意义；user 行 bot_name=NULL → 子查询
-    # 拿不到、整体仍 NULL。
-    bot_config_persona = (
-        select(text("persona_id"))
-        .select_from(text("bot_config"))
-        .where(text("bot_name = common_message.bot_name AND is_active = true"))
-        .limit(1)
-        .scalar_subquery()
-    )
-
     stmt = (
         select(
             CommonMessage,
             func.coalesce(
-                CommonAgentResponse.persona_id, bot_config_persona
+                CommonAgentResponse.persona_id, _bot_config_persona()
             ).label("persona_id"),
         )
         .outerjoin(
@@ -374,7 +399,9 @@ async def find_messages_with_user_chat_persona_by_root(
         select(
             CommonMessage,
             CommonConversation.display_name.label("chat_name"),
-            CommonAgentResponse.persona_id.label("persona_id"),
+            func.coalesce(
+                CommonAgentResponse.persona_id, _bot_config_persona()
+            ).label("persona_id"),
         )
         .outerjoin(
             CommonConversation,
@@ -426,7 +453,9 @@ async def find_messages_with_user_chat_persona_in_chat(
         select(
             CommonMessage,
             CommonConversation.display_name.label("chat_name"),
-            CommonAgentResponse.persona_id.label("persona_id"),
+            func.coalesce(
+                CommonAgentResponse.persona_id, _bot_config_persona()
+            ).label("persona_id"),
         )
         .outerjoin(
             CommonConversation,
@@ -474,24 +503,31 @@ async def find_persona_spoken_chats_in_window(
 
     参与边界合同（spec 决策 2b）：她在 ``[since_ms, until_ms]`` 闭区间内发过言的
     chat 才算她的经历——被动在场没吭声的群不算（chat 是被动唤起模型，她没被唤起
-    就没看见）。「她发过言」按 common 口径判：assistant 消息经
-    ``response_id == common_agent_response.session_id`` join 出 ``persona_id``。
+    就没看见）。「她发过言」按 common 口径判：assistant 消息的发言 persona ==
+    ``persona_id``，发言 persona 经 ``COALESCE(common_agent_response.persona_id,
+    bot_config(bot_name→persona_id))`` 取——**普通回复**经 ``response_id →
+    agent_response`` join 拿，**proactive 出站行**（``response_id=NULL``、无
+    agent_response）经 ``bot_config`` 兜底拿（承重 2：只认 response join 会把她只发过
+    proactive 的 chat 整个漏出回顾）。
 
     每个够格的 chat 取窗口内消息（user + assistant，剔除 ``proactive_trigger``
     伪消息），**条目数量控制不截断**：超 ``per_chat_limit`` 只保最近 N 条、仍按
-    发生先后升序。每条消息带发言 persona（None = 用户消息 / 无归属），让回顾分
-    得清"她说的"和"别的 bot 说的"；身份字段（user_id / username / chat_type）
-    在 ``CommonMessageRecord`` 里。返回按 chat 维度分组：
+    发生先后升序。每条消息带发言 persona（None = 用户消息 / 无归属），发言 persona
+    同样经 ``COALESCE(agent_response.persona_id, bot_config 兜底)`` 取（proactive 出站
+    行 persona 归属不丢；``_bot_config_persona`` 已加 role 限定，真人 user 行仍是
+    None、归属正确），让回顾分得清"她说的"和"别的 bot 说的"；身份字段（user_id /
+    username / chat_type）在 ``CommonMessageRecord`` 里。返回按 chat 维度分组：
     ``[(chat_id, chat 显示名, [(record, 发言 persona), ...]), ...]``。
     """
     spoke_stmt = (
         select(CommonMessage.common_conversation_id)
-        .join(
+        .outerjoin(
             CommonAgentResponse,
             CommonMessage.response_id == CommonAgentResponse.session_id,
         )
         .where(
-            CommonAgentResponse.persona_id == persona_id,
+            func.coalesce(CommonAgentResponse.persona_id, _bot_config_persona())
+            == persona_id,
             CommonMessage.role == "assistant",
             CommonMessage.event_time >= since_ms,
             CommonMessage.event_time <= until_ms,
@@ -515,7 +551,9 @@ async def find_persona_spoken_chats_in_window(
             msg_stmt = (
                 select(
                     CommonMessage,
-                    CommonAgentResponse.persona_id.label("persona_id"),
+                    func.coalesce(
+                        CommonAgentResponse.persona_id, _bot_config_persona()
+                    ).label("persona_id"),
                 )
                 .outerjoin(
                     CommonAgentResponse,

--- a/apps/agent-service/tests/data/test_persona_spoken_chats.py
+++ b/apps/agent-service/tests/data/test_persona_spoken_chats.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import uuid
 
 import pytest
+from sqlalchemy import text
 
 import app.data.session as session_mod
 from app.data.models import (
@@ -33,11 +34,24 @@ _CHAT_A = uuid.uuid5(uuid.NAMESPACE_OID, "chat-a")
 _CHAT_B = uuid.uuid5(uuid.NAMESPACE_OID, "chat-b")
 _USER_1 = uuid.uuid5(uuid.NAMESPACE_OID, "user-1")
 _USER_2 = uuid.uuid5(uuid.NAMESPACE_OID, "user-2")
+# proactive 出站行真实落库时 common_user_id = bot 自己的 common_user_id（非 NULL）。
+_BOT_USER = uuid.uuid5(uuid.NAMESPACE_OID, "spoken-bot-user")
+
+# bot_config 由 channel-server 管理、不在 agent-service 的 SQLAlchemy 模型里。proactive
+# 出站行只带 bot_name（response_id=NULL、无 agent_response），发言 persona 必须经
+# bot_config(bot_name → persona_id) 兜底拿到，所以集成测试要手动建这张表 + 灌一行。
+_BOT_CONFIG_DDL = (
+    "CREATE TABLE bot_config ("
+    "  bot_name VARCHAR(50) PRIMARY KEY,"
+    "  persona_id VARCHAR(50),"
+    "  is_active BOOLEAN NOT NULL DEFAULT TRUE"
+    ")"
+)
 
 
 @pytest.fixture
 async def chat_db(test_db):
-    """Build the common_* tables the query joins on."""
+    """Build the common_* tables the query joins on (+ bot_config for proactive)."""
     tables = [
         CommonMessage.__table__,
         CommonAgentResponse.__table__,
@@ -47,7 +61,44 @@ async def chat_db(test_db):
         await conn.run_sync(
             lambda sync_conn: Base.metadata.create_all(sync_conn, tables=tables)
         )
+        await conn.execute(text(_BOT_CONFIG_DDL))
     yield test_db
+
+
+async def _seed_bot_config(bot_name, persona_id, *, is_active=True):
+    async with session_mod.get_session() as s:
+        await s.execute(
+            text(
+                "INSERT INTO bot_config (bot_name, persona_id, is_active) "
+                "VALUES (:bn, :pid, :active)"
+            ),
+            {"bn": bot_name, "pid": persona_id, "active": is_active},
+        )
+
+
+async def _seed_proactive_bot_message(
+    chat_id, *, event_time, text_, bot_name, scope="direct"
+):
+    """proactive 出站 assistant 行真实形态：role=assistant、带 bot_name、
+    **response_id=NULL**、**无** CommonAgentResponse 行（worker 落库口径）。"""
+    async with session_mod.get_session() as s:
+        s.add(
+            CommonMessage(
+                common_message_id=uuid.uuid4(),
+                channel="lark",
+                common_conversation_id=chat_id,
+                common_user_id=_BOT_USER,
+                sender_display_name=None,
+                role="assistant",
+                content=[{"kind": "text", "text": text_}],
+                content_text=text_,
+                scope=scope,
+                message_type="post",
+                bot_name=bot_name,
+                response_id=None,
+                event_time=event_time,
+            )
+        )
 
 
 async def _seed_conversation(chat_id, *, scope="group", name="测试群"):
@@ -64,7 +115,7 @@ async def _seed_conversation(chat_id, *, scope="group", name="测试群"):
 
 async def _seed_user_message(
     chat_id, *, event_time, text, user_id=_USER_1, username="贝壳",
-    scope="group", message_type=None,
+    scope="group", message_type=None, bot_name=None,
 ):
     async with session_mod.get_session() as s:
         s.add(
@@ -79,6 +130,7 @@ async def _seed_user_message(
                 content_text=text,
                 scope=scope,
                 message_type=message_type,
+                bot_name=bot_name,
                 event_time=event_time,
             )
         )
@@ -272,3 +324,75 @@ async def test_proactive_trigger_pseudo_messages_excluded(chat_db):
     _cid, _name, entries = got[0]
     texts = [r.content for r, _p in entries]
     assert not any("伪消息" in t for t in texts)
+
+
+@pytest.mark.integration
+async def test_proactive_only_chat_qualifies_as_spoken(chat_db):
+    """承重（codex 必改 2）：她在窗口内**只发过 proactive**（response_id=NULL、无
+    agent_response、bot_name 指向她的 active bot_config）的 chat 也算「她发过言」。
+
+    旧 spoke_stmt inner join agent_response + persona_id 比对，proactive 行 join 不上 →
+    这种 chat 被整个漏出回顾。改成 outerjoin + COALESCE(persona_id, bot_config 兜底) 后
+    才纳入。且该 proactive 行在回顾里 persona 要正确归属到她（akao）。
+    """
+    await _seed_conversation(_CHAT_A, scope="direct", name=None)
+    await _seed_bot_config("chiwei", "akao")
+    await _seed_user_message(
+        _CHAT_A, event_time=1000, text="在吗", scope="direct"
+    )
+    await _seed_proactive_bot_message(
+        _CHAT_A, event_time=2000, text_="我刚在想你", bot_name="chiwei"
+    )
+
+    got = await find_persona_spoken_chats_in_window(
+        persona_id="akao", since_ms=0, until_ms=10_000, per_chat_limit=50
+    )
+
+    assert len(got) == 1, (
+        "她只发过 proactive 的 chat 也必须算她发过言（spoke_stmt 要兜底 bot_config）"
+    )
+    _cid, _name, entries = got[0]
+    by_text = {r.content: p for r, p in entries}
+    proactive_persona = next(
+        p for t, p in by_text.items() if "我刚在想你" in t
+    )
+    assert proactive_persona == "akao", (
+        "proactive 出站行在回顾证据里要经 bot_config 归属到她（akao），"
+        f"实得 {proactive_persona!r}"
+    )
+    user_persona = next(p for t, p in by_text.items() if "在吗" in t)
+    assert user_persona is None, "真人那条无 persona 归属"
+
+
+@pytest.mark.integration
+async def test_user_row_with_bot_name_not_attributed_persona_in_review(chat_db):
+    """承重红线（codex 必改 1）：睡前回顾路径**直接用 persona 分"她说的 vs 用户说的"、
+    没有 role gate**。真人 user 行也带 bot_name（channel-server 给 user 行写 bot_name），
+    helper 必须只对 role='assistant' 行兜底——否则真人话会被错归成某 persona、回顾里
+    把真人的话当成她自己说的。
+
+    构造：一个她发过 proactive 的 chat（让 chat 够格进回顾），里头有一条带 bot_name 的
+    真人 user 行；该 user 行在 msg_stmt 里 persona 必须是 None。
+    """
+    await _seed_conversation(_CHAT_A, scope="direct", name=None)
+    await _seed_bot_config("chiwei", "akao")
+    await _seed_proactive_bot_message(
+        _CHAT_A, event_time=1000, text_="我刚在想你", bot_name="chiwei"
+    )
+    await _seed_user_message(
+        _CHAT_A, event_time=2000, text="真人带 bot_name 的话", scope="direct",
+        bot_name="chiwei",
+    )
+
+    got = await find_persona_spoken_chats_in_window(
+        persona_id="akao", since_ms=0, until_ms=10_000, per_chat_limit=50
+    )
+
+    assert len(got) == 1
+    _cid, _name, entries = got[0]
+    by_text = {r.content: p for r, p in entries}
+    user_persona = next(p for t, p in by_text.items() if "真人带 bot_name 的话" in t)
+    assert user_persona is None, (
+        "真人 user 行即便带 bot_name，回顾里也不能被兜底成 persona（否则真人话被认成"
+        f"她自己说的），实得 {user_persona!r}"
+    )

--- a/apps/agent-service/tests/data/test_proactive_persona_in_reply_chain.py
+++ b/apps/agent-service/tests/data/test_proactive_persona_in_reply_chain.py
@@ -1,0 +1,266 @@
+"""proactive 出站行在「真人回复链」历史里也必须认出是赤尾自己说的。
+
+承重场景：真人回复了赤尾**主动发**的那条消息后，agent-service 走 human-chat 路径
+（``quick_search`` → ``find_messages_with_user_chat_persona_by_root`` /
+``find_messages_with_user_chat_persona_in_chat``）把这条回复的历史拉出来组装上下文。
+那段历史里**包含赤尾上一条 proactive 出站消息**。
+
+proactive 出站行真实落库形态：``role=assistant``、带 ``bot_name``、**response_id=NULL**、
+**没有** ``CommonAgentResponse`` 行（worker 口径：proactive session_id=null → responseId
+不挂、不写 agent_response）。这两个回复链查询只经
+``response_id → common_agent_response.session_id`` join 取 persona，对 proactive 行必拿
+NULL —— 缺 ``find_recent_chat_messages`` 里那条 ``bot_config(bot_name→persona_id)`` 兜底。
+persona=NULL 会让下游 ``build_p2p_messages`` 把这条判成 USER role（当成真人 bezhai 说的），
+正是本 bug：**她自己说的话被认成用户输入**。
+
+集成测试（真 Postgres）：正确性全在 SQL 的 persona 兜底语义。
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+
+import pytest
+from sqlalchemy import text
+
+import app.data.session as session_mod
+from app.data.models import (
+    Base,
+    CommonAgentResponse,
+    CommonConversation,
+    CommonMessage,
+)
+from app.data.queries.messages import (
+    find_messages_with_user_chat_persona_by_root,
+    find_messages_with_user_chat_persona_in_chat,
+)
+
+_CHAT = uuid.uuid5(uuid.NAMESPACE_OID, "proactive-reply-chat")
+_USER = uuid.uuid5(uuid.NAMESPACE_OID, "proactive-reply-user")
+_ROOT = uuid.uuid5(uuid.NAMESPACE_OID, "proactive-reply-root")
+# proactive 出站行真实落库时 common_user_id = bot 自己的 common_user_id（非 NULL）。
+_BOT_USER = uuid.uuid5(uuid.NAMESPACE_OID, "proactive-reply-bot-user")
+
+# bot_config 由 channel-server 管理、不在 agent-service 的 SQLAlchemy 模型里。proactive
+# 出站行只带 bot_name（response_id=NULL），发言 persona 必须经 bot_config(bot_name →
+# persona_id) 兜底拿到，所以集成测试要手动建这张表 + 灌一行。
+_BOT_CONFIG_DDL = (
+    "CREATE TABLE bot_config ("
+    "  bot_name VARCHAR(50) PRIMARY KEY,"
+    "  persona_id VARCHAR(50),"
+    "  is_active BOOLEAN NOT NULL DEFAULT TRUE"
+    ")"
+)
+
+
+@pytest.fixture
+async def chat_db(test_db):
+    tables = [
+        CommonMessage.__table__,
+        CommonAgentResponse.__table__,
+        CommonConversation.__table__,
+    ]
+    async with test_db.begin() as conn:
+        await conn.run_sync(
+            lambda sync_conn: Base.metadata.create_all(sync_conn, tables=tables)
+        )
+        await conn.execute(text(_BOT_CONFIG_DDL))
+    yield test_db
+
+
+async def _seed_bot_config(bot_name, persona_id, *, is_active=True):
+    async with session_mod.get_session() as s:
+        await s.execute(
+            text(
+                "INSERT INTO bot_config (bot_name, persona_id, is_active) "
+                "VALUES (:bn, :pid, :active)"
+            ),
+            {"bn": bot_name, "pid": persona_id, "active": is_active},
+        )
+
+
+async def _seed_conversation(*, scope="direct", name=None):
+    async with session_mod.get_session() as s:
+        s.add(
+            CommonConversation(
+                common_conversation_id=_CHAT,
+                channel="lark",
+                scope=scope,
+                display_name=name,
+            )
+        )
+
+
+async def _seed_user_message(
+    message_id, *, event_time, text_, root_id, scope="direct", bot_name=None
+):
+    async with session_mod.get_session() as s:
+        s.add(
+            CommonMessage(
+                common_message_id=message_id,
+                channel="lark",
+                common_conversation_id=_CHAT,
+                common_user_id=_USER,
+                common_root_message_id=root_id,
+                sender_display_name="原智鸿",
+                role="user",
+                content=[{"kind": "text", "text": text_}],
+                content_text=text_,
+                scope=scope,
+                bot_name=bot_name,
+                event_time=event_time,
+            )
+        )
+
+
+async def _seed_proactive_bot_message(
+    message_id, *, event_time, text_, root_id, bot_name, scope="direct"
+):
+    """proactive 出站 assistant 行真实形态：bot_name + common_user_id=bot id +
+    response_id=NULL + 无 CommonAgentResponse 行。"""
+    async with session_mod.get_session() as s:
+        s.add(
+            CommonMessage(
+                common_message_id=message_id,
+                channel="lark",
+                common_conversation_id=_CHAT,
+                common_user_id=_BOT_USER,
+                common_root_message_id=root_id,
+                sender_display_name=None,
+                role="assistant",
+                content=[{"kind": "text", "text": text_}],
+                content_text=text_,
+                scope=scope,
+                message_type="post",
+                bot_name=bot_name,
+                response_id=None,
+                event_time=event_time,
+            )
+        )
+
+
+@pytest.mark.integration
+async def test_by_root_attributes_proactive_persona_via_bot_name(chat_db):
+    """root 链历史里的 proactive 出站行经 bot_config(bot_name→persona) 认出是赤尾。
+
+    构造一条回复链：真人发起（root）→ 赤尾 proactive 出站（同 root，response_id=NULL、
+    无 agent_response）→ 真人回复。by_root 拉出整链，proactive 那条必须带出 persona=akao，
+    否则下游会把她自己说的判成 USER role。
+    """
+    await _seed_conversation()
+    await _seed_bot_config("chiwei", "akao")
+    await _seed_user_message(_ROOT, event_time=1000, text_="在吗", root_id=_ROOT)
+    proactive_id = uuid.uuid5(uuid.NAMESPACE_OID, "proactive-reply-out")
+    await _seed_proactive_bot_message(
+        proactive_id, event_time=2000, text_="我刚在想你", root_id=_ROOT,
+        bot_name="chiwei",
+    )
+    trigger = uuid.uuid5(uuid.NAMESPACE_OID, "proactive-reply-trigger")
+    await _seed_user_message(trigger, event_time=3000, text_="哈哈", root_id=_ROOT)
+
+    rows = await find_messages_with_user_chat_persona_by_root(
+        root_message_id=str(_ROOT), until_create_time=3000,
+    )
+
+    by_text = _persona_by_text(rows)
+    assert by_text["在吗"] is None, "真人那条无 persona"
+    assert by_text["我刚在想你"] == "akao", (
+        "proactive 出站行（response_id=NULL、无 agent_response）必须经 "
+        f"bot_config(bot_name→persona) 认出是赤尾自己说的，实得 {by_text['我刚在想你']!r}"
+    )
+    assert by_text["哈哈"] is None, "真人那条无 persona"
+
+
+@pytest.mark.integration
+async def test_in_chat_attributes_proactive_persona_via_bot_name(chat_db):
+    """补历史路径（in_chat）里的 proactive 出站行同样要带出 persona。
+
+    in_chat 是 quick_search root 链不满 limit 时的补历史路径，也走相同的 persona join，
+    必须有同样的 bot_config 兜底。
+    """
+    await _seed_conversation()
+    await _seed_bot_config("chiwei", "akao")
+    other_root = uuid.uuid5(uuid.NAMESPACE_OID, "proactive-reply-other-root")
+    proactive_id = uuid.uuid5(uuid.NAMESPACE_OID, "proactive-reply-out2")
+    await _seed_proactive_bot_message(
+        proactive_id, event_time=2000, text_="我刚在想你", root_id=other_root,
+        bot_name="chiwei",
+    )
+
+    rows = await find_messages_with_user_chat_persona_in_chat(
+        chat_id=str(_CHAT),
+        exclude_root_message_id=str(_ROOT),
+        after_create_time=0,
+        before_create_time=5000,
+        exclude_user_id="",
+        limit=15,
+    )
+
+    by_text = _persona_by_text(rows)
+    assert by_text["我刚在想你"] == "akao", (
+        "in_chat 补历史路径的 proactive 出站行也必须经 bot_config 认出 persona，"
+        f"实得 {by_text['我刚在想你']!r}"
+    )
+
+
+@pytest.mark.integration
+async def test_by_root_user_row_with_bot_name_is_not_attributed_persona(chat_db):
+    """承重红线（codex 必改 1）：真人 user 行也带 bot_name（channel-server
+    storeLarkInboundMessage 给 user 行写 bot_name=botName / claim 时再写），它指向一个
+    active 的 bot_config(bot_name→persona)。helper 若不限 role='assistant'，会把这条
+    真人话错归成某 persona —— 查询合同被串脏（睡前回顾会把真人话当成她自己说的）。
+
+    构造：真人 root 行带 bot_name=chiwei、bot_config(chiwei→akao) active。该真人行的
+    发言 persona 必须是 None（它不是 assistant 行），不能被兜底成 akao。
+    """
+    await _seed_conversation()
+    await _seed_bot_config("chiwei", "akao")
+    await _seed_user_message(
+        _ROOT, event_time=1000, text_="在吗", root_id=_ROOT, bot_name="chiwei"
+    )
+
+    rows = await find_messages_with_user_chat_persona_by_root(
+        root_message_id=str(_ROOT), until_create_time=3000,
+    )
+
+    by_text = _persona_by_text(rows)
+    assert by_text["在吗"] is None, (
+        "真人 user 行即便带 bot_name，也不能经 bot_config 兜底成 persona —— helper "
+        f"必须只对 role='assistant' 行兜底，实得 {by_text['在吗']!r}"
+    )
+
+
+@pytest.mark.integration
+async def test_in_chat_user_row_with_bot_name_is_not_attributed_persona(chat_db):
+    """补历史路径（in_chat）同样：带 bot_name 的真人 user 行不被兜底成 persona。"""
+    await _seed_conversation()
+    await _seed_bot_config("chiwei", "akao")
+    other_root = uuid.uuid5(uuid.NAMESPACE_OID, "proactive-reply-user-other-root")
+    user_id = uuid.uuid5(uuid.NAMESPACE_OID, "proactive-reply-user-in-chat")
+    await _seed_user_message(
+        user_id, event_time=2000, text_="在吗", root_id=other_root, bot_name="chiwei"
+    )
+
+    rows = await find_messages_with_user_chat_persona_in_chat(
+        chat_id=str(_CHAT),
+        exclude_root_message_id=str(_ROOT),
+        after_create_time=0,
+        before_create_time=5000,
+        exclude_user_id="",
+        limit=15,
+    )
+
+    by_text = _persona_by_text(rows)
+    assert by_text["在吗"] is None, (
+        "in_chat 路径的真人 user 行带 bot_name 也不能被兜底成 persona，"
+        f"实得 {by_text['在吗']!r}"
+    )
+
+
+def _persona_by_text(rows):
+    """按消息纯文本索引发言 persona，方便逐条断言。"""
+    out: dict[str, str | None] = {}
+    for record, _username, _chat_name, persona in rows:
+        out[json.loads(record.content)["text"]] = persona
+    return out

--- a/apps/agent-service/tests/data/test_quick_search_proactive_filter.py
+++ b/apps/agent-service/tests/data/test_quick_search_proactive_filter.py
@@ -16,8 +16,11 @@ from __future__ import annotations
 import uuid
 
 import pytest
+from sqlalchemy import text
 
 import app.data.session as session_mod
+from app.agent.neutral import Role
+from app.chat._context_messages import build_p2p_messages
 from app.chat.quick_search import quick_search
 from app.data.models import (
     Base,
@@ -29,6 +32,17 @@ from app.data.models import (
 _CHAT = uuid.uuid5(uuid.NAMESPACE_OID, "qs-chat")
 _USER = uuid.uuid5(uuid.NAMESPACE_OID, "qs-user")
 _ROOT = uuid.uuid5(uuid.NAMESPACE_OID, "qs-root")
+
+# bot_config 由 channel-server 管理、不在 agent-service 的 SQLAlchemy 模型里。quick_search
+# 走的 by_root / in_chat 查询用相关标量子查询读它做 proactive persona 兜底，所以集成测试
+# 要手动建这张表（生产里它一定存在；不建会让子查询炸 "relation bot_config does not exist"）。
+_BOT_CONFIG_DDL = (
+    "CREATE TABLE bot_config ("
+    "  bot_name VARCHAR(50) PRIMARY KEY,"
+    "  persona_id VARCHAR(50),"
+    "  is_active BOOLEAN NOT NULL DEFAULT TRUE"
+    ")"
+)
 
 
 @pytest.fixture
@@ -42,6 +56,7 @@ async def chat_db(test_db):
         await conn.run_sync(
             lambda sync_conn: Base.metadata.create_all(sync_conn, tables=tables)
         )
+        await conn.execute(text(_BOT_CONFIG_DDL))
     yield test_db
 
 
@@ -59,7 +74,7 @@ async def _seed_conversation():
 
 async def _seed_message(
     message_id, *, event_time, text, root_id, message_type=None,
-    user_id=_USER, username="贝壳",
+    user_id=_USER, username="贝壳", bot_name=None, scope="group",
 ):
     async with session_mod.get_session() as s:
         s.add(
@@ -73,10 +88,22 @@ async def _seed_message(
                 role="user",
                 content=[{"kind": "text", "text": text}],
                 content_text=text,
-                scope="group",
+                scope=scope,
                 message_type=message_type,
+                bot_name=bot_name,
                 event_time=event_time,
             )
+        )
+
+
+async def _seed_bot_config(bot_name, persona_id, *, is_active=True):
+    async with session_mod.get_session() as s:
+        await s.execute(
+            text(
+                "INSERT INTO bot_config (bot_name, persona_id, is_active) "
+                "VALUES (:bn, :pid, :active)"
+            ),
+            {"bn": bot_name, "pid": persona_id, "active": is_active},
         )
 
 
@@ -162,3 +189,48 @@ async def test_quick_search_excludes_historical_proactive_trigger_in_chat_window
     assert any("窗口内真实历史" in t for t in texts), (
         f"in_chat 补历史路径没把窗口内真实历史补进来（路径没被触发）: {texts}"
     )
+
+
+@pytest.mark.integration
+async def test_human_chat_user_words_with_bot_name_stay_user_role_e2e(chat_db):
+    """端到端（承重红线 codex 必改 1）：真人 user 行带 bot_name（channel-server 给
+    inbound user 行写 bot_name=botName），bot_config(bot_name→persona) active。一路走
+    quick_search → build_p2p_messages，真人的话**必须**仍是 ``Role.USER``——绝不串成
+    赤尾自己说的（ASSISTANT）。
+
+    人链路上有两道防线，本测试整条锁住：
+      1. 查询层 helper 的 role 限定（codex 必改 1）：``_bot_config_persona`` 只对
+         ``role='assistant'`` 行兜底，真人 user 行 join 出 persona=None；
+      2. quick_search 第二道防线（:mod:`app.chat.quick_search` 第 109 行）：对 user 行
+         强制 ``persona_id=None``。
+    单测 helper 防线的「精确捕捉」在
+    ``tests/data/test_proactive_persona_in_reply_chain.py`` /
+    ``test_recent_chat_messages.py`` /
+    ``test_persona_spoken_chats.py`` 的查询层用例里（去掉 role 限定就转红）；本测试是
+    整条人链路的 smoke：真人话稳稳出成用户输入。
+    """
+    await _seed_conversation()
+    await _seed_bot_config("chiwei", "akao")
+    # 真人发起：root 行，带 bot_name=chiwei（channel-server inbound 落库口径）。
+    await _seed_message(
+        _ROOT, event_time=1000, text="赤尾在吗", root_id=_ROOT,
+        bot_name="chiwei", scope="direct",
+    )
+
+    results = await quick_search(str(_ROOT), limit=15)
+    by_text = {r.content: r for r in results}
+    real = next(r for t, r in by_text.items() if "赤尾在吗" in t)
+    assert real.persona_id is None, (
+        f"真人 user 行不能带出 persona（两道防线之一漏了），实得 {real.persona_id!r}"
+    )
+
+    # 渲染层：build_p2p_messages 据 persona 判 is_self，真人话必须是 USER role。
+    msgs = build_p2p_messages(
+        results, image_key_to_url={}, image_key_to_filename={},
+        current_persona_id="akao",
+    )
+    assert len(msgs) == 1
+    assert msgs[0].role == Role.USER, (
+        "真人带 bot_name 的话一路到渲染层仍必须是 Role.USER（不能串成她自己说的）"
+    )
+    assert "赤尾在吗" in msgs[0].text()

--- a/apps/agent-service/tests/data/test_recent_chat_messages.py
+++ b/apps/agent-service/tests/data/test_recent_chat_messages.py
@@ -31,6 +31,10 @@ from app.data.queries.messages import find_recent_chat_messages
 
 _CHAT = uuid.uuid5(uuid.NAMESPACE_OID, "recent-chat")
 _USER = uuid.uuid5(uuid.NAMESPACE_OID, "recent-user")
+# bot 在 common_user 里的身份。proactive 出站行真实落库时 common_user_id 是 bot 自己
+# 的 common_user_id（channel-server storeLarkOutboundMessage 写 botCommonUserId），
+# 不是 NULL —— 真实形态复现要带上它。
+_BOT_USER = uuid.uuid5(uuid.NAMESPACE_OID, "recent-bot-user")
 
 # bot_config 由 channel-server 管理、不在 agent-service 的 SQLAlchemy 模型里。
 # proactive 出站落库的 assistant 行只带 bot_name（response_id=NULL），发言 persona
@@ -72,11 +76,14 @@ async def _seed_bot_config(bot_name, persona_id, *, is_active=True):
 
 
 async def _seed_proactive_bot_message(
-    chat_id, *, event_time, msg_text, bot_name, scope="direct"
+    chat_id, *, event_time, msg_text, bot_name, scope="direct", common_user_id=None
 ):
     """造一条**真实形态**的 proactive 出站 assistant 行：role=assistant、带 bot_name、
     **response_id=NULL**、**没有** CommonAgentResponse 行（worker 真实落库口径，见
     channel-server storeLarkOutboundMessage：proactive session_id=null → responseId 不挂）。
+
+    ``common_user_id`` 默认 None；真实落库口径里它是 bot 自己的 common_user_id（非
+    NULL），传进来即可复现完整形态。
     """
     async with session_mod.get_session() as s:
         s.add(
@@ -84,7 +91,7 @@ async def _seed_proactive_bot_message(
                 common_message_id=uuid.uuid4(),
                 channel="lark",
                 common_conversation_id=chat_id,
-                common_user_id=None,
+                common_user_id=common_user_id,
                 sender_display_name=None,
                 role="assistant",
                 content=[{"kind": "text", "text": msg_text}],
@@ -111,7 +118,7 @@ async def _seed_conversation(chat_id, *, scope="direct", name=None):
 
 
 async def _seed_user_message(
-    chat_id, *, event_time, text, message_type=None, scope="direct"
+    chat_id, *, event_time, text, message_type=None, scope="direct", bot_name=None
 ):
     async with session_mod.get_session() as s:
         s.add(
@@ -126,6 +133,7 @@ async def _seed_user_message(
                 content_text=text,
                 scope=scope,
                 message_type=message_type,
+                bot_name=bot_name,
                 event_time=event_time,
             )
         )
@@ -262,6 +270,56 @@ async def test_proactive_assistant_row_attributes_persona_via_bot_name(chat_db):
     assert got[1][1] == "akao", (
         "proactive 出站行 response_id=NULL，必须经 bot_config(bot_name→persona) "
         f"认出是赤尾自己说的，实得 {got[1][1]!r}"
+    )
+
+
+@pytest.mark.integration
+async def test_proactive_row_with_bot_common_user_id_attributes_persona(chat_db):
+    """真实落库形态复现：proactive 出站行 **common_user_id = bot 自己的 id**（非 NULL，
+    channel-server storeLarkOutboundMessage 写 botCommonUserId）、response_id=NULL、
+    无 agent_response 行。仍必须经 bot_config(bot_name→persona) 认出是赤尾自己说的。
+
+    这是与 ``test_proactive_assistant_row_attributes_persona_via_bot_name`` 唯一的差别
+    （那条 common_user_id=None）—— 坐实「bot 身份 id 在场是否影响 persona 兜底」。
+    """
+    await _seed_conversation(_CHAT)
+    await _seed_bot_config("chiwei", "akao")
+    await _seed_user_message(_CHAT, event_time=1000, text="在吗")
+    await _seed_proactive_bot_message(
+        _CHAT,
+        event_time=2000,
+        msg_text="我刚在想你",
+        bot_name="chiwei",
+        common_user_id=_BOT_USER,
+    )
+
+    got = await find_recent_chat_messages(chat_id=str(_CHAT), limit=10)
+
+    assert len(got) == 2
+    assert got[0][1] is None, "真人那条无 persona"
+    assert got[1][1] == "akao", (
+        "proactive 出站行（带 bot common_user_id、response_id=NULL）必须经 "
+        f"bot_config(bot_name→persona) 认出是赤尾自己说的，实得 {got[1][1]!r}"
+    )
+
+
+@pytest.mark.integration
+async def test_user_row_with_bot_name_is_not_attributed_persona(chat_db):
+    """承重红线（codex 必改 1）：真人 user 行也带 bot_name（channel-server
+    storeLarkInboundMessage 给 user 行写 bot_name），它指向 active 的
+    bot_config(bot_name→persona)。helper 必须只对 role='assistant' 行兜底——真人 user
+    行的发言 persona 仍是 None，否则会被误判为某 persona 自己说的（串味）。
+    """
+    await _seed_conversation(_CHAT)
+    await _seed_bot_config("chiwei", "akao")
+    await _seed_user_message(_CHAT, event_time=1000, text="在吗", bot_name="chiwei")
+
+    got = await find_recent_chat_messages(chat_id=str(_CHAT), limit=10)
+
+    assert len(got) == 1
+    assert got[0][1] is None, (
+        "真人 user 行即便带 bot_name，也不能经 bot_config 兜底成 persona，"
+        f"实得 {got[0][1]!r}"
     )
 
 

--- a/apps/agent-service/tests/unit/data/test_messages_quick_search_global_id.py
+++ b/apps/agent-service/tests/unit/data/test_messages_quick_search_global_id.py
@@ -88,7 +88,10 @@ async def test_by_root_reads_sender_display_name_no_lark_join():
         assert "sender_display_name" in sql_text
         assert "lark_" not in sql_text
         assert "union_id" not in sql_text
-        assert "coalesce" not in sql_text
+        # persona 经 COALESCE(agent_response, bot_config 兜底) 取（proactive 行 persona
+        # 兜底）；coalesce 必须存在、且其唯一来源是 bot_config 子查询，不是 lark join。
+        assert "coalesce" in sql_text
+        assert "bot_config" in sql_text
     finally:
         for p in patches:
             p.stop()
@@ -123,7 +126,10 @@ async def test_in_chat_reads_sender_display_name_no_lark_join():
         assert "sender_display_name" in sql_text
         assert "lark_" not in sql_text
         assert "union_id" not in sql_text
-        assert "coalesce" not in sql_text
+        # persona 经 COALESCE(agent_response, bot_config 兜底) 取（proactive 行 persona
+        # 兜底）；coalesce 必须存在、且其唯一来源是 bot_config 子查询，不是 lark join。
+        assert "coalesce" in sql_text
+        assert "bot_config" in sql_text
     finally:
         for p in patches:
             p.stop()

--- a/apps/channel-server/src/plugins/lark/common-projector.reply.test.ts
+++ b/apps/channel-server/src/plugins/lark/common-projector.reply.test.ts
@@ -1,0 +1,262 @@
+import { beforeEach, describe, expect, it, mock } from 'bun:test';
+
+// Maps standing in for the lark_message / common_* tables.
+const larkMessages = new Map<string, { om_id: string; common_message_id: string }>();
+const larkUsers = new Map<string, { commonUserId: string }>();
+const larkChats = new Map<string, { common_conversation_id: string }>();
+
+const warn = mock((_message: string, _meta?: Record<string, unknown>) => undefined);
+
+mock.module('@logger/index', () => ({
+    default: {
+        warn,
+        info: mock(() => undefined),
+        error: mock(() => undefined),
+        debug: mock(() => undefined),
+    },
+}));
+
+mock.module('ormconfig', () => ({
+    default: {
+        getRepository: (entity: { name?: string }) => {
+            if (entity.name === 'LarkMessage') {
+                return {
+                    findOne: mock(async ({ where }: { where: { om_id?: string } }) => {
+                        if (where.om_id) return larkMessages.get(where.om_id) ?? null;
+                        return null;
+                    }),
+                };
+            }
+            if (entity.name === 'LarkUserOpenId') {
+                return {
+                    findOne: mock(
+                        async ({
+                            where,
+                        }: {
+                            where: { appId: string; openId: string } | { unionId: string };
+                        }) => {
+                            if ('unionId' in where) return null;
+                            return larkUsers.get(`${where.appId}:${where.openId}`) ?? null;
+                        },
+                    ),
+                    findOneOrFail: mock(
+                        async ({ where }: { where: { appId: string; openId: string } }) => {
+                            const row = larkUsers.get(`${where.appId}:${where.openId}`);
+                            return row ?? { commonUserId: '018f-user' };
+                        },
+                    ),
+                    upsert: mock(
+                        async (row: { appId: string; openId: string; commonUserId: string }) => {
+                            larkUsers.set(`${row.appId}:${row.openId}`, {
+                                commonUserId: row.commonUserId,
+                            });
+                        },
+                    ),
+                };
+            }
+            if (entity.name === 'LarkBaseChatInfo') {
+                return {
+                    findOne: mock(async ({ where }: { where: { chat_id: string } }) => {
+                        return larkChats.get(where.chat_id) ?? null;
+                    }),
+                    findOneOrFail: mock(async ({ where }: { where: { chat_id: string } }) => {
+                        const row = larkChats.get(where.chat_id);
+                        return row ?? { common_conversation_id: '018f-chat' };
+                    }),
+                    upsert: mock(
+                        async (row: { chat_id: string; common_conversation_id: string }) => {
+                            larkChats.set(row.chat_id, {
+                                common_conversation_id: row.common_conversation_id,
+                            });
+                        },
+                    ),
+                    update: mock(async () => undefined),
+                };
+            }
+            // CommonUser / CommonConversation: write-only sinks here.
+            return {
+                findOne: mock(async () => null),
+                findOneOrFail: mock(async () => ({})),
+                update: mock(async () => undefined),
+                upsert: mock(async () => undefined),
+            };
+        },
+    },
+}));
+
+mock.module('@cache/redis-client', () => ({
+    get: mock(async () => null),
+    setWithExpire: mock(async () => 'OK'),
+    hgetall: mock(async () => ({})),
+    setNx: mock(async () => 'OK'),
+    evalScript: mock(async () => 1),
+    exists: mock(async () => 0),
+}));
+
+mock.module('@middleware/context', () => ({
+    context: {
+        getBotName: () => 'chiwei',
+        getLane: () => undefined,
+    },
+}));
+
+mock.module('@integrations/rabbitmq', () => ({
+    CHAT_REQUEST: 'chat_request',
+    PROACTIVE_EVAL: 'proactive_eval',
+    getLane: () => undefined,
+    getRabbitChannel: () => ({
+        assertQueue: mock(async () => undefined),
+        sendToQueue: mock(() => true),
+    }),
+}));
+
+mock.module('@core/services/bot/multi-bot-manager', () => ({
+    multiBotManager: {
+        getAllBotConfigs: () => [],
+        getBotConfig: () => null,
+        getBotCommonUserId: () => '018f-bot-common-user',
+    },
+}));
+
+const { prepareLarkInboundProjection } = await import('./common-projector');
+
+// A reply message whose parent_id/root_id point at an om_id that was never
+// projected into lark_message (typical in group chats where not every message
+// is processed). Mirrors the real Lark "回复引用" event shape.
+function replyEvent(opts: { rootId?: string; parentId?: string }) {
+    return {
+        app_id: 'cli-current',
+        sender: {
+            sender_id: {
+                open_id: 'ou_sender',
+                union_id: 'on_sender',
+            },
+        },
+        message: {
+            message_id: 'om_self',
+            chat_id: 'oc_group',
+            root_id: opts.rootId,
+            parent_id: opts.parentId,
+            message_type: 'text',
+            create_time: '1780309200000',
+            mentions: [],
+        },
+    } as any;
+}
+
+const groupMessage = {
+    senderInfo: { name: 'sender', avatar_origin: 'avatar' },
+    groupChatInfo: {
+        name: 'group',
+        avatar: 'group-avatar',
+        user_count: 3,
+        is_leave: false,
+    },
+    isP2P: () => false,
+    allowDownloadResource: () => true,
+} as any;
+
+const inbound = {
+    conversation_scope: 'group',
+    content: [{ kind: 'text', text: 'reply text' }],
+} as any;
+
+describe('prepareLarkInboundProjection reply ingest', () => {
+    beforeEach(() => {
+        larkMessages.clear();
+        larkUsers.clear();
+        larkChats.clear();
+        warn.mockClear();
+    });
+
+    it('tolerates a parent_id whose referenced message has no common mapping', async () => {
+        const projection = await prepareLarkInboundProjection(
+            replyEvent({ parentId: 'om_unknown_parent' }),
+            groupMessage,
+            inbound,
+        );
+
+        // Reply chain field stays empty because the parent was never projected.
+        expect(projection.commonReplyMessageId).toBeUndefined();
+        // This message itself still gets a valid common_message_id.
+        expect(projection.commonMessageId).toBeDefined();
+        expect(projection.commonMessageId.length).toBeGreaterThan(0);
+    });
+
+    it('tolerates a root_id whose referenced message has no common mapping', async () => {
+        const projection = await prepareLarkInboundProjection(
+            replyEvent({ rootId: 'om_unknown_root' }),
+            groupMessage,
+            inbound,
+        );
+
+        // Falls back to the message's own id when the root cannot be resolved.
+        expect(projection.commonRootMessageId).toBe(projection.commonMessageId);
+        expect(projection.commonMessageId).toBeDefined();
+    });
+
+    it('still resolves reply/root chain when the referenced message is mapped', async () => {
+        larkMessages.set('om_known', {
+            om_id: 'om_known',
+            common_message_id: '018f-known-common',
+        });
+
+        const projection = await prepareLarkInboundProjection(
+            replyEvent({ rootId: 'om_known', parentId: 'om_known' }),
+            groupMessage,
+            inbound,
+        );
+
+        expect(projection.commonReplyMessageId).toBe('018f-known-common');
+        expect(projection.commonRootMessageId).toBe('018f-known-common');
+    });
+
+    it('warns once with om_id and parent label when a parent reference is dropped', async () => {
+        await prepareLarkInboundProjection(
+            replyEvent({ parentId: 'om_unknown_parent' }),
+            groupMessage,
+            inbound,
+        );
+
+        expect(warn).toHaveBeenCalledTimes(1);
+        const [message, meta] = warn.mock.calls[0]!;
+        expect(message).toContain('om_unknown_parent');
+        expect(meta).toMatchObject({
+            referenceKind: 'parent',
+            referencedOmId: 'om_unknown_parent',
+            selfOmId: 'om_self',
+        });
+    });
+
+    it('warns once with om_id and root label when a root reference is dropped', async () => {
+        await prepareLarkInboundProjection(
+            replyEvent({ rootId: 'om_unknown_root' }),
+            groupMessage,
+            inbound,
+        );
+
+        expect(warn).toHaveBeenCalledTimes(1);
+        const [message, meta] = warn.mock.calls[0]!;
+        expect(message).toContain('om_unknown_root');
+        expect(meta).toMatchObject({
+            referenceKind: 'root',
+            referencedOmId: 'om_unknown_root',
+            selfOmId: 'om_self',
+        });
+    });
+
+    it('does not warn when the referenced message resolves', async () => {
+        larkMessages.set('om_known', {
+            om_id: 'om_known',
+            common_message_id: '018f-known-common',
+        });
+
+        await prepareLarkInboundProjection(
+            replyEvent({ rootId: 'om_known', parentId: 'om_known' }),
+            groupMessage,
+            inbound,
+        );
+
+        expect(warn).not.toHaveBeenCalled();
+    });
+});

--- a/apps/channel-server/src/plugins/lark/common-projector.ts
+++ b/apps/channel-server/src/plugins/lark/common-projector.ts
@@ -9,6 +9,7 @@ import { LarkBaseChatInfo } from '@entities/lark-base-chat-info';
 import { LarkMessage } from '@entities/lark-message';
 import { LarkUserOpenId } from '@entities/lark-user-open-id';
 import { context } from '@middleware/context';
+import logger from '@logger/index';
 import { multiBotManager } from '@core/services/bot/multi-bot-manager';
 import { evalScript, setNx } from '@cache/redis-client';
 import type { LarkMention, LarkReceiveMessage } from 'types/lark';
@@ -278,20 +279,34 @@ async function findCommonMessageIdByOmId(omId: string): Promise<string | undefin
 
 async function resolveReferencedMessage(
     omId: string | undefined,
+    referenceKind: 'root' | 'parent',
     selfOmId: string,
     selfCommonMessageId: string,
-    which: string,
 ): Promise<string | undefined> {
     if (!omId) return undefined;
     if (omId === selfOmId) return selfCommonMessageId;
-    const existing = await findCommonMessageIdByOmId(omId);
-    if (!existing) {
-        throw new Error(
-            `lark ${which} message ${omId} has no common mapping; ` +
-                'historical backfill must run before runtime cutover',
+    // The referenced message may never have been projected into lark_message
+    // (e.g. a group message that was not processed at the time). Tolerate the
+    // missing mapping: drop the reply/root link instead of failing the whole
+    // inbound projection, so the current message still gets stored.
+    const resolved = await findCommonMessageIdByOmId(omId);
+    if (!resolved) {
+        // The link is silently dropped (we keep storing the message). Emit a
+        // warning so the data loss is observable: the reply/root chain for this
+        // message will be incomplete because the referenced om_id has no
+        // lark_message -> common_message mapping.
+        logger.warn(
+            `[lark common projector] dropping ${referenceKind} reply link: ` +
+                `referenced om_id=${omId} has no common_message mapping ` +
+                `(message om_id=${selfOmId})`,
+            {
+                referenceKind,
+                referencedOmId: omId,
+                selfOmId,
+            },
         );
     }
-    return existing;
+    return resolved;
 }
 
 export async function prepareLarkInboundProjection(
@@ -333,15 +348,15 @@ export async function prepareLarkInboundProjection(
     const commonRootMessageId =
         (await resolveReferencedMessage(
             event.message.root_id,
+            'root',
             event.message.message_id,
             commonMessageId,
-            'root',
         )) ?? commonMessageId;
     const commonReplyMessageId = await resolveReferencedMessage(
         event.message.parent_id,
+        'parent',
         event.message.message_id,
         commonMessageId,
-        'parent',
     );
 
     return {


### PR DESCRIPTION
## Summary
Two prod bugs from #274 (rolled back, fixed on a clean branch off main):

- **Proactive persona role (agent-service)**: proactive messages (response_id=NULL, no agent_response row) were attributed persona=None in the human-chat history queries (`find_messages_with_user_chat_persona_by_root`/`_in_chat`) and the bedtime-review query (`find_persona_spoken_chats_in_window`), so her own words rendered as the *user's* input after a real person replied. Fix: shared `_bot_config_persona()` fallback (bot_name→persona), `role='assistant'` limited so real user rows (which also carry bot_name) stay None; `find_persona_spoken_chats_in_window` now counts proactive-only chats and attributes proactive rows.
- **Group reply ingest (channel-server)**: replying to a message whose referenced parent/root has no `lark_message` mapping made `resolveReferencedMessage` throw → the whole inbound projection failed → the reply message was never stored. Group messages often were never projected. Fix: tolerate the missing mapping (drop the reply/root link, keep storing) + warn for observability. Introduced by #246 (common identity layer), surfaced now because #274 first shipped the accumulated channel-server inbound refactors to prod.

codex T3: 2 must-fix + 3 suggestions all accepted.

## Verify
agent-service 344 passed / channel-server 296 passed (8 pre-existing `data_thinking_tokens_spent` world_life integration failures unrelated). coe-world-life2 (agent 1.2.0.82 / channel 1.0.0.44): services healthy, proactive renders via chat-turn (session_id=null + main-chat-model), messages incl. reply field ingest fine.

## Deploy — compound cutover (prod is currently rolled back to pre-#274)
Shipping this re-cutovers the whole #274 stack (proactive via chat-turn + objective-event-driven world/life) plus these two fixes. Two images, four services (channel-server + recall-worker + chat-response-worker same image).
- Langfuse: `life_wake` → v11 (after new pods ready; early publish stalls the old schedule self-wake), `world_presence_match` → re-add production label (new code calls it, 404 now), `world_deliberate` v12 / `main` v105 unchanged.
- Deploy interrupts in-flight prod world/life rounds (currently old schedule paradigm); new pods take over the objective-event-driven paradigm.
- Then drop gateway `dev-webhook-to-coe-world-life2` + unbind dev (route back to prod), tear down coe-world-life2.

## Rollback anchor
agent-service `1.2.0.74` / channel-server `1.0.0.41` (roll together) / `life_wake` back to v9 / drop `world_presence_match` production label. (= current rolled-back state.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
