### PR TITLE
feat(auth): one operator secret across dashboard and paas-engine APIs

### DIFF
--- a/.claude/skills/api-test/SKILL.md
+++ b/.claude/skills/api-test/SKILL.md
@@ -1,63 +1,69 @@
 ---
 name: api-test
-description: 常规 HTTP API 调用 helper。优先用 scripts/http.sh 获得统一 JSON 输出；当需要复杂 curl 能力（长超时、stream、文件、特殊参数、详细调试）时可以直接 curl，并说明原因。
+description: 项目 HTTP API 调用 helper。写路径就行，scripts/http.sh 自动补 $PAAS_API、注 PAAS_TOKEN、透泳道，统一返回 {status, ms, body}。需要复杂 curl 能力（stream、文件、TLS/proxy、详细调试）时直接 curl，并说明原因。
 user_invocable: true
 ---
 
 # /api-test
 
-常规 JSON API 调用优先用 `scripts/http.sh`，它会把响应包装成 `{"status":...,"body":...}`，方便后续判断。
+`scripts/http.sh` 比裸 curl 强的地方：**你只写路径，剩下的它办**。
 
-这个 helper 不替代 curl。遇到它不支持的场景，直接用 curl，不要让用户手动代劳。典型场景：stream、文件上传/下载、长时间日志、复杂 TLS/proxy/redirect、需要 `-v` 看握手细节。
+- 以 `/` 开头的路径自动拼上 `$PAAS_API`；完整 `http(s)://` URL 原样使用。
+- 路径在 `/dashboard/...` 或 `/api/paas/...` 下时，自动注入 `X-API-Key: $PAAS_TOKEN`。**对内对外一把钥匙**——dashboard 也认 PAAS_TOKEN，两个面同一个 token，调用方不用再想该传哪个。
+- `--lane LANE` 自动加 `x-lane` 头；显式传了 `X-API-Key` / `x-lane` 或 `--no-auth` 时不覆盖。
+- 始终返回 `{"status":..,"ms":..,"body":..}`，`ms` 是耗时。
+
+完整 `http(s)://` URL 永远不自动注 token，所以历史上"传完整 URL + 显式 header"的调用方不受影响。
+
+这个 helper 不替代 curl。它不支持的场景直接用 curl，不要让用户手动代劳：stream、文件上传/下载、长日志、复杂 TLS/proxy/redirect、`-v` 看握手。
 
 ## 用法
 
 ```bash
-# GET
-.claude/skills/api-test/scripts/http.sh GET "<url>" [header:value ...]
+HTTP=.claude/skills/api-test/scripts/http.sh
+
+# 裸路径：自动补 base + 自动注 PAAS_TOKEN
+$HTTP GET /dashboard/api/ops/services
+$HTTP GET "/api/paas/apps/agent-service/resolved-config?lane=prod"
+
+# 带泳道
+$HTTP --lane ppe-foo GET /api/paas/apps/agent-service/pods
 
 # POST（第三个参数是 JSON body）
-.claude/skills/api-test/scripts/http.sh POST "<url>" '<json>' [header:value ...]
+$HTTP POST /api/paas/apps/x '{"a":1}'
 
-# PUT / DELETE 同理；默认超时 60s
-.claude/skills/api-test/scripts/http.sh DELETE "<url>" [header:value ...]
+# 选项放任意位置都认（含末尾）
+$HTTP GET /dashboard/api/ops/services --jq '.apps | length'
 
-# 指定超时
-.claude/skills/api-test/scripts/http.sh --timeout 180 GET "<url>" [header:value ...]
+# 断言状态码：不匹配则退出码非 0（脚本里好用）
+$HTTP --expect 200 GET /dashboard/api/health
 
-# body 来自文件
-.claude/skills/api-test/scripts/http.sh PUT "<url>" @/tmp/body.json "Content-Type: application/json"
+# 其它选项：--timeout SEC（默认 60）、--save FILE、--no-auth、--raw
+$HTTP --timeout 180 GET /dashboard/api/...
+$HTTP PUT /api/paas/apps/x @/tmp/body.json
+$HTTP POST /api/paas/... --data "plain text" "Content-Type: text/plain"
 
-# 非 JSON body
-.claude/skills/api-test/scripts/http.sh POST "<url>" --data "plain text" "Content-Type: text/plain"
-
-# 需要原生 curl 能力时，显式透传
-.claude/skills/api-test/scripts/http.sh --curl -v --max-time 300 -H "X-API-Key: $TOKEN" "<url>"
+# 需要原生 curl 能力时显式透传
+$HTTP --curl -v --max-time 300 -H "X-API-Key: $PAAS_TOKEN" "<url>"
 ```
