### PR TITLE
fix(channel-server): make lark emoji sync atomic

### DIFF
--- a/apps/channel-server/src/infrastructure/crontab/services/emoji.test.ts
+++ b/apps/channel-server/src/infrastructure/crontab/services/emoji.test.ts
@@ -1,0 +1,100 @@
+import { beforeEach, describe, expect, it, mock } from 'bun:test';
+import type { Repository } from 'typeorm';
+import { EmojiService } from './emoji';
+import { LarkEmojiRepository, type LarkEmojiRow } from '@repositories/lark-emoji-repository';
+import type { LarkEmoji } from '@entities/lark-emoji';
+
+const replaceAllEmojisMock = mock(async (_emojis: LarkEmojiRow[]) => undefined);
+const getAllEmojisMock = mock(async () => []);
+const getEmojiByKeyMock = mock(async (_key: string) => null);
+const getEmojiByTextMock = mock(async (_texts: string[]) => []);
+
+const serviceRepository = {
+    replaceAllEmojis: replaceAllEmojisMock,
+    getAllEmojis: getAllEmojisMock,
+    getEmojiByKey: getEmojiByKeyMock,
+    getEmojiByText: getEmojiByTextMock,
+} as unknown as LarkEmojiRepository;
+
+const upsertMock = mock(async () => undefined);
+const deleteMock = mock(async () => undefined);
+const saveMock = mock(async () => {
+    throw new Error('save should not be used for lark_emoji sync');
+});
+const transactionalRepo = {
+    upsert: upsertMock,
+    delete: deleteMock,
+    save: saveMock,
+};
+const transactionMock = mock(
+    async (
+        fn: (manager: { getRepository: () => typeof transactionalRepo }) => Promise<void>,
+    ) => fn({ getRepository: () => transactionalRepo }),
+);
+const typeormRepository = {
+    manager: {
+        transaction: transactionMock,
+    },
+} as unknown as Repository<LarkEmoji>;
+
+describe('EmojiService.syncEmojiData', () => {
+    beforeEach(() => {
+        replaceAllEmojisMock.mockClear();
+    });
+
+    it('replaces the emoji set without clearing the table first', async () => {
+        const service = new EmojiService(serviceRepository);
+        service.fetchEmojiData = mock(async () => ({
+            emojiData: {
+                active: {
+                    key: 'OK',
+                    text: 'ok',
+                    imageKey: 'img_ok',
+                    isDeleted: false,
+                },
+                deleted: {
+                    key: 'DELETED',
+                    text: 'deleted',
+                    imageKey: 'img_deleted',
+                    isDeleted: true,
+                },
+            },
+        }));
+
+        await service.syncEmojiData();
+
+        expect(replaceAllEmojisMock).toHaveBeenCalledWith([{ key: 'OK', text: 'ok' }]);
+    });
+});
+
+describe('LarkEmojiRepository.replaceAllEmojis', () => {
+    beforeEach(() => {
+        upsertMock.mockClear();
+        deleteMock.mockClear();
+        saveMock.mockClear();
+        transactionMock.mockClear();
+    });
+
+    it('uses native upsert in one transaction so concurrent syncs do not hit primary-key conflicts', async () => {
+        const repository = new LarkEmojiRepository(typeormRepository);
+
+        await repository.replaceAllEmojis([
+            { key: 'OK', text: 'ok' },
+            { key: 'THUMBSUP', text: 'thumbsup' },
+        ]);
+
+        expect(transactionMock).toHaveBeenCalledTimes(1);
+        expect(saveMock).not.toHaveBeenCalled();
+        expect(upsertMock).toHaveBeenCalledWith(
+            [
+                { key: 'OK', text: 'ok' },
+                { key: 'THUMBSUP', text: 'thumbsup' },
+            ],
+            {
+                conflictPaths: ['key'],
+                skipUpdateIfNoValuesChanged: true,
+            },
+        );
+        expect(deleteMock).toHaveBeenCalledTimes(1);
+    });
+});

--- a/apps/channel-server/src/infrastructure/crontab/services/emoji.ts
+++ b/apps/channel-server/src/infrastructure/crontab/services/emoji.ts
@@ -1,6 +1,7 @@
 import http from '@http/client';
-import { LarkEmoji } from '@entities/lark-emoji';
 import { larkEmojiRepository } from '@repositories/lark-emoji-repository';
