### PR TITLE
feat(agent-service): add image quality fallback

### DIFF
--- a/apps/agent-service/app/agent/image_gen.py
+++ b/apps/agent-service/app/agent/image_gen.py
@@ -1,4 +1,4 @@
-"""Image generation — text-to-image / image-to-image via Ark, OpenAI, or Gemini.
+"""Image generation — text-to-image / image-to-image via provider-native APIs.
 
 Public API:
   - generate_image() — dispatch to the correct backend based on provider config
@@ -17,6 +17,9 @@ logger = logging.getLogger(__name__)
 
 ARK_IMAGE_GENERATION_TIMEOUT_SECONDS = 240.0
 ARK_IMAGE_GENERATION_MAX_RETRIES = 0
+AZURE_IMAGE_GENERATION_TIMEOUT_SECONDS = 240.0
+AZURE_IMAGE_GENERATION_MAX_RETRIES = 0
+_AZURE_API_VERSION = "2024-08-01-preview"
 
 
 # ---------------------------------------------------------------------------
@@ -33,7 +36,8 @@ async def generate_image(
 ) -> list[str]:
     """Generate images from a text prompt (and optional reference images).
 
-    Dispatches to Ark, OpenAI, or Gemini based on provider's ``client_type``.
+    Dispatches to Ark, OpenAI, Azure, or Gemini based on provider's
+    ``client_type``.
 
     Args:
         model_id: Internal model alias (e.g. ``"generate-image-high-model"``).
@@ -49,6 +53,8 @@ async def generate_image(
 
     if client_type == "ark":
         return await _generate_image_ark(info, prompt, size, reference_images)
+    if client_type == "azure-http":
+        return await _generate_image_azure(info, prompt, size, reference_images)
     if client_type == "google":
         return await _generate_image_gemini(info, prompt, size, reference_images)
     # Default: OpenAI-compatible
@@ -175,6 +181,54 @@ async def _generate_image_openai(
             size=_normalize_openai_image_size(size),  # type: ignore[arg-type]
             n=1,
             extra_body=extra_body,
+        )
+        return [f"data:image/jpeg;base64,{img.b64_json}" for img in resp.data or []]
+    finally:
+        await client.close()
+        if http_client:
+            await http_client.aclose()
+
+
+async def _generate_image_azure(
+    info: dict[str, Any],
+    prompt: str,
+    size: str,
+    reference_images: list[str] | None,
+) -> list[str]:
+    """Generate an image through the ModelHub Azure-compatible endpoint."""
+    if reference_images:
+        raise ValueError(
+            "ModelHub image generation does not accept reference image URLs"
+        )
+
+    from openai import AsyncAzureOpenAI
+
+    kwargs: dict[str, Any] = {
+        "azure_endpoint": info["base_url"],
+        "azure_deployment": info["model_name"],
+        "api_key": info["api_key"],
+        "api_version": _AZURE_API_VERSION,
+        "timeout": AZURE_IMAGE_GENERATION_TIMEOUT_SECONDS,
+        "max_retries": AZURE_IMAGE_GENERATION_MAX_RETRIES,
+    }
+    http_client = None
+    if info.get("use_proxy"):
+        from app.infra.config import settings
+
+        if settings.forward_proxy_url:
+            from app.capabilities.image_gen import proxy_http_client
+
+            http_client = proxy_http_client(settings.forward_proxy_url)
+            kwargs["http_client"] = http_client
+
+    client = AsyncAzureOpenAI(**kwargs)
+    try:
+        resp = await client.images.generate(
+            model=info["model_name"],
+            response_format="b64_json",
+            prompt=prompt,
+            size=_normalize_openai_image_size(size),  # type: ignore[arg-type]
+            n=1,
         )
         return [f"data:image/jpeg;base64,{img.b64_json}" for img in resp.data or []]
     finally:

--- a/apps/agent-service/app/agent/image_gen.py
+++ b/apps/agent-service/app/agent/image_gen.py
@@ -19,7 +19,9 @@ ARK_IMAGE_GENERATION_TIMEOUT_SECONDS = 240.0
 ARK_IMAGE_GENERATION_MAX_RETRIES = 0
 AZURE_IMAGE_GENERATION_TIMEOUT_SECONDS = 240.0
 AZURE_IMAGE_GENERATION_MAX_RETRIES = 0
-_AZURE_API_VERSION = "2024-08-01-preview"
+_MODELHUB_IMAGE_BASE_URL = (
+    "https://aidp.bytedance.net/api/modelhub/online/v2/crawl/openai"
+)
 
 
 # ---------------------------------------------------------------------------
@@ -201,13 +203,11 @@ async def _generate_image_azure(
             "ModelHub image generation does not accept reference image URLs"
         )
 
-    from openai import AsyncAzureOpenAI
+    from openai import AsyncOpenAI
 
     kwargs: dict[str, Any] = {
-        "azure_endpoint": info["base_url"],
-        "azure_deployment": info["model_name"],
         "api_key": info["api_key"],
-        "api_version": _AZURE_API_VERSION,
+        "base_url": _MODELHUB_IMAGE_BASE_URL,
         "timeout": AZURE_IMAGE_GENERATION_TIMEOUT_SECONDS,
         "max_retries": AZURE_IMAGE_GENERATION_MAX_RETRIES,
     }
@@ -221,16 +221,16 @@ async def _generate_image_azure(
             http_client = proxy_http_client(settings.forward_proxy_url)
             kwargs["http_client"] = http_client
 
-    client = AsyncAzureOpenAI(**kwargs)
+    client = AsyncOpenAI(**kwargs)
     try:
         resp = await client.images.generate(
             model=info["model_name"],
-            response_format="b64_json",
             prompt=prompt,
             size=_normalize_openai_image_size(size),  # type: ignore[arg-type]
             n=1,
+            extra_headers={"api-key": info["api_key"]},
         )
-        return [f"data:image/jpeg;base64,{img.b64_json}" for img in resp.data or []]
+        return [f"data:image/png;base64,{img.b64_json}" for img in resp.data or []]
     finally:
         await client.close()
         if http_client:

--- a/apps/agent-service/app/agent/image_gen.py
+++ b/apps/agent-service/app/agent/image_gen.py
@@ -36,7 +36,7 @@ async def generate_image(
     Dispatches to Ark, OpenAI, or Gemini based on provider's ``client_type``.
 
     Args:
-        model_id: Internal model alias (e.g. ``"default-generate-image-model"``).
+        model_id: Internal model alias (e.g. ``"generate-image-high-model"``).
         prompt: Generation prompt.
         size: Size spec (e.g. ``"2048x2048"``, ``"1K"``, ``"2K"``, ``"4K"``).
         reference_images: Optional list of reference image URLs for img2img.
@@ -72,6 +72,47 @@ def _create_ark_client(info: dict[str, Any]) -> Any:
     )
 
 
+def _parse_pixel_size(size: str) -> tuple[int, int] | None:
+    s = size.strip().lower()
+    if "x" not in s:
+        return None
+    try:
+        w_str, h_str = s.split("x", 1)
+        w, h = int(w_str), int(h_str)
+    except ValueError:
+        return None
+    if w <= 0 or h <= 0:
+        return None
+    return w, h
+
+
+def _normalize_ark_image_size(size: str) -> str:
+    """Normalize public tool size to Ark image-generation size syntax."""
+    s = size.strip().lower()
+    if s in {"1k", "2k", "4k"}:
+        return s
+    pixels = _parse_pixel_size(s)
+    if pixels is None:
+        return "2048x2048"
+    w, h = pixels
+    return f"{w}x{h}"
+
+
+def _normalize_openai_image_size(size: str) -> str:
+    """Normalize public tool size to OpenAI-compatible image size syntax."""
+    pixels = _parse_pixel_size(size)
+    if pixels is None:
+        return "1024x1024"
+
+    w, h = pixels
+    ratio = w / h
+    if ratio >= 1.2:
+        return "1536x1024"
+    if ratio <= 1 / 1.2:
+        return "1024x1536"
+    return "1024x1024"
+
+
 async def _generate_image_ark(
     info: dict[str, Any],
     prompt: str,
@@ -84,7 +125,7 @@ async def _generate_image_ark(
         resp = await client.images.generate(
             model=info["model_name"],
             prompt=prompt,
-            size=size,
+            size=_normalize_ark_image_size(size),
             image=reference_images or None,
             response_format="b64_json",
             watermark=False,
@@ -131,7 +172,7 @@ async def _generate_image_openai(
             model=info["model_name"],
             response_format="b64_json",
             prompt=prompt,
-            size=size,  # type: ignore[arg-type]
+            size=_normalize_openai_image_size(size),  # type: ignore[arg-type]
             n=1,
             extra_body=extra_body,
         )

--- a/apps/agent-service/app/agent/tools/image.py
+++ b/apps/agent-service/app/agent/tools/image.py
@@ -6,7 +6,7 @@ Merges the old image/read.py, image/generate.py, and image/processor.py.
 from __future__ import annotations
 
 import logging
-from typing import Annotated, Any
+from typing import Annotated, Any, Literal
 
 from pydantic import Field
 
@@ -15,6 +15,14 @@ from app.agent.tooling import tool
 from app.agent.tools._common import tool_error, upload_and_register
 
 logger = logging.getLogger(__name__)
+
+ImageQuality = Literal["high", "normal"]
+
+_DEFAULT_IMAGE_QUALITY: ImageQuality = "high"
+_IMAGE_MODEL_BY_QUALITY: dict[ImageQuality, str] = {
+    "high": "generate-image-high-model",
+    "normal": "generate-image-normal-model",
+}
 
 
 # =========================================================================
@@ -81,6 +89,10 @@ async def generate_image(
         list[str] | None,
         Field(description='参考图片列表，使用 @N.png 文件名，如 ["4.png", "5.png"]'),
     ] = None,
+    quality: Annotated[
+        ImageQuality,
+        Field(description="生成质量。high 更精细；normal 更快更稳定。不要询问或提及具体模型。"),
+    ] = _DEFAULT_IMAGE_QUALITY,
 ) -> str | list[dict[str, Any]]:
     """生成图片。调用前必须先 load_skill("drawing") 加载画图指南并遵循其流程。"""
     context = get_context()
@@ -101,19 +113,32 @@ async def generate_image(
 
     logger.info("Image generation request: %s", query)
 
-    model_name = "default-generate-image-model"
-    if context.get_feature("image_model"):
-        model_name = context.get_feature("image_model")
-        logger.info("Feature flag overrides image model to: %s", model_name)
-
     from app.agent.image_gen import generate_image as _gen_image
 
-    base64_images = await _gen_image(
-        model_name,
-        prompt=query,
-        size=size,
-        reference_images=reference_urls if reference_urls else None,
-    )
+    base64_images: list[str] = []
+    last_error: Exception | None = None
+    for candidate_label, model_name in _model_candidates(
+        quality,
+        image_model_override=context.get_feature("image_model"),
+    ):
+        try:
+            base64_images = await _gen_image(
+                model_name,
+                prompt=query,
+                size=size,
+                reference_images=reference_urls if reference_urls else None,
+            )
+            if base64_images:
+                if candidate_label not in {quality, "override"}:
+                    logger.info("Image generation fell back to %s quality", candidate_label)
+                break
+            last_error = RuntimeError("image generation returned no images")
+            logger.warning("Image generation returned no images for %s", candidate_label)
+        except Exception as exc:
+            last_error = exc
+            logger.warning("Image generation failed for %s: %s", candidate_label, exc)
+    else:
+        raise RuntimeError("图片生成服务暂时不可用") from last_error
 
     content_blocks: list[dict[str, Any]] = []
     filenames: list[str] = []
@@ -144,3 +169,24 @@ async def generate_image(
     )
 
     return content_blocks
+
+
+def _quality_candidates(quality: str) -> list[ImageQuality]:
+    if quality == "high":
+        return ["high", "normal"]
+    if quality == "normal":
+        return ["normal"]
+    raise ValueError("quality must be high or normal")
+
+
+def _model_candidates(
+    quality: str,
+    *,
+    image_model_override: Any = None,
+) -> list[tuple[str, str]]:
+    if image_model_override:
+        return [("override", str(image_model_override))]
+    return [
+        (candidate, _IMAGE_MODEL_BY_QUALITY[candidate])
+        for candidate in _quality_candidates(quality)
+    ]

--- a/apps/agent-service/app/agent/tools/image.py
+++ b/apps/agent-service/app/agent/tools/image.py
@@ -79,11 +79,16 @@ async def read_images(
 async def generate_image(
     query: Annotated[
         str,
-        Field(description="英文生成图片提示词。按 drawing skill 指南撰写。"),
+        Field(description="英文生成图片提示词。具体描述主体、画面、环境和风格。"),
     ],
     size: Annotated[
         str,
-        Field(description="图片尺寸。可选值：1K、2K、4K 或像素值如 2048x2048"),
+        Field(
+            description=(
+                "目标画幅，使用像素格式，如 2048x2048、1536x2048、2048x1152；"
+                "后端会映射到模型支持的最近尺寸。"
+            )
+        ),
     ] = "2048x2048",
     image_list: Annotated[
         list[str] | None,
@@ -94,7 +99,7 @@ async def generate_image(
         Field(description="生成质量。high 更精细；normal 更快更稳定。不要询问或提及具体模型。"),
     ] = _DEFAULT_IMAGE_QUALITY,
 ) -> str | list[dict[str, Any]]:
-    """生成图片。调用前必须先 load_skill("drawing") 加载画图指南并遵循其流程。"""
+    """生成图片。普通明确画图请求可直接调用；涉及三姐妹或 Cosplay 时，先 load_skill("drawing") 加载人物画图指南。"""
     context = get_context()
     registry = context.image_registry
 

--- a/apps/agent-service/tests/unit/agent/test_image_gen.py
+++ b/apps/agent-service/tests/unit/agent/test_image_gen.py
@@ -18,6 +18,8 @@ import pytest
 
 from app.agent import image_gen as mod
 from app.agent.image_gen import (
+    _normalize_ark_image_size,
+    _normalize_openai_image_size,
     _parse_gemini_size,
     generate_image,
 )
@@ -68,6 +70,23 @@ class TestParseGeminiSize:
         ar, sz = _parse_gemini_size("1920x1080")
         assert ar == "16:9"
         assert sz == "2K"
+
+
+class TestNormalizeImageSize:
+    def test_ark_lowercases_k_size(self):
+        assert _normalize_ark_image_size("2K") == "2k"
+
+    def test_ark_preserves_pixel_size(self):
+        assert _normalize_ark_image_size("1920x1080") == "1920x1080"
+
+    def test_openai_maps_landscape_pixels_to_supported_size(self):
+        assert _normalize_openai_image_size("1920x1080") == "1536x1024"
+
+    def test_openai_maps_portrait_pixels_to_supported_size(self):
+        assert _normalize_openai_image_size("1080x1920") == "1024x1536"
+
+    def test_openai_maps_k_size_to_square(self):
+        assert _normalize_openai_image_size("2K") == "1024x1024"
 
 
 # ---------------------------------------------------------------------------
@@ -185,6 +204,7 @@ class TestGenerateImageArk:
         assert result == ["data:image/jpeg;base64,abc123"]
         call_kwargs = mock_client.images.generate.call_args.kwargs
         assert call_kwargs["prompt"] == "a cat"
+        assert call_kwargs["size"] == "1024x1024"
         assert call_kwargs["image"] is None
         assert "sequential_image_generation" not in call_kwargs
         mock_client.close.assert_called_once()
@@ -236,6 +256,7 @@ class TestGenerateImageOpenai:
         assert result == ["data:image/jpeg;base64,oai_result"]
         call_kwargs = mock_client_instance.images.generate.call_args.kwargs
         assert call_kwargs["extra_body"] == {"watermark": False}
+        assert call_kwargs["size"] == "1024x1024"
         assert mock_cls.call_args.kwargs["timeout"] == 60.0
         assert mock_cls.call_args.kwargs["max_retries"] == 3
         mock_client_instance.close.assert_called_once()

--- a/apps/agent-service/tests/unit/agent/test_image_gen.py
+++ b/apps/agent-service/tests/unit/agent/test_image_gen.py
@@ -2,9 +2,10 @@
 
 Covers:
   - _parse_gemini_size: pixel sizes, shorthand, fallback
-  - generate_image dispatch: ark, openai, google
+  - generate_image dispatch: ark, openai, azure-http, google
   - _generate_image_ark: mock AsyncArk, verify params including reference_images
   - _generate_image_openai: mock AsyncOpenAI, verify proxy handling
+  - _generate_image_azure: mock AsyncAzureOpenAI, verify ModelHub-safe params
   - _generate_image_gemini: mock genai.Client, verify empty response raises RuntimeError
 """
 