+
+## 选项
+
+- `--lane LANE` 加 `x-lane`（也可用 `HTTP_LANE` 环境变量）
+- `--jq FILTER` 对**原始 body**（不是 `{status,ms,body}` 外层）跑 `jq -r`，只打印结果
+- `--expect CODE` 状态码 ≠ CODE 时退出码非 0
+- `--save FILE` 额外把原始 body 落盘
+- `--no-auth` 不自动注 token；`--raw` 直出原始 body（不包 JSON、不计时）
+- `--curl <args...>` 后续参数原样交给 curl
 
 ## 输出
 
-始终返回合法 JSON：
 ```json
-{"status": 200, "body": {"key": "value"}}
-{"status": 500, "body": {"message": "error detail"}}
+{"status": 200, "ms": 36, "body": {"key": "value"}}
+{"status": 500, "ms": 12, "body": {"message": "error detail"}}
 {"status": 0, "error": "curl exit 28: timeout"}
 ```
 
-`--raw` 可直接输出原始 body；`--curl` 会把后面的参数原样交给 curl。
+## 测试
 
-## 示例
-
-```bash
-# 健康检查
-.claude/skills/api-test/scripts/http.sh GET "$PAAS_API/dashboard/api/health"
-
-# 带认证 + 泳道
-.claude/skills/api-test/scripts/http.sh GET "$PAAS_API/dashboard/api/ops/services" \
-  "X-API-Key: $DASHBOARD_CC_TOKEN" "x-lane: feat-xxx"
-
-# POST 带 body
-.claude/skills/api-test/scripts/http.sh POST "$PAAS_API/dashboard/api/ops/db-query" \
-  '{"sql":"SELECT 1","db":"paas_engine"}' \
-  "X-API-Key: $DASHBOARD_CC_TOKEN"
-```
+`scripts/test_http.sh`：dry-run 单测（解析/补 base/注 token/透泳道）+ 本地 server e2e（计时/--jq/--expect）。改 http.sh 后跑 `bash .claude/skills/api-test/scripts/test_http.sh`。

--- a/.claude/skills/api-test/scripts/http.sh
+++ b/.claude/skills/api-test/scripts/http.sh
@@ -1,35 +1,48 @@
 #!/usr/bin/env bash
-# Small HTTP helper for common JSON API calls.
+# Small HTTP helper for this project's JSON APIs.
 #
-# It is not meant to replace curl. For unsupported cases, use curl directly.
+# It is not meant to replace curl. For unsupported cases, use curl directly
+# (or the --curl escape hatch below).
+#
+# The point of this helper over raw curl: you write a *path*, it figures out
+# the rest. A path that starts with "/" is resolved against $PAAS_API, and the
+# one secret ($PAAS_TOKEN) is injected automatically — token choice never
+# reaches the caller. Both surfaces accept it (the dashboard takes PAAS_TOKEN
+# too), so /dashboard/... and /api/paas/... use the same key:
+#   /dashboard/... -> X-API-Key: $PAAS_TOKEN  (audited dashboard entry)
+#   /api/paas/...  -> X-API-Key: $PAAS_TOKEN  (direct paas-engine admin)
+# A full http(s):// URL is used verbatim and never gets an auto token, so
+# existing callers that pass full URLs + explicit headers are unaffected.
 #
 # Usage:
-#   http.sh [--timeout SEC] [--raw] METHOD URL [BODY] [HEADER...]
-#   http.sh [--timeout SEC] [--raw] METHOD URL --data <BODY> [HEADER...]
-#   http.sh [--timeout SEC] [--raw] METHOD URL --data-binary @file [HEADER...]
-#   http.sh --curl <curl args...>
+#   http.sh [opts] METHOD URL_OR_PATH [BODY] [HEADER...]
+#   http.sh [opts] METHOD URL_OR_PATH --data <BODY> [HEADER...]
+#   http.sh [opts] METHOD URL_OR_PATH --data-binary @file [HEADER...]
+#   http.sh --curl <curl args...>          # raw passthrough to curl
+#
+# opts:
+#   --timeout SEC   request timeout (default 60, or $HTTP_TIMEOUT)
+#   --lane LANE     add "x-lane: LANE" (default $HTTP_LANE)
+#   --no-auth       do not auto-inject any token
+#   --jq FILTER     run `jq -r FILTER` over the raw response body (not the
+#                   {status,ms,body} wrapper) and print only that
+#   --expect CODE   exit nonzero if the HTTP status != CODE
+#   --save FILE     also write the raw response body to FILE
+#   --raw           stream the raw body (no JSON wrapping, no timing)
 #
 # Examples:
