### PR TITLE
fix(media-sync-worker): survive Mongo hangs — socket timeout, cycle watchdog, stale-task reclaim

### DIFF
--- a/apps/media-sync-worker/src/mongo/client.ts
+++ b/apps/media-sync-worker/src/mongo/client.ts
@@ -1,5 +1,6 @@
 import { Collection } from "mongodb";
 import { MongoService, MongoCollection, getMongoService } from "@inner/shared/mongo";
+import { loadMongoConfigFromEnv } from "./config";
 import { DownloadTask, PixivImageInfo, TranslateWord } from "./types";
 
 // MongoDB 服务实例
@@ -19,19 +20,6 @@ export let BangumiSubjectCharacterCollection: Collection;
 export let BangumiSubjectPersonCollection: Collection;
 export let BangumiPersonCharacterCollection: Collection;
 export let BangumiSubjectRelationCollection: Collection;
-
-function parseEnvInt(name: string, defaultValue: number): number {
-  const raw = process.env[name];
-  if (!raw) {
-    return defaultValue;
-  }
-  const parsed = Number.parseInt(raw, 10);
-  return Number.isFinite(parsed) && parsed > 0 ? parsed : defaultValue;
-}
-
-function hostHasPort(host: string): boolean {
-  return host.includes(':');
-}
 
 /**
  * 创建 Bangumi Archive 相关的索引
@@ -77,18 +65,8 @@ async function createBangumiIndexes(): Promise<void> {
 
 export const mongoInitPromise = (async () => {
   try {
-    const mongoHost = process.env.MONGO_HOST || 'mongo';
-
     // 使用共享的 MongoService
-    mongoService = getMongoService({
-      host: mongoHost,
-      port: hostHasPort(mongoHost) ? undefined : parseEnvInt('MONGO_PORT', 27017),
-      username: process.env.MONGO_INITDB_ROOT_USERNAME,
-      password: process.env.MONGO_INITDB_ROOT_PASSWORD,
-      database: 'chiwei',
-      authSource: 'admin',
-      connectTimeoutMS: parseEnvInt('MONGO_CONNECT_TIMEOUT_MS', 10000),
-    });
+    mongoService = getMongoService(loadMongoConfigFromEnv());
 
     await mongoService.initialize();
 

--- a/apps/media-sync-worker/src/mongo/config.test.ts
+++ b/apps/media-sync-worker/src/mongo/config.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'bun:test';
+import { loadMongoConfigFromEnv } from './config';
+
+describe('loadMongoConfigFromEnv', () => {
+    it('defaults socketTimeoutMS to 60s so a half-open connection cannot hang the consumer forever', () => {
+        const config = loadMongoConfigFromEnv({});
+
+        expect(config).toEqual({
+            host: 'mongo',
+            port: 27017,
+            username: undefined,
+            password: undefined,
+            database: 'chiwei',
+            authSource: 'admin',
+            connectTimeoutMS: 10000,
+            socketTimeoutMS: 60000,
+        });
+    });
+
+    it('allows env overrides and ignores invalid values', () => {
+        const config = loadMongoConfigFromEnv({
+            MONGO_HOST: 'other-host',
+            MONGO_PORT: '27018',
+            MONGO_INITDB_ROOT_USERNAME: 'user',
+            MONGO_INITDB_ROOT_PASSWORD: 'pass',
+            MONGO_CONNECT_TIMEOUT_MS: '5000',
+            MONGO_SOCKET_TIMEOUT_MS: '30000',
+        });
+
+        expect(config.host).toBe('other-host');
+        expect(config.port).toBe(27018);
+        expect(config.username).toBe('user');
+        expect(config.password).toBe('pass');
+        expect(config.connectTimeoutMS).toBe(5000);
+        expect(config.socketTimeoutMS).toBe(30000);
+
+        const invalid = loadMongoConfigFromEnv({ MONGO_SOCKET_TIMEOUT_MS: 'abc' });
+        expect(invalid.socketTimeoutMS).toBe(60000);
+    });
+
+    it('treats MONGO_SOCKET_TIMEOUT_MS=0 as an explicit off switch (driver default: wait forever)', () => {
+        const config = loadMongoConfigFromEnv({ MONGO_SOCKET_TIMEOUT_MS: '0' });
+
+        expect(config.socketTimeoutMS).toBe(0);
+    });
+
+    it('leaves port undefined when the host already contains one', () => {
+        const config = loadMongoConfigFromEnv({ MONGO_HOST: 'mongo-host:27019' });
+
+        expect(config.host).toBe('mongo-host:27019');
+        expect(config.port).toBeUndefined();
+    });
+});

--- a/apps/media-sync-worker/src/mongo/config.ts
+++ b/apps/media-sync-worker/src/mongo/config.ts
@@ -1,0 +1,41 @@
+import { MongoConfig } from "@inner/shared/mongo";
+
+type EnvLike = Record<string, string | undefined>;
+
+function parseEnvInt(env: EnvLike, name: string, defaultValue: number, allowZero = false): number {
+  const raw = env[name];
+  if (!raw) {
+    return defaultValue;
+  }
+  const parsed = Number.parseInt(raw, 10);
+  const min = allowZero ? 0 : 1;
+  return Number.isFinite(parsed) && parsed >= min ? parsed : defaultValue;
+}
+
+function hostHasPort(host: string): boolean {
+  return host.includes(":");
+}
+
+/**
+ * 从环境变量构造 worker 主 Mongo 连接配置。
+ *
+ * socketTimeoutMS 默认 60s：driver 默认是 0（无限等待），网络抖动产生半开连接时
+ * 已发出的命令会永久挂起，下载 consumer 的取任务循环会静默卡死（2026-06-27 prod 实例）。
+ * 注意这是 socket 不活动超时而非操作总时长，且 driver 的 retryReads/retryWrites
+ * 可能重试一次，逻辑操作可超过 60s 才抛错——但不会再无限挂。
+ * MONGO_SOCKET_TIMEOUT_MS=0 是显式关闭开关（回到 driver 默认无限等待），误杀慢操作时可用。
+ */
+export function loadMongoConfigFromEnv(env: EnvLike = process.env): MongoConfig {
+  const host = env.MONGO_HOST || "mongo";
+
+  return {
+    host,
+    port: hostHasPort(host) ? undefined : parseEnvInt(env, "MONGO_PORT", 27017),
+    username: env.MONGO_INITDB_ROOT_USERNAME,
+    password: env.MONGO_INITDB_ROOT_PASSWORD,
+    database: "chiwei",
+    authSource: "admin",
+    connectTimeoutMS: parseEnvInt(env, "MONGO_CONNECT_TIMEOUT_MS", 10000),
+    socketTimeoutMS: parseEnvInt(env, "MONGO_SOCKET_TIMEOUT_MS", 60000, true),
+  };
+}

