### PR TITLE
feat(agent): main chat uses Gemini native google search grounding

### DIFF
--- a/apps/agent-service/app/agent/adapters/gemini.py
+++ b/apps/agent-service/app/agent/adapters/gemini.py
@@ -110,6 +110,26 @@ class GeminiAdapter(ModelClient):
         self._client = genai.Client(api_key=api_key, http_options=http_options)
 
     # ------------------------------------------------------------------
+    # native web search capability
+    # ------------------------------------------------------------------
+
+    @property
+    def supports_native_web_search(self) -> bool:
+        """Only Gemini 3 can co-host native google search with custom tools.
+
+        Gemini 2.5's native grounding and custom function declarations can't
+        live in the same request, and main chat always carries custom tools, so
+        2.5 (and non-Gemini) report ``False``. The model name is normalised
+        (drop a ``models/`` prefix, lower-case) before the ``gemini-3`` check;
+        anything unrecognised stays ``False`` (fail-closed — better to fall back
+        to ``search_web`` than send a request the provider would reject).
+        """
+        name = self._model.strip().lower()
+        if name.startswith("models/"):
+            name = name[len("models/") :]
+        return name.startswith("gemini-3")
+
+    # ------------------------------------------------------------------
     # construction helpers
     # ------------------------------------------------------------------
 
@@ -140,9 +160,13 @@ class GeminiAdapter(ModelClient):
         **kwargs: Any,
     ) -> Message:
         kwargs.pop("session_id", None)  # prompt-cache control param; not a Gemini arg
+        native_search = kwargs.pop("native_web_search", False)
         contents, system_instruction = await self._to_wire_contents(messages)
         config = self._build_config(
-            system_instruction=system_instruction, tools=tools, **kwargs
+            system_instruction=system_instruction,
+            tools=tools,
+            native_web_search=native_search,
+            **kwargs,
         )
 
         with generation_span(
@@ -173,9 +197,13 @@ class GeminiAdapter(ModelClient):
         **kwargs: Any,
     ) -> AsyncIterator[StreamChunk]:
         kwargs.pop("session_id", None)  # prompt-cache control param; not a Gemini arg
+        native_search = kwargs.pop("native_web_search", False)
         contents, system_instruction = await self._to_wire_contents(messages)
         config = self._build_config(
-            system_instruction=system_instruction, tools=tools, **kwargs
+            system_instruction=system_instruction,
+            tools=tools,
+            native_web_search=native_search,
+            **kwargs,
         )
 
         with generation_span(
@@ -257,6 +285,7 @@ class GeminiAdapter(ModelClient):
         *,
         system_instruction: str | None,
         tools: list[ToolDef] | None,
+        native_web_search: bool = False,
         response_mime_type: str | None = None,
         response_schema: dict[str, Any] | None = None,
         **kwargs: Any,
@@ -271,12 +300,20 @@ class GeminiAdapter(ModelClient):
         }
         if system_instruction is not None:
             cfg["system_instruction"] = system_instruction
+        # Custom function tools and Gemini's native google search co-exist as two
+        # separate Tool entries (Gemini 3 supports both in one request). Only the
+        # runtime turns native_web_search on, and only for main chat on Gemini 3.
+        tool_list: list[types.Tool] = []
         if tools:
-            cfg["tools"] = [
+            tool_list.append(
                 types.Tool(
                     function_declarations=[_tool_to_declaration(t) for t in tools]
                 )
-            ]
+            )
+        if native_web_search:
+            tool_list.append(types.Tool(google_search=types.GoogleSearch()))
+        if tool_list:
+            cfg["tools"] = tool_list
         if response_mime_type is not None:
             cfg["response_mime_type"] = response_mime_type
         if response_schema is not None:

--- a/apps/agent-service/app/agent/adapters/gemini.py
+++ b/apps/agent-service/app/agent/adapters/gemini.py
@@ -312,6 +312,14 @@ class GeminiAdapter(ModelClient):
             )
         if native_web_search:
             tool_list.append(types.Tool(google_search=types.GoogleSearch()))
+            # Gemini 3 rejects a built-in tool (google search) combined with
+            # function declarations unless server-side tool invocations are
+            # explicitly enabled, 400-ing otherwise ("Please enable
+            # tool_config.include_server_side_tool_invocations ..."). Set it only
+            # on the native-search path so every other request is unchanged.
+            cfg["tool_config"] = types.ToolConfig(
+                include_server_side_tool_invocations=True
+            )
         if tool_list:
             cfg["tools"] = tool_list
         if response_mime_type is not None:

--- a/apps/agent-service/app/agent/adapters/openai.py
+++ b/apps/agent-service/app/agent/adapters/openai.py
@@ -151,6 +151,8 @@ class OpenAIAdapter(ModelClient):
         **kwargs: Any,
     ) -> Message:
         session_id = kwargs.pop("session_id", None)
+        # Gemini-only native-search control signal; never an OpenAI request field.
+        kwargs.pop("native_web_search", None)
         wire_messages = self._to_wire_messages(messages)
         request: dict[str, Any] = {
             "model": self._model,
@@ -187,6 +189,8 @@ class OpenAIAdapter(ModelClient):
         **kwargs: Any,
     ) -> AsyncIterator[StreamChunk]:
         session_id = kwargs.pop("session_id", None)
+        # Gemini-only native-search control signal; never an OpenAI request field.
+        kwargs.pop("native_web_search", None)
         wire_messages = self._to_wire_messages(messages)
         request: dict[str, Any] = {
             "model": self._model,

--- a/apps/agent-service/app/agent/client.py
+++ b/apps/agent-service/app/agent/client.py
@@ -88,6 +88,17 @@ class ModelClient(ABC):
     ) -> dict[str, Any]:
         """Single structured output → dict the caller validates (``extract``)."""
 
+    @property
+    def supports_native_web_search(self) -> bool:
+        """Whether this model can run native web search alongside custom tools.
+
+        Default ``False`` (fail-closed): only providers whose native grounding
+        co-exists with custom function declarations override this. OpenAI and
+        every other adapter inherit the default — the agent layer reads it to
+        decide whether to swap the ``search_web`` tool for native search.
+        """
+        return False
+
 
 # ---------------------------------------------------------------------------
 # Adapter registry (client_type → factory)

