### PR TITLE
fix: propagate ops-db api errors

### DIFF
--- a/.claude/skills/ops-db/query.py
+++ b/.claude/skills/ops-db/query.py
@@ -36,34 +36,60 @@ def get_env():
     return paas_api, cc_token
 
 
-def curl_post(url, payload, token):
+def _curl_json(args):
     result = subprocess.run(
+        args + ["-w", "\n%{http_code}"],
+        capture_output=True, text=True,
+    )
+    if result.returncode != 0:
+        detail = result.stderr.strip() or result.stdout.strip()
+        print(f"ERROR: API 调用失败: {detail}", file=sys.stderr)
+        sys.exit(1)
+
+    body, sep, status_text = result.stdout.rpartition("\n")
+    if not sep or not status_text.strip().isdigit():
+        print("ERROR: API 调用失败: 响应缺少 HTTP 状态码", file=sys.stderr)
+        sys.exit(1)
+
+    status = int(status_text.strip())
+    try:
+        data = json.loads(body) if body.strip() else {}
+    except json.JSONDecodeError as e:
+        if status < 200 or status >= 300:
+            message = body.strip() or e.msg
+            print(f"ERROR: API 调用失败 (HTTP {status}): {message}", file=sys.stderr)
+            sys.exit(1)
+        print(f"ERROR: API 返回非 JSON 响应: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    if status < 200 or status >= 300:
+        message = data.get("error") if isinstance(data, dict) else None
+        if not message:
+            message = body.strip() or "empty response body"
+        print(f"ERROR: API 调用失败 (HTTP {status}): {message}", file=sys.stderr)
+        sys.exit(1)
+
+    return data
+
+
+def curl_post(url, payload, token):
+    return _curl_json(
         [
-            "curl", "-sfS", "-X", "POST", url,
+            "curl", "-sS", "-X", "POST", url,
             "-H", "Content-Type: application/json",
             "-H", f"X-API-Key: {token}",
             "-d", json.dumps(payload),
-        ],
-        capture_output=True, text=True,
+        ]
     )
-    if result.returncode != 0:
-        print(f"ERROR: API 调用失败: {result.stderr}", file=sys.stderr)
-        sys.exit(1)
-    return json.loads(result.stdout)
 
 
 def curl_get(url, token):
-    result = subprocess.run(
+    return _curl_json(
         [
-            "curl", "-sfS", url,
+            "curl", "-sS", url,
             "-H", f"X-API-Key: {token}",
-        ],
-        capture_output=True, text=True,
+        ]
     )
-    if result.returncode != 0:
-        print(f"ERROR: API 调用失败: {result.stderr}", file=sys.stderr)
-        sys.exit(1)
-    return json.loads(result.stdout)
 
 
 def cmd_query(args):

--- a/.claude/skills/ops-db/test_query.py
+++ b/.claude/skills/ops-db/test_query.py
@@ -57,6 +57,46 @@ def test_unknown_db_still_rejected(captured):
         query.cmd_query(["@chiwei-prod", "SELECT", "1"])
 
 
+def test_curl_post_non_2xx_surfaces_server_error(monkeypatch, capsys):
+    def fake_run(cmd, capture_output, text):
+        return query.subprocess.CompletedProcess(
+            cmd,
+            0,
+            stdout='{"error":"pq: relation \\"missing\\" does not exist"}\n500',
+            stderr="",
+        )
+
+    monkeypatch.setattr(query.subprocess, "run", fake_run)
+
+    with pytest.raises(SystemExit) as exc:
+        query.curl_post("http://fake", {"sql": "SELECT * FROM missing"}, "tok")
+
+    assert exc.value.code == 1
+    err = capsys.readouterr().err
+    assert "HTTP 500" in err
+    assert 'pq: relation "missing" does not exist' in err
+
+
+def test_curl_get_non_2xx_surfaces_server_error(monkeypatch, capsys):
+    def fake_run(cmd, capture_output, text):
+        return query.subprocess.CompletedProcess(
+            cmd,
+            0,
+            stdout='{"error":"mutation not found"}\n404',
+            stderr="",
+        )
+
+    monkeypatch.setattr(query.subprocess, "run", fake_run)
+
+    with pytest.raises(SystemExit) as exc:
+        query.curl_get("http://fake/mutations/999", "tok")
+
+    assert exc.value.code == 1
+    err = capsys.readouterr().err
+    assert "HTTP 404" in err
+    assert "mutation not found" in err
+
+
 def test_available_list_includes_chiwei_test(capsys):
     with pytest.raises(SystemExit):
         query.cmd_query(["@nope", "SELECT", "1"])


### PR DESCRIPTION
## Summary
- preserve ops-db API response bodies for non-2xx curl calls
- surface server JSON `error` messages to the caller instead of generic curl failures
- add regression coverage for POST and GET non-2xx error propagation

## Tests
- `python3 -m pytest .claude/skills/ops-db/test_query.py`