--- a/apps/media-sync-worker/src/mongo/service.test.ts
+++ b/apps/media-sync-worker/src/mongo/service.test.ts
@@ -1,5 +1,13 @@
 import { describe, expect, it } from 'bun:test';
-import { buildImageByPixivAddrFilter } from './service';
+import {
+    buildClaimableTaskFilter,
+    buildClaimUpdate,
+    buildCompletionFilter,
+    buildExhaustedReclaimFilter,
+    buildDeadLetterUpdate,
+    buildImageByPixivAddrFilter,
+} from './service';
+import { DownloadTask, DownloadTaskStatus } from './types';
 
 // buildImageByPixivAddrFilter is a pure query builder so it can be unit-tested
 // without importing ./client (which would trigger a real Mongo connect) and
@@ -18,5 +26,106 @@ describe('buildImageByPixivAddrFilter', () => {
         // a doc whose tos_file_name is missing or empty must NOT match this filter,
         // so the $nin guard against null/'' must be present
         expect(filter!.tos_file_name).toEqual({ $nin: [null, ''] } as any);
+    });
+});
+
+describe('buildClaimableTaskFilter', () => {
+    const now = new Date('2026-07-06T12:00:00.000Z');
+    const reclaimMs = 90 * 60 * 1000;
+
+    it('claims Pending and Fail unconditionally', () => {
+        const filter = buildClaimableTaskFilter(now, reclaimMs);
+
+        expect(filter.$or?.[0]).toEqual({
+            status: { $in: [DownloadTaskStatus.Pending, DownloadTaskStatus.Fail] },
+        });
+    });
+
+    it('claims Running only when last_run_time is older than the reclaim threshold', () => {
+        const filter = buildClaimableTaskFilter(now, reclaimMs);
+
+        expect(filter.$or?.[1]).toEqual({
+            status: DownloadTaskStatus.Running,
+            last_run_time: { $lt: new Date('2026-07-06T10:30:00.000Z') },
+        });
+    });
+
+    it('has no other branch, so fresh Running / Success / Dead can never match', () => {
+        const filter = buildClaimableTaskFilter(now, reclaimMs);
+
+        expect(Object.keys(filter)).toEqual(['$or']);
+        expect(filter.$or).toHaveLength(2);
+    });
+});
+
+describe('buildClaimUpdate', () => {
+    it('marks Running, stamps a new generation (last_run_time) and consumes retry budget atomically', () => {
+        const now = new Date('2026-07-06T12:00:00.000Z');
+
+        expect(buildClaimUpdate(now)).toEqual({
+            $set: {
+                status: DownloadTaskStatus.Running,
+                last_run_time: now,
+                update_time: now,
+                last_run_error: '',
+            },
+            $inc: { retry_time: 1 },
+        });
+    });
+});
+
+// A poison task (one that hangs the consumer every time) never reaches the
+// fail() completion path, so retry_time keeps growing via claim $inc while the
+// task bounces between Running and reclaim forever. The dead-letter sweep must
+// catch exactly these: reclaim-eligible Running docs whose retry budget is gone.
+describe('buildExhaustedReclaimFilter', () => {
+    const now = new Date('2026-07-06T12:00:00.000Z');
+    const reclaimMs = 90 * 60 * 1000;
+
+    it('matches only stale Running docs whose retry budget is exhausted', () => {
+        expect(buildExhaustedReclaimFilter(now, reclaimMs)).toEqual({
+            status: DownloadTaskStatus.Running,
+            last_run_time: { $lt: new Date('2026-07-06T10:30:00.000Z') },
+            retry_time: { $gte: DownloadTask.MaxRetryTime },
+        } as any);
+    });
+
+    it('never matches docs that still have retry budget (they go back through reclaim)', () => {
+        const filter = buildExhaustedReclaimFilter(now, reclaimMs) as any;
+
+        expect(filter.retry_time.$gte).toBe(3);
+    });
+});
+
+describe('buildDeadLetterUpdate', () => {
+    // returns bare fields (NOT an {$set:...} document): MongoCollection.updateMany
+    // wraps its update argument in $set itself, so a pre-wrapped document would
+    // become {$set:{$set:...}} and fail at runtime
+    it('marks Dead with an explanation so operators can tell sweep from download failure', () => {
+        const now = new Date('2026-07-06T12:00:00.000Z');
+        const update = buildDeadLetterUpdate(now) as any;
+
+        expect(update.$set).toBeUndefined();
+        expect(update.status).toBe(DownloadTaskStatus.Dead);
+        expect(update.update_time).toEqual(now);
+        expect(update.last_run_error).toContain('reclaim');
+    });
+});
+
+describe('buildCompletionFilter', () => {
+    it('pins illust_id AND the claimed generation, so a doc re-claimed later (new last_run_time) does not match', () => {
+        const claimedRunTime = new Date('2026-07-06T12:00:00.000Z');
+
+        expect(buildCompletionFilter('123', claimedRunTime)).toEqual({
+            illust_id: '123',
+            last_run_time: claimedRunTime,
+        } as any);
+    });
+
+    it('undefined generation only matches docs with null/missing last_run_time (never a claimed doc)', () => {
+        expect(buildCompletionFilter('123', undefined)).toEqual({
+            illust_id: '123',
+            last_run_time: null,
+        } as any);
     });
 });

