### PR TITLE
Add Langfuse lane trace tags

### DIFF
--- a/apps/agent-service/app/agent/core.py
+++ b/apps/agent-service/app/agent/core.py
@@ -79,9 +79,15 @@ from app.agent.trace import (
     current_generation_context,
     current_turn_trace_id,
 )
+from app.api.middleware import get_lane
 from app.capabilities.retry import retry as _retry_decorator
 from app.infra import cst_time
 from app.infra.config import settings
+from app.runtime.lane_policy import (
+    classify_deployment_lane,
+    current_deployment_lane,
+    normalize_deployment_lane,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -153,20 +159,58 @@ class _NoOpRootSpan:
         pass
 
 
+def _trace_lane_attributes() -> tuple[dict[str, str], list[str]]:
+    """Return Langfuse trace attributes that make lane lookup cheap.
+
+    ``tags`` are the primary query surface (``list-traces`` supports tags
+    directly); metadata carries the same lane fields for the trace detail page
+    and later analytics.
+    """
+    raw_request_lane = get_lane()
+    if raw_request_lane:
+        lane = normalize_deployment_lane(raw_request_lane) or "prod"
+        source = "request"
+    else:
+        deployment_lane = current_deployment_lane()
+        lane = deployment_lane or "prod"
+        source = "deployment" if deployment_lane else "default"
+
+    lane_class = classify_deployment_lane(lane)
+    metadata = {
+        "app": "agent-service",
+        "lane": lane,
+        "laneClass": lane_class,
+        "laneSource": source,
+    }
+    tags = [
+        "app:agent-service",
+        f"lane:{lane}",
+        f"lane_class:{lane_class}",
+    ]
+    return metadata, tags
+
+
 def _set_current_trace(
     *, name: str | None = None, input: Any = None, session_id: str | None = None
 ) -> None:
-    """Set the current trace's name / input / session, swallowing langfuse errors.
+    """Set current trace attributes, swallowing langfuse errors.
 
     ``None`` fields are skipped by the SDK, so passing only ``name`` updates the
     trace name and leaves its input untouched. ``session_id`` is a *trace*
     attribute (the langfuse v3 way to group related traces — it is NOT part of a
     span's ``trace_context``); passing it groups this trace into that session.
-    Tracing must never break the call.
+    Lane tags/metadata are always written so every root trace is queryable by
+    ``tags=["lane:<lane>"]`` even when ``update_trace=False``. Tracing must never
+    break the call.
     """
     try:
+        metadata, tags = _trace_lane_attributes()
         _get_trace_client().update_current_trace(
-            name=name, input=input, session_id=session_id
+            name=name,
+            input=input,
+            session_id=session_id,
+            metadata=metadata,
+            tags=tags,
         )
     except Exception as exc:  # pragma: no cover - tracing must not break the call
         logger.warning("langfuse update_current_trace failed: %s", exc)
@@ -248,11 +292,8 @@ def _root_span(
     tid = current_turn_trace_id()
     trace_context = {"trace_id": tid} if tid else None
     with _safe_current_span(span_name, input, trace_context) as span:
-        if session_id is not None:
-            # Session grouping is orthogonal to the name/input ownership below:
-            # set it whenever provided so even a guard (update_trace=False) on a
-            # session-bound run tags the trace's session.
-            _set_current_trace(session_id=session_id)
+        trace_name: str | None = None
+        trace_input: Any = None
         if tid is not None:
             # Inside a turn the guards / main / post-safety are separate root
             # spans on one trace; langfuse would name the whole trace after the
@@ -261,11 +302,12 @@ def _root_span(
             # name only, each span keeps its own observation name. Only the main
             # path (``update_trace``) owns the trace input, so the trace top
             # reads the chat turn, not a guard's safety prompt.
-            _set_current_trace(
-                name=TURN_TRACE_NAME, input=input if update_trace else None
-            )
+            trace_name = TURN_TRACE_NAME
+            trace_input = input if update_trace else None
         elif update_trace:
-            _set_current_trace(name=span_name, input=input)
+            trace_name = span_name
+            trace_input = input
+        _set_current_trace(name=trace_name, input=trace_input, session_id=session_id)
         yield span
 
 

--- a/apps/agent-service/tests/unit/agent/test_core.py
+++ b/apps/agent-service/tests/unit/agent/test_core.py
@@ -323,7 +323,10 @@ class TestTurnTraceUnifiedName:
         with patch.object(core, "_get_trace_client", return_value=client):
             with core._root_span(name="guard", input=[], update_trace=False):
                 pass
-        client.update_current_trace.assert_not_called()
+        kw = client.update_current_trace.call_args.kwargs
+        assert kw.get("name") is None
+        assert kw.get("input") is None
+        assert kw["tags"] == ["app:agent-service", "lane:prod", "lane_class:prod"]
 
 
 class TestRootSpanSession:
@@ -377,19 +380,20 @@ class TestRootSpanSession:
 
     def test_no_session_id_does_not_touch_trace_session(self):
         """Backward compat: without a session_id the run behaves exactly as
-        before — no update_current_trace call carries a session_id, and an
-        update_trace=False/no-turn run still makes no update_current_trace call
-        at all (this is the chat / guard status quo)."""
+        before re: session — no update_current_trace call carries a session_id,
+        while lane tags/metadata are still written for trace lookup."""
         from app.agent import core
 
         client = MagicMock()
         with patch.object(core, "_get_trace_client", return_value=client):
             with core._root_span(name="guard", input=[], update_trace=False):
                 pass
-        client.update_current_trace.assert_not_called()
+        kw = client.update_current_trace.call_args.kwargs
+        assert kw.get("session_id") is None
+        assert kw["metadata"]["lane"] == "prod"
 
     def test_no_session_id_with_update_trace_keeps_status_quo(self):
-        """update_trace=True without a session: still only name+input, no
+        """update_trace=True without a session: name+input are set and no
         session_id leaks into the call."""
         from app.agent import core
 
@@ -401,6 +405,67 @@ class TestRootSpanSession:
         assert kw["name"] == "world-engine"
         assert kw["input"] == [1]
         assert kw.get("session_id") is None
+
+
+class TestRootSpanLaneAttributes:
+    """Lane must be written as trace tags because list-traces filters tags
+    directly; metadata mirrors the same fields for trace detail inspection."""
+
+    def test_request_lane_writes_queryable_tags_and_metadata(self):
+        from app.agent import core
+
+        client = MagicMock()
+        with (
+            patch.object(core, "_get_trace_client", return_value=client),
+            patch.object(core, "get_lane", return_value="ppe-lf"),
+            patch.object(core, "current_deployment_lane", return_value=None),
+        ):
+            with core._root_span(name="main", input=[], update_trace=True):
+                pass
+        kw = client.update_current_trace.call_args.kwargs
+        assert kw["tags"] == [
+            "app:agent-service",
+            "lane:ppe-lf",
+            "lane_class:ppe",
+        ]
+        assert kw["metadata"] == {
+            "app": "agent-service",
+            "lane": "ppe-lf",
+            "laneClass": "ppe",
+            "laneSource": "request",
+        }
+
+    def test_deployment_lane_used_when_request_lane_absent(self):
+        from app.agent import core
+
+        client = MagicMock()
+        with (
+            patch.object(core, "_get_trace_client", return_value=client),
+            patch.object(core, "get_lane", return_value=None),
+            patch.object(core, "current_deployment_lane", return_value="coe-lf"),
+        ):
+            with core._root_span(name="world", input=[], update_trace=True):
+                pass
+        kw = client.update_current_trace.call_args.kwargs
+        assert "lane:coe-lf" in kw["tags"]
+        assert "lane_class:coe" in kw["tags"]
+        assert kw["metadata"]["laneSource"] == "deployment"
+
+    def test_prod_default_when_no_lane_context(self):
+        from app.agent import core
+
+        client = MagicMock()
+        with (
+            patch.object(core, "_get_trace_client", return_value=client),
+            patch.object(core, "get_lane", return_value=None),
+            patch.object(core, "current_deployment_lane", return_value=None),
+        ):
+            with core._root_span(name="main", input=[], update_trace=False):
+                pass
+        kw = client.update_current_trace.call_args.kwargs
+        assert "lane:prod" in kw["tags"]
+        assert kw["metadata"]["lane"] == "prod"
+        assert kw["metadata"]["laneSource"] == "default"
 
 
 class TestRunSessionPlumbing:


### PR DESCRIPTION
## Summary\n- add lane tags and metadata to Langfuse traces in agent-service\n- keep lane attributes on root spans even when update_trace is disabled\n- add unit coverage for request, deployment, and prod lane attribution\n\n## Verification\n- python3 -m py_compile apps/agent-service/app/agent/core.py apps/agent-service/tests/unit/agent/test_core.py\n- git diff --check -- apps/agent-service/app/agent/core.py apps/agent-service/tests/unit/agent/test_core.py\n- verified PPE traces are queryable with tags:["lane:ppe-langfuse-lane"]