### PR TITLE
feat(agent-service): split life_wake onto its own life-model alias

### DIFF
--- a/apps/agent-service/app/infra/config.py
+++ b/apps/agent-service/app/infra/config.py
@@ -120,11 +120,6 @@ class Settings:
     # -- Lane (fallback for workers without HTTP context) --
     lane: str | None = field(default_factory=lambda: _env_or_none("LANE"))
 
-    # -- Life Engine --
-    life_engine_model: str = field(
-        default_factory=lambda: _env("LIFE_ENGINE_MODEL", "offline-model")
-    )
-
     # -- Utility --
 
     def field_names(self) -> list[str]:

--- a/apps/agent-service/app/nodes/life_wake.py
+++ b/apps/agent-service/app/nodes/life_wake.py
@@ -306,11 +306,15 @@ _LIFE_CD_SECONDS = 45
 def _cd_key(lane: str, persona_id: str) -> str:
     return f"life_cd:{lane}:{persona_id}"
 
-# offline-model：异步后台思考用离线模型（见 feedback_model_selection），主对话才用
-# gemini。recursion_limit 给够（让她在一轮里连续调多次工具，不被默认 6 卡住）。
+# life-model：life_wake 产出她的独白、三姐妹互聊、以及主动消息的内容意图（最终
+# 对真人/群的出站措辞由 chat 渲染层的 main-chat-model 生成）。说话场景的模型走
+# 独立别名，与 world 推演等其他离线任务（offline-model）解耦，可按场景单独切换；
+# 两个别名指向谁由 DB model_mappings 决定（别名缺失会 fallback 到不存在的
+# 302.ai 模型并失败，部署前必须先在目标库种好 life-model 记录）。
+# recursion_limit 给够（让她在一轮里连续调多次工具，不被默认 6 卡住）。
 # trace_name 让这一轮 life 思考接进 langfuse。
 _LIFE_WAKE_CFG = AgentConfig(
-    "life_wake", "offline-model", "life-wake", recursion_limit=30
+    "life_wake", "life-model", "life-wake", recursion_limit=30
 )
 
 def _humanize_elapsed(occurred_at: str, now: datetime) -> str | None:

--- a/apps/agent-service/tests/nodes/test_life_wake.py
+++ b/apps/agent-service/tests/nodes/test_life_wake.py
@@ -3712,3 +3712,17 @@ async def test_turn_idempotent_still_skips_when_marker_in_transcript(patched, mo
 
     assert _FakeAgent.instances == [], "本轮 marker 已在 transcript → 整轮 skip，run 不该被调"
     assert patched["marked"] == [], "skip 的轮不重复标已读"
+
+
+def test_life_wake_cfg_uses_life_model_alias():
+    """AgentConfig：life_wake 走独立的 life-model 别名，与 offline-model 解耦。
+
+    life_wake 产出独白、三姐妹互聊、主动消息的内容意图（对真人/群的最终出站措辞
+    由 chat 渲染层 main-chat-model 另行生成）。说话场景的模型要能独立于 world
+    推演和其他离线任务单独切换（按场景选模型，不一刀切）。别名解析在 DB
+    model_mappings，prod / coe 两库各自决定 life-model 指向谁；别名缺失会
+    fallback 到不存在的 302.ai 模型并失败，所以部署前必须先种 DB 记录。
+    """
+    assert lw._LIFE_WAKE_CFG.prompt_id == "life_wake"
+    assert lw._LIFE_WAKE_CFG.model_id == "life-model"
+    assert lw._LIFE_WAKE_CFG.trace_name == "life-wake"

--- a/apps/agent-service/tests/unit/infra/test_config.py
+++ b/apps/agent-service/tests/unit/infra/test_config.py
@@ -67,7 +67,6 @@ class TestSettingsDefaults:
 
             s = Settings()
             assert s.siliconflow_base_url == "https://api.siliconflow.cn/v1"
-            assert s.life_engine_model == "offline-model"
 
 
 class TestSettingsFromEnv:


### PR DESCRIPTION
## Why

gpt-5.5 speech in the life engine (inner monologue / sister chat) reads too AI-flavored. To swap the speaking model per scenario without dragging world deliberation along, life_wake gets its own model alias.

## What

- `life_wake` model alias: shared `offline-model` → dedicated `life-model`. The other 8 offline-model call sites (world deliberate/eyes/reflect/presence_match/world_sediment, life_sediment/day_review/persona_review) are intentionally untouched — they are deliberation/judgment workloads, not speech, and their prompts are tuned against gpt-5.5.
- Proactive boundary (caught in codex T3): life_wake only produces the *intent* of proactive messages; final outbound wording renders via `main-chat-model`. Comments/tests state this precisely.
- Drop dead setting `LIFE_ENGINE_MODEL` (defined, never read).

## DB prerequisite (already executed)

`model_mappings` must contain a `life-model` row before this deploys — a missing alias falls back to provider 302.ai with a nonexistent model name and fails life rounds (negative-cached 5min):

- prod: `life-model` → `gpt-5.5-2026-04-24` (mutation 221, behavior-neutral; switching prod to qwen is a later one-row update)
- chiwei-test: `life-model` → `openai_qwen3.7-max` (mutation 220)

## Verification

- Full suite: 2666 passed, 3 skipped.
- coe lane `coe-life-qwen` (1.2.0.118): qwen3.7-max first-call verified end to end — 8 life rounds closed, function calling/ReAct/idempotent closing normal, sisters chatted naturally about a rainstorm with distinct personas; gateway implicit prompt cache works for qwen too (~80% hit on life rounds).

🤖 Generated with [Claude Code](https://claude.com/claude-code)