--- a/apps/media-sync-worker/src/mongo/service.ts
+++ b/apps/media-sync-worker/src/mongo/service.ts
@@ -1,5 +1,6 @@
 import {
   Filter,
+  MatchKeysAndValues,
   MongoError,
   SortDirection,
   UpdateFilter,
@@ -16,6 +17,7 @@ import {
     UploadImgV2Req,
 } from "./types";
 import { DownloadTaskMap, ImgCollection, TranslateWordMap } from "./client";
+import { loadConsumerGuardConfig } from "../service/downloadRuntime";
 
 /**
  * 获取给定 illustIds 中最大值的 illust_id
@@ -80,38 +82,145 @@ export async function insertDownloadTask(illustId: string): Promise<boolean> {
 }
 
 /**
- * 查找一个未下载的任务
- * @returns 返回一个 Promise，表示找到的任务；如果没有任务返回 null
- * @throws 如果在数据库操作中发生错误，将抛出错误
+ * 构建「可领取任务」的查询条件。
+ *
+ * 语义：Pending / Fail 无条件可领取；Running 仅当 last_run_time 早于回收阈值时可领取
+ * （consumer 卡死或部署杀 pod 后滞留的任务由此被重新捞回）。Success / Dead 永不匹配。
+ *
+ * @param now - 当前时间（由调用方传入以保证可单测）
+ * @param reclaimMs - Running 任务回收阈值（毫秒）
  */
-export async function SearchUnDownloadTask(): Promise<DownloadTask | null> {
-  // 1. 从数据库中查询 status 为 Pending 或 Fail 的任务，限制为 1 个任务
-  const filter: Filter<DownloadTask> = {
-    status: { $in: [DownloadTaskStatus.Pending, DownloadTaskStatus.Fail] },
+export function buildClaimableTaskFilter(
+  now: Date,
+  reclaimMs: number
+): Filter<DownloadTask> {
+  return {
+    $or: [
+      { status: { $in: [DownloadTaskStatus.Pending, DownloadTaskStatus.Fail] } },
+      {
+        status: DownloadTaskStatus.Running,
+        last_run_time: { $lt: new Date(now.getTime() - reclaimMs) },
+      },
+    ],
   };
-
-  // 使用封装的 find 方法查找未下载的任务
-  const existingTasks = await DownloadTaskMap.find(filter, { limit: 1 });
-
-  // 如果没有找到任何任务，返回 null
-  if (existingTasks.length === 0) {
-    return null;
-  }
-
-  const task = new DownloadTask(existingTasks[0]); // 获取第一个任务
-
-  // 2. 更新任务状态为“开始下载”
-  const updateFilter: Filter<DownloadTask> = { illust_id: task.illust_id };
-
-  // 执行任务状态更新
-  await DownloadTaskMap.updateOne(updateFilter, task.startToDownload());
-
-  // 3. 返回找到的任务
-  return task;
 }
 
 /**
- * 更新任务状态为失败，并记录失败原因
+ * 构建「领取任务」的原子更新操作（配合 findOneAndUpdate 使用）。
+ *
+ * last_run_time 同时充当领取代次：收尾更新以它为条件（见 buildCompletionFilter），
+ * 旧轮次迟到的收尾因代次不中而被静默丢弃。retry_time 由 $inc 服务端自增——回收重领
+ * 同样消耗重试预算，连续多次 consumer 死亡会把任务推进 Dead 留痕，而不是无限重试。
+ *
+ * @param now - 领取时间，写入 last_run_time / update_time
+ */
+export function buildClaimUpdate(now: Date): UpdateFilter<DownloadTask> {
+  return {
+    $set: {
+      status: DownloadTaskStatus.Running,
+      last_run_time: now,
+      update_time: now,
+      last_run_error: "",
+    },
+    $inc: { retry_time: 1 },
+  };
+}
+
+/**
+ * 构建「回收预算耗尽」的死信清扫条件。
+ *
+ * 毒任务（每次领取都把 consumer 拖到挂死/超时）永远走不到 fail() 的收尾路径,
+ * 只靠领取 $inc 涨 retry_time——不清扫就会每隔回收阈值被无限重领。领取前把
+ * 超阈值 Running 且预算耗尽（retry_time >= MaxRetryTime）的任务批量标 Dead 留痕。
+ *
+ * @param now - 当前时间（由调用方传入以保证可单测）
+ * @param reclaimMs - Running 任务回收阈值（毫秒），与领取条件同一阈值
+ */
+export function buildExhaustedReclaimFilter(
+  now: Date,
+  reclaimMs: number
+): Filter<DownloadTask> {
+  return {
+    status: DownloadTaskStatus.Running,
+    last_run_time: { $lt: new Date(now.getTime() - reclaimMs) },
+    retry_time: { $gte: DownloadTask.MaxRetryTime },
+  };
+}
+
+/**
+ * 构建「死信化」更新字段。last_run_error 写明来自回收清扫,
+ * 便于运维区分「下载失败进 Dead」和「反复拖死 consumer 进 Dead」。
+ *
+ * 返回裸字段而非 {$set:...}:MongoCollection.updateMany 会自己包一层 $set,
+ * 预包裹会变成 {$set:{$set:...}} 在运行时报错。
+ */
+export function buildDeadLetterUpdate(now: Date): MatchKeysAndValues<DownloadTask> {
+  return {
+    status: DownloadTaskStatus.Dead,
+    update_time: now,
+    last_run_error:
+      "dead-lettered by reclaim sweep: retry budget exhausted without completion",
+  };
+}
+
+/**
+ * 构建「收尾更新（Success/Fail）」的查询条件。
+ *
+ * 除 illust_id 外把 last_run_time 钉在本次领取的代次上：若任务已被回收重领
+ * （last_run_time 被改写），旧轮次迟到的收尾条件不中、不会覆盖新领取。
+ *
+ * @param illustId - 任务 ID
+ * @param claimedRunTime - 领取时写入的 last_run_time；undefined 时匹配 null/缺失
+ *   （原子领取后必有值，此分支仅为类型完备，永远匹配不到已领取的文档）
+ */
+export function buildCompletionFilter(
+  illustId: string,
+  claimedRunTime: Date | undefined
+): Filter<DownloadTask> {
+  return {
+    illust_id: illustId,
+    last_run_time: (claimedRunTime ??
+      null) as Filter<DownloadTask>["last_run_time"],
+  };
+}
+
+/**
+ * 原子领取一个可执行的下载任务（Pending / Fail / 超过回收阈值的 Running）
+ * @returns 返回一个 Promise，表示领取到的任务；如果没有任务返回 null
+ * @throws 如果在数据库操作中发生错误，将抛出错误
+ */
+export async function SearchUnDownloadTask(): Promise<DownloadTask | null> {
+  const now = new Date();
+  const { runningTaskReclaimMs } = loadConsumerGuardConfig();
+
+  // 领取前先死信化清扫预算耗尽的滞留任务，否则它们会被无限回收重领
+  const swept = await DownloadTaskMap.updateMany(
+    buildExhaustedReclaimFilter(now, runningTaskReclaimMs),
+    buildDeadLetterUpdate(now)
+  );
+  if (swept.modifiedCount > 0) {
+    console.warn(
+      `Dead-lettered ${swept.modifiedCount} stale Running task(s) with exhausted retry budget`
+    );
+  }
+
+  // findOneAndUpdate 原子领取，杜绝 find+update 之间被其他协程抢占的窗口
+  const claimed = await DownloadTaskMap.findOneAndUpdate(
+    buildClaimableTaskFilter(now, runningTaskReclaimMs),
+    buildClaimUpdate(now),
+    { returnDocument: "after" }
+  );
+
+  if (!claimed) {
+    return null;
+  }
+
+  return new DownloadTask(claimed);
+}
+
+/**
+ * 更新任务状态为失败，并记录失败原因。
+ * 仅当任务仍属于本次领取代次时生效；已被回收重领的任务收尾静默丢弃。
  * @param task - 任务对象
  * @param createErr - 任务失败时的错误信息
  * @returns 返回一个 Promise，表示是否成功更新任务状态
@@ -121,8 +230,8 @@ export async function Fail(
   task: DownloadTask,
   createErr: Error
 ): Promise<void> {
-  // 构建查询条件
-  const filter: Filter<DownloadTask> = { illust_id: task.illust_id };
+  // 先取领取代次构建条件，再生成更新操作
+  const filter = buildCompletionFilter(task.illust_id, task.last_run_time);
 
   // 调用任务对象的 fail 方法，生成更新操作
   const update = task.fail(createErr);
@@ -132,14 +241,15 @@ export async function Fail(
 }
 
 /**
- * 更新任务状态为成功
+ * 更新任务状态为成功。
+ * 仅当任务仍属于本次领取代次时生效；已被回收重领的任务收尾静默丢弃。
  * @param task - 任务对象
  * @returns 返回一个 Promise，表示是否成功更新任务状态
  * @throws 如果在数据库操作中发生错误，将抛出错误
  */
 export async function Success(task: DownloadTask): Promise<void> {
-  // 构建查询条件
-  const filter: Filter<DownloadTask> = { illust_id: task.illust_id };
+  // 先取领取代次构建条件，再生成更新操作
+  const filter = buildCompletionFilter(task.illust_id, task.last_run_time);
 
   // 调用任务对象的 success 方法，生成更新操作
   const update = task.success();

--- a/apps/media-sync-worker/src/mongo/types.ts
+++ b/apps/media-sync-worker/src/mongo/types.ts
@@ -76,15 +76,8 @@ export class DownloadTask {
     });
   }
 
-  // 开始下载
-  startToDownload(): DownloadTask {
-    this.last_run_error = "";
-    this.last_run_time = new Date();
-    this.update_time = new Date();
-    this.retry_time++;
-    this.status = DownloadTaskStatus.Running;
-    return this;
-  }
+  // 领取（开始下载）语义已移到 mongo/service.ts 的 buildClaimUpdate：
+  // 领取必须与查询同一条 findOneAndUpdate 原子完成，无法用实例方法表达。
 
   // 下载成功
   success(): DownloadTask {

--- a/apps/media-sync-worker/src/service/consumeService.ts
+++ b/apps/media-sync-worker/src/service/consumeService.ts
@@ -15,11 +15,17 @@ import { MultiTag } from "../mongo/types";
 import { getContent } from "../pixiv/pixivProxy";
 import {
   elapsedMs,
+  loadConsumerGuardConfig,
   loadDownloadDelayConfig,
   nowMs,
   waitMs,
   type DownloadDelayConfig,
 } from "./downloadRuntime";
+import {
+  ConsecutiveTimeoutGuard,
+  CycleTimeoutError,
+  runWithTimeout,
+} from "./consumerWatchdog";
 import { schedulePostDownloadSync } from "./postDownloadSync";
 
 type DownloadIllustStatus =
@@ -59,6 +65,12 @@ interface PageDownloadMetrics {
   error?: string;
 }
 
+// 连续超时退出阈值：约 3 × 循环上限（默认 3 小时）不消费即判定系统性故障。
+// 计数只统计"连续"——空轮次/普通错误轮次会清零，所以单个毒任务（每次领取都拖到
+// 超时、但轮次间隔着正常任务）不靠这里终结：它每次领取消耗重试预算，最多
+// MaxRetryTime 次后被 SearchUnDownloadTask 的死信化清扫标 Dead。
+const CONSECUTIVE_CYCLE_TIMEOUT_EXIT_THRESHOLD = 3;
+
 // 异步消费下载任务的函数
 export async function consumeDownloadTaskAsync() {
   console.log("Starting async download task consumer...");
@@ -66,53 +78,82 @@ export async function consumeDownloadTaskAsync() {
   const delayConfig = loadDownloadDelayConfig();
   console.log(`Download delay config: ${JSON.stringify(delayConfig)}`);
 
+  const guardConfig = loadConsumerGuardConfig();
+  console.log(`Consumer guard config: ${JSON.stringify(guardConfig)}`);
+
   // 创建下载限制器，限制每 60 次下载后进入可配置冷却期（默认 2 分钟）
   const downloadLimiter = new DownloadLimiter(60, delayConfig.limiterCooldownMs);
 
+  const timeoutGuard = new ConsecutiveTimeoutGuard(
+    CONSECUTIVE_CYCLE_TIMEOUT_EXIT_THRESHOLD,
+    () => {
+      console.error(
+        `Consumer hit ${CONSECUTIVE_CYCLE_TIMEOUT_EXIT_THRESHOLD} consecutive cycle timeouts; ` +
+          `exiting so K8s restarts the pod.`
+      );
+      process.exit(1);
+    }
+  );
+
   let sleepTime = 1;
+
+  // 单轮循环体（被 watchdog 包裹；watchdog 放弃后本轮仍在后台继续，
+  // 其迟到的 Success/Fail 收尾由领取代次条件化静默丢弃）
+  const runOneCycle = async () => {
+    // 1. 获取未下载的任务
+    const task = await SearchUnDownloadTask();
+
+    if (!task) {
+      sleepTime = sleepTime >= 60 ? sleepTime : sleepTime * 2;
+      console.log(
+        `No pending tasks found. Waiting for ${sleepTime} seconds...`
+      );
+      await setTimeout(sleepTime * 1000);
+      return;
+    }
+
+    sleepTime = 1;
+
+    // 2. 尝试获取下载许可
+    await downloadLimiter.tryDownload(); // 等待限流器允许下载
+
+    try {
+      // 3. 下载任务
+      await downloadIllust(task.illust_id, delayConfig);
+      console.log(`Download successful for task: ${task.illust_id}`);
+
+      // 4. 标记任务成功
+      await Success(task);
+      console.log(`Task ${task.illust_id} marked as success.`);
+    } catch (downloadError) {
+      console.warn(
+        `Download failed for task ${task.illust_id}, error: `,
+        downloadError
+      );
+
+      // 5. 标记任务失败
+      await Fail(task, downloadError as Error);
+      console.warn(`Task ${task.illust_id} marked as failed.`);
+    }
+
+    // 6. 每个任务处理完后按配置休眠（默认已从旧值 5s 降到 2.5s）
+    await waitMs(delayConfig.afterTaskMs);
+  };
+
   // 无限循环处理任务
   while (true) {
     try {
-      // 1. 获取未下载的任务
-      const task = await SearchUnDownloadTask();
-
-      if (!task) {
-        sleepTime = sleepTime >= 60 ? sleepTime : sleepTime * 2;
-        console.log(
-          `No pending tasks found. Waiting for ${sleepTime} seconds...`
-        );
-        await setTimeout(sleepTime * 1000);
-        continue;
-      }
-
-      sleepTime = 1;
-
-      // 2. 尝试获取下载许可
-      await downloadLimiter.tryDownload(); // 等待限流器允许下载
-
-      try {
-        // 3. 下载任务
-        await downloadIllust(task.illust_id, delayConfig);
-        console.log(`Download successful for task: ${task.illust_id}`);
-
-        // 4. 标记任务成功
-        await Success(task);
-        console.log(`Task ${task.illust_id} marked as success.`);
-      } catch (downloadError) {
-        console.warn(
-          `Download failed for task ${task.illust_id}, error: `,
-          downloadError
-        );
-
-        // 5. 标记任务失败
-        await Fail(task, downloadError as Error);
-        console.warn(`Task ${task.illust_id} marked as failed.`);
-      }
-
-      // 6. 每个任务处理完后按配置休眠（默认已从旧值 5s 降到 2.5s）
-      await waitMs(delayConfig.afterTaskMs);
+      await runWithTimeout(runOneCycle(), guardConfig.cycleTimeoutMs);
+      timeoutGuard.recordSettled();
     } catch (err) {
-      console.warn(`Error in consumeDownloadTaskAsync:`, err);
+      if (err instanceof CycleTimeoutError) {
+        console.error(`Consumer cycle watchdog fired:`, err);
+        timeoutGuard.recordTimeout();
+      } else {
+        // 普通错误说明本轮已 settle，不属于连续超时
+        timeoutGuard.recordSettled();
+        console.warn(`Error in consumeDownloadTaskAsync:`, err);
+      }
     }
   }
 }

--- a/apps/media-sync-worker/src/service/consumerWatchdog.test.ts
+++ b/apps/media-sync-worker/src/service/consumerWatchdog.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'bun:test';
+import { ConsecutiveTimeoutGuard, CycleTimeoutError, runWithTimeout } from './consumerWatchdog';
+
+describe('runWithTimeout', () => {
+    it('passes through the resolved value when the cycle settles in time', async () => {
+        await expect(runWithTimeout(Promise.resolve(42), 1000)).resolves.toBe(42);
+    });
+
+    it('passes through the cycle rejection unchanged', async () => {
+        const boom = new Error('boom');
+
+        await expect(runWithTimeout(Promise.reject(boom), 1000)).rejects.toBe(boom);
+    });
+
+    it('rejects with CycleTimeoutError when the cycle never settles', async () => {
+        const neverSettles = new Promise<void>(() => {});
+
+        await expect(runWithTimeout(neverSettles, 20)).rejects.toBeInstanceOf(CycleTimeoutError);
+    });
+});
+
+describe('ConsecutiveTimeoutGuard', () => {
+    it('fires the exhausted callback only at the consecutive-timeout threshold', () => {
+        let exhausted = 0;
+        const guard = new ConsecutiveTimeoutGuard(3, () => {
+            exhausted++;
+        });
+
+        guard.recordTimeout();
+        guard.recordTimeout();
+        expect(exhausted).toBe(0);
+
+        guard.recordTimeout();
+        expect(exhausted).toBe(1);
+    });
+
+    it('a settled cycle resets the streak, so non-consecutive timeouts never exhaust', () => {
+        let exhausted = 0;
+        const guard = new ConsecutiveTimeoutGuard(3, () => {
+            exhausted++;
+        });
+
+        guard.recordTimeout();
+        guard.recordTimeout();
+        guard.recordSettled();
+        guard.recordTimeout();
+        guard.recordTimeout();
+        expect(exhausted).toBe(0);
+
+        guard.recordTimeout();
+        expect(exhausted).toBe(1);
+    });
+});

--- a/apps/media-sync-worker/src/service/consumerWatchdog.ts
+++ b/apps/media-sync-worker/src/service/consumerWatchdog.ts
@@ -1,0 +1,58 @@
+/**
+ * consumer 循环 watchdog：单轮硬时间上限 + 连续超时自愈。
+ *
+ * watchdog 不能释放底层挂死的 promise——不承诺资源回收，只承诺消费不永久停摆：
+ * 单次超时 continue（可能是极端慢任务或孤立挂点，不误伤同进程的 tagger worker / cron），
+ * 连续超时达到阈值说明系统性故障（如连接池被泄漏协程耗尽），退出进程交给 K8s 重拉。
+ */
+
+export class CycleTimeoutError extends Error {
+    constructor(timeoutMs: number) {
+        super(`consumer cycle did not settle within ${timeoutMs}ms watchdog limit`);
+        this.name = 'CycleTimeoutError';
+    }
+}
+
+/**
+ * 给单轮循环包一层硬超时：cycle 在限时内 settle 则透传结果 / 原样抛错；
+ * 超时则抛 CycleTimeoutError（cycle 本身仍在后台继续，其迟到收尾由领取代次条件化丢弃）。
+ */
+export async function runWithTimeout<T>(cycle: Promise<T>, timeoutMs: number): Promise<T> {
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    try {
+        return await Promise.race([
+            cycle,
+            new Promise<never>((_, reject) => {
+                timer = setTimeout(() => reject(new CycleTimeoutError(timeoutMs)), timeoutMs);
+            }),
+        ]);
+    } finally {
+        if (timer !== undefined) {
+            clearTimeout(timer);
+        }
+    }
+}
+
+/**
+ * 连续超时计数器：recordTimeout 累加、达到阈值触发 onExhausted（生产为 process.exit，
+ * 以回调注入以便测试不真杀进程）；recordSettled（正常完成或普通错误的轮次）清零。
+ */
+export class ConsecutiveTimeoutGuard {
+    private consecutiveTimeouts = 0;
+
+    constructor(
+        private readonly threshold: number,
+        private readonly onExhausted: () => void
+    ) {}
+
+    recordTimeout(): void {
+        this.consecutiveTimeouts++;
+        if (this.consecutiveTimeouts >= this.threshold) {
+            this.onExhausted();
+        }
+    }
+
+    recordSettled(): void {
+        this.consecutiveTimeouts = 0;
+    }
+}

--- a/apps/media-sync-worker/src/service/downloadRuntime.test.ts
+++ b/apps/media-sync-worker/src/service/downloadRuntime.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'bun:test';
-import { loadDownloadDelayConfig } from './downloadRuntime';
+import { loadConsumerGuardConfig, loadDownloadDelayConfig } from './downloadRuntime';
 
 describe('loadDownloadDelayConfig', () => {
     it('defaults artificial waits to half of the old hard-coded values', () => {
@@ -27,6 +27,85 @@ describe('loadDownloadDelayConfig', () => {
             afterTaskMs: 2500,
             afterAuthorMs: 1500,
             limiterCooldownMs: 60000,
+        });
+    });
+});
+
+describe('loadConsumerGuardConfig', () => {
+    it('defaults the Running reclaim threshold to 90 minutes', () => {
+        expect(loadConsumerGuardConfig({}).runningTaskReclaimMs).toBe(90 * 60 * 1000);
+    });
+
+    it('accepts a positive RUNNING_TASK_RECLAIM_MS override', () => {
+        const config = loadConsumerGuardConfig({ RUNNING_TASK_RECLAIM_MS: '7200000' });
+
+        expect(config.runningTaskReclaimMs).toBe(7200000);
+    });
+
+    it('falls back to the default when RUNNING_TASK_RECLAIM_MS is non-positive or not a number', () => {
+        expect(loadConsumerGuardConfig({ RUNNING_TASK_RECLAIM_MS: '0' }).runningTaskReclaimMs).toBe(
+            90 * 60 * 1000
+        );
+        expect(loadConsumerGuardConfig({ RUNNING_TASK_RECLAIM_MS: 'abc' }).runningTaskReclaimMs).toBe(
+            90 * 60 * 1000
+        );
+    });
+
+    it('defaults the cycle watchdog timeout to 60 minutes', () => {
+        expect(loadConsumerGuardConfig({}).cycleTimeoutMs).toBe(60 * 60 * 1000);
+    });
+
+    it('accepts a positive CONSUMER_CYCLE_TIMEOUT_MS override', () => {
+        const config = loadConsumerGuardConfig({
+            CONSUMER_CYCLE_TIMEOUT_MS: '1800000',
+        });
+
+        expect(config.cycleTimeoutMs).toBe(1800000);
+    });
+
+    it('falls back to the default when CONSUMER_CYCLE_TIMEOUT_MS is non-positive or not a number', () => {
+        expect(loadConsumerGuardConfig({ CONSUMER_CYCLE_TIMEOUT_MS: '0' }).cycleTimeoutMs).toBe(
+            60 * 60 * 1000
+        );
+        expect(loadConsumerGuardConfig({ CONSUMER_CYCLE_TIMEOUT_MS: '-5' }).cycleTimeoutMs).toBe(
+            60 * 60 * 1000
+        );
+    });
+
+    it('reverts both thresholds to defaults when reclaim is not strictly greater than cycle timeout', () => {
+        // reclaim (1.5h) < cycle timeout (2h): watchdog-abandoned round could still be
+        // running when its task gets re-claimed, so the pair is rejected as a whole
+        expect(
+            loadConsumerGuardConfig({
+                CONSUMER_CYCLE_TIMEOUT_MS: '7200000',
+                RUNNING_TASK_RECLAIM_MS: '5400000',
+            })
+        ).toEqual({
+            cycleTimeoutMs: 60 * 60 * 1000,
+            runningTaskReclaimMs: 90 * 60 * 1000,
+        });
+
+        // equality also violates the "strictly greater" invariant
+        expect(
+            loadConsumerGuardConfig({
+                CONSUMER_CYCLE_TIMEOUT_MS: '3600000',
+                RUNNING_TASK_RECLAIM_MS: '3600000',
+            })
+        ).toEqual({
+            cycleTimeoutMs: 60 * 60 * 1000,
+            runningTaskReclaimMs: 90 * 60 * 1000,
+        });
+    });
+
+    it('keeps a valid override pair intact', () => {
+        expect(
+            loadConsumerGuardConfig({
+                CONSUMER_CYCLE_TIMEOUT_MS: '1800000',
+                RUNNING_TASK_RECLAIM_MS: '2700000',
+            })
+        ).toEqual({
+            cycleTimeoutMs: 1800000,
+            runningTaskReclaimMs: 2700000,
         });
     });
 });

--- a/apps/media-sync-worker/src/service/downloadRuntime.ts
+++ b/apps/media-sync-worker/src/service/downloadRuntime.ts
@@ -43,6 +43,49 @@ export function loadDownloadDelayConfig(
     };
 }
 
+export interface ConsumerGuardConfig {
+    cycleTimeoutMs: number;
+    runningTaskReclaimMs: number;
+}
+
+// 60 分钟：最坏合法单轮 ≈ 20 页/并发 2 的大任务，每页代理请求最坏顶满 180s（10 批 ×
+// 180s = 30min）+ 前置 info/pages 请求各最坏 180s + 限流冷却 120s + 翻译与 Mongo 杂项
+// ≈ 40min；留余量后凡超过 60min 必是挂死而非慢。
+const DEFAULT_CONSUMER_CYCLE_TIMEOUT_MS = 60 * 60 * 1000;
+
+// 90 分钟：必须严格大于 consumer 单轮 watchdog 上限（60 分钟），保证被 watchdog 放弃
+// 的轮次要么已被自身超时终结、要么其收尾早于回收发生，缩小"旧轮次 vs 新领取"并发窗口。
+const DEFAULT_RUNNING_TASK_RECLAIM_MS = 90 * 60 * 1000;
+
+export function loadConsumerGuardConfig(
+    env: Record<string, string | undefined> = process.env
+): ConsumerGuardConfig {
+    const cycleTimeoutMs = readPositiveMs(
+        env.CONSUMER_CYCLE_TIMEOUT_MS,
+        DEFAULT_CONSUMER_CYCLE_TIMEOUT_MS
+    );
+    const runningTaskReclaimMs = readPositiveMs(
+        env.RUNNING_TASK_RECLAIM_MS,
+        DEFAULT_RUNNING_TASK_RECLAIM_MS
+    );
+
+    // 阈值耦合校验：回收阈值不大于 watchdog 上限时，被放弃的旧轮次可能还在跑就被
+    // 重新领取。两个值是一对约束，任何一边越界都整对回退默认。
+    if (runningTaskReclaimMs <= cycleTimeoutMs) {
+        console.warn(
+            `Invalid consumer guard config: RUNNING_TASK_RECLAIM_MS (${runningTaskReclaimMs}) must be ` +
+                `strictly greater than CONSUMER_CYCLE_TIMEOUT_MS (${cycleTimeoutMs}); ` +
+                `reverting both to defaults (${DEFAULT_RUNNING_TASK_RECLAIM_MS}/${DEFAULT_CONSUMER_CYCLE_TIMEOUT_MS}).`
+        );
+        return {
+            cycleTimeoutMs: DEFAULT_CONSUMER_CYCLE_TIMEOUT_MS,
+            runningTaskReclaimMs: DEFAULT_RUNNING_TASK_RECLAIM_MS,
+        };
+    }
+
+    return { cycleTimeoutMs, runningTaskReclaimMs };
+}
+
 export function nowMs(): number {
     return performance.now();
 }
@@ -64,6 +107,19 @@ function readNonNegativeMs(value: string | undefined, fallback: number): number 
     }
     const parsed = Number.parseInt(value, 10);
     if (!Number.isFinite(parsed) || parsed < 0) {
+        return fallback;
+    }
+    return parsed;
+}
+
+// 与 readNonNegativeMs 不同：阈值类配置取 0 没有合法语义（0 回收阈值会让所有 Running
+// 任务立即可被重复领取），所以 0 也回退默认值。
+function readPositiveMs(value: string | undefined, fallback: number): number {
+    if (value === undefined || value === '') {
+        return fallback;
+    }
+    const parsed = Number.parseInt(value, 10);
+    if (!Number.isFinite(parsed) || parsed <= 0) {
         return fallback;
     }
     return parsed;

--- a/packages/ts-shared/src/mongo/collection.test.ts
+++ b/packages/ts-shared/src/mongo/collection.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'bun:test';
+import { MongoCollection } from './collection';
+
+describe('MongoCollection.updateMany', () => {
+    it('returns the driver UpdateResult so callers can observe modifiedCount', async () => {
+        const nativeResult = {
+            acknowledged: true,
+            matchedCount: 2,
+            modifiedCount: 2,
+            upsertedCount: 0,
+            upsertedId: null,
+        };
+        const stub = {
+            updateMany: async () => nativeResult,
+        };
+        const collection = new MongoCollection(stub as any);
+
+        const result = await collection.updateMany({}, {});
+
+        expect(result.modifiedCount).toBe(2);
+    });
+});

--- a/packages/ts-shared/src/mongo/collection.ts
+++ b/packages/ts-shared/src/mongo/collection.ts
@@ -11,6 +11,7 @@ import {
     OptionalUnlessRequiredId,
     MatchKeysAndValues,
     UpdateFilter,
+    UpdateResult,
     BulkWriteOptions,
     AnyBulkWriteOperation,
     IndexSpecification,
@@ -90,8 +91,8 @@ export class MongoCollection<T extends Document> {
         filter: Filter<T>,
         update: MatchKeysAndValues<T>,
         options?: UpdateOptions
-    ): Promise<void> {
-        await this.collection.updateMany(filter, { $set: update }, options);
+    ): Promise<UpdateResult> {
+        return this.collection.updateMany(filter, { $set: update }, options);
     }
 
     /**

--- a/packages/ts-shared/src/mongo/types.test.ts
+++ b/packages/ts-shared/src/mongo/types.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'bun:test';
+import { MongoClient } from 'mongodb';
+import { buildMongoUrl } from './types';
+
+describe('buildMongoUrl', () => {
+    it('includes socketTimeoutMS in the connection URL when configured', () => {
+        const url = buildMongoUrl({
+            host: 'mongo-host',
+            port: 27017,
+            database: 'chiwei',
+            authSource: 'admin',
+            connectTimeoutMS: 10000,
+            socketTimeoutMS: 60000,
+        });
+
+        expect(url).toContain('socketTimeoutMS=60000');
+        expect(url).toContain('connectTimeoutMS=10000');
+    });
+
+    it('omits socketTimeoutMS when not configured or explicitly 0 (driver default applies)', () => {
+        const url = buildMongoUrl({
+            host: 'mongo-host',
+            port: 27017,
+            database: 'chiwei',
+        });
+        expect(url).not.toContain('socketTimeoutMS');
+
+        const disabled = buildMongoUrl({
+            host: 'mongo-host',
+            port: 27017,
+            database: 'chiwei',
+            socketTimeoutMS: 0,
+        });
+        expect(disabled).not.toContain('socketTimeoutMS');
+    });
+
+    it('produces a URL the driver actually parses into socketTimeoutMS', () => {
+        const url = buildMongoUrl({
+            host: 'mongo-host',
+            port: 27017,
+            database: 'chiwei',
+            socketTimeoutMS: 60000,
+        });
+
+        const client = new MongoClient(url);
+        expect(client.options.socketTimeoutMS).toBe(60000);
+    });
+});

--- a/packages/ts-shared/src/mongo/types.ts
+++ b/packages/ts-shared/src/mongo/types.ts
@@ -18,6 +18,8 @@ export interface MongoConfig {
     authSource?: string;
     /** 连接超时时间（毫秒） */
     connectTimeoutMS?: number;
+    /** socket 不活动超时（毫秒）。不设或为 0 时用 driver 默认（无限等待），半开连接上的命令会永久挂起 */
+    socketTimeoutMS?: number;
     /** 额外的连接选项 */
     options?: Record<string, string | number | boolean>;
 }
@@ -41,7 +43,8 @@ export function createDefaultMongoConfig(database: string = 'chiwei'): MongoConf
  * 根据配置生成 MongoDB 连接 URL
  */
 export function buildMongoUrl(config: MongoConfig): string {
-    const { host, port, username, password, database, authSource, connectTimeoutMS, options } = config;
+    const { host, port, username, password, database, authSource, connectTimeoutMS, socketTimeoutMS, options } =
+        config;
 
     let url = 'mongodb://';
 
@@ -64,6 +67,10 @@ export function buildMongoUrl(config: MongoConfig): string {
 
     if (connectTimeoutMS) {
         params.push(`connectTimeoutMS=${connectTimeoutMS}`);
+    }
+
+    if (socketTimeoutMS) {
+        params.push(`socketTimeoutMS=${socketTimeoutMS}`);
     }
 
     if (authSource) {


### PR DESCRIPTION
## Problem

The download consumer hung permanently on 2026-06-27 after a network blip: MongoClient had no socketTimeoutMS (driver default 0 = wait forever), so one command stranded on a half-open socket silently killed the single-coroutine consume loop. No new images were ingested for a week and the 19:30 daily-new-photo cron failed every day with "no images found" while reporting task success.

## Fix (two layers)

**Direct cause** — `MongoConfig` gains an optional `socketTimeoutMS` (passed through the connection URL); the worker defaults to 60s via `MONGO_SOCKET_TIMEOUT_MS` (0 = explicit off switch). A stuck command now throws and the loop's existing catch continues.

**Structural hardening** (spec: media-sync-consumer-hardening, codex T1+T3 reviewed):
- Cycle watchdog: each loop iteration races a 60min limit (`CONSUMER_CYCLE_TIMEOUT_MS`); timeout logs and continues, 3 consecutive timeouts exit so K8s restarts the pod.
- Stale Running reclaim: claiming is an atomic findOneAndUpdate that also picks up Running tasks older than 90min (`RUNNING_TASK_RECLAIM_MS`); completions are pinned to the claim generation so zombie cycles abandoned by the watchdog cannot overwrite a re-claim.
- Dead-letter sweep: poison tasks that keep killing the consumer never reach the fail() path; the claim query first dead-letters stale Running tasks with exhausted retry budget, ending the infinite reclaim loop.
- `MongoCollection.updateMany` now returns the driver UpdateResult (backward compatible).

## Verification

- Unit: media-sync-worker 114 pass, ts-shared 99 pass, both tsc clean (all TDD red-green).
- Real mongod lifecycle script: 12/12 checks — atomic claim + $inc, completion filter matches through BSON Date round-trip, late completion with stale generation matches nothing, reclaim consumes budget, sweep hits exactly the exhausted task.
- coe lane (isolated chiwei-test Mongo, image 1.0.5.1): guard config loaded (60/90min), consumed 8 real leftover tasks end-to-end with zero duplicate claims, no watchdog false positives, no false dead-letters.
- prod recovery already done separately (pod restart); this PR ships the code so the hang cannot recur.

🤖 Generated with [Claude Code](https://claude.com/claude-code)