### PR TITLE
fix(agent-service): dedup chat/life duplicate replies, retry empty LLM output

### DIFF
--- a/apps/agent-service/app/agent/core.py
+++ b/apps/agent-service/app/agent/core.py
@@ -117,6 +117,20 @@ _BACKOFF_MAX = 8  # seconds (clamp)
 # stays equivalent to the langchain path.
 _DEFAULT_RECURSION_LIMIT = 6
 
+# Max attempts (including the first) for ONE ReAct turn when the model returns
+# an empty result — no text, no tool_calls (trace 82323210372fe067ec2a60abd8e9
+# fdb3: a gemini-3.5-flash generate_image closure turn came back as
+# ``{"text": "", "tool_calls": []}``, silently passed through as the final
+# reply). 3 gives the model two independent extra samples to recover from what
+# looks like a decoding glitch rather than a deterministic refusal, while
+# staying inside the "2-3 attempts" a one-off empty turn should reasonably
+# cost. This budget is spent entirely INSIDE one turn (same transcript, no new
+# messages, no tool re-dispatch) and is independent of ``recursion_limit``
+# (which counts ReAct turns, not raw model calls) — the normal, non-empty path
+# still costs exactly one model call, so this never adds latency/cost to the
+# common case.
+_EMPTY_TURN_MAX_ATTEMPTS = 3
+
 
 # ---------------------------------------------------------------------------
 # Agent configuration
@@ -409,6 +423,72 @@ def _is_terminal_tool_call(call: ToolCall) -> bool:
     return call.name in _TERMINAL_TOOL_NAMES
 
 
