### PR TITLE
fix(agent-service): tune Ark image generation timeout

### DIFF
--- a/apps/agent-service/app/agent/image_gen.py
+++ b/apps/agent-service/app/agent/image_gen.py
@@ -15,6 +15,9 @@ from app.agent.models import resolve_model_info
 
 logger = logging.getLogger(__name__)
 
+ARK_IMAGE_GENERATION_TIMEOUT_SECONDS = 240.0
+ARK_IMAGE_GENERATION_MAX_RETRIES = 0
+
 
 # ---------------------------------------------------------------------------
 # Public API
@@ -64,8 +67,8 @@ def _create_ark_client(info: dict[str, Any]) -> Any:
     return AsyncArk(
         api_key=info["api_key"],
         base_url=info["base_url"],
-        timeout=60.0,
-        max_retries=3,
+        timeout=ARK_IMAGE_GENERATION_TIMEOUT_SECONDS,
+        max_retries=ARK_IMAGE_GENERATION_MAX_RETRIES,
     )
 
 

--- a/apps/agent-service/tests/unit/agent/test_image_gen.py
+++ b/apps/agent-service/tests/unit/agent/test_image_gen.py
@@ -159,6 +159,13 @@ class TestGenerateImageDispatch:
 
 
 class TestGenerateImageArk:
+    def test_create_client_uses_image_timeout(self):
+        with patch("volcenginesdkarkruntime.AsyncArk") as mock_cls:
+            mod._create_ark_client(_fake_info(client_type="ark"))
+
+        assert mock_cls.call_args.kwargs["timeout"] == mod.ARK_IMAGE_GENERATION_TIMEOUT_SECONDS
+        assert mock_cls.call_args.kwargs["max_retries"] == mod.ARK_IMAGE_GENERATION_MAX_RETRIES
+
     async def test_basic_generation(self):
         mock_client = AsyncMock()
         mock_img = SimpleNamespace(b64_json="abc123")
@@ -218,7 +225,7 @@ class TestGenerateImageOpenai:
         mock_client_instance.images.generate = AsyncMock(return_value=mock_resp)
         mock_client_instance.close = AsyncMock()
 
-        with patch("openai.AsyncOpenAI", return_value=mock_client_instance):
+        with patch("openai.AsyncOpenAI", return_value=mock_client_instance) as mock_cls:
             result = await mod._generate_image_openai(
                 _fake_info(),
                 "a dog",
@@ -229,6 +236,8 @@ class TestGenerateImageOpenai:
         assert result == ["data:image/jpeg;base64,oai_result"]
         call_kwargs = mock_client_instance.images.generate.call_args.kwargs
         assert call_kwargs["extra_body"] == {"watermark": False}
+        assert mock_cls.call_args.kwargs["timeout"] == 60.0
+        assert mock_cls.call_args.kwargs["max_retries"] == 3
         mock_client_instance.close.assert_called_once()
 
     async def test_with_reference_images(self):


### PR DESCRIPTION
## Summary
- Set Ark image generation to wait up to 240s for a single image request
- Disable Ark SDK automatic retries for image generation so one tool call is not expanded into repeated 60s read timeouts
- Keep OpenAI-compatible image generation timeout/retry behavior unchanged

## Evidence
- Langfuse trace 58823eab43beeedcf66f3b9b6a673ec4 showed three generate_image tool calls, each about 246s, ending in ArkAPITimeoutError
- Production logs showed httpx.ReadTimeout while waiting for response headers, with Ark SDK retry frames
- Local direct model test showed seedream pro can return in ~77-83s, but timeout=60 fails

## Verification
- uv run pytest tests/unit/agent/test_image_gen.py -q
- uv run ruff check app/agent/image_gen.py tests/unit/agent/test_image_gen.py
- Codex T3 review: adopted required change to keep OpenAI-compatible retry behavior unchanged