--- a/apps/agent-service/app/agent/core.py
+++ b/apps/agent-service/app/agent/core.py
@@ -50,6 +50,7 @@ from contextlib import contextmanager
 from dataclasses import dataclass
 from typing import Any
 
+from inner_shared.dynamic_config import dynamic_config
 from langfuse import Langfuse
 from openai import (
     APIConnectionError,
@@ -134,6 +135,10 @@ class AgentConfig:
     model_id: str
     trace_name: str | None = None
     recursion_limit: int = _DEFAULT_RECURSION_LIMIT
+    # Opt-in: this agent wants Gemini's native google search to replace the
+    # ``search_web`` tool when the resolved model actually supports it. Only
+    # main chat declares it; every other config keeps the default (off).
+    native_web_search: bool = False
 
 
 # ---------------------------------------------------------------------------
@@ -352,6 +357,16 @@ def _record_tool_output(span: Any, result: ToolResult) -> None:
 
 _TERMINAL_TOOL_NAMES = {"no_reply"}
 
+# The self-written web-search tool. When an agent that opted into native search
+# runs on a model that supports it (and the flag is on), this tool is dropped
+# from the model's tool list and replaced by the provider's native grounding.
+_SEARCH_WEB_TOOL_NAME = "search_web"
+
+# Dynamic Config kill-switch for the native-search swap. Default off so the
+# swap stays dark until explicitly enabled per lane; flipping it back off
+# restores ``search_web`` at runtime with no redeploy.
+_NATIVE_WEB_SEARCH_FLAG = "main_chat_native_web_search"
+
 
 def _tooldefs(tools: list[Tool]) -> list[ToolDef] | None:
     """Project neutral Tools to the ToolDefs the model sees, or None if empty."""
@@ -402,6 +417,7 @@ async def _run_loop(
     context: AgentContext | None,
     recursion_limit: int,
     session_id: str | None = None,
+    native_web_search: bool = False,
     model_kwargs: dict[str, Any] | None = None,
     transcript_sink: list[Message] | None = None,
 ) -> Message:
@@ -431,12 +447,16 @@ async def _run_loop(
     convo = list(messages)
     tool_defs = _tooldefs(tools)
     extra = model_kwargs or {}
+    # Only forward native_web_search when enabled: a False would hand existing
+    # adapters (which don't know the kwarg) a parameter they never received,
+    # so the non-native path stays byte-for-byte unchanged.
+    call_kwargs = {**extra, "session_id": session_id}
+    if native_web_search:
+        call_kwargs["native_web_search"] = True
     last: Message | None = None
 
     for _ in range(max(1, recursion_limit)):
-        last = await model.complete(
-            convo, tools=tool_defs, **{**extra, "session_id": session_id}
-        )
+        last = await model.complete(convo, tools=tool_defs, **call_kwargs)
         if not last.tool_calls:
             if transcript_sink is not None:
                 transcript_sink.append(last)
@@ -473,6 +493,7 @@ async def _stream_loop(
     context: AgentContext | None,
     recursion_limit: int,
     session_id: str | None = None,
+    native_web_search: bool = False,
     model_kwargs: dict[str, Any] | None = None,
     transcript_sink: list[Message] | None = None,
 ) -> AsyncIterator[StreamChunk]:
@@ -497,15 +518,18 @@ async def _stream_loop(
     convo = list(messages)
     tool_defs = _tooldefs(tools)
     extra = model_kwargs or {}
+    # Same rule as _run_loop: only forward native_web_search when enabled, so a
+    # non-native stream call carries exactly the kwargs it always did.
+    call_kwargs = {**extra, "session_id": session_id}
+    if native_web_search:
+        call_kwargs["native_web_search"] = True
 
     for _ in range(max(1, recursion_limit)):
         text_parts: list[str] = []
         reasoning_parts: list[str] = []
         turn_calls = []
 
-        async for chunk in model.stream(
-            convo, tools=tool_defs, **{**extra, "session_id": session_id}
-        ):
+        async for chunk in model.stream(convo, tools=tool_defs, **call_kwargs):
             if chunk.text:
                 text_parts.append(chunk.text)
             if chunk.reasoning:
@@ -643,6 +667,40 @@ class Agent:
         )
         return model, prompt_messages
 
+    async def _resolve_native_web_search(
+        self, model: ModelClient
+    ) -> tuple[list[Tool], bool]:
+        """Decide this run's tool list and whether to enable native web search.
+
+        The swap fires only when all three conditions hold — this agent opted in
+        (``cfg.native_web_search``, only main chat does), the resolved model can
+        run native grounding alongside custom tools (Gemini 3), and the runtime
+        flag is on — AND ``search_web`` is actually mounted. When it fires the
+        ``search_web`` tool is dropped (the model uses native search instead) and
+        the signal is returned. Otherwise the tool list is returned unchanged and
+        the signal is False, so every other agent (world / life / guard, never
+        opted in) calls the model byte-for-byte as before.
+
+        The two cheap in-memory predicates are checked first so every non-opted
+        agent short-circuits *before* touching Dynamic Config — the flag read is
+        the only blocking bit, wrapped in ``asyncio.to_thread`` because the SDK's
+        cache-miss refresh is sync httpx that would otherwise stall the shared
+        event loop (mirrors ``app.life.feed_whitelist``).
+
+        Computed once per run (the model is fixed across retry attempts) so the
+        loops stay free of this business judgment.
+        """
+        tools = self._tools
+        if not (self._cfg.native_web_search and model.supports_native_web_search):
+            return tools, False
+        flag_on = await asyncio.to_thread(
+            dynamic_config.get_bool, _NATIVE_WEB_SEARCH_FLAG, default=False
+        )
+        if flag_on and any(t.name == _SEARCH_WEB_TOOL_NAME for t in tools):
+            tools = [t for t in tools if t.name != _SEARCH_WEB_TOOL_NAME]
+            return tools, True
+        return tools, False
+
     # ------------------------------------------------------------------
     # public API
     # ------------------------------------------------------------------
@@ -667,6 +725,7 @@ class Agent:
         decision 3).
         """
         model, prompt_messages = await self._prepare(prompt_vars or {})
+        tools, native_web_search = await self._resolve_native_web_search(model)
 
         # Read the stored history ONCE (before retry) so a retried attempt
         # replays the same prefix and never double-reads. None → stateless.
@@ -691,10 +750,11 @@ class Agent:
                 result = await _run_loop(
                     model,
                     messages=full_messages,
-                    tools=self._tools,
+                    tools=tools,
                     context=context,
                     recursion_limit=self._cfg.recursion_limit,
                     session_id=trace_session_id,
+                    native_web_search=native_web_search,
                     model_kwargs=self._model_kwargs,
                     transcript_sink=sink,
                 )
@@ -737,6 +797,7 @@ class Agent:
         Redis untouched, behaviour byte-for-byte as before.
         """
         model, prompt_messages = await self._prepare(prompt_vars or {})
+        tools, native_web_search = await self._resolve_native_web_search(model)
 
         history = await load_session(session_id) if session_id else []
         full_messages = [*prompt_messages, *history, *messages]
@@ -755,10 +816,11 @@ class Agent:
                     async for chunk in _stream_loop(
                         model,
                         messages=full_messages,
-                        tools=self._tools,
+                        tools=tools,
                         context=context,
                         recursion_limit=self._cfg.recursion_limit,
                         session_id=trace_session_id,
+                        native_web_search=native_web_search,
                         model_kwargs=self._model_kwargs,
                         transcript_sink=sink,
                     ):

--- a/apps/agent-service/app/chat/render.py
+++ b/apps/agent-service/app/chat/render.py
@@ -44,7 +44,7 @@ from app.skills.registry import SkillRegistry
 
 logger = logging.getLogger(__name__)
 
-_MAIN_CFG = AgentConfig("main", "main-chat-model", "main")
+_MAIN_CFG = AgentConfig("main", "main-chat-model", "main", native_web_search=True)
 
 
 class RenderFailed(Exception):

--- a/apps/agent-service/pyproject.toml
+++ b/apps/agent-service/pyproject.toml
@@ -9,7 +9,7 @@ dependencies = [
     "arrow>=1.3.0",
     "asyncpg>=0.30.0",
     "fastapi>=0.116.1",
-    "google-genai>=1.0.0",
+    "google-genai==2.9.0",
     "greenlet>=3.2.3",
     "jieba>=0.42.1",
     "jinja2>=3.1.6",

--- a/apps/agent-service/tests/agent/test_gemini_adapter.py
+++ b/apps/agent-service/tests/agent/test_gemini_adapter.py
@@ -1062,6 +1062,11 @@ async def test_complete_native_web_search_appends_google_search_tool(mock_sdk):
     assert func_tools[0].function_declarations[0].name == "draw"
     # native google search co-hosted
     assert len(search_tools) == 1
+    # Gemini 3 requires include_server_side_tool_invocations to combine a built-in
+    # tool (google search) with function declarations — without it the API 400s
+    # ("Please enable tool_config.include_server_side_tool_invocations ...").
+    assert cfg.tool_config is not None
+    assert cfg.tool_config.include_server_side_tool_invocations is True
 
 
 async def test_stream_native_web_search_appends_google_search_tool(mock_sdk):
@@ -1098,6 +1103,8 @@ async def test_complete_without_native_web_search_has_no_google_search_tool(mock
     func_tools, search_tools = _split_tools(cfg)
     assert len(func_tools) == 1
     assert search_tools == []
+    # no native search → no server-side-tool toggle (non-native path unchanged)
+    assert cfg.tool_config is None
 
 
 async def test_complete_native_web_search_false_has_no_google_search_tool(mock_sdk):

--- a/apps/agent-service/tests/agent/test_gemini_adapter.py
+++ b/apps/agent-service/tests/agent/test_gemini_adapter.py
@@ -984,3 +984,249 @@ async def test_registration_dispatches_google(monkeypatch):
 
     client = await build_model_client("whatever")
     assert isinstance(client, GeminiAdapter)
+
+
+# ---------------------------------------------------------------------------
+# supports_native_web_search — only Gemini 3 can co-host native google search
+# with custom function declarations; Gemini 2.5 can't, so it stays False.
+# Model-name normalisation strips a "models/" prefix and is case-insensitive;
+# anything we can't recognise is treated as unsupported (fail-closed).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "model_name",
+    [
+        "gemini-3.5-flash",  # main chat
+        "gemini-3-flash-preview",  # diary
+        "models/gemini-3.5-flash",  # SDK-style "models/" prefix
+        "Gemini-3.5-Flash",  # mixed case
+        "MODELS/Gemini-3-Pro",  # prefix + case
+    ],
+)
+def test_supports_native_web_search_true_for_gemini_3(mock_sdk, model_name):
+    adapter = GeminiAdapter(model_name=model_name, api_key="k", base_url="https://g")
+    assert adapter.supports_native_web_search is True
+
+
+@pytest.mark.parametrize(
+    "model_name",
+    [
+        "gemini-2.5-flash",  # Gemini 2.5 can't co-host grounding + tools
+        "models/gemini-2.5-pro",
+        "Gemini-2.5-Flash",
+        "gemini-2.0-flash",
+        "gpt-4o",  # not Gemini at all
+        "",  # unknown → fail-closed
+    ],
+)
+def test_supports_native_web_search_false_for_non_gemini_3(mock_sdk, model_name):
+    adapter = GeminiAdapter(model_name=model_name, api_key="k", base_url="https://g")
+    assert adapter.supports_native_web_search is False
+
+
+# ---------------------------------------------------------------------------
+# native_web_search signal → request carries native google search tool
+# (④). When the loop hands native_web_search=True, the adapter appends a
+# Tool(google_search=GoogleSearch()) ALONGSIDE the custom function-declaration
+# tool (Gemini 3 co-hosts both). Default (no signal) leaves only the function
+# tool — non-Gemini-3 paths and the switch-off case are byte-for-byte unchanged.
+# ---------------------------------------------------------------------------
+
+
+def _split_tools(cfg: Any) -> tuple[list[Any], list[Any]]:
+    """Partition a config's tools into (function-declaration tools, search tools)."""
+    tools = cfg.tools or []
+    func_tools = [t for t in tools if t.function_declarations]
+    search_tools = [t for t in tools if getattr(t, "google_search", None) is not None]
+    return func_tools, search_tools
+
+
+async def test_complete_native_web_search_appends_google_search_tool(mock_sdk):
+    adapter = GeminiAdapter(
+        model_name="gemini-3.5-flash", api_key="k", base_url="https://g"
+    )
+    mock_sdk.instance.set_result(_response(parts=[_part(text="ok")]))
+
+    tools = [ToolDef(name="draw", description="d", parameters={"type": "object"})]
+    await adapter.complete(
+        [Message(role=Role.USER, content="weather?")],
+        tools=tools,
+        native_web_search=True,
+    )
+
+    cfg = mock_sdk.instance.last_generate_kwargs["config"]
+    func_tools, search_tools = _split_tools(cfg)
+    # custom function tool still present
+    assert len(func_tools) == 1
+    assert func_tools[0].function_declarations[0].name == "draw"
+    # native google search co-hosted
+    assert len(search_tools) == 1
+
+
+async def test_stream_native_web_search_appends_google_search_tool(mock_sdk):
+    adapter = GeminiAdapter(
+        model_name="gemini-3.5-flash", api_key="k", base_url="https://g"
+    )
+    mock_sdk.instance.set_stream([_response(parts=[_part(text="ok")])])
+
+    tools = [ToolDef(name="draw", description="d", parameters={"type": "object"})]
+    async for _ in adapter.stream(
+        [Message(role=Role.USER, content="weather?")],
+        tools=tools,
+        native_web_search=True,
+    ):
+        pass
+
+    cfg = mock_sdk.instance.last_generate_kwargs["config"]
+    func_tools, search_tools = _split_tools(cfg)
+    assert len(func_tools) == 1
+    assert len(search_tools) == 1
+
+
+async def test_complete_without_native_web_search_has_no_google_search_tool(mock_sdk):
+    """Default (no signal): only the custom function tool, no google_search."""
+    adapter = GeminiAdapter(
+        model_name="gemini-3.5-flash", api_key="k", base_url="https://g"
+    )
+    mock_sdk.instance.set_result(_response(parts=[_part(text="ok")]))
+
+    tools = [ToolDef(name="draw", description="d", parameters={"type": "object"})]
+    await adapter.complete([Message(role=Role.USER, content="q")], tools=tools)
+
+    cfg = mock_sdk.instance.last_generate_kwargs["config"]
+    func_tools, search_tools = _split_tools(cfg)
+    assert len(func_tools) == 1
+    assert search_tools == []
+
+
+async def test_complete_native_web_search_false_has_no_google_search_tool(mock_sdk):
+    """Explicit native_web_search=False is the same as no signal: no search tool."""
+    adapter = GeminiAdapter(
+        model_name="gemini-3.5-flash", api_key="k", base_url="https://g"
+    )
+    mock_sdk.instance.set_result(_response(parts=[_part(text="ok")]))
+
+    tools = [ToolDef(name="draw", description="d", parameters={"type": "object"})]
+    await adapter.complete(
+        [Message(role=Role.USER, content="q")],
+        tools=tools,
+        native_web_search=False,
+    )
+
+    cfg = mock_sdk.instance.last_generate_kwargs["config"]
+    _, search_tools = _split_tools(cfg)
+    assert search_tools == []
+
+
+async def test_native_web_search_signal_not_leaked_into_config_fields(mock_sdk):
+    """native_web_search is a control param, never a GenerateContentConfig field
+    or a trace model_parameter — it's consumed, not passed through."""
+    adapter = GeminiAdapter(
+        model_name="gemini-3.5-flash", api_key="k", base_url="https://g"
+    )
+    mock_sdk.instance.set_result(_response(parts=[_part(text="ok")]))
+
+    await adapter.complete(
+        [Message(role=Role.USER, content="q")],
+        native_web_search=True,
+    )
+
+    assert "native_web_search" not in _span_calls[0]["model_parameters"]
+    cfg = mock_sdk.instance.last_generate_kwargs["config"]
+    assert not hasattr(cfg, "native_web_search")
+
+
+async def test_native_web_search_with_no_tools_still_appends_google_search(mock_sdk):
+    """Even with no custom tools, the native search signal yields a search tool.
+
+    (In practice main chat always carries tools, but _build_config must not gate
+    the search tool on the function tool existing.)
+    """
+    adapter = GeminiAdapter(
+        model_name="gemini-3.5-flash", api_key="k", base_url="https://g"
+    )
+    mock_sdk.instance.set_result(_response(parts=[_part(text="ok")]))
+
+    await adapter.complete(
+        [Message(role=Role.USER, content="q")],
+        native_web_search=True,
+    )
+
+    cfg = mock_sdk.instance.last_generate_kwargs["config"]
+    func_tools, search_tools = _split_tools(cfg)
+    assert func_tools == []
+    assert len(search_tools) == 1
+
+
+# ---------------------------------------------------------------------------
+# ⑤ grounding sources must not leak into赤尾's visible reply. The wire→neutral
+# helpers only read part.text (skipping thoughts) and never touch
+# candidate.grounding_metadata / search_entry_point. These fixtures attach
+# grounding metadata (source urls / chunks / search-entry html) and assert the
+# neutral content is the visible prose ONLY.
+# ---------------------------------------------------------------------------
+
+_SOURCE_URL = "https://example.com/grounded-source"
+_SEARCH_ENTRY_HTML = '<div class="search-entry">google search suggestions</div>'
+
+
+def _grounding_metadata() -> SimpleNamespace:
+    """A canned grounding_metadata bundle with source urls + search entry point."""
+    chunk = SimpleNamespace(
+        web=SimpleNamespace(uri=_SOURCE_URL, title="Grounded Source")
+    )
+    return SimpleNamespace(
+        grounding_chunks=[chunk],
+        web_search_queries=["today's weather"],
+        search_entry_point=SimpleNamespace(rendered_content=_SEARCH_ENTRY_HTML),
+    )
+
+
+def _grounded_response(visible_text: str) -> SimpleNamespace:
+    """A response whose candidate carries grounding_metadata + visible prose."""
+    candidate = SimpleNamespace(
+        content=_content([_part(text=visible_text)]),
+        finish_reason="STOP",
+        index=0,
+        grounding_metadata=_grounding_metadata(),
+    )
+    return SimpleNamespace(candidates=[candidate], usage_metadata=_usage())
+
+
+async def test_complete_drops_grounding_metadata_from_visible_content(mock_sdk):
+    adapter = GeminiAdapter(
+        model_name="gemini-3.5-flash", api_key="k", base_url="https://g"
+    )
+    mock_sdk.instance.set_result(
+        _grounded_response("今天广州多云转晴，气温 28 度。")
+    )
+
+    out = await adapter.complete([Message(role=Role.USER, content="天气?")])
+
+    assert out.content == "今天广州多云转晴，气温 28 度。"
+    assert _SOURCE_URL not in out.content
+    assert "example.com" not in out.content
+    assert _SEARCH_ENTRY_HTML not in out.content
+    assert "search-entry" not in out.content
+    assert "web_search_queries" not in out.content
+
+
+async def test_stream_drops_grounding_metadata_from_visible_content(mock_sdk):
+    adapter = GeminiAdapter(
+        model_name="gemini-3.5-flash", api_key="k", base_url="https://g"
+    )
+    mock_sdk.instance.set_stream(
+        [_grounded_response("今天广州多云转晴，气温 28 度。")]
+    )
+
+    chunks = [
+        c async for c in adapter.stream([Message(role=Role.USER, content="天气?")])
+    ]
+    text = "".join(c.text for c in chunks if c.text)
+
+    assert text == "今天广州多云转晴，气温 28 度。"
+    assert _SOURCE_URL not in text
+    assert "example.com" not in text
+    assert _SEARCH_ENTRY_HTML not in text
+    assert "search-entry" not in text

--- a/apps/agent-service/tests/agent/test_model_client.py
+++ b/apps/agent-service/tests/agent/test_model_client.py
@@ -212,6 +212,19 @@ async def test_openai_family_adapters_implemented(monkeypatch, client_type):
     assert isinstance(client, openai_mod.OpenAIAdapter)
 
 
+# ---------------------------------------------------------------------------
+# Native web search capability: base default is "unsupported" (fail-closed).
+# Only the Gemini 3 adapter overrides it (covered in test_gemini_adapter.py);
+# everyone else — OpenAI family included — inherits this False.
+# ---------------------------------------------------------------------------
+
+
+def test_model_client_default_does_not_support_native_web_search():
+    """The base ``ModelClient`` reports no native web search (OpenAI inherits)."""
+    client = _FakeAdapter(model_name="m", api_key="k", base_url=None)
+    assert client.supports_native_web_search is False
+
+
 async def test_gemini_adapter_implemented(monkeypatch):
     """T3 implements the ``google`` client_type; the seam dispatches it.
 

--- a/apps/agent-service/tests/agent/test_openai_adapter.py
+++ b/apps/agent-service/tests/agent/test_openai_adapter.py
@@ -1146,3 +1146,41 @@ async def test_azure_cache_params_merge_into_existing_extra(mock_sdk):
     assert sent["extra_body"]["prompt_cache_retention"] == "24h"
     assert sent["extra_headers"]["X-Trace"] == "t"
     assert json.loads(sent["extra_headers"]["extra"]) == {"session_id": "s"}
+
+
+# ---------------------------------------------------------------------------
+# native_web_search is a Gemini-only control signal (it lets a Gemini-3 request
+# co-host native google search). The runtime decides per model whether to send
+# it, so OpenAI never sees True — but the adapter still defensively drops the
+# kwarg so it can never leak into the chat.completions request as an unknown
+# field (which the SDK / gateway would reject).
+# ---------------------------------------------------------------------------
+
+
+async def test_complete_discards_native_web_search_signal(mock_sdk):
+    adapter = OpenAIAdapter(
+        model_name="gpt-4o", api_key="sk", base_url="https://x", client_type="openai"
+    )
+    mock_sdk.instance.set_result(_completion(content="ok"))
+
+    await adapter.complete(
+        [Message(role=Role.USER, content="hi")], native_web_search=True
+    )
+
+    sent = mock_sdk.instance.last_create_kwargs
+    assert "native_web_search" not in sent
+
+
+async def test_stream_discards_native_web_search_signal(mock_sdk):
+    adapter = OpenAIAdapter(
+        model_name="gpt-4o", api_key="sk", base_url="https://x", client_type="openai"
+    )
+    mock_sdk.instance.set_stream([_chunk(content="ok", finish_reason="stop")])
+
+    async for _ in adapter.stream(
+        [Message(role=Role.USER, content="hi")], native_web_search=True
+    ):
+        pass
+
+    sent = mock_sdk.instance.last_create_kwargs
+    assert "native_web_search" not in sent

--- a/apps/agent-service/tests/unit/agent/test_core.py
+++ b/apps/agent-service/tests/unit/agent/test_core.py
@@ -590,6 +590,14 @@ class TestAgentConfig:
     def test_defaults(self):
         assert AgentConfig("p", "m").trace_name is None
 
+    def test_native_web_search_defaults_false(self):
+        """New opt-in field defaults off, so every existing config is unaffected."""
+        assert AgentConfig("p", "m").native_web_search is False
+
+    def test_native_web_search_opt_in(self):
+        """A config may declare it wants native web search."""
+        assert AgentConfig("p", "m", native_web_search=True).native_web_search is True
+
     def test_replace(self):
         from dataclasses import replace
 
@@ -830,6 +838,205 @@ class TestStream:
 
         assert call_count == 2  # first attempt failed, second succeeded
         assert "".join(c.text or "" for c in collected) == "ok"
+
+
+# ---------------------------------------------------------------------------
+# native web search — runtime decision: when main chat runs on a Gemini-3
+# model and the dynamic flag is on, drop the ``search_web`` tool and signal the
+# model to use its native google search instead. Any condition false → the tool
+# list and the model call are byte-for-byte unchanged (no native signal).
+# ---------------------------------------------------------------------------
+
+_NATIVE_CFG = AgentConfig("main", "main-chat-model", "main", native_web_search=True)
+
+
+def _search_web_tool():
+    from app.agent.tooling import tool
+
+    @tool
+    async def search_web(query: str) -> str:
+        """Search the web.
+
+        Args:
+            query: the query.
+        """
+        return "results"
+
+    return search_web
+
+
+def _other_tool():
+    from app.agent.tooling import tool
+
+    @tool
+    async def draw_picture(prompt: str) -> str:
+        """Draw a picture.
+
+        Args:
+            prompt: the prompt.
+        """
+        return "drawn"
+
+    return draw_picture
+
+
+@pytest.fixture()
+def flag_on():
+    """Patch the dynamic flag ``main_chat_native_web_search`` → True."""
+    with patch("app.agent.core.dynamic_config") as dc:
+        dc.get_bool.return_value = True
+        yield dc
+
+
+@pytest.fixture()
+def flag_off():
+    with patch("app.agent.core.dynamic_config") as dc:
+        dc.get_bool.return_value = False
+        yield dc
+
+
+class TestNativeWebSearchDecision:
+    """The three conditions (cfg opt-in AND model supports AND flag on) plus a
+    'search_web is actually present' guard gate the swap. The swap drops
+    search_web from the tools the model sees and forwards native_web_search=True;
+    otherwise the tools and the model call are unchanged and no signal leaks."""
+
+    async def test_run_all_conditions_true_drops_search_web_and_signals(
+        self, mock_deps, flag_on
+    ):
+        mock_deps["model"].supports_native_web_search = True
+        search_web, other = _search_web_tool(), _other_tool()
+        await Agent(_NATIVE_CFG, tools=[search_web, other]).run(
+            messages=[Message(role=Role.USER, content="今天天气")]
+        )
+        kw = mock_deps["model"].complete.await_args.kwargs
+        tool_names = [t.name for t in (kw["tools"] or [])]
+        assert "search_web" not in tool_names
+        assert "draw_picture" in tool_names
+        assert kw.get("native_web_search") is True
+        # the flag was consulted with the documented key + safe default
+        flag_on.get_bool.assert_called_once_with(
+            "main_chat_native_web_search", default=False
+        )
+
+    async def test_run_model_unsupported_keeps_search_web_no_signal(
+        self, mock_deps, flag_on
+    ):
+        mock_deps["model"].supports_native_web_search = False
+        search_web, other = _search_web_tool(), _other_tool()
+        await Agent(_NATIVE_CFG, tools=[search_web, other]).run(
+            messages=[Message(role=Role.USER, content="今天天气")]
+        )
+        kw = mock_deps["model"].complete.await_args.kwargs
+        tool_names = [t.name for t in (kw["tools"] or [])]
+        assert "search_web" in tool_names
+        assert "native_web_search" not in kw
+        # short-circuit: an unsupported model never reaches the (blocking) flag read
+        flag_on.get_bool.assert_not_called()
+
+    async def test_run_flag_off_keeps_search_web_no_signal(
+        self, mock_deps, flag_off
+    ):
+        mock_deps["model"].supports_native_web_search = True
+        search_web, other = _search_web_tool(), _other_tool()
+        await Agent(_NATIVE_CFG, tools=[search_web, other]).run(
+            messages=[Message(role=Role.USER, content="今天天气")]
+        )
+        kw = mock_deps["model"].complete.await_args.kwargs
+        tool_names = [t.name for t in (kw["tools"] or [])]
+        assert "search_web" in tool_names
+        assert "native_web_search" not in kw
+
+    async def test_run_cfg_not_opted_in_keeps_search_web_no_signal(
+        self, mock_deps, flag_on
+    ):
+        # world/life/guard configs never declare native_web_search → even a
+        # Gemini-3 model with the flag on must not trigger the swap.
+        mock_deps["model"].supports_native_web_search = True
+        search_web, other = _search_web_tool(), _other_tool()
+        await Agent(_CFG, tools=[search_web, other]).run(
+            messages=[Message(role=Role.USER, content="hi")]
+        )
+        kw = mock_deps["model"].complete.await_args.kwargs
+        tool_names = [t.name for t in (kw["tools"] or [])]
+        assert "search_web" in tool_names
+        assert "native_web_search" not in kw
+        # short-circuit: a non-opted agent never reaches the (blocking) flag read
+        flag_on.get_bool.assert_not_called()
+
+    async def test_run_no_search_web_present_does_not_signal(
+        self, mock_deps, flag_on
+    ):
+        # opted in, model supports, flag on — but the agent never mounted
+        # search_web → must NOT enable native search for free (cost guard).
+        mock_deps["model"].supports_native_web_search = True
+        other = _other_tool()
+        await Agent(_NATIVE_CFG, tools=[other]).run(
+            messages=[Message(role=Role.USER, content="hi")]
+        )
+        kw = mock_deps["model"].complete.await_args.kwargs
+        tool_names = [t.name for t in (kw["tools"] or [])]
+        assert tool_names == ["draw_picture"]
+        assert "native_web_search" not in kw
+
+    async def test_non_native_agent_with_flag_present_is_byte_for_byte(
+        self, mock_deps, flag_on
+    ):
+        # A world/life-style agent (not opted in) on this path must call the
+        # model exactly as before: tools unchanged, no native signal, even when
+        # the global flag happens to be on.
+        mock_deps["model"].supports_native_web_search = True
+        search_web = _search_web_tool()
+        await Agent(_CFG, tools=[search_web]).run(
+            messages=[Message(role=Role.USER, content="hi")]
+        )
+        kw = mock_deps["model"].complete.await_args.kwargs
+        assert [t.name for t in (kw["tools"] or [])] == ["search_web"]
+        assert "native_web_search" not in kw
+
+    async def test_stream_all_conditions_true_drops_search_web_and_signals(
+        self, mock_deps, flag_on
+    ):
+        captured: dict = {}
+
+        async def fake_stream(messages, *, tools=None, **kwargs):
+            captured["tools"] = tools
+            captured["kwargs"] = kwargs
+            yield StreamChunk(text="hi")
+            yield StreamChunk(finish_reason="stop")
+
+        mock_deps["model"].stream = fake_stream
+        mock_deps["model"].supports_native_web_search = True
+        search_web, other = _search_web_tool(), _other_tool()
+        async for _ in Agent(_NATIVE_CFG, tools=[search_web, other]).stream(
+            messages=[Message(role=Role.USER, content="今天天气")]
+        ):
+            pass
+        tool_names = [t.name for t in (captured["tools"] or [])]
+        assert "search_web" not in tool_names
+        assert "draw_picture" in tool_names
+        assert captured["kwargs"].get("native_web_search") is True
+
+    async def test_stream_flag_off_keeps_search_web_no_signal(
+        self, mock_deps, flag_off
+    ):
+        captured: dict = {}
+
+        async def fake_stream(messages, *, tools=None, **kwargs):
+            captured["tools"] = tools
+            captured["kwargs"] = kwargs
+            yield StreamChunk(text="hi")
+            yield StreamChunk(finish_reason="stop")
+
+        mock_deps["model"].stream = fake_stream
+        mock_deps["model"].supports_native_web_search = True
+        search_web = _search_web_tool()
+        async for _ in Agent(_NATIVE_CFG, tools=[search_web]).stream(
+            messages=[Message(role=Role.USER, content="今天天气")]
+        ):
+            pass
+        assert [t.name for t in (captured["tools"] or [])] == ["search_web"]
+        assert "native_web_search" not in captured["kwargs"]
 
 
 # ---------------------------------------------------------------------------

--- a/apps/agent-service/tests/unit/agent/test_react_loop.py
+++ b/apps/agent-service/tests/unit/agent/test_react_loop.py
@@ -744,3 +744,94 @@ class TestSessionIdPassthrough:
         )
         assert fake.complete_kwargs[0]["session_id"] == "real"
         assert fake.complete_kwargs[0]["reasoning_effort"] == "low"
+
+
+# ---------------------------------------------------------------------------
+# native_web_search passthrough — the loop forwards the signal to the model
+# ONLY when it is True, so every existing (non-native) call is byte-for-byte
+# unchanged: a model never sees an unknown ``native_web_search`` kwarg unless
+# the agent layer decided to enable native search this run.
+# ---------------------------------------------------------------------------
+
+
+class TestNativeWebSearchPassthrough:
+    async def test_run_loop_forwards_native_web_search_when_true(self):
+        _run_loop, _ = _import_loops()
+        fake = FakeModelClient(
+            complete_script=[Message(role=Role.ASSISTANT, content="hi")]
+        )
+        await _run_loop(
+            fake,
+            messages=[Message(role=Role.USER, content="hello")],
+            tools=[],
+            context=None,
+            recursion_limit=12,
+            native_web_search=True,
+        )
+        assert fake.complete_kwargs[0]["native_web_search"] is True
+
+    async def test_run_loop_omits_native_web_search_by_default(self):
+        # The default (False) must NOT appear in the kwargs at all, so existing
+        # adapters that don't know the kwarg are never handed it.
+        _run_loop, _ = _import_loops()
+        fake = FakeModelClient(
+            complete_script=[Message(role=Role.ASSISTANT, content="hi")]
+        )
+        await _run_loop(
+            fake,
+            messages=[Message(role=Role.USER, content="hello")],
+            tools=[],
+            context=None,
+            recursion_limit=12,
+        )
+        assert "native_web_search" not in fake.complete_kwargs[0]
+
+    async def test_run_loop_omits_native_web_search_when_false(self):
+        _run_loop, _ = _import_loops()
+        fake = FakeModelClient(
+            complete_script=[Message(role=Role.ASSISTANT, content="hi")]
+        )
+        await _run_loop(
+            fake,
+            messages=[Message(role=Role.USER, content="hello")],
+            tools=[],
+            context=None,
+            recursion_limit=12,
+            native_web_search=False,
+        )
+        assert "native_web_search" not in fake.complete_kwargs[0]
+
+    async def test_stream_loop_forwards_native_web_search_when_true(self):
+        _, _stream_loop = _import_loops()
+        fake = FakeModelClient(
+            stream_script=[
+                [StreamChunk(text="hi"), StreamChunk(finish_reason="stop")]
+            ]
+        )
+        async for _ in _stream_loop(
+            fake,
+            messages=[Message(role=Role.USER, content="hi")],
+            tools=[],
+            context=None,
+            recursion_limit=12,
+            native_web_search=True,
+        ):
+            pass
+        assert fake.stream_kwargs[0]["native_web_search"] is True
+
+    async def test_stream_loop_omits_native_web_search_by_default(self):
+        _, _stream_loop = _import_loops()
+        fake = FakeModelClient(
+            stream_script=[
+                [StreamChunk(text="hi"), StreamChunk(finish_reason="stop")]
+            ]
+        )
+        async for _ in _stream_loop(
+            fake,
+            messages=[Message(role=Role.USER, content="hi")],
+            tools=[],
+            context=None,
+            recursion_limit=12,
+        ):
+            pass
+        assert "native_web_search" not in fake.stream_kwargs[0]

--- a/apps/agent-service/tests/unit/chat/test_render.py
+++ b/apps/agent-service/tests/unit/chat/test_render.py
@@ -73,6 +73,22 @@ def test_render_chat_turn_signature_has_no_source_message_lookup():
     assert "message_id" not in params
 
 
+def test_main_cfg_opts_into_native_web_search():
+    """main chat 是唯一声明启用 Gemini 原生谷歌搜索的 config。"""
+    from app.chat.render import _MAIN_CFG
+
+    assert _MAIN_CFG.native_web_search is True
+
+
+def test_other_configs_do_not_opt_into_native_web_search():
+    """world / life 等其它 config 不声明,默认关,天然进不来新路径。"""
+    from app.life.review import _REVIEW_CFG
+    from app.world.engine import _WORLD_CFG
+
+    assert _WORLD_CFG.native_web_search is False
+    assert _REVIEW_CFG.native_web_search is False
+
+
 @pytest.mark.asyncio
 async def test_render_chat_turn_streams_text_and_builds_prompt_vars(monkeypatch):
     """正常路径:用 persona bundle + inner_context + 渲染期变量拼 prompt_vars,

--- a/apps/agent-service/uv.lock
+++ b/apps/agent-service/uv.lock
@@ -87,7 +87,7 @@ requires-dist = [
     { name = "cnlunar", specifier = ">=0.2.4" },
     { name = "croniter", specifier = ">=6.2.2" },
     { name = "fastapi", specifier = ">=0.116.1" },
-    { name = "google-genai", specifier = ">=1.0.0" },
+    { name = "google-genai", specifier = "==2.9.0" },
     { name = "greenlet", specifier = ">=3.2.3" },
     { name = "inner-shared", editable = "../../packages/py-shared" },
     { name = "jieba", specifier = ">=0.42.1" },
@@ -797,16 +797,15 @@ wheels = [
 
 [[package]]
 name = "google-auth"
-version = "2.48.0"
+version = "2.55.0"
 source = { registry = "https://mirrors.aliyun.com/pypi/simple/" }
 dependencies = [
     { name = "cryptography" },
     { name = "pyasn1-modules" },
-    { name = "rsa" },
 ]
-sdist = { url = "https://mirrors.aliyun.com/pypi/packages/0c/41/242044323fbd746615884b1c16639749e73665b718209946ebad7ba8a813/google_auth-2.48.0.tar.gz", hash = "sha256:4f7e706b0cd3208a3d940a19a822c37a476ddba5450156c3e6624a71f7c841ce" }
+sdist = { url = "https://mirrors.aliyun.com/pypi/packages/81/1c/70b23fc52b2bb3c70b379f3bd05c4a60ab3a873e30c6bd21c57e0154848a/google_auth-2.55.0.tar.gz", hash = "sha256:fcd3a130f575fa36403d38774af1c64a4fbfbca09215f0589d2372b5119697cb" }
 wheels = [
-    { url = "https://mirrors.aliyun.com/pypi/packages/83/1d/d6466de3a5249d35e832a52834115ca9d1d0de6abc22065f049707516d47/google_auth-2.48.0-py3-none-any.whl", hash = "sha256:2e2a537873d449434252a9632c28bfc268b0adb1e53f9fb62afc5333a975903f" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/44/71/c0321dc6d63d99946da45f7c06299b934e4f7f7da5c4f14d101bcb39adf1/google_auth-2.55.0-py3-none-any.whl", hash = "sha256:a17cef9dedf98c4ebae2fb0c48c8f75952c877cbc2efe09f329ef16c2783d88a" },
 ]
 
 [package.optional-dependencies]
@@ -816,7 +815,7 @@ requests = [
 
 [[package]]
 name = "google-genai"
-version = "1.62.0"
+version = "2.9.0"
 source = { registry = "https://mirrors.aliyun.com/pypi/simple/" }
 dependencies = [
     { name = "anyio" },
@@ -830,9 +829,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "websockets" },
 ]
-sdist = { url = "https://mirrors.aliyun.com/pypi/packages/94/4c/71b32b5c8db420cf2fd0d5ef8a672adbde97d85e5d44a0b4fca712264ef1/google_genai-1.62.0.tar.gz", hash = "sha256:709468a14c739a080bc240a4f3191df597bf64485b1ca3728e0fb67517774c18" }
+sdist = { url = "https://mirrors.aliyun.com/pypi/packages/51/75/81c01294db3a3005dc8a807ed889a10ecd66ef89462c118adcffa5f7981c/google_genai-2.9.0.tar.gz", hash = "sha256:a8a10e9113f460cc668c1d9deeb62ba393ad1ba704bf3166d5a0f32a434f9415" }
 wheels = [
-    { url = "https://mirrors.aliyun.com/pypi/packages/09/5f/4645d8a28c6e431d0dd6011003a852563f3da7037d36af53154925b099fd/google_genai-1.62.0-py3-none-any.whl", hash = "sha256:4c3daeff3d05fafee4b9a1a31f9c07f01bc22051081aa58b4d61f58d16d1bcc0" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/a3/17/bb2cdd0a6c6fec32f14e85735917d1052f82430b1de58c2b606740740419/google_genai-2.9.0-py3-none-any.whl", hash = "sha256:2a79e2b08e8439f5f25c2b42f98e3f3e8ea4be9c9265f5d7321580dbaf2764f4" },
 ]
 
 [[package]]
@@ -2155,18 +2154,6 @@ dependencies = [
 sdist = { url = "https://mirrors.aliyun.com/pypi/packages/c9/74/b3ff8e6c8446842c3f5c837e9c3dfcfe2018ea6ecef224c710c85ef728f4/requests-2.32.5.tar.gz", hash = "sha256:dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf" }
 wheels = [
     { url = "https://mirrors.aliyun.com/pypi/packages/1e/db/4254e3eabe8020b458f1a747140d32277ec7a271daf1d235b70dc0b4e6e3/requests-2.32.5-py3-none-any.whl", hash = "sha256:2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6" },
-]
-
-[[package]]
-name = "rsa"
-version = "4.9.1"
-source = { registry = "https://mirrors.aliyun.com/pypi/simple/" }
-dependencies = [
-    { name = "pyasn1" },
-]
-sdist = { url = "https://mirrors.aliyun.com/pypi/packages/da/8a/22b7beea3ee0d44b1916c0c1cb0ee3af23b700b6da9f04991899d0c555d4/rsa-4.9.1.tar.gz", hash = "sha256:e7bdbfdb5497da4c07dfd35530e1a902659db6ff241e39d9953cad06ebd0ae75" }
-wheels = [
-    { url = "https://mirrors.aliyun.com/pypi/packages/64/8d/0133e4eb4beed9e425d9a98ed6e081a55d195481b7632472be1af08d2f6b/rsa-4.9.1-py3-none-any.whl", hash = "sha256:68635866661c6836b8d39430f97a996acbd61bfa49406748ea243539fe239762" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What

When an agent's resolved model is a Gemini 3 (currently main chat's `gemini-3.5-flash`), swap the self-written `search_web` function tool for Gemini's native Google Search grounding. The model decides when to search and folds results straight into its reply — more human than an explicit tool round-trip.

## How (signal flows render → adapter)

- `ModelClient.supports_native_web_search` (Gemini 3 only — 2.5 can't co-host grounding with function calls, fail-closed); `AgentConfig.native_web_search` opt-in (main chat only).
- `Agent` resolves the swap from three ANDed conditions (opt-in ∧ model supports ∧ Dynamic Config `main_chat_native_web_search`) and only when `search_web` is actually mounted — drops it and signals the adapter. Every non-Gemini agent (world/life/guard on GPT) is byte-for-byte unchanged; a model override away from Gemini auto-falls-back. No hardcoded model/agent name.
- Gemini adapter appends `Tool(google_search=GoogleSearch())` alongside function declarations and sets `tool_config.include_server_side_tool_invocations=True` (Gemini 3 400s without it). OpenAI adapter defensively drops the control kwarg.
- Grounding source metadata is never read into the visible reply (fixture-locked) so replies stay in character.

## Dependency

Bumps `google-genai` 1.62 → 2.9 — the `include_server_side_tool_invocations` field doesn't exist in 1.62. Existing Gemini adapter tests stay green across the major bump.

## Verified (ppe real-bot)

Asked the bot about tonight's matches; it answered live World Cup fixtures with no `search_web` tool call, no 400, reply fully in-character with no source links — the grounding fingerprint. Gated by a Dynamic Config flag, default off, flip per-lane.

## Follow-up (backlog, non-blocking)

The persona prompt's `<tools>` block still describes `search_web` even when grounding replaces it — cosmetic only (the model can only call declared tools, not prompt-text ones), worth cleaning up later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)