+def _is_empty_turn(text: str, tool_calls: list[ToolCall]) -> bool:
+    """Whether one model turn produced nothing usable: no tool_calls AND no
+    non-whitespace text.
+
+    ``text`` should be the turn's plain-text view (``Message.text()`` for
+    ``_run_loop``, the joined streamed text parts for ``_stream_loop``) —
+    reasoning is deliberately excluded from both: a turn that only "thought"
+    (``reasoning_content`` set, or streamed ``reasoning`` chunks) without
+    producing text or a tool_call is still empty, because reasoning is never
+    surfaced to the user.
+    """
+    return not tool_calls and not text.strip()
+
+
+def _model_label(model: ModelClient) -> str:
+    """Best-effort model identifier for the empty-turn warning log.
+
+    ``ModelClient`` has no public "which model" accessor; both real adapters
+    (openai, gemini) stash the resolved model name on the private ``_model``
+    attribute. Falling back to the class name keeps this purely diagnostic —
+    never load-bearing — so a fake/test client or a future adapter without
+    that attribute still logs something useful instead of raising.
+    """
+    return getattr(model, "_model", None) or type(model).__name__
+
+
+async def _complete_turn(
+    model: ModelClient,
+    convo: list[Message],
+    tool_defs: list[ToolDef] | None,
+    call_kwargs: dict[str, Any],
+) -> Message:
+    """Call ``model.complete`` for one ReAct turn, transparently retrying THIS
+    SAME turn (identical ``convo``, nothing appended, no tools dispatched) up
+    to ``_EMPTY_TURN_MAX_ATTEMPTS`` times when the model returns an empty
+    result (see ``_is_empty_turn``).
+
+    Exhausting the budget changes nothing about the return value or control
+    flow below this call — the caller gets whatever ``Message`` the last
+    attempt produced (possibly still empty), exactly as it always has. Only a
+    warning log marks the exhaustion, so this never introduces a new exception
+    type or return shape: raising here would let the exception escape into
+    ``app.chat.render.render_chat_turn``'s broad ``except Exception`` (default
+    ``on_error="yield_text"``), which turns ANY non-``RenderFailed`` exception
+    into user-facing error text — exactly the "send something anyway" outcome
+    this fix exists to prevent.
+    """
+    last = await model.complete(convo, tools=tool_defs, **call_kwargs)
+    attempts = 1
+    while (
+        _is_empty_turn(last.text(), last.tool_calls)
+        and attempts < _EMPTY_TURN_MAX_ATTEMPTS
+    ):
+        attempts += 1
+        last = await model.complete(convo, tools=tool_defs, **call_kwargs)
+    if _is_empty_turn(last.text(), last.tool_calls):
+        logger.warning(
+            "agent turn empty (no text, no tool_calls) after %d/%d attempts; "
+            "model=%s",
+            attempts,
+            _EMPTY_TURN_MAX_ATTEMPTS,
+            _model_label(model),
+        )
+    return last
+
+
 async def _run_loop(
     model: ModelClient,
     *,
@@ -456,7 +536,7 @@ async def _run_loop(
     last: Message | None = None
 
     for _ in range(max(1, recursion_limit)):
-        last = await model.complete(convo, tools=tool_defs, **call_kwargs)
+        last = await _complete_turn(model, convo, tool_defs, call_kwargs)
         if not last.tool_calls:
             if transcript_sink is not None:
                 transcript_sink.append(last)
@@ -527,16 +607,48 @@ async def _stream_loop(
     for _ in range(max(1, recursion_limit)):
         text_parts: list[str] = []
         reasoning_parts: list[str] = []
-        turn_calls = []
+        turn_calls: list[ToolCall] = []
+        attempts = 0
 
-        async for chunk in model.stream(convo, tools=tool_defs, **call_kwargs):
-            if chunk.text:
-                text_parts.append(chunk.text)
-            if chunk.reasoning:
-                reasoning_parts.append(chunk.reasoning)
-            if chunk.tool_call is not None:
-                turn_calls.append(chunk.tool_call)
-            yield chunk
+        # Transparent single-turn retry, mirroring _complete_turn: an empty
+        # attempt (no text, no tool_calls — see _is_empty_turn) re-issues
+        # model.stream for the SAME turn (identical convo, nothing appended,
+        # no tools dispatched) instead of being accepted as the final turn.
+        # Chunks are still forwarded live as they arrive (yield below) so a
+        # normal turn keeps true token-by-token streaming — only once this
+        # attempt's stream is fully drained do we know whether it was empty.
+        # An empty attempt only ever carried reasoning / a bare finish_reason
+        # (never non-whitespace text or a tool_call, by definition), so
+        # nothing user-visible needs to be undone when we loop for another
+        # attempt. Exhausting the budget changes nothing about what happens
+        # below — same control flow, same shape — only a log marks it (see
+        # _complete_turn's docstring for why this must never raise instead).
+        while True:
+            attempts += 1
+            text_parts = []
+            reasoning_parts = []
+            turn_calls = []
+
+            async for chunk in model.stream(convo, tools=tool_defs, **call_kwargs):
+                if chunk.text:
+                    text_parts.append(chunk.text)
+                if chunk.reasoning:
+                    reasoning_parts.append(chunk.reasoning)
+                if chunk.tool_call is not None:
+                    turn_calls.append(chunk.tool_call)
+                yield chunk
+
+            empty_turn = _is_empty_turn("".join(text_parts), turn_calls)
+            if not empty_turn or attempts >= _EMPTY_TURN_MAX_ATTEMPTS:
+                if empty_turn:
+                    logger.warning(
+                        "agent stream turn empty (no text, no tool_calls) after "
+                        "%d/%d attempts; model=%s",
+                        attempts,
+                        _EMPTY_TURN_MAX_ATTEMPTS,
+                        _model_label(model),
+                    )
+                break
 
         if not turn_calls:
             # final assistant turn — never appended to convo, so capture it for

--- a/apps/agent-service/app/domain/world_events.py
+++ b/apps/agent-service/app/domain/world_events.py
@@ -88,11 +88,25 @@ from app.runtime.persist import insert_idempotent
 #                      但也不能无条件断言"此刻正在发生"——信箱积压 / cd 重排 / 补敲对账
 #                      都可能让送达延迟，渲染侧要带诚实的感知时刻时间锚（见 life_wake
 #                      的 ``_format_idle_sense``），态度介于两者之间。
+#   * ``own_chat_reply`` chat 对真人的回复已经发出去了（chat/life 并发重复回复修复）：
+#                      chat_node 确认一段回复内容确实要发给真人后，把这段回复原文
+#                      ``deliver_event`` 进对应 persona **自己**的信箱，让并发被别的
+#                      event 唤醒的 life 也能在 ``list_unread_events`` 里可靠读到「我刚
+#                      对这次交互回复了什么」，不再依赖对 ``common_message`` 异步落库
+#                      时序的假设（旧路径：chat 只 emit 不带内容的 ``EventArrived``，
+#                      life 醒来时实时查 ``common_message`` 猜"有没有回过"，channel-server
+#                      落库慢于 5s debounce 触发时会误判、重复生成一次相近回复）。不是
+#                      "不主动唤醒、下次自然醒来才读到"的被动 kind——**仍然主动唤醒**
+#                      life（不在 ``PASSIVE_EVENT_KINDS`` 里），只是内容来源从"猜"变成
+#                      "确定收到"，所以不复用 #279 删除的被动 ``EVENT_KIND_EXTERNAL_
+#                      PASSIVE``，另起一个语义清晰的新 kind。``source`` 固定为
+#                      ``"chat"``（区别于姐妹直投 speech/message 的 persona_id 来源）。
 EVENT_KIND_AMBIENT = "ambient"
 EVENT_KIND_SURROUNDINGS = "surroundings"
 EVENT_KIND_SPEECH = "speech"
 EVENT_KIND_MESSAGE = "message"
 EVENT_KIND_IDLE_SENSE = "idle_sense"
+EVENT_KIND_OWN_CHAT_REPLY = "own_chat_reply"
 
 
 # 被动 event kind——单一定义处，写 / 读两端都从这里取（宪法「禁止重复定义」）。语义：

--- a/apps/agent-service/app/nodes/chat_node.py
+++ b/apps/agent-service/app/nodes/chat_node.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import time
+import uuid
 from uuid import uuid4
 
 # MessageRouter / emit / 各 helper 都 imported at module level so 单元测试可
@@ -32,13 +33,24 @@ from app.data.queries import (
     resolve_bot_name_for_persona,
     set_agent_response_bot,
 )
+from app.data.queries.mailbox import (
+    deliver_event,  # module-level so tests can monkeypatch
+)
 from app.domain.chat_dataflow import ChatRequest, ChatResponseSegment, ChatTrigger
-from app.domain.world_events import EventArrived
+from app.domain.world_events import EVENT_KIND_OWN_CHAT_REPLY
+from app.infra import cst_time
 from app.life.feed_whitelist import should_feed_chat_to_life
 from app.nodes._chat_pre_safety import _resolve_pre_safety_for_part
 from app.runtime import node
 from app.runtime.emit import emit
 from app.runtime.lane_policy import current_deployment_lane
+
+# chat 已回复投信箱的 event_id 派生命名空间：固定 UUID，让同一次 (lane, message_id,
+# persona_id) 重投(mq redelivery / ChatRequest 重放)派生同一 event_id，
+# deliver_event 按 (lane, persona, event_id) 幂等去重，不重复叫醒。与
+# world/tools.py、life_wake.py 里各自的 event_id 派生命名空间分开，避免同文字撞 id
+# （同一惯例见 app.world.tools._EVENT_ID_NS 系列注释）。
+_CHAT_REPLY_EVENT_NS = uuid.UUID("d3a8f1c2-6b4e-4f9a-8c1d-2e3f4a5b6c7d")
 
 logger = logging.getLogger(__name__)
 
@@ -320,11 +332,34 @@ async def chat_node(req: ChatRequest) -> None:
     if result.blocked:
         await _emit_block_guard()
         return
+    # 显式判空:LLM 单轮偶发返回空文本+空 tool_calls(trace
+    # 82323210372fe067ec2a60abd8e9fdb3)时,render_chat_turn 整段吐不出任何
+    # token,final_content 会落到 `remaining or full_content` 的兜底分支——
+    # remaining 已 strip 过,但兜底用的 full_content 未 strip,纯空白 token
+    # (只吐空格/换行)会在这里绕过朴素的真值判断被当"非空"内容。channel-server
+    # 侧(chat-response-handler.ts)本来就有"content 为空 + is_last=True → 不
+    # 发送给用户但标记 completed"的分支,只是它用 JS 的 `!content` 判真值——非空
+    # 白字符串(比如一个空格)是 truthy,会绕过那个分支被当"非空"内容真的发出
+    # 去,这正是用户偶发看到"空气泡"的根因。这里把即将 emit 的 content strip
+    # 干净,真正为空的会变成空字符串,命中 channel-server 已有的正确分支(不
+    # 发送、但仍标记完成)。不能直接跳过这次 emit——那样会让 channel-server 永
+    # 远收不到这一轮的收尾消息,common_agent_response.status 卡在 pending 拿不
+    # 到完成标记,is_chat_request_completed 的重投短路判断也会跟着失效。
+    final_text = result.content.strip()
+    if not final_text:
+        logger.warning(
+            "chat_node final segment empty after strip: "
+            "session_id=%s persona_id=%s message_id=%s part_index=%s",
+            req.session_id,
+            req.persona_id,
+            req.message_id,
+            part_index,
+        )
     await emit(
         ChatResponseSegment(
             **base_payload,
             part_index=part_index,
-            content=result.content,
+            content=final_text,
             status="success",
             is_last=True,
             full_content=clean_full,
@@ -350,16 +385,53 @@ async def chat_node(req: ChatRequest) -> None:
         },
     )
 
-    await _wake_life_after_chat(req)
+    # Task 1 与 Task 3 的执行顺序命门:clean_full 是「这一轮实际发给用户的完整
+    # 内容」(SPLIT_MARKER 已还原、已 strip)——不管 final 段是否被上面判空跳过,
+    # clean_full 忠实反映的都只是"真正发出去的那些字"(final 段被跳过时,
+    # clean_full 的尾部本来就只是空白、strip 后自然不带出未发送的内容)。只有
+    # clean_full 非空(这一轮确实有内容发给了用户)才投递信箱告诉 life「我刚回复
+    # 了什么」;完全空的一轮(判空检查让什么都没发出去)不告诉她"我刚回复了",
+    # 避免对着一段没发出去的空回复,还让 life 以为已经处理过这次交互。
+    if clean_full:
+        await _wake_life_after_chat(req, reply_text=clean_full)
 
 
-async def _wake_life_after_chat(req: ChatRequest) -> None:
-    """chat 完成后只做纯唤醒，不再把对话内容写进 life 信箱。
+def _derive_chat_reply_event_id(
+    *, lane: str, message_id: str, persona_id: str
+) -> str:
+    """确定性派生一条「chat 已回复」投信箱 event 的 id（重投幂等）。
 
-    对话内容是持续状态，life 醒来时会实时从 ``common_message`` 拉「最近聊过的对话」。
-    这里的副作用只解决一件事：刚发生过一次 chat，敲一下对应 persona，让她有机会立刻
-    读取实时对话上下文。真人私聊直接唤醒；群聊必须在白名单内才唤醒。唤醒失败只记
-    warning，不影响已经 emit 出去的即时回复。
+    ChatRequest 按 (message_id, persona_id) 是自然键，同一次交互的重投（MQ
+    redelivery / 整轮重放）派生同一 id，``deliver_event`` 按 (lane, persona,
+    event_id) 幂等去重，不会重复投递、也不会重复敲门唤醒 life。
+    """
+    return uuid.uuid5(
+        _CHAT_REPLY_EVENT_NS, f"{lane}\x1f{message_id}\x1f{persona_id}"
+    ).hex
+
+
+async def _wake_life_after_chat(req: ChatRequest, reply_text: str) -> None:
+    """chat 确认这段回复内容已经发出去后，把回复原文投进 life 的 durable 信箱。
+
+    旧实现只 ``emit(EventArrived(...))`` 纯敲门、不带内容，life 醒来时靠实时查
+    ``common_message`` 猜"我是否已经回复过这句话"——但 chat 的回复是由
+    channel-server 的 chat-response-worker 在飞书发送成功后才异步落库的，存在
+    时序竞态：落库慢于 life 的 5 秒 debounce 触发时，life 会误判"没人回过"，自己
+    再生成一次内容相近的回复。
+
+    改用 ``deliver_event``（world notify / npc_visit 等既有场景同款的 durable
+    信箱投递机制）：回复原文落 durable 表，不受 ``EventArrived`` 的 debounce
+    折叠影响——同一 5 秒窗口内即使还有别的唤醒事件到达，最先投递的这条内容依旧
+    完整躺在信箱里，被唤醒的那一轮 ``life_wake_node`` 靠 ``list_unread_events``
+    扫描整个信箱、不靠"是哪一条 EventArrived 触发了这一轮"来找内容。
+
+    ``deliver_event`` 内部对新投递的非被动 event 会自己 ``emit(EventArrived(...))``
+    敲门唤醒（``own_chat_reply`` 不在 ``PASSIVE_EVENT_KINDS`` 里），所以这里**不再
+    自己额外 emit** —— 否则会敲两次门、造成重复唤醒。
+
+    真人私聊直接投递（不查白名单）；群聊必须在白名单内才投递。投递/唤醒失败只记
+    warning，不影响已经 emit 出去的即时回复（回复已经发给用户了，这里失败只是
+    life 少了一次"及时"的机会，不是回复本身失败）。
     """
     if not req.persona_id:
         return
@@ -375,8 +447,21 @@ async def _wake_life_after_chat(req: ChatRequest) -> None:
         return
 
     lane = current_deployment_lane() or "prod"
+    event_id = _derive_chat_reply_event_id(
+        lane=lane, message_id=req.message_id, persona_id=req.persona_id
+    )
     try:
-        await emit(EventArrived(lane=lane, persona_id=req.persona_id))
+        await deliver_event(
+            lane=lane,
+            persona_id=req.persona_id,
+            event_id=event_id,
+            summary=reply_text,
+            occurred_at=cst_time.now_cst_iso(),
+            kind=EVENT_KIND_OWN_CHAT_REPLY,
+            source="chat",
+            chat_id=req.chat_id,
+            chat_scope="direct" if req.is_p2p else "group",
+        )
     except Exception as e:  # noqa: BLE001 — chat 回复已发出，唤醒副作用失败不拖垮回复
         logger.warning(
             "chat life wake failed: lane=%s persona=%s chat=%s is_p2p=%s: %s",

--- a/apps/agent-service/app/nodes/life_tools.py
+++ b/apps/agent-service/app/nodes/life_tools.py
@@ -96,6 +96,7 @@ from app.domain.recipient_directory import (
 )
 from app.domain.world_events import (
     EVENT_KIND_MESSAGE,
+    EVENT_KIND_OWN_CHAT_REPLY,
     EVENT_KIND_SPEECH,
     perform_act,
 )
@@ -659,6 +660,41 @@ def build_life_tools(
                     full_content=rendered,
                 )
             )
+
+            # chat/life 并发重复回复同款修复：emit 出站成功（这句话确实要发出去）之后，
+            # 把渲染后的原话投进**发送者自己**（persona_id）的信箱——不是收件人的（真人/
+            # 群没有 life 信箱）。这条主动发和 chat_node._wake_life_after_chat 面对的是
+            # 同一个根因：都是先 emit(ChatResponseSegment(...)) 走 chat-response-worker
+            # 异步落库，如果这次发送之后、common_message 真正落库之前又有新的事件触发了
+            # 下一轮 life_wake，下一轮同样会在 find_persona_related_chats_recent 里查不到
+            # 这句话，可能对同一话题又主动开口一次、且措辞和这次不一致（prod 已用 ops-db
+            # 查库 + Langfuse trace 实锤复现过：两条 response_id 均为 null 的主动发消息，
+            # 相隔 3 分钟对同一件事说法前后矛盾）。kind 复用同一个 EVENT_KIND_OWN_CHAT_
+            # REPLY，life_wake 侧 _format_own_chat_reply 不区分 chat 回复还是主动发，都
+            # 呈现成"你刚回复了/说了：xxx"。失败只记 warning，不拖垮已经发出的消息——
+            # 消息已经入队，这里失败只是下一轮 life 少了一次"及时"的机会。
+            try:
+                await deliver_event(
+                    lane=lane,
+                    persona_id=persona_id,
+                    event_id=str(
+                        uuid.uuid5(
+                            uuid.NAMESPACE_OID, f"{proactive_message_id}:own_reply"
+                        )
+                    ),
+                    summary=rendered,
+                    occurred_at=observed_at,
+                    kind=EVENT_KIND_OWN_CHAT_REPLY,
+                    source="life",
+                    chat_id=chat_id,
+                    chat_scope=chat_scope,
+                )
+            except Exception as e:  # noqa: BLE001 — 消息已发出，投信箱失败不拖垮发送
+                logger.warning(
+                    "[life_tools] %s proactive own-reply mailbox delivery failed "
+                    "(uid=%s): %s",
+                    persona_id, uid, e, exc_info=True,
+                )
 
         if isinstance(target, LarkP2PTarget):
             # 真人（飞书私聊）→ 共享渲染 + 出站；is_p2p=True、chat_id=真实 p2p 会话 id。

--- a/apps/agent-service/app/nodes/life_wake.py
+++ b/apps/agent-service/app/nodes/life_wake.py
@@ -89,6 +89,7 @@ from app.domain.world_events import (
     EVENT_KIND_AMBIENT,
     EVENT_KIND_IDLE_SENSE,
     EVENT_KIND_MESSAGE,
+    EVENT_KIND_OWN_CHAT_REPLY,
     EVENT_KIND_SPEECH,
     EVENT_KIND_SURROUNDINGS,
     EventArrived,
@@ -505,6 +506,26 @@ def _format_messages(messages: list[EventEnvelope]) -> str:
     )
 
 
+def _format_own_chat_reply(own_replies: list[EventEnvelope]) -> str:
+    """把 chat 已发出的回复（kind=own_chat_reply）拼成"你自己刚说的话"，按发生先后。
+
+    这是 chat/life 并发重复回复修复的核心呈现：chat_node 确认一段回复内容确实发给
+    了真人后，把回复原文 ``deliver_event`` 进这个 persona 自己的信箱（见
+    ``app.nodes.chat_node._wake_life_after_chat``）。这条内容存在的唯一目的是让
+    被并发唤醒的 life 明确知道"这次交互我已经回复过了、回复的是什么"——不再依赖对
+    ``common_message`` 的实时查询去猜"我是否已经回复过这句话"（那条路径与
+    channel-server 异步落库存在时序竞态，是重复回复的根因）。
+
+    呈现上刻意强调"这是你自己刚发出去的话"、"不用再回一遍"，与当面话（speech，
+    别人对她说的）、离散动静（dynamics，环境里发生的客观事）明确区分——绝不能让
+    模型把自己刚发的回复误当成"外部发生的一件事"又去回应一次。
+    """
+    return "\n".join(
+        f"（{cst_time.to_cst_hms(ev.occurred_at)}）你刚回复了：{ev.summary}"
+        for ev in own_replies
+    )
+
+
 def _split_perception(
     unread: list[EventEnvelope],
 ) -> tuple[
@@ -513,12 +534,14 @@ def _split_perception(
     list[EventEnvelope],
     list[EventEnvelope],
     list[EventEnvelope],
+    list[EventEnvelope],
 ]:
-    """把未读分成（闲时主动切片, 周遭切片, 当面话, 手机消息, 离散动静），各保持原始
-    （按发生先后）顺序。
+    """把未读分成（闲时主动切片, 周遭切片, 当面话, 手机消息, 你刚回复的话, 离散动静），
+    各保持原始（按发生先后）顺序。
 
-    五类语义不同、stimulus 里分层呈现（两个正交维度各自标清，spec 决策 7；闲时主动切片
-    是 life-idle-wake-via-sense Task 1 新增的第五类）：
+    六类语义不同、stimulus 里分层呈现（两个正交维度各自标清，spec 决策 7；闲时主动切片
+    是 life-idle-wake-via-sense Task 1 新增，你刚回复的话是 chat/life 并发重复回复修复
+    新增）：
 
       * 闲时主动切片（kind=idle_sense）—— world 判断她此刻处于天然闲时刻时用
         sense(idle=True) 投的周遭切片，内容形态同 surroundings、但它是这一轮唤醒她的
@@ -529,18 +552,24 @@ def _split_perception(
       * 手机消息（kind=message）—— 另一角色不在一起时 send_message 隔空发来的消息
         「X 给你发消息：内容」（task 3 / 5）。**通信介质维度**：隔着手机/飞书发的，与当面
         speech 收件人侧必须可区分（spec 决策 5：否则又把「当面还是手机」混为一谈）。
+      * 你刚回复的话（kind=own_chat_reply）—— chat 已经确认发给真人的回复原文，让 life
+        知道"这次交互我已经回复过了"，不用再靠猜（chat/life 并发重复回复修复）。这是她
+        **自己**发的话，绝不能混进离散动静或当面话——否则会被误当成"发生在她身上的一件
+        客观动静 / 别人对她说的话"，反而诱发她再回应一次，恰好与修复目的相反。
       * 离散动静（其余 kind）—— 环境里出现的新声响光线气味等。
 
-    按 kind 五分（不改各自内部顺序——``list_unread_events`` 已按真实时刻升序）。message
-    必须从 dynamics 桶排除（必改 ①）——否则会被 :func:`_format_dynamics` 当离散动静渲染
-    成「[message] ...」，与当面话混淆。idle_sense 同理必须从 surroundings / dynamics
-    两个桶都排除——混进 surroundings 会套上不适合它的"上一次感知到的周遭...可能已经变了"
-    旧快照框，混进 dynamics 会失去它作为"此刻"的叙事形态、被压成一行机读列表项。
+    按 kind 六分（不改各自内部顺序——``list_unread_events`` 已按真实时刻升序）。message /
+    own_chat_reply 都必须从 dynamics 桶排除——否则会被 :func:`_format_dynamics` 当离散
+    动静渲染成「[message] ...」/「[own_chat_reply] ...」，与当面话 / "这是我自己刚说的
+    话" 的语义混淆。idle_sense 同理必须从 surroundings / dynamics 两个桶都排除——混进
+    surroundings 会套上不适合它的"上一次感知到的周遭...可能已经变了"旧快照框，混进
+    dynamics 会失去它作为"此刻"的叙事形态、被压成一行机读列表项。
     """
     idle_sense = [e for e in unread if e.kind == EVENT_KIND_IDLE_SENSE]
     surroundings = [e for e in unread if e.kind == EVENT_KIND_SURROUNDINGS]
     speech = [e for e in unread if e.kind == EVENT_KIND_SPEECH]
     messages = [e for e in unread if e.kind == EVENT_KIND_MESSAGE]
+    own_replies = [e for e in unread if e.kind == EVENT_KIND_OWN_CHAT_REPLY]
     dynamics = [
         e
         for e in unread
@@ -550,9 +579,10 @@ def _split_perception(
             EVENT_KIND_SURROUNDINGS,
             EVENT_KIND_SPEECH,
             EVENT_KIND_MESSAGE,
+            EVENT_KIND_OWN_CHAT_REPLY,
         )
     ]
-    return idle_sense, surroundings, speech, messages, dynamics
+    return idle_sense, surroundings, speech, messages, own_replies, dynamics
 
 
 # 「最近聊过的对话」段的拉取上限（条目数量控制规模、不字符截断——见 no_context_truncation）：
@@ -1082,8 +1112,8 @@ async def _run_life_round(
             f"（心情 {snapshot.response_mood}、活动 {snapshot.activity_type}）。"
         )
 
-    # 五官分层呈现（1C Task 2 + Task 3 + task 5 + life-idle-wake-via-sense Task 1）：
-    # 她信箱里有五类，分层呈现两个正交维度（spec 决策 7）——
+    # 五官分层呈现（1C Task 2 + Task 3 + task 5 + life-idle-wake-via-sense Task 1 +
+    # chat/life 并发重复回复修复）：她信箱里有六类，分层呈现两个正交维度（spec 决策 7）——
     #   * 「这一刻」（idle_sense，world 判断她此刻处于天然闲时刻时主动投的周遭切片）——
     #     这一轮唤醒她的理由，不套被动周遭切片那种"可能已经变了"的怀疑框，但也不能
     #     无条件断言"此刻确实是这样"（信箱积压 / cd 重排可能延迟送达）——带诚实的
@@ -1095,15 +1125,22 @@ async def _run_life_round(
     #   * 「别人隔着手机给你发的消息」（message，另一角色不在一起时 send_message 隔空发的
     #     「X 给你发消息：内容」，task 3 / 5）—— **通信介质维度**：隔着手机/飞书，不是当面。
     #     与当面 speech 收件人侧明确可区分（spec 决策 5：否则又把「当面还是手机」混为一谈）。
+    #   * 「你刚回复的话」（own_chat_reply，chat_node 确认发给真人的回复原文
+    #     ``deliver_event`` 进信箱，见 chat/life 并发重复回复修复）—— 让她可靠知道
+    #     "这次交互我已经回复过了、回复的是什么"，不用再靠对 common_message 的实时查询猜
+    #     （那条路径与 channel-server 异步落库存在时序竞态，是重复回复的根因）。
     #   * 「离散动静」（ambient 等，环境里出现的新声响这类事件）。
     # 分层呈现让她既感知到这一刻是不是被主动唤醒、自己周遭什么样（物理在场）、又看清谁
-    # 当面说了话 / 谁隔手机发了消息（通信介质两态）、还知道刚发生了什么动静（五类不互相
-    # 混淆）。五类都只取自她自己信箱的未读（_format_* 只取 summary/source/kind/时间，全是
-    # 投给她的、她够得着的），绝不含 world 全局快照——信息差命门由 world 逐角色推演产出
-    # 每人切片守住，不在这里。speech / message 都是直投（不经 world），原话/内容只在收件人
-    # 这条流里出现、world 那条流绝不含（承重红线，由 chat / send_message 工具双轨守住）。
+    # 当面说了话 / 谁隔手机发了消息（通信介质两态）、还记得自己刚回复过什么、还知道刚
+    # 发生了什么动静（六类不互相混淆）。六类都只取自她自己信箱的未读（_format_* 只取
+    # summary/source/kind/时间，全是投给她的、她够得着的），绝不含 world 全局快照——
+    # 信息差命门由 world 逐角色推演产出每人切片守住，不在这里。speech / message /
+    # own_chat_reply 都是直投（不经 world），原话/内容只在收件人这条流里出现、world 那条
+    # 流绝不含（承重红线，由 chat / send_message 工具三轨守住）。
     if unread:
-        idle_sense, surroundings, speech, messages, dynamics = _split_perception(unread)
+        idle_sense, surroundings, speech, messages, own_replies, dynamics = (
+            _split_perception(unread)
+        )
         if idle_sense:
             parts.append(
                 "【这一刻】（这份场景是这一轮真正唤醒你的理由，见下方它的感知时刻）：\n"
@@ -1127,6 +1164,15 @@ async def _run_life_round(
                 "【有人隔着手机给你发消息】（你们这会儿不在一起、隔着手机/飞书发来的，"
                 "不是当面说的，按发生先后）：\n"
                 f"{_format_messages(messages)}"
+            )
+        if own_replies:
+            # chat/life 并发重复回复修复：这是她**自己**刚发出去的话，绝不能和「别人
+            # 对你说话」/「离散动静」混在一起——混进去会被误当成"外部又来了一件事"，
+            # 诱发她再回应一次，与修复目的相反。
+            parts.append(
+                "【你刚对这次交流的回复】（这是你自己刚发出去的话，不是别人对你说的，"
+                "已经发过了、不用再回一遍）：\n"
+                f"{_format_own_chat_reply(own_replies)}"
             )
         if dynamics:
             parts.append(

--- a/apps/agent-service/tests/nodes/test_chat_node.py
+++ b/apps/agent-service/tests/nodes/test_chat_node.py
@@ -467,6 +467,103 @@ async def test_chat_node_no_split_emits_single_final_segment(monkeypatch, base_r
 
 
 @pytest.mark.asyncio
+async def test_chat_node_skips_fully_empty_final_segment(monkeypatch, base_request):
+    """LLM 单轮返回空文本+空 tool_calls 时(trace 82323210372fe067ec2a60abd8e9fdb3
+    的收尾轮场景),render_chat_turn 的 stream 从头到尾不产出任何 token。
+    channel-server 侧(chat-response-handler.ts)本来就有"content 为空 +
+    is_last=True → 不发送给用户但标记 completed"的分支,所以 chat_node 仍要
+    emit 这条收尾消息(不能整段跳过,否则 common_agent_response.status 永远卡
+    在 pending、拿不到完成标记),只是 content 必须是真正的空字符串,不能带任何
+    空气泡文案。"""
+    from app.nodes import chat_node as cn
+
+    async def fake_pre(*a, **k):
+        from app.domain.safety import PreSafetyVerdict
+        return PreSafetyVerdict(pre_request_id="x", message_id="m1", is_blocked=False)
+
+    async def fake_stream(*a, **k):
+        return
+        yield  # pragma: no cover - 让函数保持 async generator 形态，但从不 yield
+
+    async def fake_resolve(p, c): return "bot-x"
+    async def fake_set(*a, **k): pass
+    async def fake_find_msg(mid): return "input"
+    async def fake_find_gray(mid): return {}
+    async def fake_guard(p): return "guard"
+
+    monkeypatch.setattr(cn, "find_message_content", fake_find_msg)
+    monkeypatch.setattr(cn, "find_gray_config", fake_find_gray)
+    monkeypatch.setattr(cn, "fetch_guard_message", fake_guard)
+    monkeypatch.setattr(cn, "run_pre_safety_check", fake_pre)
+    monkeypatch.setattr(cn, "resolve_bot_name_for_persona", fake_resolve)
+    monkeypatch.setattr(cn, "set_agent_response_bot", fake_set)
+    _patch_context(monkeypatch, cn)
+    monkeypatch.setattr(cn, "render_chat_turn", fake_stream)
+
+    emitted = []
+    async def fake_emit(d): emitted.append(d)
+    monkeypatch.setattr(cn, "emit", fake_emit)
+
+    await cn.chat_node(base_request)
+
+    segments = _chat_segments(emitted)
+    assert len(segments) == 1, "仍要 emit 一条收尾消息,让 channel-server 能标记完成"
+    assert segments[0].content == "", "content 必须是真正的空字符串,不能带空气泡文案"
+    assert segments[0].is_last is True
+    assert segments[0].status == "success"
+
+
+@pytest.mark.asyncio
+async def test_chat_node_skips_whitespace_only_final_segment(monkeypatch, base_request):
+    """LLM 只吐出空白字符(非严格空串)时,emit 出去的 content 必须被 strip 干净。
+
+    复现原 final_content 兜底分支的坑：``remaining`` strip 后为空、
+    ``part_index == 0`` 时会退回**未 strip** 的 ``full_content``——若
+    ``full_content`` 本身只是空白（如模型吐了几个空格 / 换行 token），未 strip
+    的空白字符串在 Python 侧是 truthy。channel-server 侧用 JS 的 ``!content``
+    判断是否要发送,非空白字符串(比如一个空格)在 JS 里同样是 truthy,会绕过
+    channel-server 已有的空内容分支被当"非空"内容真的发出去——这正是用户偶发
+    看到"空气泡"的根因。这里必须确保 emit 出去的 content 是 strip 后的空字符
+    串,而不是原始空白。"""
+    from app.nodes import chat_node as cn
+
+    async def fake_pre(*a, **k):
+        from app.domain.safety import PreSafetyVerdict
+        return PreSafetyVerdict(pre_request_id="x", message_id="m1", is_blocked=False)
+
+    async def fake_stream(*a, **k):
+        for p in ["  ", "\n", " "]:
+            yield p
+
+    async def fake_resolve(p, c): return "bot-x"
+    async def fake_set(*a, **k): pass
+    async def fake_find_msg(mid): return "input"
+    async def fake_find_gray(mid): return {}
+    async def fake_guard(p): return "guard"
+
+    monkeypatch.setattr(cn, "find_message_content", fake_find_msg)
+    monkeypatch.setattr(cn, "find_gray_config", fake_find_gray)
+    monkeypatch.setattr(cn, "fetch_guard_message", fake_guard)
+    monkeypatch.setattr(cn, "run_pre_safety_check", fake_pre)
+    monkeypatch.setattr(cn, "resolve_bot_name_for_persona", fake_resolve)
+    monkeypatch.setattr(cn, "set_agent_response_bot", fake_set)
+    _patch_context(monkeypatch, cn)
+    monkeypatch.setattr(cn, "render_chat_turn", fake_stream)
+
+    emitted = []
+    async def fake_emit(d): emitted.append(d)
+    monkeypatch.setattr(cn, "emit", fake_emit)
+
+    await cn.chat_node(base_request)
+
+    segments = _chat_segments(emitted)
+    assert len(segments) == 1
+    assert segments[0].content == "", "空白字符不能绕过 strip 被当成非空内容发出去"
+    assert segments[0].is_last is True
+    assert segments[0].status == "success"
+
+
+@pytest.mark.asyncio
 async def test_resolve_pre_safety_for_part_fail_open_on_timeout():
     """Helper should return ALLOW with original content when pre_task times out."""
     from app.nodes.chat_node import _resolve_pre_safety_for_part

--- a/apps/agent-service/tests/nodes/test_chat_node_group_wake.py
+++ b/apps/agent-service/tests/nodes/test_chat_node_group_wake.py
@@ -1,16 +1,26 @@
-"""chat 完成后的 life 唤醒契约。
+"""chat 完成后的 life 唤醒契约（chat/life 并发重复回复修复）。
 
-chat 内容不再回灌进 EventEnvelope 信箱。life 醒来时会实时从 common_message 拉
-「最近聊过的对话」。chat_node 的事后副作用只剩：私聊完成后纯 emit EventArrived
-叫醒对应 persona；群聊必须过白名单；白名单外群不唤醒。
+chat 完成一轮回复后,不再只 emit 一条不带内容的 ``EventArrived`` 敲门信号——
+那条信号本身走 debounce,同一 5 秒窗口内多条到达时只有最后发布的一条会被消费,
+更早的连同其字段一起被当 stale 丢弃(参见 app/runtime/debounce.py),把回复内容
+塞进这个会被折叠丢弃的信号里,在并发唤醒场景下会静默丢内容。
+
+改用项目里已有的 durable 信箱投递机制 ``deliver_event``(world notify / npc_visit
+等既有场景在用同一套):内容落 durable 表,不受 debounce 折叠影响；``deliver_event``
+内部本身会在新投递的非被动 event 上 emit ``EventArrived`` 触发唤醒,chat_node 不必
+(也不应该)再自己额外 emit 一次,否则会重复唤醒。
+
+真人私聊直接唤醒(不查白名单)；群聊必须在白名单内才唤醒。唤醒失败只记 warning,
+不影响已经 emit 出去的即时回复。
 """
 
 from __future__ import annotations
 
 import pytest
 
+from app.data.queries.mailbox import deliver_event as real_deliver_event
 from app.domain.chat_dataflow import ChatRequest, ChatResponseSegment
-from app.domain.world_events import EventArrived
+from app.domain.world_events import EVENT_KIND_OWN_CHAT_REPLY, EventArrived
 
 
 def _happy_path_mocks(cn, monkeypatch, *, user_msg="input", reply_parts=None):
@@ -81,14 +91,20 @@ def _request(*, is_p2p: bool, chat_id="chat-1") -> ChatRequest:
 
 
 @pytest.mark.asyncio
-async def test_p2p_chat_wakes_life_without_whitelist(monkeypatch):
-    """真人私聊完成后纯唤醒 life，且不查群白名单。"""
+async def test_p2p_chat_delivers_reply_content_without_whitelist(monkeypatch):
+    """真人私聊完成后把回复内容投进信箱(deliver_event),且不查群白名单。"""
     from app.nodes import chat_node as cn
 
-    _happy_path_mocks(cn, monkeypatch)
+    _happy_path_mocks(cn, monkeypatch, reply_parts=["hello there"])
 
     async def should_not_be_called(**kwargs):
         raise AssertionError("p2p path must not consult group whitelist")
+
+    delivered = []
+
+    async def fake_deliver_event(**kwargs):
+        delivered.append(kwargs)
+        return 1
 
     emitted = []
 
@@ -96,72 +112,98 @@ async def test_p2p_chat_wakes_life_without_whitelist(monkeypatch):
         emitted.append(data)
 
     monkeypatch.setattr(cn, "should_feed_chat_to_life", should_not_be_called)
+    monkeypatch.setattr(cn, "deliver_event", fake_deliver_event)
     monkeypatch.setattr(cn, "emit", fake_emit)
 
     await cn.chat_node(_request(is_p2p=True))
 
     assert any(isinstance(e, ChatResponseSegment) for e in emitted)
-    knocks = [e for e in emitted if isinstance(e, EventArrived)]
-    assert len(knocks) == 1
-    assert knocks[0].persona_id == "akao"
+    # chat_node 自己绝不再直接 emit EventArrived —— deliver_event 内部会做这件事,
+    # 这里若还出现 EventArrived 说明重复唤醒了一次。
+    assert not any(isinstance(e, EventArrived) for e in emitted), (
+        "chat_node 不应再自己直接 emit(EventArrived(...))，"
+        "deliver_event 内部已经会做这件事，否则重复唤醒"
+    )
+    assert len(delivered) == 1
+    call = delivered[0]
+    assert call["persona_id"] == "akao"
+    assert call["kind"] == EVENT_KIND_OWN_CHAT_REPLY
+    assert "hello there" in call["summary"], "投递的内容必须是实际发给用户的回复原文"
+    assert call["event_id"], "event 必须带稳定标识以应对重投/重复消费"
 
 
 @pytest.mark.asyncio
-async def test_whitelisted_group_chat_wakes_life_after_reply(monkeypatch):
-    """白名单群聊完成后纯 emit EventArrived，lane 取进程部署泳道。"""
+async def test_whitelisted_group_chat_delivers_reply_after_reply(monkeypatch):
+    """白名单群聊完成后投递回复内容进信箱，lane 取进程部署泳道。"""
     from app.nodes import chat_node as cn
 
-    _happy_path_mocks(cn, monkeypatch)
+    _happy_path_mocks(cn, monkeypatch, reply_parts=["group hello"])
     monkeypatch.setenv("LANE", "coe-t1")
     whitelist_calls = []
+    delivered = []
     emitted = []
 
     async def fake_should_feed(*, chat_id, is_p2p):
         whitelist_calls.append((chat_id, is_p2p))
         return True
 
+    async def fake_deliver_event(**kwargs):
+        delivered.append(kwargs)
+        return 1
+
     async def fake_emit(data):
         emitted.append(data)
 
     monkeypatch.setattr(cn, "should_feed_chat_to_life", fake_should_feed)
+    monkeypatch.setattr(cn, "deliver_event", fake_deliver_event)
     monkeypatch.setattr(cn, "emit", fake_emit)
 
     await cn.chat_node(_request(is_p2p=False, chat_id="group-1"))
 
     assert whitelist_calls == [("group-1", False)]
-    knocks = [e for e in emitted if isinstance(e, EventArrived)]
-    assert len(knocks) == 1
-    assert knocks[0].lane == "coe-t1"
-    assert knocks[0].persona_id == "akao"
-    assert any(isinstance(e, ChatResponseSegment) for e in emitted)
-
-
-@pytest.mark.asyncio
-async def test_non_whitelisted_group_chat_does_not_wake_life(monkeypatch):
-    """白名单外群聊只回复，不叫醒 life。"""
-    from app.nodes import chat_node as cn
-
-    _happy_path_mocks(cn, monkeypatch)
-    emitted = []
-
-    async def fake_should_feed(*, chat_id, is_p2p):
-        return False
-
-    async def fake_emit(data):
-        emitted.append(data)
-
-    monkeypatch.setattr(cn, "should_feed_chat_to_life", fake_should_feed)
-    monkeypatch.setattr(cn, "emit", fake_emit)
-
-    await cn.chat_node(_request(is_p2p=False, chat_id="group-2"))
-
+    assert len(delivered) == 1
+    call = delivered[0]
+    assert call["lane"] == "coe-t1"
+    assert call["persona_id"] == "akao"
+    assert call["kind"] == EVENT_KIND_OWN_CHAT_REPLY
+    assert "group hello" in call["summary"]
     assert any(isinstance(e, ChatResponseSegment) for e in emitted)
     assert not any(isinstance(e, EventArrived) for e in emitted)
 
 
 @pytest.mark.asyncio
+async def test_non_whitelisted_group_chat_does_not_deliver(monkeypatch):
+    """白名单外群聊只回复，不投递信箱、不唤醒 life。"""
+    from app.nodes import chat_node as cn
+
+    _happy_path_mocks(cn, monkeypatch)
+    emitted = []
+    delivered = []
+
+    async def fake_should_feed(*, chat_id, is_p2p):
+        return False
+
+    async def fake_deliver_event(**kwargs):
+        delivered.append(kwargs)
+        return 1
+
+    async def fake_emit(data):
+        emitted.append(data)
+
+    monkeypatch.setattr(cn, "should_feed_chat_to_life", fake_should_feed)
+    monkeypatch.setattr(cn, "deliver_event", fake_deliver_event)
+    monkeypatch.setattr(cn, "emit", fake_emit)
+
+    await cn.chat_node(_request(is_p2p=False, chat_id="group-2"))
+
+    assert any(isinstance(e, ChatResponseSegment) for e in emitted)
+    assert not delivered
+    assert not any(isinstance(e, EventArrived) for e in emitted)
+
+
+@pytest.mark.asyncio
 async def test_group_wake_failure_does_not_fail_chat(monkeypatch):
-    """群聊纯唤醒失败只记 warning，不拖垮已经发出的 chat 回复。"""
+    """群聊投递信箱失败只记 warning，不拖垮已经发出的 chat 回复。"""
     from app.nodes import chat_node as cn
 
     _happy_path_mocks(cn, monkeypatch)
@@ -170,14 +212,63 @@ async def test_group_wake_failure_does_not_fail_chat(monkeypatch):
     async def fake_should_feed(*, chat_id, is_p2p):
         return True
 
+    async def fake_deliver_event(**kwargs):
+        raise RuntimeError("pg unavailable")
+
     async def fake_emit(data):
-        if isinstance(data, EventArrived):
-            raise RuntimeError("redis unavailable")
         emitted_segments.append(data)
 
     monkeypatch.setattr(cn, "should_feed_chat_to_life", fake_should_feed)
+    monkeypatch.setattr(cn, "deliver_event", fake_deliver_event)
     monkeypatch.setattr(cn, "emit", fake_emit)
 
     await cn.chat_node(_request(is_p2p=False, chat_id="group-3"))
 
     assert any(isinstance(e, ChatResponseSegment) for e in emitted_segments)
+
+
+@pytest.mark.asyncio
+async def test_empty_final_reply_does_not_wake_life(monkeypatch):
+    """回复整轮只有空白字符时,chat_node 仍要 emit 一条 content="" 的收尾消息
+    (让 channel-server 标记 completed,见 chat-response-handler.ts 的既有空内容
+    分支),但不应该投递信箱告诉 life「我刚回复了」——Task 1 与 Task 3 的顺序命门:
+    没有实际发出去的内容,就不告诉 life 已经回复过。
+    """
+    from app.nodes import chat_node as cn
+
+    _happy_path_mocks(cn, monkeypatch, reply_parts=["   ", "\n"])
+    delivered = []
+
+    async def fake_should_feed(*, chat_id, is_p2p):
+        return True
+
+    async def fake_deliver_event(**kwargs):
+        delivered.append(kwargs)
+        return 1
+
+    emitted = []
+
+    async def fake_emit(data):
+        emitted.append(data)
+
+    monkeypatch.setattr(cn, "should_feed_chat_to_life", fake_should_feed)
+    monkeypatch.setattr(cn, "deliver_event", fake_deliver_event)
+    monkeypatch.setattr(cn, "emit", fake_emit)
+
+    await cn.chat_node(_request(is_p2p=True))
+
+    segments = [e for e in emitted if isinstance(e, ChatResponseSegment)]
+    assert len(segments) == 1, "仍要 emit 收尾消息,让 channel-server 能标记完成"
+    assert segments[0].content == "", "空白回复的 content 必须被 strip 成空字符串"
+    assert not delivered, "没有实际发出去的内容时不该投递信箱告诉 life 已经回复过"
+
+
+@pytest.mark.asyncio
+async def test_wake_life_after_chat_calls_real_deliver_event_with_own_chat_reply_kind(
+    monkeypatch,
+):
+    """契约测试:确认 chat_node 模块引用的确实是 app.data.queries.mailbox.deliver_event
+    这一个真实实现(而不是随便一个同名 stub),且默认走 kind=own_chat_reply、非被动。"""
+    from app.nodes import chat_node as cn
+
+    assert cn.deliver_event is real_deliver_event

--- a/apps/agent-service/tests/nodes/test_life_tools.py
+++ b/apps/agent-service/tests/nodes/test_life_tools.py
@@ -2658,8 +2658,10 @@ async def test_send_message_to_person_renders_through_chat_turn_then_emits(
     assert cc["user_id"] == "u-real-1"
     # 渲染层被调（喂渲染后出站）。
     assert len(stub_directory["render_args"]) == 1
-    # 真人不进信箱（真人没有 life 信箱）。
-    assert stub_handlers["delivered"] == []
+    # 真人自己不进信箱（真人没有 life 信箱），但发送者（akao 自己）的信箱要收到一条
+    # "我刚回复了什么"（chat/life 并发重复回复修复同款机制，详见
+    # test_send_message_to_person_delivers_own_reply_to_sender_mailbox）。
+    assert len(stub_handlers["delivered"]) == 1
     # 恰好 emit 一条出站段。
     assert len(stub_directory["emitted"]) == 1
     seg = stub_directory["emitted"][0]
@@ -2679,6 +2681,50 @@ async def test_send_message_to_person_renders_through_chat_turn_then_emits(
     assert seg.is_last is True, "主动发是一段完整消息（worker 据 is_last 收口）"
     # full_content 是渲染后完整文本（worker 据它收口）。
     assert seg.full_content == "嘿，在忙吗？想问问你周末有没有空一起吃个饭呀～"
+
+
+@pytest.mark.asyncio
+async def test_send_message_to_person_delivers_own_reply_to_sender_mailbox(
+    stub_handlers, stub_directory
+):
+    """真人分支 emit 出站成功后，把渲染后的原话投进**发送者自己**（persona_id）的信箱，
+    kind=EVENT_KIND_OWN_CHAT_REPLY —— 和 chat_node._wake_life_after_chat 同一套机制、
+    同一个 kind。
+
+    根因（prod 已用 ops-db + Langfuse trace 实锤复现）：主动发消息和 chat 回复一样，都
+    是先 emit(ChatResponseSegment(...)) 走 chat-response-worker 异步落库，同样存在时序
+    竞态——如果这次主动发之后、common_message 真正落库之前又有新的 life_wake 被触发，
+    下一轮同样会看不到"我刚主动说过这句话"，导致连续主动开口两次、且措辞可能前后不
+    一致。这里补的信箱投递就是让下一轮 life_wake 不再依赖那次异步落库。
+    """
+    from app.domain.world_events import EVENT_KIND_OWN_CHAT_REPLY
+
+    stub_directory["resolve_result"] = stub_directory["_LarkP2PTarget"](
+        common_conversation_id="cc-direct-1",
+        bot_name="chiwei",
+        user_id="u-real-1",
+        channel="lark",
+    )
+    stub_directory["render_text"] = "嘿，在忙吗？想问问你周末有没有空一起吃个饭呀～"
+    tools = _tools_by_name(
+        lt.build_life_tools(
+            lane="coe-t3", persona_id="akao", act_id="a-1",
+            observed_at="2026-06-03T12:30:00+00:00",
+        )
+    )
+    await tools["send_message"].invoke(
+        {"uid": "user:u-real-1", "content": "想问他周末有没有空一起吃饭"}
+    )
+
+    assert len(stub_handlers["delivered"]) == 1
+    d = stub_handlers["delivered"][0]
+    assert d["lane"] == "coe-t3"
+    assert d["persona_id"] == "akao", "投给发送者自己，不是收件的真人（真人没有信箱）"
+    assert d["summary"] == "嘿，在忙吗？想问问你周末有没有空一起吃个饭呀～", (
+        "投递的是渲染后真正发出去的话，不是 life 给的意图原文"
+    )
+    assert d["kind"] == EVENT_KIND_OWN_CHAT_REPLY
+    assert d["occurred_at"] == "2026-06-03T12:30:00+00:00"
 
 
 @pytest.mark.asyncio
@@ -3241,8 +3287,10 @@ async def test_send_message_to_group_renders_and_emits_group_segment(
     )
 
     assert isinstance(out, str) and out
-    # 群不进信箱（群没有 life 信箱）。
-    assert stub_handlers["delivered"] == []
+    # 群本身不进信箱（群没有 life 信箱），但发送者（akao 自己）的信箱要收到一条
+    # "我刚回复了什么"（同 p2p 分支，详见
+    # test_send_message_to_group_delivers_own_reply_to_sender_mailbox）。
+    assert len(stub_handlers["delivered"]) == 1
     # 恰好 emit 一条群出站段。
     assert len(stub_directory["emitted"]) == 1
     seg = stub_directory["emitted"][0]
@@ -3259,6 +3307,41 @@ async def test_send_message_to_group_renders_and_emits_group_segment(
     assert seg.is_last is True
     assert not seg.root_id, "群主动发没有来源消息，root_id 不伪造"
     assert seg.full_content == "刚那个话题我也想接一句～"
+
+
+@pytest.mark.asyncio
+async def test_send_message_to_group_delivers_own_reply_to_sender_mailbox(
+    stub_handlers, stub_directory
+):
+    """群分支 emit 出站成功后，同样把渲染后的原话投进发送者自己（persona_id）的信箱，
+    kind=EVENT_KIND_OWN_CHAT_REPLY —— 对称 p2p 分支（同一根因：群主动发一样先 emit 走
+    chat-response-worker 异步落库，一样存在时序竞态）。
+    """
+    from app.domain.world_events import EVENT_KIND_OWN_CHAT_REPLY
+
+    stub_directory["resolve_result"] = stub_directory["_GroupTarget"](
+        common_conversation_id="cc-group-1",
+        bot_name="chiwei",
+        channel="lark",
+    )
+    stub_directory["render_text"] = "刚那个话题我也想接一句～"
+    tools = _tools_by_name(
+        lt.build_life_tools(
+            lane="coe-t3", persona_id="akao", act_id="a-1",
+            observed_at="2026-06-03T12:30:00+00:00",
+        )
+    )
+    await tools["send_message"].invoke(
+        {"uid": "group:cc-group-1", "content": "想接着群里的话题说一句"}
+    )
+
+    assert len(stub_handlers["delivered"]) == 1
+    d = stub_handlers["delivered"][0]
+    assert d["lane"] == "coe-t3"
+    assert d["persona_id"] == "akao", "投给发送者自己，不是群（群没有信箱）"
+    assert d["summary"] == "刚那个话题我也想接一句～", "投递的是渲染后真正发出去的话"
+    assert d["kind"] == EVENT_KIND_OWN_CHAT_REPLY
+    assert d["occurred_at"] == "2026-06-03T12:30:00+00:00"
 
 
 @pytest.mark.asyncio

--- a/apps/agent-service/tests/nodes/test_life_wake.py
+++ b/apps/agent-service/tests/nodes/test_life_wake.py
@@ -33,6 +33,7 @@ from app.domain.world_events import (
     EVENT_KIND_AMBIENT,
     EVENT_KIND_IDLE_SENSE,
     EVENT_KIND_MESSAGE,
+    EVENT_KIND_OWN_CHAT_REPLY,
     EVENT_KIND_SPEECH,
     EVENT_KIND_SURROUNDINGS,
     EventArrived,
@@ -1271,30 +1272,38 @@ async def test_message_not_lumped_into_ambient_dynamics(patched, monkeypatch):
     assert "给你发消息" in msg_blob
 
 
-def test_split_perception_five_way_idle_sense_and_message_separate_buckets():
-    """_split_perception 把未读五分：闲时主动切片 / 周遭 / 当面话 / 手机消息 / 离散动静
-    （task 5 必改 ① + life-idle-wake-via-sense Task 1）。
+def test_split_perception_six_way_idle_sense_and_own_chat_reply_separate_buckets():
+    """_split_perception 把未读六分：闲时主动切片 / 周遭 / 当面话 / 手机消息 /
+    自己刚回复过 / 离散动静（task 5 必改 ① + life-idle-wake-via-sense Task 1 +
+    chat/life 并发重复回复修复）。
 
     message kind 必须单独成一桶、绝不和 ambient 混进 dynamics —— 否则 _format_dynamics
     会把手机消息当离散动静渲染（「[message] ...」），又制造一遍当面/手机混淆。
     idle_sense（world 判断为闲时刻的主动周遭切片）同理必须独立成桶、不能被塞进被动
     surroundings 桶——否则会套上不适合它的"上一次感知到的周遭...可能已经变了"旧快照
-    框（那是唤醒她的当下理由，被框成旧快照会自相矛盾）。
+    框（那是唤醒她的当下理由，被框成旧快照会自相矛盾）。``own_chat_reply``（chat/life
+    并发重复回复修复新增 kind）同理必须单独成一桶、绝不和 ambient 混进 dynamics ——
+    否则 ``_format_dynamics`` 会把"我刚回复了什么"当离散动静渲染
+    （「[own_chat_reply] ...」），模型读不出"这是我自己说的话"。
     """
     unread = [
         _envelope("i1", "你窝在沙发上", kind=EVENT_KIND_IDLE_SENSE),
         _envelope("s1", "你在客厅", kind=EVENT_KIND_SURROUNDINGS),
         _envelope("sp1", "当面说的话", kind=EVENT_KIND_SPEECH, source="akao"),
         _envelope("msg1", "手机发来的", kind=EVENT_KIND_MESSAGE, source="chinagi"),
+        _envelope("r1", "你刚回复的内容", kind=EVENT_KIND_OWN_CHAT_REPLY, source="chat"),
         _envelope("a1", "开关门声", kind=EVENT_KIND_AMBIENT),
     ]
-    idle_sense, surroundings, speech, messages, dynamics = lw._split_perception(unread)
+    idle_sense, surroundings, speech, messages, own_replies, dynamics = (
+        lw._split_perception(unread)
+    )
     assert [e.event_id for e in idle_sense] == ["i1"], "idle_sense 必须单独成一桶"
     assert [e.event_id for e in surroundings] == ["s1"]
     assert [e.event_id for e in speech] == ["sp1"]
     assert [e.event_id for e in messages] == ["msg1"], "message 必须单独成一桶"
+    assert [e.event_id for e in own_replies] == ["r1"], "own_chat_reply 必须单独成一桶"
     assert [e.event_id for e in dynamics] == ["a1"], (
-        "dynamics 只剩 ambient，不含 message / idle_sense"
+        "dynamics 只剩 ambient，不含 message / idle_sense / own_chat_reply"
     )
 
 
@@ -1542,6 +1551,112 @@ async def test_idle_sense_pushed_past_inbox_cap_reaches_her_in_next_real_round(
     assert "你窝在沙发上，屋里很安静。" in round2_stimulus, (
         "第二轮必须真的读到被 cap 截断线挤掉的 idle_sense"
     )
+
+
+# ---------------------------------------------------------------------------
+# chat/life 并发重复回复修复：kind=own_chat_reply 承载"chat 刚对这次交互回复了
+# 什么"，取代不带内容的 EventArrived + 实时查 common_message 的时序竞态方案。
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_own_chat_reply_event_rendered_as_already_replied(
+    patched, monkeypatch
+):
+    """信箱里 kind=own_chat_reply 的事件 → stimulus 明确呈现"这是我自己刚回复的话"。
+
+    这条内容的存在意义只有一个：让被并发唤醒的 life 可靠知道"这次交互我已经回复过
+    了、回复的是什么"，不用再靠对 ``common_message`` 的实时查询猜。呈现上必须强调
+    这是"她自己发出去的"，而不是被误当成外部动静又生成一次相近回复。
+    """
+    patched["unread"] = [
+        _envelope(
+            "r1",
+            "早点睡哦，明天还要上班呢",
+            kind=EVENT_KIND_OWN_CHAT_REPLY,
+            source="chat",
+            persona_id="akao",
+        ),
+    ]
+    _FakeAgent.install(monkeypatch, script=None)
+
+    await lw.life_wake_node(EventArrived(lane="coe-t3", persona_id="akao"))
+
+    msg_blob = "".join(m.text() for m in _FakeAgent.last_run()["messages"])
+    # 回复原文进 stimulus
+    assert "早点睡哦，明天还要上班呢" in msg_blob
+    # 明确框出"这是我自己刚发出去的话"，不用再回一遍
+    assert "你刚" in msg_blob and "回复" in msg_blob
+    # 标已读（同其它 kind 一样，只标本轮实际读到的）
+    assert patched["marked"] == [["r1"]]
+
+
+@pytest.mark.asyncio
+async def test_own_chat_reply_not_lumped_into_ambient_dynamics(
+    patched, monkeypatch
+):
+    """kind=own_chat_reply 不该被误归进离散动静（ambient）桶。
+
+    旧 _split_perception 只认 surroundings/speech/message 三类，新 kind 若不显式
+    加分支会被塞进「[own_chat_reply] ...」离散动静清单，模型读到时会当成一件"发生在
+    她身上的客观动静"而非"我自己刚说的话"，达不到"不用再回一遍"的效果。
+    """
+    patched["unread"] = [
+        _envelope(
+            "a1", "玄关传来开关门的声音", kind=EVENT_KIND_AMBIENT, persona_id="akao",
+        ),
+        _envelope(
+            "r1", "早点睡哦", kind=EVENT_KIND_OWN_CHAT_REPLY,
+            source="chat", persona_id="akao",
+        ),
+    ]
+    _FakeAgent.install(monkeypatch, script=None)
+
+    await lw.life_wake_node(EventArrived(lane="coe-t3", persona_id="akao"))
+
+    msg_blob = "".join(m.text() for m in _FakeAgent.last_run()["messages"])
+    assert "[own_chat_reply]" not in msg_blob, (
+        "own_chat_reply 不该呈现成离散动静的「[own_chat_reply] ...」清单项"
+    )
+    assert "早点睡哦" in msg_blob
+    assert "你刚" in msg_blob and "回复" in msg_blob
+
+
+@pytest.mark.asyncio
+async def test_own_chat_reply_survives_concurrent_ambient_wake(
+    patched, monkeypatch
+):
+    """并发唤醒场景：chat 已回复的内容与另一条几乎同时到达的唤醒事件同一轮读到。
+
+    这是修复"chat/life 并发重复回复"的核心不变量:不管这一轮是被哪一条
+    ``EventArrived`` 触发的（debounce 只保证至少唤醒一次、不保证是哪一条），
+    ``list_unread_events`` 扫描的是整个信箱，chat 回复内容只要durable 落库了
+    就一定会跟着这一轮一起被读到、不会因为"来了另一条唤醒事件"而丢失——不像旧
+    方案里内容依赖对 common_message 的实时查询，可能因为 channel-server 异步
+    落库慢于 debounce 窗口而查不到。
+    """
+    patched["unread"] = [
+        _envelope(
+            "r1", "这个我已经帮你查好啦", kind=EVENT_KIND_OWN_CHAT_REPLY,
+            source="chat", persona_id="akao",
+        ),
+        _envelope(
+            "a1", "世界那边几乎同时来了一条动静", kind=EVENT_KIND_AMBIENT,
+            persona_id="akao",
+        ),
+    ]
+    _FakeAgent.install(monkeypatch, script=None)
+
+    # 唤醒信号本身是 debounce 折叠后的最后一条（谁触发的不重要），信箱里已经
+    # durable 落库了两条未读——模拟"chat 回复几乎同时有其它唤醒事件到达"。
+    await lw.life_wake_node(EventArrived(lane="coe-t3", persona_id="akao"))
+
+    msg_blob = "".join(m.text() for m in _FakeAgent.last_run()["messages"])
+    assert "这个我已经帮你查好啦" in msg_blob, (
+        "chat 已回复的内容不该因为同轮还有其它唤醒事件到达而丢失"
+    )
+    assert "世界那边几乎同时来了一条动静" in msg_blob
+    assert patched["marked"] == [["r1", "a1"]]
 
 
 @pytest.mark.asyncio

--- a/apps/agent-service/tests/unit/agent/test_react_loop.py
+++ b/apps/agent-service/tests/unit/agent/test_react_loop.py
@@ -883,3 +883,324 @@ class TestNativeWebSearchPassthrough:
         ):
             pass
         assert "native_web_search" not in fake.stream_kwargs[0]
+
+
+# ---------------------------------------------------------------------------
+# empty-turn retry — a turn that comes back with no text AND no tool_calls
+# (e.g. the collapsed ``{"text": "", "tool_calls": []}`` observed after a
+# generate_image tool call in trace 82323210372fe067ec2a60abd8e9fdb3) is
+# transparently retried in place — same ``convo``, no new messages appended,
+# no tools re-dispatched — up to a bounded number of attempts for that ONE
+# turn. Exhausting retries never raises a new exception or changes the return
+# shape: the loop falls back to exactly the pre-retry behaviour (return /
+# end the generator with whatever the last attempt produced), just logging the
+# exhaustion so it is observable. A normal non-empty result must never trigger
+# a second request.
+# ---------------------------------------------------------------------------
+
+
+class TestRunLoopEmptyTurnRetry:
+    async def test_empty_completion_is_retried_then_succeeds(self):
+        _run_loop, _ = _import_loops()
+        empty = Message(role=Role.ASSISTANT, content="")
+        fake = FakeModelClient(
+            complete_script=[empty, Message(role=Role.ASSISTANT, content="real reply")]
+        )
+        result = await _run_loop(
+            fake,
+            messages=[Message(role=Role.USER, content="go")],
+            tools=[],
+            context=None,
+            recursion_limit=12,
+        )
+        assert result.text() == "real reply"
+        assert len(fake.complete_calls) == 2
+
+    async def test_reasoning_only_completion_counts_as_empty_and_is_retried(self):
+        # text blank, no tool_calls, but reasoning_content set — reasoning is
+        # never surfaced to the user, so a "thought but didn't answer" turn
+        # must still count as empty and get retried.
+        _run_loop, _ = _import_loops()
+        reasoning_only = Message(
+            role=Role.ASSISTANT, content="", reasoning_content="thinking..."
+        )
+        fake = FakeModelClient(
+            complete_script=[
+                reasoning_only,
+                Message(role=Role.ASSISTANT, content="ok"),
+            ]
+        )
+        result = await _run_loop(
+            fake,
+            messages=[Message(role=Role.USER, content="go")],
+            tools=[],
+            context=None,
+            recursion_limit=12,
+        )
+        assert result.text() == "ok"
+        assert len(fake.complete_calls) == 2
+
+    async def test_whitespace_only_text_counts_as_empty_and_is_retried(self):
+        _run_loop, _ = _import_loops()
+        whitespace_only = Message(role=Role.ASSISTANT, content="   \n\t  ")
+        fake = FakeModelClient(
+            complete_script=[
+                whitespace_only,
+                Message(role=Role.ASSISTANT, content="ok"),
+            ]
+        )
+        result = await _run_loop(
+            fake,
+            messages=[Message(role=Role.USER, content="go")],
+            tools=[],
+            context=None,
+            recursion_limit=12,
+        )
+        assert result.text() == "ok"
+        assert len(fake.complete_calls) == 2
+
+    async def test_empty_completion_exhausts_retries_and_returns_empty_message(
+        self, caplog
+    ):
+        # every attempt comes back empty — the loop must give up after a
+        # bounded number of tries, return the SAME shape it always has (a
+        # Message, never an exception), and log the exhaustion so the
+        # occurrence rate can be observed in prod.
+        import logging
+
+        _run_loop, _ = _import_loops()
+        empty = Message(role=Role.ASSISTANT, content="")
+        fake = FakeModelClient(complete_script=[empty, empty, empty])
+        with caplog.at_level(logging.WARNING):
+            result = await _run_loop(
+                fake,
+                messages=[Message(role=Role.USER, content="go")],
+                tools=[],
+                context=None,
+                recursion_limit=12,
+            )
+        assert isinstance(result, Message)
+        assert result.text() == ""
+        assert not result.tool_calls
+        assert len(fake.complete_calls) == 3  # 3 tries total, then give up
+        assert any("empty" in r.message.lower() for r in caplog.records)
+
+    async def test_tool_call_turn_with_blank_text_is_not_retried(self):
+        # tool_calls present -> not "empty" even though text is blank; a real
+        # tool-call turn must never trigger the empty-retry path.
+        _run_loop, _ = _import_loops()
+        call = ToolCall(id="c1", name="echo_tool", arguments={"text": "x"})
+        fake = FakeModelClient(
+            complete_script=[
+                Message(role=Role.ASSISTANT, content="", tool_calls=[call]),
+                Message(role=Role.ASSISTANT, content="done"),
+            ]
+        )
+        result = await _run_loop(
+            fake,
+            messages=[Message(role=Role.USER, content="go")],
+            tools=[echo_tool],
+            context=None,
+            recursion_limit=12,
+        )
+        assert result.text() == "done"
+        # exactly 2 calls: the tool-call turn + the final turn, no extra retry
+        assert len(fake.complete_calls) == 2
+
+    async def test_normal_non_empty_result_is_not_retried(self):
+        # the common case: a single model call, zero added request cost.
+        _run_loop, _ = _import_loops()
+        fake = FakeModelClient(
+            complete_script=[Message(role=Role.ASSISTANT, content="hi there")]
+        )
+        result = await _run_loop(
+            fake,
+            messages=[Message(role=Role.USER, content="go")],
+            tools=[],
+            context=None,
+            recursion_limit=12,
+        )
+        assert result.text() == "hi there"
+        assert len(fake.complete_calls) == 1
+
+
+class TestStreamLoopEmptyTurnRetry:
+    async def test_empty_turn_is_retried_then_succeeds(self):
+        _, _stream_loop = _import_loops()
+        fake = FakeModelClient(
+            stream_script=[
+                [StreamChunk(finish_reason="stop")],  # empty: no text, no tool_calls
+                [StreamChunk(text="real reply"), StreamChunk(finish_reason="stop")],
+            ]
+        )
+        out = [
+            c
+            async for c in _stream_loop(
+                fake,
+                messages=[Message(role=Role.USER, content="go")],
+                tools=[],
+                context=None,
+                recursion_limit=12,
+            )
+        ]
+        assert "".join(c.text or "" for c in out) == "real reply"
+        assert len(fake.stream_calls) == 2
+
+    async def test_reasoning_only_turn_counts_as_empty_and_is_retried(self):
+        _, _stream_loop = _import_loops()
+        fake = FakeModelClient(
+            stream_script=[
+                [
+                    StreamChunk(reasoning="thinking..."),
+                    StreamChunk(finish_reason="stop"),
+                ],
+                [StreamChunk(text="ok"), StreamChunk(finish_reason="stop")],
+            ]
+        )
+        out = [
+            c
+            async for c in _stream_loop(
+                fake,
+                messages=[Message(role=Role.USER, content="go")],
+                tools=[],
+                context=None,
+                recursion_limit=12,
+            )
+        ]
+        assert "".join(c.text or "" for c in out) == "ok"
+        assert len(fake.stream_calls) == 2
+
+    async def test_empty_turn_exhausts_retries_and_ends_generator(self, caplog):
+        import logging
+
+        _, _stream_loop = _import_loops()
+        empty_turn = [StreamChunk(finish_reason="stop")]
+        fake = FakeModelClient(stream_script=[empty_turn, empty_turn, empty_turn])
+        with caplog.at_level(logging.WARNING):
+            out = [
+                c
+                async for c in _stream_loop(
+                    fake,
+                    messages=[Message(role=Role.USER, content="go")],
+                    tools=[],
+                    context=None,
+                    recursion_limit=12,
+                )
+            ]
+        assert "".join(c.text or "" for c in out) == ""
+        assert len(fake.stream_calls) == 3  # 3 tries total, then give up
+        assert any("empty" in r.message.lower() for r in caplog.records)
+
+    async def test_tool_call_turn_with_blank_text_is_not_retried(self):
+        _, _stream_loop = _import_loops()
+        call = ToolCall(id="c1", name="echo_tool", arguments={"text": "x"})
+        fake = FakeModelClient(
+            stream_script=[
+                [StreamChunk(tool_call=call), StreamChunk(finish_reason="tool_calls")],
+                [StreamChunk(text="done"), StreamChunk(finish_reason="stop")],
+            ]
+        )
+        out = [
+            c
+            async for c in _stream_loop(
+                fake,
+                messages=[Message(role=Role.USER, content="go")],
+                tools=[echo_tool],
+                context=None,
+                recursion_limit=12,
+            )
+        ]
+        assert "".join(c.text or "" for c in out) == "done"
+        assert len(fake.stream_calls) == 2
+
+    async def test_normal_non_empty_turn_is_not_retried(self):
+        _, _stream_loop = _import_loops()
+        fake = FakeModelClient(
+            stream_script=[
+                [StreamChunk(text="hello"), StreamChunk(finish_reason="stop")]
+            ]
+        )
+        out = [
+            c
+            async for c in _stream_loop(
+                fake,
+                messages=[Message(role=Role.USER, content="go")],
+                tools=[],
+                context=None,
+                recursion_limit=12,
+            )
+        ]
+        assert "".join(c.text or "" for c in out) == "hello"
+        assert len(fake.stream_calls) == 1
+
+    async def test_content_filter_only_turn_is_empty_per_is_empty_turn(self):
+        """``_is_empty_turn`` only looks at text/tool_calls — it has no
+        opinion on ``finish_reason``. A turn whose only chunk is
+        ``finish_reason="content_filter"`` (no text, no tool_calls) therefore
+        DOES match the retry condition if something keeps draining
+        ``_stream_loop`` to exhaustion, as this test does directly. This is
+        not a correctness bug for the real chat path: ``render_chat_turn``
+        (``app/chat/render.py``) reacts to a content_filter chunk the instant
+        it sees one — it yields the persona content_filter message and
+        ``return``s, which abandons (never resumes) this same generator
+        *before* it would reach the retry-decision point below the inner
+        ``async for``. See the next test for that production-safety property.
+        This test exists so that fact is asserted, not just reasoned about in
+        a docstring — if ``_is_empty_turn`` ever grows a
+        content_filter/length exclusion, this test's expected call count
+        must change too."""
+        _, _stream_loop = _import_loops()
+        fake = FakeModelClient(
+            stream_script=[
+                [StreamChunk(finish_reason="content_filter")],
+                [StreamChunk(text="ignored if reached"), StreamChunk(finish_reason="stop")],
+            ]
+        )
+        out = [
+            c
+            async for c in _stream_loop(
+                fake,
+                messages=[Message(role=Role.USER, content="go")],
+                tools=[],
+                context=None,
+                recursion_limit=12,
+            )
+        ]
+        assert len(fake.stream_calls) == 2, (
+            "_stream_loop in isolation has no content_filter awareness, so a "
+            "fully-drained consumer does retry this turn once — this is the "
+            "documented, acceptable behavior, not the production path"
+        )
+        assert out[0].finish_reason == "content_filter"
+
+    async def test_early_abandonment_on_content_filter_prevents_retry(self):
+        """The actual safety net for the case above: render_chat_turn's real
+        consumption pattern is "see a content_filter/length chunk, stop
+        pulling more chunks immediately" (app/chat/render.py's
+        ``is_content_filter``/``is_length_truncated`` checks, which return
+        without ever calling ``.__anext__()`` again). This test reproduces
+        that exact consumption pattern directly against ``_stream_loop``
+        (without going through the full render_chat_turn + Agent + model
+        registry machinery) and proves ``model.stream()`` is called exactly
+        once — the retry-decision code below the inner ``async for`` in
+        ``_stream_loop`` is never reached because nothing ever asks this
+        generator for its next chunk after the content_filter one."""
+        _, _stream_loop = _import_loops()
+        fake = FakeModelClient(
+            stream_script=[
+                [StreamChunk(finish_reason="content_filter")],
+                [StreamChunk(text="should never be requested"), StreamChunk(finish_reason="stop")],
+            ]
+        )
+        gen = _stream_loop(
+            fake,
+            messages=[Message(role=Role.USER, content="go")],
+            tools=[],
+            context=None,
+            recursion_limit=12,
+        )
+        first = await gen.__anext__()
+        assert first.finish_reason == "content_filter"
+        # render_chat_turn stops here — it never calls __anext__() again.
+        await gen.aclose()
+        assert len(fake.stream_calls) == 1


### PR DESCRIPTION
## Summary
- chat finishes a reply, then life wakes up almost immediately and independently re-decides it hasn't replied yet (it polls `common_message`, which chat-response-worker writes to asynchronously) — causes duplicate/near-duplicate replies. Fixed by having chat deliver its own reply text durably into its own mailbox (`deliver_event` + new `own_chat_reply` event kind) instead of relying on the racy DB read.
- Same race also hits life's own proactive `send_message` (to real people/groups) — a subsequent life_wake round could forget it just sent something and repeat/contradict itself. Confirmed on prod via a real bad case (repeated/inconsistent statements about 嘉然's birthday). Fixed with the same mailbox-delivery mechanism.
- LLM occasionally returns fully empty output (no text, no tool_calls) with no retry, producing empty bot replies. `_run_loop`/`_stream_loop` now detect an empty turn and transparently retry once before giving up (no new exception type, no change to the render_chat_turn contract).

## Test plan
- [x] Unit tests for core.py empty-turn retry (run/stream loops)
- [x] Unit tests for chat_node.py mailbox delivery + wake gating (p2p/group/whitelist/failure paths)
- [x] Unit tests for life_wake.py 6-way event split (idle_sense/surroundings/speech/message/own_chat_reply/dynamics) rendering
- [x] Unit tests for life_tools.py proactive send_message mailbox delivery (person + group)
- [x] Full agent-service suite green after rebase onto main (2311 passed, 2 skipped)
- [x] Live-verified on ppe-chat-life-dedup lane via real Feishu trace: chat reply text correctly surfaced in the next life_wake round's stimulus, no duplicate generation