@@ -132,6 +133,27 @@ class TestGenerateImageDispatch:
 
         assert result == ["data:image/jpeg;base64,def"]
         mock_openai.assert_called_once()
+
+    async def test_dispatch_azure_http(self):
+        with (
+            patch(
+                "app.agent.image_gen.resolve_model_info",
+                new_callable=AsyncMock,
+                return_value=_fake_info(client_type="azure-http"),
+            ),
+            patch.object(
+                mod,
+                "_generate_image_azure",
+                new_callable=AsyncMock,
+                return_value=["data:image/jpeg;base64,azure"],
+            ) as mock_azure,
+        ):
+            result = await generate_image(
+                "img-model", prompt="a dog", size="1536x2048"
+            )
+
+        assert result == ["data:image/jpeg;base64,azure"]
+        mock_azure.assert_called_once()
 
     async def test_dispatch_google(self):
         with (
@@ -317,6 +339,68 @@ class TestGenerateImageOpenai:
         # Both clients closed
         mock_client_instance.close.assert_called_once()
         mock_http_client.aclose.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# _generate_image_azure
+# ---------------------------------------------------------------------------
+
+
+class TestGenerateImageAzure:
+    async def test_basic_generation_uses_azure_protocol_and_supported_params(self):
+        mock_img = SimpleNamespace(b64_json="azure_result", url=None)
+        mock_resp = SimpleNamespace(data=[mock_img])
+
+        mock_client_instance = AsyncMock()
+        mock_client_instance.images.generate = AsyncMock(return_value=mock_resp)
+        mock_client_instance.close = AsyncMock()
+
+        info = _fake_info(
+            model_name="gpt-image-2",
+            base_url="https://modelhub.test/v2/crawl",
+            client_type="azure-http",
+        )
+        with patch(
+            "openai.AsyncAzureOpenAI", return_value=mock_client_instance
+        ) as mock_cls:
+            result = await mod._generate_image_azure(
+                info,
+                "a dog",
+                "1536x2048",
+                None,
+            )
+
+        assert result == ["data:image/jpeg;base64,azure_result"]
+        init_kwargs = mock_cls.call_args.kwargs
+        assert init_kwargs["azure_endpoint"] == "https://modelhub.test/v2/crawl"
+        assert init_kwargs["azure_deployment"] == "gpt-image-2"
+        assert init_kwargs["max_retries"] == 0
+
+        call_kwargs = mock_client_instance.images.generate.call_args.kwargs
+        assert call_kwargs == {
+            "model": "gpt-image-2",
+            "response_format": "b64_json",
+            "prompt": "a dog",
+            "size": "1024x1536",
+            "n": 1,
+        }
+        mock_client_instance.close.assert_called_once()
+
+    async def test_reference_urls_fail_before_request(self):
+        mock_client_instance = AsyncMock()
+
+        with (
+            patch("openai.AsyncAzureOpenAI", return_value=mock_client_instance),
+            pytest.raises(ValueError, match="reference image URLs"),
+        ):
+            await mod._generate_image_azure(
+                _fake_info(client_type="azure-http"),
+                "edit this",
+                "1024x1024",
+                ["https://example.com/ref.jpg"],
+            )
+
+        mock_client_instance.images.generate.assert_not_called()
 
 
 # ---------------------------------------------------------------------------

--- a/apps/agent-service/tests/unit/agent/test_image_gen.py
+++ b/apps/agent-service/tests/unit/agent/test_image_gen.py
@@ -5,7 +5,7 @@ Covers:
   - generate_image dispatch: ark, openai, azure-http, google
   - _generate_image_ark: mock AsyncArk, verify params including reference_images
   - _generate_image_openai: mock AsyncOpenAI, verify proxy handling
-  - _generate_image_azure: mock AsyncAzureOpenAI, verify ModelHub-safe params
+  - _generate_image_azure: mock AsyncOpenAI, verify ModelHub image API contract
   - _generate_image_gemini: mock genai.Client, verify empty response raises RuntimeError
 """
 
@@ -267,7 +267,9 @@ class TestGenerateImageOpenai:
         mock_client_instance.images.generate = AsyncMock(return_value=mock_resp)
         mock_client_instance.close = AsyncMock()
 
-        with patch("openai.AsyncOpenAI", return_value=mock_client_instance) as mock_cls:
+        with patch(
+            "openai.AsyncOpenAI", return_value=mock_client_instance
+        ) as mock_cls:
             result = await mod._generate_image_openai(
                 _fake_info(),
                 "a dog",
@@ -347,7 +349,7 @@ class TestGenerateImageOpenai:
 
 
 class TestGenerateImageAzure:
-    async def test_basic_generation_uses_azure_protocol_and_supported_params(self):
+    async def test_basic_generation_uses_modelhub_openai_image_api(self):
         mock_img = SimpleNamespace(b64_json="azure_result", url=None)
         mock_resp = SimpleNamespace(data=[mock_img])
 
@@ -360,9 +362,7 @@ class TestGenerateImageAzure:
             base_url="https://modelhub.test/v2/crawl",
             client_type="azure-http",
         )
-        with patch(
-            "openai.AsyncAzureOpenAI", return_value=mock_client_instance
-        ) as mock_cls:
+        with patch("openai.AsyncOpenAI", return_value=mock_client_instance) as mock_cls:
             result = await mod._generate_image_azure(
                 info,
                 "a dog",
@@ -370,19 +370,20 @@ class TestGenerateImageAzure:
                 None,
             )
 
-        assert result == ["data:image/jpeg;base64,azure_result"]
+        assert result == ["data:image/png;base64,azure_result"]
         init_kwargs = mock_cls.call_args.kwargs
-        assert init_kwargs["azure_endpoint"] == "https://modelhub.test/v2/crawl"
-        assert init_kwargs["azure_deployment"] == "gpt-image-2"
+        assert init_kwargs["base_url"] == (
+            "https://aidp.bytedance.net/api/modelhub/online/v2/crawl/openai"
+        )
         assert init_kwargs["max_retries"] == 0
 
         call_kwargs = mock_client_instance.images.generate.call_args.kwargs
         assert call_kwargs == {
             "model": "gpt-image-2",
-            "response_format": "b64_json",
             "prompt": "a dog",
             "size": "1024x1536",
             "n": 1,
+            "extra_headers": {"api-key": "sk-test"},
         }
         mock_client_instance.close.assert_called_once()
 
@@ -390,7 +391,7 @@ class TestGenerateImageAzure:
         mock_client_instance = AsyncMock()
 
         with (
-            patch("openai.AsyncAzureOpenAI", return_value=mock_client_instance),
+            patch("openai.AsyncOpenAI", return_value=mock_client_instance),
             pytest.raises(ValueError, match="reference image URLs"),
         ):
             await mod._generate_image_azure(

--- a/apps/agent-service/tests/unit/agent/tools/test_image_tool.py
+++ b/apps/agent-service/tests/unit/agent/tools/test_image_tool.py
@@ -20,6 +20,21 @@ async def test_generate_image_exposes_quality_levels_without_model_names():
     assert "gpt-image" not in str(schema).lower()
 
 
+async def test_generate_image_allows_general_requests_without_loading_drawing_skill():
+    definition = image_tool.generate_image.definition
+    query_description = definition.parameters["properties"]["query"]["description"]
+    size_description = definition.parameters["properties"]["size"]["description"]
+
+    assert "普通明确画图请求可直接调用" in definition.description
+    assert "涉及三姐妹或 Cosplay" in definition.description
+    assert "必须先 load_skill" not in definition.description
+    assert "drawing skill" not in query_description
+    assert "像素格式" in size_description
+    assert "1K" not in size_description
+    assert "2K" not in size_description
+    assert "4K" not in size_description
+
+
 async def test_generate_image_defaults_to_high_and_falls_back_to_normal():
     generated = AsyncMock(
         side_effect=[

--- a/apps/agent-service/tests/unit/agent/tools/test_image_tool.py
+++ b/apps/agent-service/tests/unit/agent/tools/test_image_tool.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.agent.context import AgentContext
+from app.agent.runtime_context import agent_context
+from app.agent.tools import image as image_tool
+
+pytestmark = pytest.mark.unit
+
+
+async def test_generate_image_exposes_quality_levels_without_model_names():
+    schema = image_tool.generate_image.definition.parameters["properties"]
+
+    assert schema["quality"]["enum"] == ["high", "normal"]
+    assert "modelhub" not in str(schema).lower()
+    assert "doubao" not in str(schema).lower()
+    assert "gpt-image" not in str(schema).lower()
+
+
+async def test_generate_image_defaults_to_high_and_falls_back_to_normal():
+    generated = AsyncMock(
+        side_effect=[
+            RuntimeError("primary failed"),
+            ["data:image/jpeg;base64,abc"],
+        ]
+    )
+
+    with (
+        agent_context(AgentContext()),
+        patch("app.agent.image_gen.generate_image", generated),
+        patch.object(
+            image_tool,
+            "upload_and_register",
+            new=AsyncMock(return_value=("https://tos/1.png", "1.png")),
+        ),
+    ):
+        result = await image_tool.generate_image.invoke(
+            {"query": "a cat", "size": "1920x1080"}
+        )
+
+    assert isinstance(result, list)
+    assert [call.args[0] for call in generated.call_args_list] == [
+        "generate-image-high-model",
+        "generate-image-normal-model",
+    ]
+    assert "modelhub" not in str(result).lower()
+    assert "doubao" not in str(result).lower()
+
+
+async def test_generate_image_normal_uses_only_normal_model():
+    generated = AsyncMock(return_value=["data:image/jpeg;base64,abc"])
+
+    with (
+        agent_context(AgentContext()),
+        patch("app.agent.image_gen.generate_image", generated),
+        patch.object(
+            image_tool,
+            "upload_and_register",
+            new=AsyncMock(return_value=("https://tos/1.png", "1.png")),
+        ),
+    ):
+        await image_tool.generate_image.invoke(
+            {"query": "a cat", "size": "1920x1080", "quality": "normal"}
+        )
+
+    assert [call.args[0] for call in generated.call_args_list] == [
+        "generate-image-normal-model",
+    ]
+
+
+async def test_generate_image_high_empty_result_falls_back_to_normal():
+    generated = AsyncMock(
+        side_effect=[
+            [],
+            ["data:image/jpeg;base64,abc"],
+        ]
+    )
+
+    with (
+        agent_context(AgentContext()),
+        patch("app.agent.image_gen.generate_image", generated),
+        patch.object(
+            image_tool,
+            "upload_and_register",
+            new=AsyncMock(return_value=("https://tos/1.png", "1.png")),
+        ),
+    ):
+        await image_tool.generate_image.invoke({"query": "a cat"})
+
+    assert [call.args[0] for call in generated.call_args_list] == [
+        "generate-image-high-model",
+        "generate-image-normal-model",
+    ]
+
+
+async def test_generate_image_keeps_internal_feature_override():
+    generated = AsyncMock(return_value=["data:image/jpeg;base64,abc"])
+
+    with (
+        agent_context(AgentContext(features={"image_model": "override-alias"})),
+        patch("app.agent.image_gen.generate_image", generated),
+        patch.object(
+            image_tool,
+            "upload_and_register",
+            new=AsyncMock(return_value=("https://tos/1.png", "1.png")),
+        ),
+    ):
+        await image_tool.generate_image.invoke(
+            {"query": "a cat", "quality": "high"}
+        )
+
+    assert [call.args[0] for call in generated.call_args_list] == ["override-alias"]
+
+
+async def test_generate_image_double_failure_does_not_expose_model_names():
+    generated = AsyncMock(
+        side_effect=[
+            RuntimeError("modelhub/gpt-image-2 failed"),
+            RuntimeError("doubao/ep-20251024125110-4xhl4 failed"),
+        ]
+    )
+
+    with (
+        agent_context(AgentContext()),
+        patch("app.agent.image_gen.generate_image", generated),
+    ):
+        result = await image_tool.generate_image.invoke({"query": "a cat"})
+
+    assert isinstance(result, dict)
+    visible = str(result).lower()
+    assert "modelhub" not in visible
+    assert "gpt-image" not in visible
+    assert "doubao" not in visible
+    assert "ep-20251024125110" not in visible


### PR DESCRIPTION
## Summary
- expose high/normal image quality without provider model names
- route high quality to ModelHub gpt-image-2 and fall back to Doubao
- normalize provider-specific image sizes and relax image tool invocation
- use the official ModelHub OpenAI image endpoint

## Verification
- uv run pytest tests/unit/agent/test_image_gen.py tests/unit/agent/tools/test_image_tool.py -q (33 passed)
- uv run ruff check app/agent/image_gen.py tests/unit/agent/test_image_gen.py
- direct gpt-image-2 request returned a valid 1024x1024 PNG in 14.7s
- agent-service PPE version 1.2.0.126 is Ready