-#   http.sh GET "$PAAS_API/health"
-#   http.sh --timeout 120 POST "$URL" '{"a":1}' "X-API-Key: $TOKEN"
-#   http.sh PUT "$URL" @/tmp/body.json "Content-Type: application/json"
+#   http.sh GET /dashboard/api/ops/services             # auto CC token + base
+#   http.sh GET /api/paas/apps/agent-service/resolved-config?lane=prod
+#   http.sh --lane ppe-x GET /api/paas/apps/agent-service/pods
+#   http.sh POST /api/paas/apps/x '{"a":1}'
+#   http.sh --jq '.body.version' GET /api/paas/apps/x
+#   http.sh --expect 200 GET /dashboard/api/health
 #   http.sh --curl -v --max-time 300 -H "X-API-Key: $TOKEN" "$URL"
 
 set -uo pipefail
 
 usage() {
-  cat >&2 <<'USAGE'
-http.sh [--timeout SEC] [--raw] METHOD URL [BODY] [HEADER...]
-http.sh [--timeout SEC] [--raw] METHOD URL --data <BODY> [HEADER...]
-http.sh [--timeout SEC] [--raw] METHOD URL --data-binary @file [HEADER...]
-http.sh --curl <curl args...>
-
-Common:
-  http.sh GET "$PAAS_API/health"
-  http.sh --timeout 120 POST "$URL" '{"a":1}' "X-API-Key: $TOKEN"
-  http.sh PUT "$URL" @/tmp/body.json "Content-Type: application/json"
-  http.sh --curl -v --max-time 300 -H "X-API-Key: $TOKEN" "$URL"
-USAGE
+  sed -n '2,/^set -uo/p' "${BASH_SOURCE[0]}" | sed '$d;s/^# \{0,1\}//' >&2
   exit 2
 }
 
@@ -44,76 +57,122 @@ if [[ "${1:-}" == "--curl" ]]; then
 fi
 
 TIMEOUT="${HTTP_TIMEOUT:-60}"
+LANE="${HTTP_LANE:-}"
 RAW=0
+NO_AUTH=0
+JQ_FILTER=""
+EXPECT=""
+SAVE=""
 
