### PR TITLE
fix(agent-service): drop unsupported image generation param

### DIFF
--- a/apps/agent-service/app/agent/image_gen.py
+++ b/apps/agent-service/app/agent/image_gen.py
@@ -85,7 +85,6 @@ async def _generate_image_ark(
             image=reference_images or None,
             response_format="b64_json",
             watermark=False,
-            sequential_image_generation="disabled",
         )
         return [f"data:image/jpeg;base64,{img.b64_json}" for img in resp.data or []]
     finally:
@@ -121,7 +120,6 @@ async def _generate_image_openai(
     try:
         extra_body: dict[str, Any] = {
             "watermark": False,
-            "sequential_image_generation": "disabled",
         }
         if reference_images:
             extra_body["image"] = reference_images

--- a/apps/agent-service/tests/unit/agent/test_image_gen.py
+++ b/apps/agent-service/tests/unit/agent/test_image_gen.py
@@ -179,6 +179,7 @@ class TestGenerateImageArk:
         call_kwargs = mock_client.images.generate.call_args.kwargs
         assert call_kwargs["prompt"] == "a cat"
         assert call_kwargs["image"] is None
+        assert "sequential_image_generation" not in call_kwargs
         mock_client.close.assert_called_once()
 
     async def test_with_reference_images(self):
@@ -226,6 +227,30 @@ class TestGenerateImageOpenai:
             )
 
         assert result == ["data:image/jpeg;base64,oai_result"]
+        call_kwargs = mock_client_instance.images.generate.call_args.kwargs
+        assert call_kwargs["extra_body"] == {"watermark": False}
+        mock_client_instance.close.assert_called_once()
+
+    async def test_with_reference_images(self):
+        mock_img = SimpleNamespace(b64_json="oai_ref_result")
+        mock_resp = SimpleNamespace(data=[mock_img])
+
+        mock_client_instance = AsyncMock()
+        mock_client_instance.images.generate = AsyncMock(return_value=mock_resp)
+        mock_client_instance.close = AsyncMock()
+
+        refs = ["https://example.com/ref1.jpg", "https://example.com/ref2.jpg"]
+        with patch("openai.AsyncOpenAI", return_value=mock_client_instance):
+            result = await mod._generate_image_openai(
+                _fake_info(),
+                "a dog like this",
+                "1024x1024",
+                refs,
+            )
+
+        assert result == ["data:image/jpeg;base64,oai_ref_result"]
+        call_kwargs = mock_client_instance.images.generate.call_args.kwargs
+        assert call_kwargs["extra_body"] == {"watermark": False, "image": refs}
         mock_client_instance.close.assert_called_once()
 
     async def test_proxy_handling(self):


### PR DESCRIPTION
## Summary
- Remove unsupported sequential_image_generation from Ark image generation requests
- Remove the same unsupported field from OpenAI-compatible image generation extra_body
- Add unit coverage to prevent the field from being reintroduced, including reference-image requests

## Verification
- uv run pytest tests/unit/agent/test_image_gen.py -q
- uv run ruff check app/agent/image_gen.py tests/unit/agent/test_image_gen.py