+import type { LarkEmoji } from '@entities/lark-emoji';
+import type { LarkEmojiRepository, LarkEmojiRow } from '@repositories/lark-emoji-repository';
 import { Crontab, registerCrontabService } from '@crontab/decorators';
 
 export interface EmojiDataResponse {
@@ -25,6 +26,8 @@ export interface EmojiDataResponse {
 export class EmojiService {
     private static readonly EMOJI_API_URL = 'https://ywh-emoji-bot.fn-boe.bytedance.net/api/emojis';
 
+    constructor(private readonly repository: LarkEmojiRepository = larkEmojiRepository) {}
+
     /**
      * 从远程API获取emoji数据
      */
@@ -41,8 +44,8 @@ export class EmojiService {
     /**
      * 提取有效的emoji数据（isDeleted=false）
      */
-    private extractValidEmojis(emojiDataResponse: EmojiDataResponse): Partial<LarkEmoji>[] {
-        const validEmojis: Partial<LarkEmoji>[] = [];
+    private extractValidEmojis(emojiDataResponse: EmojiDataResponse): LarkEmojiRow[] {
+        const validEmojis: LarkEmojiRow[] = [];
 
         Object.values(emojiDataResponse.emojiData).forEach((emojiData) => {
             if (!emojiData.isDeleted) {
@@ -80,12 +83,8 @@ export class EmojiService {
                 return;
             }
 
-            // 3. 清空现有数据
-            await larkEmojiRepository.clearAllEmojis();
-            console.info('Cleared existing emoji data');
-
-            // 4. 批量插入新数据
-            await larkEmojiRepository.upsertEmojis(validEmojis);
+            // 3. 原子替换本地集合
+            await this.repository.replaceAllEmojis(validEmojis);
             console.info(`Successfully synced ${validEmojis.length} emojis to database`);
         } catch (error) {
             console.error('Failed to sync emoji data:', error);
@@ -97,21 +96,21 @@ export class EmojiService {
      * 获取所有emoji数据
      */
     async getAllEmojis(): Promise<LarkEmoji[]> {
-        return larkEmojiRepository.getAllEmojis();
+        return this.repository.getAllEmojis();
     }
 
     /**
      * 根据key获取emoji
      */
     async getEmojiByKey(key: string): Promise<LarkEmoji | null> {
-        return larkEmojiRepository.getEmojiByKey(key);
+        return this.repository.getEmojiByKey(key);
     }
 
     /**
      * 根据name获取emoji
      */
     async getEmojiByText(texts: string[]): Promise<LarkEmoji[]> {
-        return larkEmojiRepository.getEmojiByText(texts);
+        return this.repository.getEmojiByText(texts);
     }
 }
 
@@ -119,4 +118,3 @@ export const emojiService = new EmojiService();
 
 // 注册定时任务
 registerCrontabService(emojiService);
-

--- a/apps/channel-server/src/infrastructure/dal/repositories/lark-emoji-repository.ts
+++ b/apps/channel-server/src/infrastructure/dal/repositories/lark-emoji-repository.ts
@@ -1,12 +1,15 @@
-import { In, Repository } from 'typeorm';
+import { In, Not } from 'typeorm';
+import type { Repository } from 'typeorm';
 import AppDataSource from '@ormconfig';
 import { LarkEmoji } from '@entities/lark-emoji';
+
+export type LarkEmojiRow = Pick<LarkEmoji, 'key' | 'text'>;
 
 export class LarkEmojiRepository {
     private repository: Repository<LarkEmoji>;
 
-    constructor() {
-        this.repository = AppDataSource.getRepository(LarkEmoji);
+    constructor(repository: Repository<LarkEmoji> = AppDataSource.getRepository(LarkEmoji)) {
+        this.repository = repository;
     }
 
     // 获取所有emoji
@@ -30,8 +33,29 @@ export class LarkEmojiRepository {
     }
 
     // 批量插入或更新emoji数据
-    async upsertEmojis(emojis: Partial<LarkEmoji>[]): Promise<LarkEmoji[]> {
-        return this.repository.save(emojis);
+    async upsertEmojis(emojis: LarkEmojiRow[]): Promise<void> {
+        await this.repository.upsert(emojis, {
+            conflictPaths: ['key'],
+            skipUpdateIfNoValuesChanged: true,
+        });
+    }
+
+    // 用远端有效集合替换本地集合；upsert 避免并发同步时主键冲突。
+    async replaceAllEmojis(emojis: LarkEmojiRow[]): Promise<void> {
+        if (emojis.length === 0) {
+            return;
+        }
+
+        const keys = emojis.map((emoji) => emoji.key);
+
+        await this.repository.manager.transaction(async (manager) => {
+            const repository = manager.getRepository(LarkEmoji);
+            await repository.upsert(emojis, {
+                conflictPaths: ['key'],
+                skipUpdateIfNoValuesChanged: true,
+            });
+            await repository.delete({ key: Not(In(keys)) });
+        });
     }
 
     // 删除所有emoji（用于重新同步）


### PR DESCRIPTION
## Summary
- replace lark emoji sync clear+save flow with transactional native upsert
- delete stale emoji keys after upserting the current remote valid set
- add regression coverage for non-clearing sync and native upsert usage

## Verification
- bun test src/infrastructure/crontab/services/emoji.test.ts
- bunx tsc --noEmit
- bun test
- ppe-lark-emoji deployed image 1.0.0.70; channel-server/recall-worker/chat-response-worker pods ready; no error logs in last 10m