+# Options may appear anywhere (before or after METHOD/URL) — tacking --jq or
+# --lane onto the end of a call is the natural habit. Pull options out of the
+# stream and leave the positionals (METHOD, URL, body, headers) in POSITIONALS.
+POSITIONALS=()
+END_OPTS=0
 while [[ $# -gt 0 ]]; do
+  if [[ "$END_OPTS" -eq 1 ]]; then POSITIONALS+=("$1"); shift; continue; fi
   case "$1" in
-    --timeout)
-      [[ $# -ge 2 ]] || usage
-      TIMEOUT="$2"
-      shift 2
-      ;;
-    --raw)
-      RAW=1
-      shift
-      ;;
-    --help|-h)
-      usage
-      ;;
-    --)
-      shift
-      break
-      ;;
-    -*)
-      echo "unknown option: $1" >&2
-      usage
-      ;;
-    *)
-      break
-      ;;
+    --timeout) [[ $# -ge 2 ]] || usage; TIMEOUT="$2"; shift 2 ;;
+    --lane)    [[ $# -ge 2 ]] || usage; LANE="$2";    shift 2 ;;
+    --jq)      [[ $# -ge 2 ]] || usage; JQ_FILTER="$2"; shift 2 ;;
+    --expect)  [[ $# -ge 2 ]] || usage; EXPECT="$2";  shift 2 ;;
+    --save)    [[ $# -ge 2 ]] || usage; SAVE="$2";    shift 2 ;;
+    --raw)     RAW=1; shift ;;
+    --no-auth) NO_AUTH=1; shift ;;
+    --help|-h) usage ;;
+    --) END_OPTS=1; shift ;;
+    # Body markers stay positional; grab the value too so it is never re-parsed.
+    --data|--data-binary) [[ $# -ge 2 ]] || usage; POSITIONALS+=("$1" "$2"); shift 2 ;;
+    --*) echo "unknown option: $1" >&2; usage ;;
+    *) POSITIONALS+=("$1"); shift ;;
   esac
 done
 
+set -- "${POSITIONALS[@]:-}"
 [[ $# -ge 2 ]] || usage
 
 METHOD="$1"
-URL="$2"
+TARGET="$2"
 shift 2
 
-BODY=""
-CURL_ARGS=(-sS --max-time "$TIMEOUT")
+# Resolve TARGET into a full URL. A leading "/" means "a path under $PAAS_API";
+# anything with a scheme is used verbatim. PATH_FOR_AUTH is the path we inspect
+# to choose a token (empty for full URLs => no auto token).
+PATH_FOR_AUTH=""
+case "$TARGET" in
+  http://*|https://*)
+    URL="$TARGET"
+    ;;
+  /*)
+    if [[ -z "${PAAS_API:-}" ]]; then
+      echo "PAAS_API is not set; cannot resolve path: $TARGET" >&2
+      exit 2
+    fi
+    URL="${PAAS_API%/}$TARGET"
+    PATH_FOR_AUTH="$TARGET"
+    ;;
+  *)
+    echo "URL must be a full http(s):// URL or an absolute path (/...): $TARGET" >&2
+    exit 2
+    ;;
+esac
 
-# Non-GET methods may take a JSON body or @file body as the first argument.
-# Plain/non-JSON bodies should be passed with --data or --data-binary.
+CURL_ARGS=(-sS --max-time "$TIMEOUT")
+HEADERS=()              # human-readable, for dry-run + duplicate detection
+HAS_BODY=0
+
+add_header() {
+  CURL_ARGS+=(-H "$1")
+  HEADERS+=("$1")
+}
+
+# Non-GET methods may take a JSON body / @file as the first positional arg.
 if [[ "$METHOD" != "GET" && $# -gt 0 ]]; then
   case "$1" in
-    --data)
-      [[ $# -ge 2 ]] || usage
-      CURL_ARGS+=(-d "$2")
-      shift 2
-      ;;
-    --data-binary)
-      [[ $# -ge 2 ]] || usage
-      CURL_ARGS+=(--data-binary "$2")
-      shift 2
-      ;;
+    --data)        [[ $# -ge 2 ]] || usage; CURL_ARGS+=(-d "$2"); HAS_BODY=1; shift 2 ;;
+    --data-binary) [[ $# -ge 2 ]] || usage; CURL_ARGS+=(--data-binary "$2"); HAS_BODY=1; shift 2 ;;
     \{*|\[*)
-      BODY="$1"
-      CURL_ARGS+=(-H "Content-Type: application/json" -d "$BODY")
-      shift
-      ;;
-    @*)
-      BODY="$1"
-      CURL_ARGS+=(--data-binary "$BODY")
-      shift
-      ;;
+      CURL_ARGS+=(-d "$1"); HAS_BODY=1
+      add_header "Content-Type: application/json"
+      shift ;;
+    @*) CURL_ARGS+=(--data-binary "$1"); HAS_BODY=1; shift ;;
   esac
 fi
 
+# Remaining args are explicit headers.
+EXPLICIT_AUTH=0
+EXPLICIT_LANE=0
 while [[ $# -gt 0 ]]; do
-  CURL_ARGS+=(-H "$1")
+  shopt -s nocasematch
+  [[ "$1" == X-API-Key:* ]] && EXPLICIT_AUTH=1
+  [[ "$1" == x-lane:*    ]] && EXPLICIT_LANE=1
+  shopt -u nocasematch
+  add_header "$1"
   shift
 done
+
+# Auto-inject the token for path-form targets, unless suppressed or already set.
+# One secret covers everything: the dashboard accepts PAAS_TOKEN too, so both
+# the /dashboard and /api/paas surfaces use it.
+if [[ "$NO_AUTH" -eq 0 && "$EXPLICIT_AUTH" -eq 0 && -n "$PATH_FOR_AUTH" ]]; then
+  case "$PATH_FOR_AUTH" in
+    /dashboard/*|/api/paas/*)
+      [[ -n "${PAAS_TOKEN:-}" ]] && add_header "X-API-Key: $PAAS_TOKEN" ;;
+  esac
+fi
+
+# Lane header.
+if [[ -n "$LANE" && "$EXPLICIT_LANE" -eq 0 ]]; then
+  add_header "x-lane: $LANE"
+fi
+
+if [[ "${HTTP_DRY_RUN:-0}" == "1" ]]; then
+  echo "method=$METHOD"
+  echo "url=$URL"
+  echo "hasbody=$HAS_BODY"
+  for h in "${HEADERS[@]:-}"; do [[ -n "$h" ]] && echo "header=$h"; done
+  exit 0
+fi
 
 if [[ "$RAW" == "1" ]]; then
   exec curl "${CURL_ARGS[@]}" -X "$METHOD" "$URL"
@@ -123,31 +182,55 @@ TMP_BODY="$(mktemp /tmp/http_body.XXXXXX)"
 TMP_ERR="$(mktemp /tmp/http_err.XXXXXX)"
 trap 'rm -f "$TMP_BODY" "$TMP_ERR"' EXIT
 
-HTTP_CODE=$(curl "${CURL_ARGS[@]}" -X "$METHOD" -o "$TMP_BODY" -w "%{http_code}" "$URL" 2>"$TMP_ERR")
+# Capture status + total time in one shot.
+METRICS=$(curl "${CURL_ARGS[@]}" -X "$METHOD" -o "$TMP_BODY" \
+  -w "%{http_code} %{time_total}" "$URL" 2>"$TMP_ERR")
 CURL_EXIT=$?
 
 if [[ $CURL_EXIT -ne 0 ]]; then
   CURL_ERR=$(cat "$TMP_ERR" 2>/dev/null || echo "curl failed")
   python3 - "$CURL_EXIT" "$CURL_ERR" <<'PY'
-import json
-import sys
+import json, sys
 print(json.dumps({"status": 0, "error": f"curl exit {sys.argv[1]}: {sys.argv[2]}"}, ensure_ascii=False))
 PY
-  exit 0
+  exit 1
 fi
 
-python3 - "$HTTP_CODE" "$TMP_BODY" <<'PY' || echo "{\"status\":$HTTP_CODE,\"body\":\"(parse error)\"}"
-import json
-import sys
+HTTP_CODE="${METRICS%% *}"
+TIME_TOTAL="${METRICS##* }"
 
+[[ -n "$SAVE" ]] && cp "$TMP_BODY" "$SAVE"
+
+# --jq: print the filtered body and exit on its own success.
+if [[ -n "$JQ_FILTER" ]]; then
+  if ! command -v jq >/dev/null 2>&1; then
+    echo '{"status":0,"error":"jq not installed; drop --jq or install jq"}' >&2
+    exit 3
+  fi
+  jq -r "$JQ_FILTER" "$TMP_BODY"
+  JQ_EXIT=$?
+  if [[ -n "$EXPECT" && "$HTTP_CODE" != "$EXPECT" ]]; then
+    echo "expected status $EXPECT, got $HTTP_CODE" >&2
+    exit 1
+  fi
+  exit $JQ_EXIT
+fi
+
+python3 - "$HTTP_CODE" "$TIME_TOTAL" "$TMP_BODY" <<'PY' || echo "{\"status\":$HTTP_CODE,\"body\":\"(parse error)\"}"
+import json, sys
 status = int(sys.argv[1]) if sys.argv[1].isdigit() else 0
-with open(sys.argv[2], "r", encoding="utf-8", errors="replace") as f:
+ms = round(float(sys.argv[2]) * 1000) if sys.argv[2] else 0
+with open(sys.argv[3], "r", encoding="utf-8", errors="replace") as f:
     raw = f.read()
-
 try:
     body = json.loads(raw)
 except Exception:
     body = raw
-
-print(json.dumps({"status": status, "body": body}, ensure_ascii=False))
+print(json.dumps({"status": status, "ms": ms, "body": body}, ensure_ascii=False))
 PY
+
+if [[ -n "$EXPECT" && "$HTTP_CODE" != "$EXPECT" ]]; then
+  echo "expected status $EXPECT, got $HTTP_CODE" >&2
+  exit 1
+fi
+exit 0

--- a/.claude/skills/api-test/scripts/test_http.sh
+++ b/.claude/skills/api-test/scripts/test_http.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+# Tests for http.sh.
+#
+# Two layers:
+#   1. Resolution unit tests via HTTP_DRY_RUN=1 — pin how a call resolves into
+#      final URL / auth token / lane header WITHOUT hitting the network. This is
+#      the load-bearing behavior: the caller writes a path, the skill picks the
+#      right token + base URL so token choice never reaches the caller.
+#   2. End-to-end tests against a throwaway local server — verify timing, --jq,
+#      and --expect against a real response.
+
+set -uo pipefail
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HTTP="$DIR/http.sh"
+
+PASS=0
+FAIL=0
+ok()  { echo "ok   - $1"; PASS=$((PASS + 1)); }
+ko()  { echo "FAIL - $1"; FAIL=$((FAIL + 1)); }
+
+has()    { printf '%s' "$1" | grep -qF -- "$2"; }
+assert_has() {     # haystack needle desc
+  if has "$1" "$2"; then ok "$3"; else ko "$3 -- missing [$2] in:"; printf '%s\n' "$1" | sed 's/^/      /'; fi
+}
+assert_missing() { # haystack needle desc
+  if has "$1" "$2"; then ko "$3 -- unexpected [$2] in:"; printf '%s\n' "$1" | sed 's/^/      /'; else ok "$3"; fi
+}
+
+# ---- Layer 1: resolution (dry run) ----------------------------------------
+# One secret for everything: PAAS_TOKEN is injected for both the /api/paas and
+# /dashboard surfaces (the dashboard accepts it too). DASHBOARD_CC_TOKEN is set
+# here only to prove it is no longer used.
+dry() {
+  HTTP_DRY_RUN=1 PAAS_API="http://paas.test" \
+    DASHBOARD_CC_TOKEN="cctok" PAAS_TOKEN="ptok" \
+    "$HTTP" "$@" 2>&1
+}
+
+out=$(dry GET /api/paas/apps/x)
+assert_has "$out" "url=http://paas.test/api/paas/apps/x" "bare /api/paas path gets PAAS_API prefix"
+assert_has "$out" "header=X-API-Key: ptok"               "/api/paas path auto-injects PAAS_TOKEN"
+
+out=$(dry GET /dashboard/api/ops/services)
+assert_has     "$out" "url=http://paas.test/dashboard/api/ops/services" "bare /dashboard path gets PAAS_API prefix"
+assert_has     "$out" "header=X-API-Key: ptok"  "/dashboard path uses the one PAAS_TOKEN too"
+assert_missing "$out" "header=X-API-Key: cctok" "/dashboard path no longer uses DASHBOARD_CC_TOKEN"
+
+out=$(dry GET "https://full.example/api/paas/apps/x")
+assert_has     "$out" "url=https://full.example/api/paas/apps/x" "full URL kept verbatim (no prefix)"
+assert_missing "$out" "X-API-Key"                               "full URL never auto-injects a token (back-compat)"
+
+out=$(dry --lane ppe-foo GET /api/paas/apps/x)
+assert_has "$out" "header=x-lane: ppe-foo" "--lane adds x-lane header"
+assert_has "$out" "header=X-API-Key: ptok" "--lane still auto-injects token"
+
+out=$(dry GET /api/paas/apps/x "X-API-Key: override")
+assert_has     "$out" "header=X-API-Key: override" "explicit X-API-Key is honored"
+assert_missing "$out" "X-API-Key: ptok"            "explicit X-API-Key suppresses auto token"
+
+out=$(dry --no-auth GET /api/paas/apps/x)
+assert_missing "$out" "X-API-Key" "--no-auth skips token injection"
+
+out=$(dry POST /api/paas/apps/x '{"a":1}')
+assert_has "$out" "method=POST"                         "POST method preserved"
+assert_has "$out" "hasbody=1"                           "JSON body detected on POST"
+assert_has "$out" "header=Content-Type: application/json" "JSON body sets Content-Type"
+assert_has "$out" "header=X-API-Key: ptok"             "POST to /api/paas auto-injects token"
+
+# Options must be honored wherever they appear, not only before METHOD — the
+# natural habit is to tack --jq / --lane onto the end of a call.
+out=$(dry GET /api/paas/apps/x --lane ppe-bar)
+assert_has     "$out" "header=x-lane: ppe-bar" "trailing --lane is honored"
+assert_missing "$out" "header=--lane"          "trailing --lane is not sent as a header"
+
+out=$(dry GET /api/paas/apps/x --no-auth)
+assert_missing "$out" "X-API-Key" "trailing --no-auth is honored"
+
+# ---- Layer 2: end-to-end against a local server ---------------------------
+PORT=$(python3 -c 'import socket;s=socket.socket();s.bind(("127.0.0.1",0));print(s.getsockname()[1]);s.close()')
+SRV=$(mktemp /tmp/http_srv.XXXXXX.py)
+cat >"$SRV" <<'PY'
+import sys
+from http.server import BaseHTTPRequestHandler, HTTPServer
+class H(BaseHTTPRequestHandler):
+    def _h(self):
+        if self.path == "/boom":
+            self.send_response(500); self.end_headers(); self.wfile.write(b'{"message":"boom"}')
+        else:
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json"); self.end_headers()
+            self.wfile.write(b'{"hello":"world","n":42}')
+    def do_GET(self): self._h()
+    def do_POST(self): self._h()
+    def log_message(self, *a): pass
+HTTPServer(("127.0.0.1", int(sys.argv[1])), H).serve_forever()
+PY
+python3 "$SRV" "$PORT" &
+SRV_PID=$!
+trap 'kill "$SRV_PID" 2>/dev/null; rm -f "$SRV"' EXIT
+for _ in $(seq 1 50); do
+  curl -sS "http://127.0.0.1:$PORT/" >/dev/null 2>&1 && break
+  sleep 0.1
+done
+BASE="http://127.0.0.1:$PORT"
+
+out=$("$HTTP" GET "$BASE/ok")
+assert_has "$out" '"status": 200'      "e2e: status surfaced"
+assert_has "$out" '"hello": "world"'   "e2e: body parsed as JSON"
+assert_has "$out" '"ms":'              "e2e: timing (ms) reported"
+
+out=$("$HTTP" --jq '.n' GET "$BASE/ok")
+assert_has "$out" "42" "--jq extracts a field"
+
+out=$("$HTTP" GET "$BASE/ok" --jq '.n')
+assert_has "$out" "42" "trailing --jq extracts a field"
+
+"$HTTP" --expect 200 GET "$BASE/ok" >/dev/null 2>&1
+if [[ $? -eq 0 ]]; then ok "--expect 200 passes on a 200"; else ko "--expect 200 should pass on a 200"; fi
+
+"$HTTP" --expect 200 GET "$BASE/boom" >/dev/null 2>&1
+if [[ $? -ne 0 ]]; then ok "--expect 200 fails (nonzero exit) on a 500"; else ko "--expect 200 should fail on a 500"; fi
+
+echo "-----"
+echo "PASS=$PASS FAIL=$FAIL"
+[[ $FAIL -eq 0 ]]

--- a/.claude/skills/ops-db/query.py
+++ b/.claude/skills/ops-db/query.py
@@ -28,12 +28,14 @@ DEFAULT_DB = "paas_engine"
 
 
 def get_env():
+    # One secret for everything: the dashboard accepts PAAS_TOKEN, so ops-db
+    # authenticates the audited db-query endpoint with it.
     paas_api = os.environ.get("PAAS_API", "")
-    cc_token = os.environ.get("DASHBOARD_CC_TOKEN", "")
+    token = os.environ.get("PAAS_TOKEN", "")
     if not paas_api:
         print("ERROR: PAAS_API 环境变量未设置", file=sys.stderr)
         sys.exit(1)
-    return paas_api, cc_token
+    return paas_api, token
 
 
 def _curl_json(args):

--- a/.claude/skills/ops-db/test_query.py
+++ b/.claude/skills/ops-db/test_query.py
@@ -33,6 +33,17 @@ def captured(monkeypatch):
     return box
 
 
+def test_get_env_reads_single_paas_token(monkeypatch):
+    """One secret: the dashboard now accepts PAAS_TOKEN, so ops-db authenticates
+    with it — DASHBOARD_CC_TOKEN is no longer consulted."""
+    monkeypatch.setenv("PAAS_API", "http://x")
+    monkeypatch.setenv("PAAS_TOKEN", "Y")
+    monkeypatch.delenv("DASHBOARD_CC_TOKEN", raising=False)
+    api, token = query.get_env()
+    assert api == "http://x"
+    assert token == "Y"
+
+
 @pytest.mark.parametrize("user_input", ["chiwei-test", "chiwei_test"])
 def test_query_normalizes_chiwei_test_to_canonical(captured, user_input):
     query.cmd_query([f"@{user_input}", "SELECT", "1"])

--- a/.claude/skills/ops/SKILL.md
+++ b/.claude/skills/ops/SKILL.md
@@ -23,12 +23,12 @@ user_invocable: true
 所有请求通过 `http.sh` 发送，公共参数：
 
 - **Base URL**: `$PAAS_API/dashboard/api`
-- **认证 Header**: `X-API-Key: $DASHBOARD_CC_TOKEN`
+- **认证 Header**: `X-API-Key: $PAAS_TOKEN`（对内对外同一把钥匙，dashboard 也认 PAAS_TOKEN）
 
 ```bash
 HTTP=".claude/skills/api-test/scripts/http.sh"
 BASE="$PAAS_API/dashboard/api"
-AUTH="X-API-Key: $DASHBOARD_CC_TOKEN"
+AUTH="X-API-Key: $PAAS_TOKEN"
 ```
 
 ## 子命令

--- a/apps/monitor-dashboard/src/middleware/jwt-auth.test.ts
+++ b/apps/monitor-dashboard/src/middleware/jwt-auth.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, beforeEach } from 'bun:test';
+import { Hono } from 'hono';
+import { jwtAuth } from './jwt-auth';
+
+// jwtAuth reads tokens from process.env at request time, so setting them here
+// is enough — no module reload needed.
+function buildApp() {
+  const app = new Hono();
+  app.use('/dashboard/api/*', jwtAuth as never);
+  const echo = (c: { json: (b: unknown) => unknown; get: (k: never) => unknown }) =>
+    c.json({ caller: c.get('caller' as never) });
+  app.get('/dashboard/api/ping', echo as never);
+  app.get('/dashboard/api/health', echo as never);
+  return app;
+}
+
+async function call(headers: Record<string, string>, path = '/dashboard/api/ping') {
+  const app = buildApp();
+  const res = await app.request(path, { headers });
+  let body: unknown = null;
+  try {
+    body = await res.json();
+  } catch {
+    /* non-JSON */
+  }
+  return { status: res.status, body };
+}
+
+describe('jwtAuth api-key', () => {
+  beforeEach(() => {
+    process.env.DASHBOARD_CC_TOKEN = 'CC';
+    process.env.DASHBOARD_PAAS_TOKEN = 'PAAS';
+    process.env.DASHBOARD_JWT_SECRET = 'secret';
+  });
+
+  it('accepts the dashboard CC token (existing callers keep working)', async () => {
+    const { status, body } = await call({ 'x-api-key': 'CC' });
+    expect(status).toBe(200);
+    expect(body).toMatchObject({ caller: 'claude-code' });
+  });
+
+  it('accepts the paas token so one secret works for both surfaces', async () => {
+    const { status, body } = await call({ 'x-api-key': 'PAAS' });
+    expect(status).toBe(200);
+    expect(body).toMatchObject({ caller: 'claude-code' });
+  });
+
+  it('rejects an unknown api-key with no bearer', async () => {
+    const { status } = await call({ 'x-api-key': 'nope' });
+    expect(status).toBe(401);
+  });
+
+  it('lets public paths through without any token', async () => {
+    const { status, body } = await call({}, '/dashboard/api/health');
+    expect(status).toBe(200);
+    expect(body).toMatchObject({ caller: 'public' });
+  });
+});

--- a/apps/monitor-dashboard/src/middleware/jwt-auth.ts
+++ b/apps/monitor-dashboard/src/middleware/jwt-auth.ts
@@ -15,9 +15,14 @@ export const jwtAuth: MiddlewareHandler<AppEnv> = async (c, next) => {
   }
 
   // --- API Key auth (Claude Code) ---
+  // Accept either the dedicated CC token or the paas token the dashboard
+  // already holds (DASHBOARD_PAAS_TOKEN == paas-engine's API_TOKEN). This lets
+  // the operator drive both the dashboard and the direct /api/paas/* surface
+  // with a single secret, and it stays in sync when that token is rotated.
   const apiKey = c.req.header('x-api-key');
   const ccToken = process.env.DASHBOARD_CC_TOKEN;
-  if (apiKey && ccToken && apiKey === ccToken) {
+  const paasToken = process.env.DASHBOARD_PAAS_TOKEN;
+  if (apiKey && ((ccToken && apiKey === ccToken) || (paasToken && apiKey === paasToken))) {
     c.set('caller', 'claude-code');
     return next();
   }


### PR DESCRIPTION
## What

One operator secret across both API surfaces. `monitor-dashboard`'s `jwt-auth`
now accepts `DASHBOARD_PAAS_TOKEN` (the paas-engine admin token it already holds
for internal forwarding) as a valid `X-API-Key`, in addition to the existing
`DASHBOARD_CC_TOKEN`. The operator (Claude Code) can now drive both
`/dashboard/api/*` and direct `/api/paas/*` with a single `PAAS_TOKEN`, and it
stays in sync when that token is rotated.

The `api-test`, `ops-db`, and `ops` skills are converged onto `PAAS_TOKEN`.

Also enhances the `api-test` `http.sh` helper so it earns its keep over raw
curl: path-form targets auto-resolve `$PAAS_API` + the token + `x-lane`,
responses report timing (`ms`), and it gains `--jq` / `--expect` / `--save`
plus position-independent options. Adds resolution unit tests (`test_http.sh`)
and a `jwt-auth` test.

## Why

The two-token split (`DASHBOARD_CC_TOKEN` for the dashboard, `PAAS_TOKEN` for
direct paas-engine) was pure friction for the only external caller. `PAAS_TOKEN`
was already an externally-usable full-admin key (the whole Makefile deploy
toolchain uses it against `/api/paas/*`), so accepting it at the dashboard adds
no new exposure — it just lets the operator stop juggling two keys.

## Security

`jwt-auth` keeps accepting `DASHBOARD_CC_TOKEN` (OR branch) so this is a smooth
switch. The env-level retirement of `DASHBOARD_CC_TOKEN` on prod dashboard is
the explicit sunset point and is done as a follow-up step. Web admin auth (JWT
Bearer via `DASHBOARD_JWT_SECRET`) is untouched.

## Verification

- jwt-auth tests, api-test `test_http.sh`, ops-db tests all green (TDD red→green).
- Deployed to lane `ppe-onetoken`: same `PAAS_TOKEN` + same protected endpoint
  returns 200 on the lane (new code) vs 401 on prod (old code) — confirms the
  new auth path is what makes the difference.

## Rollout note

Client skills already use `PAAS_TOKEN`; prod dashboard must ship this change
before `/ops` and `/ops-db` recover (they hit prod dashboard and currently 401).
`/api/paas/*` direct (make deploy etc.) is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
