### PR TITLE
fix(agent): forward receiving bot for inbound image downloads

### DIFF
--- a/apps/agent-service/app/chat/_context_images.py
+++ b/apps/agent-service/app/chat/_context_images.py
@@ -47,10 +47,17 @@ async def allows_download(chat_id: str, chat_type: str) -> bool:
 async def collect_images(
     results: list[QuickSearchResult],
     chat_type: str,
+    bot_name: str = "",
 ) -> tuple[dict[str, str], dict[str, str]]:
     """Collect image URLs from message history.
 
     Returns (image_key -> url, image_key -> tos_file_name).
+
+    ``bot_name`` is the bot that received the current turn's messages; it is
+    forwarded to ``process_image`` so tool-service gets the ``X-App-Name`` it
+    needs to download Lark images with the right bot credential. Without it the
+    download is rejected with HTTP 422 and the user's image silently vanishes
+    from the LLM context (trace dbde982e146840cc00610c393fc5820e).
     """
     cached_keys: list[tuple[str, str]] = []  # (image_key, tos_file)
     uncached_keys: list[tuple[str, str, str]] = []  # (image_key, message_id, role)
@@ -96,9 +103,18 @@ async def collect_images(
 
     # Uncached: full pipeline (Lark download -> compress -> TOS)
     if uncached_keys:
+        if not bot_name:
+            logger.warning(
+                "collect_images missing bot_name: %d inbound image(s) cannot "
+                "download (X-App-Name absent -> tool-service 422). Likely a stale "
+                "payload / MQ replay where ChatRequest.bot_name was empty.",
+                len(uncached_keys),
+            )
         process_results = await fan_out_wait(
             [
-                image_client.process_image(key, msg_id if role == "user" else None)
+                image_client.process_image(
+                    key, msg_id if role == "user" else None, bot_name=bot_name
+                )
                 for key, msg_id, role in uncached_keys
             ]
         )

--- a/apps/agent-service/app/chat/context.py
+++ b/apps/agent-service/app/chat/context.py
@@ -50,6 +50,7 @@ async def build_human_chat_context(
     message_id: str,
     *,
     persona_id: str,
+    bot_name: str = "",
     limit: int = 10,
 ) -> ChatTurnContext | None:
     """Build a render-ready context for a real-person chat turn.
@@ -58,6 +59,10 @@ async def build_human_chat_context(
     registry, chat address, resolved persona bundle, and assembled inner_context.
     Returns ``None`` when the source message resolves to no history — the caller
     treats that as "message not found" and emits the not-found segment.
+
+    ``bot_name`` is the bot that received this turn's message; it flows down to
+    ``collect_images`` → ``process_image`` so inbound Lark images download with
+    the right bot credential (see ``collect_images`` for why it matters).
     """
     t_build_start = time.monotonic()
     l1_results = await quick_search(message_id=message_id, limit=limit)
@@ -70,7 +75,9 @@ async def build_human_chat_context(
     chat_id = l1_results[0].chat_id or ""
 
     # --- Image processing ---
-    image_key_to_url, image_key_to_file = await collect_images(l1_results, chat_type)
+    image_key_to_url, image_key_to_file = await collect_images(
+        l1_results, chat_type, bot_name=bot_name
+    )
 
     # Persist new TOS files in background via dataflow (Phase 6 v4 Gap 5).
     if image_key_to_file:

--- a/apps/agent-service/app/nodes/chat_node.py
+++ b/apps/agent-service/app/nodes/chat_node.py
@@ -256,7 +256,9 @@ async def chat_node(req: ChatRequest) -> None:
         # context 反查为空(源消息无历史)→ 退回"未找到"文本,与旧 _build_and_stream
         # 的空 ctx 分支行为一致。
         turn_ctx = await build_human_chat_context(
-            req.message_id, persona_id=req.persona_id or ""
+            req.message_id,
+            persona_id=req.persona_id or "",
+            bot_name=req.bot_name or "",
         )
         if turn_ctx is None:
             stream = _yield_not_found()

--- a/apps/agent-service/tests/infra/test_image_client.py
+++ b/apps/agent-service/tests/infra/test_image_client.py
@@ -1,0 +1,35 @@
+"""_ImageClient 鉴权 header 契约。
+
+锁死 inbound 图片 bad case（trace dbde982e146840cc00610c393fc5820e）的直接机制：
+``X-App-Name`` 仅在 app_name(bot_name) 非空时才发；为空时整个 header 缺失，
+tool-service 直接 422、用户图片下载失败。这正是 collect_images 必须把「接收
+消息的 bot」透传到 process_image 的原因——这两条断言钉住了「空就漏 header」
+这个根因，配合 collect_images 透传测试，整条下载链才闭环。
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+
+def _client_with_stub_router(monkeypatch):
+    from app.infra import image as image_mod
+
+    stub_router = MagicMock()
+    stub_router.get_headers.return_value = {}
+    monkeypatch.setattr(image_mod, "_lane_router", lambda: stub_router)
+    return image_mod._ImageClient()
+
+
+def test_auth_headers_sets_x_app_name_when_bot_present(monkeypatch):
+    """有 bot_name → 请求带 X-App-Name，tool-service 才肯下载飞书图。"""
+    client = _client_with_stub_router(monkeypatch)
+    headers = client._auth_headers(app_name="bot-x")
+    assert headers["X-App-Name"] == "bot-x"
+
+
+def test_auth_headers_omits_x_app_name_when_empty(monkeypatch):
+    """空 app_name → 不发 X-App-Name → tool-service 422。这就是 bad case 根因，
+    所以下载入站图必须把接收消息的 bot 一路透传进来、不能为空。"""
+    client = _client_with_stub_router(monkeypatch)
+    headers = client._auth_headers(app_name="")
+    assert "X-App-Name" not in headers

--- a/apps/agent-service/tests/nodes/test_chat_node.py
+++ b/apps/agent-service/tests/nodes/test_chat_node.py
@@ -198,6 +198,55 @@ async def test_chat_node_resolves_bot_name_and_updates_agent_response(monkeypatc
     assert set_calls == [("s1", "resolved-bot-x", "p1")]
 
 
+@pytest.mark.asyncio
+async def test_chat_node_passes_req_bot_name_to_build_context(monkeypatch):
+    """chat_node 用 req.bot_name（接收消息的 bot）调 build_human_chat_context，
+    让入站图下载拿到正确 X-App-Name。修复前不传 → build_ctx 收到默认空 →
+    process_image 422、用户图丢失（trace dbde982e146840cc00610c393fc5820e）。"""
+    from app.nodes import chat_node as cn
+
+    req = ChatRequest(
+        message_id="m1", persona_id="p1", session_id="s1", channel="qq",
+        chat_id="c1", is_p2p=True, user_id="u1", lane="dev", bot_name="bot-recv",
+    )
+
+    captured: dict[str, object] = {}
+
+    async def fake_build_ctx(message_id, *, persona_id, bot_name="", **k):
+        captured["bot_name"] = bot_name
+        return _stub_turn_ctx()
+
+    async def fake_find_msg(mid): return "hi"
+    async def fake_find_gray(mid): return {}
+    async def fake_guard(p): return "guard"
+    async def fake_pre(*a, **k):
+        from app.domain.safety import PreSafetyVerdict
+        return PreSafetyVerdict(pre_request_id="x", message_id="m1", is_blocked=False)
+    async def fake_render(*a, **k):
+        if False:
+            yield ""
+    async def fake_resolve(p, c): return "bot-x"
+    async def fake_set(sid, bn, pid): pass
+    async def fake_emit(d): pass
+
+    monkeypatch.setattr(cn, "build_human_chat_context", fake_build_ctx, raising=False)
+    monkeypatch.setattr(cn, "find_message_content", fake_find_msg)
+    monkeypatch.setattr(cn, "find_gray_config", fake_find_gray)
+    monkeypatch.setattr(cn, "fetch_guard_message", fake_guard)
+    monkeypatch.setattr(cn, "run_pre_safety_check", fake_pre)
+    monkeypatch.setattr(cn, "resolve_bot_name_for_persona", fake_resolve)
+    monkeypatch.setattr(cn, "set_agent_response_bot", fake_set)
+    monkeypatch.setattr(cn, "render_chat_turn", fake_render, raising=False)
+    monkeypatch.setattr(cn, "emit", fake_emit)
+
+    await cn.chat_node(req)
+
+    assert captured.get("bot_name") == "bot-recv", (
+        f"chat_node 必须用 req.bot_name 调 build_human_chat_context，"
+        f"实得 {captured.get('bot_name')!r}"
+    )
+
+
 SPLIT = "---split---"
 
 

--- a/apps/agent-service/tests/unit/chat/test_context_images.py
+++ b/apps/agent-service/tests/unit/chat/test_context_images.py
@@ -1,0 +1,107 @@
+"""collect_images 入站图收集的契约。
+
+复现并锁死 prod bad case（chat-turn dbde982e146840cc00610c393fc5820e）的根因：
+用户发的未缓存图片走 ``image_client.process_image`` 下载时，必须带上接收消息的
+bot_name —— 否则 tool-service 拿不到 X-App-Name、返回 422、图片处理全失败，
+赤尾据此否认用户发过图。
+"""
+from __future__ import annotations
+
+import json
+from datetime import datetime
+
+import pytest
+
+from app.chat.quick_search import QuickSearchResult
+
+
+def _img_msg(mid: str, img_key: str, *, role: str = "user", chat_type: str = "p2p"):
+    """一条带 image item、且未缓存（无 tos_file）的消息 → 走 process_image 下载。"""
+    return QuickSearchResult(
+        message_id=mid,
+        content=json.dumps(
+            {
+                "v": 2,
+                "text": "你看这个",
+                "items": [
+                    {"type": "text", "value": "你看这个"},
+                    {"type": "image", "value": img_key},
+                ],
+            },
+            ensure_ascii=False,
+        ),
+        user_id="u1",
+        create_time=datetime(2026, 6, 23, 20, 0, 0),
+        role=role,
+        username="原智鸿",
+        chat_type=chat_type,
+        chat_id="oc_test",
+    )
+
+
+@pytest.mark.asyncio
+async def test_collect_images_passes_bot_name_to_process(monkeypatch):
+    """复现根因：collect_images 下载未缓存的 user 图时，process_image 必须收到
+    传入的 bot_name（接收消息的 bot）。修复前 collect_images 不接受 bot_name、
+    process_image 拿到的是 None → X-App-Name 缺失 → tool-service 422。"""
+    from app.chat import _context_images as ci
+
+    img_key = "img_v3_0212u_25501191"
+    results = [_img_msg("m1", img_key)]
+
+    calls: list[tuple] = []
+
+    async def fake_process(file_key, message_id, bot_name=None):
+        calls.append((file_key, message_id, bot_name))
+        return {"url": "https://tos/x.png", "file_name": "1.png"}
+
+    monkeypatch.setattr(ci.image_client, "process_image", fake_process)
+
+    url_map, file_map = await ci.collect_images(results, "p2p", bot_name="bot-x")
+
+    assert calls, "未缓存的 user 图必须触发 process_image 下载"
+    assert calls[0][2] == "bot-x", (
+        f"process_image 必须收到接收消息的 bot_name，实得 {calls[0][2]!r}"
+        "（None 即复现 X-App-Name 缺失 → 422 的根因）"
+    )
+    assert url_map[img_key] == "https://tos/x.png"
+    assert file_map[img_key] == "1.png"
+
+
+@pytest.mark.asyncio
+async def test_collect_images_warns_when_bot_name_missing(monkeypatch, caplog):
+    """bot_name 缺失（旧 payload / MQ replay）时下载入站图会因 X-App-Name 缺失而
+    422。这是上游数据缺失的已知限制——不静默吞掉，记一条明确指向 bot_name 的
+    warning 便于排查（codex T1 必改 2）。"""
+    import logging
+
+    from app.chat import _context_images as ci
+
+    img_key = "img_v3_0212u_missing"
+    results = [_img_msg("m1", img_key)]
+
+    received: list[object] = []
+
+    async def fake_process(file_key, message_id, bot_name=None):
+        received.append(bot_name)
+        return None  # 缺凭证 → tool-service 422 → None
+
+    monkeypatch.setattr(ci.image_client, "process_image", fake_process)
+
+    with caplog.at_level(logging.WARNING):
+        await ci.collect_images(results, "p2p", bot_name="")
+
+    # 不伪造凭证：空 bot_name 原样下传，让下游暴露失败而非静默成功。
+    assert received == [""], (
+        f"bot_name 缺失时仍应以空串调 process_image，实得 {received!r}"
+    )
+    # warning 来自未缓存图片下载路径，且为 WARNING 级。
+    warn_recs = [
+        r
+        for r in caplog.records
+        if r.levelno == logging.WARNING and "bot_name" in r.message
+    ]
+    assert warn_recs, (
+        "bot_name 缺失时应有一条 WARNING 级、指向 bot_name 的日志，"
+        f"实得 warnings: {[r.message for r in caplog.records]!r}"
+    )

--- a/apps/agent-service/tests/unit/chat/test_human_context.py
+++ b/apps/agent-service/tests/unit/chat/test_human_context.py
@@ -106,6 +106,45 @@ async def test_build_human_chat_context_packs_render_ready_context(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_build_human_chat_context_forwards_bot_name_to_collect_images(monkeypatch):
+    """bot_name 透传：build_human_chat_context 把接收消息的 bot 传给 collect_images，
+    后者据此带 X-App-Name 下载入站图。修复前签名无 bot_name → 链路断、图片 422、
+    赤尾否认用户发图（trace dbde982e146840cc00610c393fc5820e）。"""
+    from app.chat import context as ctx_mod
+
+    history = [_msg("m1", text="你看这个", user_id="u1", username="原智鸿", minute=0)]
+
+    captured: dict[str, object] = {}
+
+    async def fake_collect(results, chat_type, bot_name=""):
+        captured["bot_name"] = bot_name
+        return ({}, {})
+
+    async def fake_load_persona(pid):
+        return _FakePersona()
+
+    async def fake_inner(**kwargs):
+        return "INNER"
+
+    with (
+        patch("app.chat.context.quick_search", new=AsyncMock(return_value=history)),
+        patch("app.chat.context.collect_images", new=fake_collect),
+        patch("app.chat.context.build_p2p_messages",
+              new=MagicMock(return_value=["built"])),
+        patch("app.chat.context.load_persona", new=fake_load_persona),
+        patch("app.chat.context.build_inner_context", new=fake_inner),
+    ):
+        await ctx_mod.build_human_chat_context(
+            "m1", persona_id="akao", bot_name="bot-x"
+        )
+
+    assert captured.get("bot_name") == "bot-x", (
+        f"build_human_chat_context 必须把 bot_name 透传给 collect_images，"
+        f"实得 {captured.get('bot_name')!r}"
+    )
+
+
+@pytest.mark.asyncio
 async def test_build_human_chat_context_returns_none_when_no_history(monkeypatch):
     """message_id 反查为空 -> 返回 None(调用方据此走"未找到")。"""
     from app.chat import context as ctx_mod


### PR DESCRIPTION
## Summary
- forward the receiving bot name through chat context image collection
- pass bot_name to image processing so inbound Feishu images use the correct app identity
- add coverage for image context collection and chat node propagation

## Tests
- cd apps/agent-service && uv run pytest tests/infra/test_image_client.py tests/unit/chat/test_context_images.py tests/unit/chat/test_human_context.py::test_build_human_chat_context_forwards_bot_name_to_collect_images tests/nodes/test_chat_node.py::test_chat_node_passes_req_bot_name_to_build_context