### PR TITLE
fix(qq): group sender name + scene context for nameless peers

### DIFF
--- a/apps/agent-service/app/memory/context.py
+++ b/apps/agent-service/app/memory/context.py
@@ -288,26 +288,35 @@ def _scene_section(
     username = html.escape(trigger_username or "")
     medium_parts: list[str] = []
     if chat_type == "p2p":
+        # 平台 + 私聊场景不依赖有没有对方名字（QQ 私聊事件平台不给昵称、username
+        # 为空）——有名字当称呼带上，没名字也照样标清「在哪个平台、是私聊」。
         if username:
             medium_parts.append(
                 f"{_MEDIUM_HEADER}你正通过{platform}私聊和 {username}"
                 f" 打字（隔着{platform}，不是当面）。"
             )
+        else:
+            medium_parts.append(
+                f"{_MEDIUM_HEADER}你正通过{platform}私聊打字"
+                f"（隔着{platform}，不是当面）。"
+            )
     else:
+        # 平台 + 群聊场景同样不依赖有没有群名——有群名带上当称呼，没群名也照样
+        # 标清「在哪个平台、是群聊」。
         if chat_name:
             medium_parts.append(
                 f"{_MEDIUM_HEADER}你正在{platform}群聊「{chat_name}」里打字"
+                f"（隔着{platform}，不是当面）。"
+            )
+        else:
+            medium_parts.append(
+                f"{_MEDIUM_HEADER}你正在{platform}群聊里打字"
                 f"（隔着{platform}，不是当面）。"
             )
         if username:
             medium_parts.append(
                 f"需要回复 {username} 的消息。"
             )
-
-    # 没有可标的通信介质（无对方名 / 无群名）时整段缺席——不硬塞物理在场提示
-    # （它依附于「有一次交流」这个前提）。
-    if not medium_parts:
-        return ""
 
     return "\n".join(medium_parts) + "\n" + _presence_hint(platform)
 

--- a/apps/agent-service/tests/unit/memory/test_context.py
+++ b/apps/agent-service/tests/unit/memory/test_context.py
@@ -1232,6 +1232,75 @@ def test_scene_empty_channel_neutral_degrade_never_feishu():
 
 
 # ---------------------------------------------------------------------------
+# 场景标识不依赖对方名字（QQ 私聊事件平台不给昵称、username 为空）。没名字也要
+# 输出平台 + 私聊/群聊场景——绝不能因为拿不到对方名字就把整段场景信息吞掉，否则
+# LLM 完全不知道当前在哪个平台、是私聊还是群聊。
+# ---------------------------------------------------------------------------
+
+
+def test_scene_p2p_no_username_still_renders_platform_and_private():
+    """QQ 私聊 username 为空 → 仍输出平台 + 私聊场景（不塌成空、不带名字）。"""
+    scene = _scene_section("p2p", "", "", channel="qq")
+    assert scene != "", "username 为空也必须渲染场景，不能整段吞掉"
+    assert _MEDIUM_HEADER_MARK in scene, "通信介质维度仍要在"
+    assert "QQ" in scene, "平台名必须在"
+    assert "私聊" in scene, "私聊场景必须在"
+    assert _PRESENCE_HEADER_MARK in scene, "物理在场维度仍要在"
+    assert "飞书" not in scene, "qq channel 绝不能冒出飞书"
+
+
+def test_scene_group_no_username_still_renders_platform_and_group():
+    """QQ 群聊 username 为空（有群名）→ 仍输出平台 + 群聊场景。"""
+    scene = _scene_section("group", "某群", "", channel="qq")
+    assert scene != "", "username 为空也必须渲染群聊场景"
+    assert _MEDIUM_HEADER_MARK in scene
+    assert "QQ群聊" in scene, "群聊平台场景必须在"
+    assert "某群" in scene, "有群名时仍带群名"
+    assert "飞书" not in scene
+
+
+def test_scene_group_no_chat_name_no_username_still_renders():
+    """QQ 群聊既无群名也无 username → 仍输出平台 + 群聊场景（不塌成空）。"""
+    scene = _scene_section("group", "", "", channel="qq")
+    assert scene != "", "群名 / username 都空也必须渲染群聊场景"
+    assert _MEDIUM_HEADER_MARK in scene
+    assert "QQ" in scene, "平台名必须在"
+    assert "群" in scene, "群聊场景必须在"
+
+
+def test_scene_group_no_chat_name_with_username_still_renders():
+    """QQ 群聊无群名但有 username → 群聊场景 + 回复谁的指示都在。"""
+    scene = _scene_section("group", "", "浩南", channel="qq")
+    assert scene != ""
+    assert "QQ群聊" in scene
+    assert "浩南" in scene, "有 username 时仍标明回复谁"
+
+
+def test_scene_none_channel_no_username_does_not_crash():
+    """channel=None 且 username 为空 → 中性降级、不崩、不出现飞书。"""
+    scene = _scene_section("p2p", "", "", channel=None)
+    assert scene != "", "channel=None + username 空也要渲染场景"
+    assert _MEDIUM_HEADER_MARK in scene
+    assert "私聊" in scene
+    assert "飞书" not in scene, "None channel 绝不能默认回飞书"
+
+
+# 飞书私聊 username 非空的渲染：放宽「username 空也渲染」绝不能改动飞书既有路径的
+# 字节输出。这条把改动前的完整字符串钉死，任何对飞书有名字路径的回归立刻报红。
+_LARK_P2P_WITH_NAME_EXPECTED = (
+    "【通信介质】你正通过飞书私聊和 浩南 打字（隔着飞书，不是当面）。\n"
+    "【物理在场】你此刻真正所处的场景、身边有谁，看下面你自己的此刻状态。"
+    "正在和你打字的人隔着飞书在另一端，不在你身边。"
+)
+
+
+def test_scene_lark_p2p_with_username_byte_for_byte_regression():
+    """飞书私聊 username 非空 → 与改动前输出字节级一致（回归保护）。"""
+    scene = _scene_section("p2p", "", "浩南", channel="lark")
+    assert scene == _LARK_P2P_WITH_NAME_EXPECTED, "飞书有名字私聊路径不许有任何字节变化"
+
+
+# ---------------------------------------------------------------------------
 # 修复 1（私聊 scene 防冒充）：私聊 scene **不盖任何系统身份后缀**。对方是不是主人
 # 完全交给 history 里他那条消息的结构化 ``<msg rel=owner>``（与群聊 scene 一致——群聊
 # scene 也不在 scene 里标身份）。私聊句子只把对方名字当称呼用，且 trigger_username /

--- a/apps/channel-server/src/core/channels/contracts.ts
+++ b/apps/channel-server/src/core/channels/contracts.ts
@@ -64,6 +64,9 @@ export interface InboundMessage {
     // 会话作用域。常见 "direct"/"group"，但不是强制二元；非 IM channel 可定义
     // 自己的取值，adapter 负责把它映射到下游需要的 is_direct。
     conversation_scope: string;
+    // 发言人在该 channel 上的展示名（群里"谁在说话"）。通用语义：任何 channel 都能
+    // 讲得通"这条是谁发的"。可选——channel 不提供时（如 QQ 私聊不给昵称）留空，不造假名。
+    senderName?: string;
     thread_ref: ThreadRef | null;
     addressing_hints: AddressingHint[];
     content: ContentItem[];

--- a/apps/channel-server/src/plugins/qq/common-projector.test.ts
+++ b/apps/channel-server/src/plugins/qq/common-projector.test.ts
@@ -269,6 +269,7 @@ mock.module('@core/services/bot/multi-bot-manager', () => ({
 const {
     ensureQqCommonUser,
     ensureQqCommonConversation,
+    prepareQqInboundProjection,
     storeQqInboundMessage,
     storeQqOutboundMessage,
 } = await import('./common-projector');
@@ -342,6 +343,30 @@ describe('ensureQqCommonUser', () => {
             displayName: 'M',
         });
         expect(g1).not.toBe(g2);
+    });
+
+    it('writes the display name into qq_user_open_id.name and common_user.display_name', async () => {
+        const id = await ensureQqCommonUser({
+            botName: 'chiwei-qq',
+            scope: 'group',
+            conversationId: 'group_name',
+            openId: 'm_name',
+            displayName: '群友',
+        });
+        expect(qqUsers.get('chiwei-qq|group:group_name|m_name')!.name).toBe('群友');
+        expect(commonUsers.get(id)!.display_name).toBe('群友');
+    });
+
+    it('leaves the name empty without faking when no display name (e.g. direct chat)', async () => {
+        const id = await ensureQqCommonUser({
+            botName: 'chiwei-qq',
+            scope: 'direct',
+            conversationId: 'c2c_noname',
+            openId: 'u_noname',
+            displayName: undefined,
+        });
+        expect(qqUsers.get('chiwei-qq|direct|u_noname')!.name).toBe('');
+        expect(commonUsers.get(id)!.display_name).toBeUndefined();
     });
 
     it('concurrent first projection converges to the first writer (no overwrite, no orphan)', async () => {
@@ -448,6 +473,51 @@ describe('ensureQqCommonConversation', () => {
     });
 });
 
+describe('prepareQqInboundProjection', () => {
+    function inboundWith(senderName: string | undefined, over: Record<string, unknown> = {}) {
+        return {
+            channel: 'qq',
+            bot_name: 'chiwei-qq',
+            channel_message_id: 'qq_prep',
+            channel_chat_id: 'group_prep',
+            channel_user_id: 'm_prep',
+            conversation_scope: 'group',
+            senderName,
+            thread_ref: null,
+            addressing_hints: [],
+            content: [{ kind: 'text' as const, text: 'hi' }],
+            received_at: 1780000000000,
+            ...over,
+        } as any;
+    }
+
+    it('wires inbound.senderName into the projection and the qq_user_open_id name', async () => {
+        const projection = await prepareQqInboundProjection(
+            inboundWith('群友'),
+            'chiwei-qq',
+            'bot-common-user',
+        );
+        expect(projection.senderDisplayName).toBe('群友');
+        expect(qqUsers.get('chiwei-qq|group:group_prep|m_prep')!.name).toBe('群友');
+        expect(commonUsers.get(projection.commonUserId)!.display_name).toBe('群友');
+    });
+
+    it('leaves senderDisplayName undefined when inbound carries no senderName (no fake)', async () => {
+        const projection = await prepareQqInboundProjection(
+            inboundWith(undefined, {
+                channel_chat_id: 'c2c_prep',
+                channel_user_id: 'u_prep',
+                conversation_scope: 'direct',
+            }),
+            'chiwei-qq',
+            'bot-common-user',
+        );
+        expect(projection.senderDisplayName).toBeUndefined();
+        expect(qqUsers.get('chiwei-qq|direct|u_prep')!.name).toBe('');
+        expect(commonUsers.get(projection.commonUserId)!.display_name).toBeUndefined();
+    });
+});
+
 describe('storeQqInboundMessage', () => {
     const projection = {
         commonUserId: 'cu-1',
@@ -455,6 +525,7 @@ describe('storeQqInboundMessage', () => {
         commonMessageId: 'cm-1',
         commonRootMessageId: 'cm-1',
         commonReplyMessageId: undefined,
+        senderDisplayName: '群友',
         mentionedUserIds: [],
         content: [{ kind: 'text' as const, text: 'hi' }],
         contentText: 'hi',
@@ -480,6 +551,16 @@ describe('storeQqInboundMessage', () => {
         await storeQqInboundMessage(inbound(), projection);
         expect(qqMessages.get('qq_1')?.common_message_id).toBe('cm-1');
         expect(commonInsertCalls.length).toBe(1);
+    });
+
+    it('writes the sender display name onto the common_message', async () => {
+        await storeQqInboundMessage(inbound(), projection);
+        expect(commonInsertCalls[0].sender_display_name).toBe('群友');
+    });
+
+    it('writes no sender_display_name when projection carries none (no fake)', async () => {
+        await storeQqInboundMessage(inbound(), { ...projection, senderDisplayName: undefined });
+        expect(commonInsertCalls[0].sender_display_name).toBeUndefined();
     });
 
     it('fails loud when a qq message id already maps to a different common id', async () => {

--- a/apps/channel-server/src/plugins/qq/common-projector.ts
+++ b/apps/channel-server/src/plugins/qq/common-projector.ts
@@ -226,6 +226,7 @@ export interface QqInboundProjection {
     commonMessageId: string;
     commonRootMessageId: string | undefined;
     commonReplyMessageId: string | undefined;
+    senderDisplayName: string | undefined;
     mentionedUserIds: string[];
     content: ContentItem[];
     contentText: string | undefined;
@@ -242,7 +243,7 @@ export async function prepareQqInboundProjection(
         scope: inbound.conversation_scope,
         conversationId: inbound.channel_chat_id,
         openId: inbound.channel_user_id,
-        displayName: undefined,
+        displayName: inbound.senderName,
     });
 
     const commonConversationId = await ensureQqCommonConversation({
@@ -275,6 +276,7 @@ export async function prepareQqInboundProjection(
         commonMessageId,
         commonRootMessageId,
         commonReplyMessageId,
+        senderDisplayName: inbound.senderName,
         mentionedUserIds,
         content: inbound.content,
         contentText: textProjection(inbound.content),
@@ -312,6 +314,7 @@ export async function storeQqInboundMessage(
                 channel: 'qq',
                 common_conversation_id: projection.commonConversationId,
                 common_user_id: projection.commonUserId,
+                sender_display_name: projection.senderDisplayName,
                 role: 'user',
                 content: projection.content,
                 content_text: projection.contentText,

--- a/apps/channel-server/src/plugins/qq/inbound.test.ts
+++ b/apps/channel-server/src/plugins/qq/inbound.test.ts
@@ -70,6 +70,18 @@ describe('qqInbound.parse', () => {
         expect(msg.channel_user_id).toBe('member_open_1');
     });
 
+    it('carries the sender display name from a group custom message', () => {
+        const msg = qqInbound.parse(groupMsg({ senderName: '群友' })) as InboundMessage;
+        assertValidInboundMessage(msg);
+        expect(msg.senderName).toBe('群友');
+    });
+
+    it('leaves senderName undefined when the gateway gives none (e.g. direct chat)', () => {
+        const msg = qqInbound.parse(directText({ senderName: undefined })) as InboundMessage;
+        assertValidInboundMessage(msg);
+        expect(msg.senderName).toBeUndefined();
+    });
+
     it('maps isSelf mention to the self addressing-hint sentinel; non-self mentions kept by id', () => {
         const msg = qqInbound.parse(
             groupMsg({

--- a/apps/channel-server/src/plugins/qq/inbound.ts
+++ b/apps/channel-server/src/plugins/qq/inbound.ts
@@ -103,6 +103,9 @@ function parse(raw: CustomInboundMessage): InboundMessage | null {
         channel_chat_id: raw.conversationId,
         channel_user_id: raw.senderId,
         conversation_scope: conversationScope,
+        // 群里发言人昵称（网关从 d.author.username 取）。私聊 QQ 不给昵称、senderName
+        // 为 undefined，原样透传、不兜底假名。
+        senderName: raw.senderName,
         thread_ref: threadRef,
         addressing_hints: addressingHints,
         content,


### PR DESCRIPTION
Two gaps found right after QQ went live in prod:

1. **Group sender name dropped.** qq-gateway already extracts `author.username` into `CustomInboundMessage.senderName`, but channel-server never threaded it through — QQ group common_user/message had no sender name. Now `InboundMessage.senderName` carries it into common_user.display_name / common_message.sender_display_name / qq_user_open_id.name.

2. **Scene context vanished when peer name empty.** `_scene_section` only emitted the 'you're talking via {platform} {direct/group}' line when it had a name; QQ DMs have no nickname so the whole scene line was swallowed and the LLM had no idea it was on QQ. Now always emits platform + direct/group.

**QQ platform limit (not fixable):** private chat stays anonymous. C2C events give union_openid+user_openid but no nickname; group events give member_openid+username but no union_openid — the two ID spaces share no field, so a name learned in a group can't be matched to the same person in a DM. Owner is recognized via is_owner, not a QQ name.

**Safety:** Lark's named scene path is byte-for-byte unchanged (pinned by regression test); Lark's senderInfo chain is independent and untouched. Only QQ plugin + the shared InboundMessage contract (new optional senderName) changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)