### PR TITLE
fix(agent-service): ground proactive DM recipients in stimulus and contact lookup

### DIFF
--- a/apps/agent-service/app/data/message_record.py
+++ b/apps/agent-service/app/data/message_record.py
@@ -59,13 +59,29 @@ class ReadableFile:
 
 
 @dataclass(slots=True)
+class LifeChatCounterpart:
+    """私聊里对面那个真人是谁 —— 让渲染层能把私聊段具名（主动私聊具名化 Task 1）。
+
+    ``user_id`` = 对方的 ``common_user_id``（str 形态，渲染层内联拼 ``user:<uuid>``
+    句柄用）；``display_name`` 是对方展示名（数据层已做兜底，永远非空——全历史都
+    没写过 sender_display_name 时落「（不知名）」，同 ``LifeChatMessage`` 的展示名
+    口径：不暴露 raw user_id、不把 None 漏给渲染层）。
+    """
+
+    user_id: str
+    display_name: str
+
+
+@dataclass(slots=True)
 class LifeChatConversation:
     """life 醒来读对话时的一个会话分组 —— 一个会话 + 它最近一段消息 + 可读文件候选。
 
     ``scope`` = ``"direct"``（私聊）/ ``"group"``（群）；``display_name`` 是群名，
     私聊为 ``None``；``messages`` 按发生先后升序。``file_candidates`` 是这批同一段消息里
     解析出的可读文件项（读小说 Task 2：read_book 在**她这一轮看得见的同一批消息**里认文件，
-    零额外查询、真同一边界——不重跑 recent 查询避免边界漂移）。
+    零额外查询、真同一边界——不重跑 recent 查询避免边界漂移）。``counterparts`` 是私聊
+    对面的真人（主动私聊具名化 Task 1：按会话**全历史**的 role='user' 行解析、与 since
+    窗口解耦，正常 p2p 恰好 1 个、脏数据多人如实全列）；群会话恒为空。
     """
 
     chat_id: str
@@ -73,3 +89,4 @@ class LifeChatConversation:
     display_name: str | None
     messages: list[LifeChatMessage]
     file_candidates: list[ReadableFile] = field(default_factory=list)
+    counterparts: list[LifeChatCounterpart] = field(default_factory=list)

--- a/apps/agent-service/app/data/queries/messages.py
+++ b/apps/agent-service/app/data/queries/messages.py
@@ -15,6 +15,7 @@ from sqlalchemy.future import select
 from app.data.message_record import (
     CommonMessageRecord,
     LifeChatConversation,
+    LifeChatCounterpart,
     LifeChatMessage,
     ReadableFile,
 )
@@ -634,6 +635,81 @@ def _life_chat_message(
     )
 
 
+async def _direct_counterparts_by_chat(
+    chat_ids: list[str],
+) -> dict[str, list[LifeChatCounterpart]]:
+    """私聊会话 → 对面真人列表（id + 展示名），对一批会话**一次查**（不逐会话 N+1）。
+
+    锚定 ``role='user'`` 行取对方——已查实的两个陷阱决定了不能取会话内任意 distinct
+    common_user_id：真人 user 行**也写 bot_name**（不能拿 bot_name 排除真人）、proactive
+    出站 assistant 行的 ``common_user_id`` 非空但是 **bot 自己的**（拿它当对方就把她自己
+    认成聊天对象）。role='user' 是「这行是真人说的」唯一干净锚。
+
+    **全历史、不带 since 窗口**（spec 决策 3）：会话对面是谁是稳定事实，不随内容增量
+    窗口变化——对方最后发言早于窗口、窗口内只剩她自己独白时（她刚主动发过话、对方还
+    没回，正是最需要具名的场景）也必须具名。仅全历史都无真人行才返回空（渲染层匿名
+    兜底）。``proactive_trigger`` 伪消息剔除（触发器记录不是真人发言，同各消息查询口径）。
+
+    每个真人一行：``DISTINCT ON (会话, 真人)`` 取**有名字的最近一行**（sender_display_name
+    为空的行排后——最新一行恰好没写展示名时不把名字弄丢），展示名兜底
+    ``_UNKNOWN_SPEAKER``（同 ``_life_chat_message`` 口径：不暴露 raw user_id）。正常 p2p
+    恰好 1 个；>1 个是约定外脏数据，如实全列、按最近发言在前排序（忠实呈现，不替她挑
+    「主对象」）。
+    """
+    chat_uuids = _uuid_list(chat_ids)
+    if not chat_uuids:
+        return {}
+    unnamed = or_(
+        CommonMessage.sender_display_name.is_(None),
+        CommonMessage.sender_display_name == "",
+    )
+    stmt = (
+        select(
+            CommonMessage.common_conversation_id,
+            CommonMessage.common_user_id,
+            CommonMessage.sender_display_name,
+            CommonMessage.event_time,
+        )
+        .where(
+            CommonMessage.common_conversation_id.in_(chat_uuids),
+            CommonMessage.role == "user",
+            CommonMessage.common_user_id.is_not(None),
+            or_(
+                CommonMessage.message_type.is_(None),
+                CommonMessage.message_type != "proactive_trigger",
+            ),
+        )
+        .distinct(
+            CommonMessage.common_conversation_id,
+            CommonMessage.common_user_id,
+        )
+        .order_by(
+            CommonMessage.common_conversation_id,
+            CommonMessage.common_user_id,
+            unnamed,
+            CommonMessage.event_time.desc(),
+        )
+    )
+    async with auto_tx():
+        rows = (await current_session().execute(stmt)).all()
+
+    grouped: dict[str, list[tuple[int, LifeChatCounterpart]]] = {}
+    for chat_uuid, user_uuid, display_name, event_time in rows:
+        grouped.setdefault(str(chat_uuid), []).append(
+            (
+                event_time,
+                LifeChatCounterpart(
+                    user_id=str(user_uuid),
+                    display_name=display_name or _UNKNOWN_SPEAKER,
+                ),
+            )
+        )
+    return {
+        chat_id: [cp for _, cp in sorted(pairs, key=lambda p: p[0], reverse=True)]
+        for chat_id, pairs in grouped.items()
+    }
+
+
 async def find_persona_related_chats_recent(
     *,
     persona_id: str,
@@ -657,7 +733,11 @@ async def find_persona_related_chats_recent(
     每个会话取最近消息（user + assistant，剔除 ``proactive_trigger`` 伪消息），**条目数
     量控制不字符截断**：超 ``per_chat_limit`` 只保最近 N 条、仍按发生先后升序。每条折成
     ``LifeChatMessage``（发言者展示名 / 是否她自己 / 文本 / CST 时间），返回
-    ``LifeChatConversation`` 列表（chat_id + scope + 群名 + 消息列表）。
+    ``LifeChatConversation`` 列表（chat_id + scope + 群名 + 消息列表 + 私聊对面真人）。
+
+    私聊会话额外聚合「对面是谁」（主动私聊具名化 Task 1）：对选中的私聊**批量一次**
+    经 :func:`_direct_counterparts_by_chat` 解析对方真人（口径见该函数——按全历史
+    role='user' 行锚定、与 since 窗口解耦），让渲染层能把私聊段具名；群会话恒为空。
     """
     # 她在 since_ms 之后发过言的会话，按各会话她发言的最近时刻降序，连会话元数据
     # 一把取出（scope / 群名）。白名单读 Dynamic Config 是同步 httpx（网络 IO），
@@ -706,6 +786,12 @@ async def find_persona_related_chats_recent(
             selected.append((str(chat_uuid), scope, display_name))
         if len(selected) >= max_conversations:
             break
+
+    # 私聊对面真人：对选中的私聊批量一次查（不逐会话 N+1），身份按全历史解析、
+    # 与 since 窗口解耦（spec 决策 3——窗口内只剩她自己独白时也要能具名）。
+    counterparts_by_chat = await _direct_counterparts_by_chat(
+        [chat_id for chat_id, scope, _ in selected if scope == "direct"]
+    )
 
     out: list[LifeChatConversation] = []
     for chat_id, scope, display_name in selected:
@@ -756,6 +842,7 @@ async def find_persona_related_chats_recent(
                 display_name=display_name,
                 messages=messages,
                 file_candidates=file_candidates,
+                counterparts=counterparts_by_chat.get(chat_id, []),
             )
         )
     return out

--- a/apps/agent-service/app/domain/recipient_directory.py
+++ b/apps/agent-service/app/domain/recipient_directory.py
@@ -64,6 +64,7 @@ from sqlalchemy import text
 
 from app.data.queries.persona import find_persona
 from app.data.session import get_session
+from app.infra.cst_time import to_cst
 from app.life.feed_whitelist import (
     LIFE_FEED_CHAT_WHITELIST_KEY,
     parse_whitelist,
@@ -193,14 +194,32 @@ def _persona_intro(display_name: str, persona_lite: str) -> str:
     return f"{display_name}（你的姐妹）：{head}" if head else f"{display_name}（你的姐妹）"
 
 
-def _user_intro(display_name: str) -> str:
-    """真人简介：目前只有显示名可用（common_user 没有更多资料）。
+def _user_intro(display_name: str, *, last_dm_ms: int | None) -> str:
+    """真人简介：显示名 + 与调用 persona 的私聊线事实（帮 life 区分重名、别编 uid）。
 
-    common_user 只存 display_name —— 真人没有像 persona_lite 那样的身份正文。重名
-    真人当前只能靠显示名区分；要更强的区分信息（最近聊天上下文等）是后续增量，本
-    task 不补存储（spec：先不建表）。
+    common_user 只存 display_name —— 真人没有像 persona_lite 那样的身份正文，重名
+    区分靠**私聊线事实**：``last_dm_ms`` 是「此刻调用 persona 名下 active bot 与 ta
+    之间可投递的 direct + lark 私聊线」（存在判定同 :func:`_resolve_user` 的可投递
+    口径）里**最近一条消息的毫秒时刻——双向、不限 role**（含 bot 主动出站行；只算
+    ta 自己的发言会在"刚主动私聊过、ta 没回"时报旧日期，codex T3 必改 1），None =
+    此刻没有这样的线。
+
+    **措辞只陈述"此刻有没有能发过去的线"，不做"历史上从没私聊过"的断言**（spec
+    决策 5）：线不存在可能是 bot 下线 / 那条线归属别的姐妹，不代表历史上没聊过——
+    查询口径查的就是可投递现状，文案不能越过口径去说历史。日期按 CST 显示成自然
+    中文（event_time 是 Unix 毫秒，经 :func:`app.infra.cst_time.to_cst` 归一）。
     """
-    return f"{display_name}（真人）"
+    if last_dm_ms is None:
+        return f"{display_name}（真人）——你这边没有能直接发过去的私聊线"
+    dt = to_cst(str(last_dm_ms))
+    if dt is None:
+        # event_time 理论上总是合法毫秒；万一解析不出就退回不带日期的事实陈述
+        # （不编日期、不静默吞掉"有线"这个事实）。
+        return f"{display_name}（真人）——你这边有能直接发过去的私聊"
+    return (
+        f"{display_name}（真人）——你这边有能直接发过去的私聊，"
+        f"最近一次是{dt.year}年{dt.month}月{dt.day}日"
+    )
 
 
 def _group_intro(display_name: str) -> str:
@@ -225,17 +244,25 @@ async def _load_chat_whitelist() -> frozenset[str]:
     return parse_whitelist(raw)
 
 
-async def search_recipients(query: str) -> list[RecipientCandidate]:
+async def search_recipients(
+    query: str, *, persona_id: str
+) -> list[RecipientCandidate]:
     """按名字模糊查可发送对象，返回候选列表（typed uid + 简介）。
 
     匹配口径：对显示名做大小写无关的子串匹配（``ILIKE %query%``），姐妹查
     ``bot_persona.display_name``、真人查 ``common_user.display_name``。空 / 全空白
     query 直接返回空（没给名字就没有候选）。
 
+    ``persona_id`` 是**调用方 persona**（谁在查）：真人候选的简介按它附「此刻你名下
+    有没有能直接发过去的私聊线 + 最近一次时间」的事实（帮 life 区分重名、别盲选），
+    口径复用 :func:`_resolve_user` 的可投递判定（direct + lark + bot_config 归属该
+    persona 且 active）。姐妹 / 群候选不消费它。
+
     **只返回候选，不做任何替 life 决策的事**（赤尾设计宪法）：不按亲密度 / 活跃度 /
     兴趣排序、不筛、不自动取第一个。返回顺序是稳定的纯机制序（姐妹在前按
     persona_id 升序，真人在后按 common_user_id 升序），只为输出确定性，不含「谁更
-    该被选」的语义——重名 / 多候选时全列出来交给 life 自己挑。
+    该被选」的语义——重名 / 多候选时全列出来交给 life 自己挑。私聊线事实只进 intro
+    文案，**绝不影响候选顺序**。
     """
     q = (query or "").strip()
     if not q:
@@ -278,13 +305,67 @@ async def search_recipients(query: str) -> list[RecipientCandidate]:
                 {"like": like},
             )
         ).mappings().all()
+
+        # 真人候选的私聊线事实（persona 感知）：对整批命中真人**一次批量查**「该真人 ×
+        # 调用 persona 名下 active bot 之间有没有 direct + lark 私聊线 + 最近一次消息时间」，
+        # 不逐候选 N+1。两层结构：
+        #
+        #   1. 内层 pair：线的**存在判定**逐字对齐 _resolve_user 的可投递口径
+        #      （scope='direct' + channel='lark' + bot_config(persona_id, is_active)），
+        #      定位 (真人, 可投递会话) 对——查的是「此刻能不能发过去」，不是「历史上
+        #      聊没聊过」，intro 措辞按前者陈述（spec 决策 5）。
+        #   2. 外层对会话**全消息**聚合 MAX(event_time)——「最近一次」必须**双向、不限
+        #      role**（codex T3 必改 1）：proactive 出站 assistant 行的 common_user_id
+        #      是 bot 自己的，只按真人自己的发言行聚合会漏掉它，「赤尾昨天刚主动私聊
+        #      过、ta 没回」时日期停在 ta 上次发言，恰好在主动私聊场景失真。
+        #
+        # 参数形态（codex T3 必改 2）：common_message.common_user_id 是带索引的 uuid
+        # 列，**列侧裸用、参数侧给 uuid 列表**（PG 从 `= ANY($n)` 推出 uuid[]，asyncpg
+        # 直接编码 UUID 对象）——列侧 CAST 成 text 会绕开索引走全表扫。上面群白名单的
+        # `CAST(... AS text) = ANY(:wl)` 是小表（common_conversation）先例，别学到大表上。
+        last_dm_by_user: dict[str, int] = {}
+        if user_rows:
+            dm_rows = (
+                await s.execute(
+                    text(
+                        "SELECT pair.common_user_id AS uid, "
+                        "       MAX(m.event_time) AS last_event "
+                        "FROM ("
+                        "  SELECT DISTINCT cm.common_user_id, "
+                        "         cm.common_conversation_id "
+                        "  FROM common_message cm "
+                        "  JOIN common_conversation cc "
+                        "    ON cc.common_conversation_id = cm.common_conversation_id "
+                        "   AND cc.scope = 'direct' "
+                        "   AND cc.channel = 'lark' "
+                        "  JOIN bot_config bc "
+                        "    ON bc.bot_name = cm.bot_name "
+                        "   AND bc.persona_id = :pid "
+                        "   AND bc.is_active = true "
+                        "  WHERE cm.common_user_id = ANY(:uids) "
+                        ") pair "
+                        "JOIN common_message m "
+                        "  ON m.common_conversation_id = pair.common_conversation_id "
+                        "GROUP BY pair.common_user_id"
+                    ),
+                    {
+                        "pid": persona_id,
+                        "uids": [r["common_user_id"] for r in user_rows],
+                    },
+                )
+            ).mappings().all()
+            last_dm_by_user = {str(r["uid"]): r["last_event"] for r in dm_rows}
+
         for row in user_rows:
             name = row["display_name"] or ""
             candidates.append(
                 RecipientCandidate(
                     uid=user_uid(row["common_user_id"]),
                     display_name=name,
-                    intro=_user_intro(name),
+                    intro=_user_intro(
+                        name,
+                        last_dm_ms=last_dm_by_user.get(str(row["common_user_id"])),
+                    ),
                 )
             )
 

--- a/apps/agent-service/app/nodes/life_tools.py
+++ b/apps/agent-service/app/nodes/life_tools.py
@@ -482,7 +482,9 @@ def build_life_tools(
         Returns:
             候选列表文本（每个候选带 uid + 简介）；查不到时一句如实说明。
         """
-        candidates = await search_recipients(query)
+        # 带上调用方 persona_id（Task 3）：真人候选的简介按它附「你这边此刻有没有能
+        # 直接发过去的私聊线 + 最近一次时间」的事实——重名真人靠这个区分，别盲选。
+        candidates = await search_recipients(query, persona_id=persona_id)
         if not candidates:
             return f"没找到叫「{query}」的人——换个名字再查，或者就算了。"
         # 原样把候选（uid + 简介）列给她挑，**不排序、不取第一个、不替她筛**（spec

--- a/apps/agent-service/app/nodes/life_wake.py
+++ b/apps/agent-service/app/nodes/life_wake.py
@@ -599,13 +599,22 @@ def _format_recent_chats(conversations: list[LifeChatConversation]) -> str:
     """把她相关会话的最近一段消息渲成「最近聊过的对话」段，按会话分组忠实呈现。
 
     T1 已把「她相关会话」捞成 ``LifeChatConversation`` 列表（私聊 + 白名单内的群、每个带
-    最近一段消息、已判明每条「谁说的」）。这里只做渲染——按会话分块：
+    最近一段消息、已判明每条「谁说的」、私聊带对面真人身份）。这里只做渲染——按会话分块：
 
-      * 群（``scope == "group"``）标群名「· 群「群名」里：」；群名缺失（查不到）兜底
-        「· 一个群里：」，**绝不把 None 拼进文案**（spec 决策 3 同口径）。
-      * 私聊（其余）标「· 一段私聊里：」。
+      * 群（``scope == "group"``）标群名 + 群句柄「· 群「群名」里（群句柄 group:<id>）：」；
+        群名缺失（查不到）兜底「· 一个群里（群句柄 group:<id>）：」，**绝不把 None 拼进
+        文案**（spec 决策 3 同口径）。
+      * 私聊（其余）具名「· 和 田申（user:<id>）的私聊里：」（主动私聊具名化 Task 2：
+        让她主动发消息时首发 uid 即合法、不用编）；多对象（约定外脏数据）如实全列、
+        不替她挑「主对象」；``counterparts`` 为空（全历史无真人行）保持匿名兜底
+        「· 一段私聊里：」，不硬造名字。
       * 组内每条 ``（时间）发言人：内容``——``m.is_self`` 为真（她自己的回复）显示「我」、
-        否则用 ``m.speaker_display_name``（真人昵称 / 别的 persona）。
+        否则用 ``m.speaker_display_name``（真人昵称 / 别的 persona）。句柄只标在会话头部、
+        不进 speaker 名。
+
+    uid 句柄在这里内联拼 ``user:`` / ``group:`` 前缀（同 :func:`_group_handle_suffix`
+    先例：life_wake 刻意不 import 投递目标解析层，口径一致但不共享代码）。句柄只做身份
+    grounding、不承诺可投递——发不出去仍由 resolve_delivery fail-loud 喂回她处置。
 
     **忠实呈现、不加工**（spec 命门）：不改写成「某人对你说 X / 你回了 Y」这类叙述体、
     不截断单条 ``m.text``——她读到的就是对话原貌。规模由上面三个条目上限在拉取侧控住，
@@ -614,11 +623,17 @@ def _format_recent_chats(conversations: list[LifeChatConversation]) -> str:
     blocks: list[str] = ["【最近聊过的对话】（这一阵你和谁聊过的，按会话分开）："]
     for conv in conversations:
         if conv.scope == "group":
+            group_handle = f"group:{conv.chat_id}"
             header = (
-                f"· 群「{conv.display_name}」里："
+                f"· 群「{conv.display_name}」里（群句柄 {group_handle}）："
                 if conv.display_name
-                else "· 一个群里："
+                else f"· 一个群里（群句柄 {group_handle}）："
             )
+        elif conv.counterparts:
+            named = "、".join(
+                f"{cp.display_name}（user:{cp.user_id}）" for cp in conv.counterparts
+            )
+            header = f"· 和 {named}的私聊里："
         else:
             header = "· 一段私聊里："
         lines = [header]

--- a/apps/agent-service/tests/data/test_persona_related_chats.py
+++ b/apps/agent-service/tests/data/test_persona_related_chats.py
@@ -518,6 +518,252 @@ async def test_no_file_messages_means_empty_candidates(chat_db, allow_all_groups
     assert got[0].file_candidates == []
 
 
+# ---------------------------------------------------------------------------
+# 私聊对方真人身份（主动私聊具名化 Task 1）：私聊会话聚合出「对面是谁」
+# （common_user_id + 展示名），挂到 LifeChatConversation.counterparts 上，让渲染层
+# 能把私聊段具名成「和 田申（user:<uuid>）的私聊里」。口径（spec 决策 2 / 3）：
+# - 锚定 role='user' 行取对方（真人行也写 bot_name、proactive 出站 assistant 行的
+#   common_user_id 是 bot 自己的——都不能当锚）。
+# - 身份按会话**全历史**解析、与 since 窗口解耦：对方最后发言早于窗口、窗口内只剩
+#   她自己独白时也要能具名；仅全历史无真人行才为空（匿名兜底）。
+# - 对选中会话批量一次查，不逐会话 N+1。
+# ---------------------------------------------------------------------------
+
+_CHAT_DIRECT_2 = uuid.uuid5(uuid.NAMESPACE_OID, "rel-chat-direct-2")
+_CHAT_DIRECT_3 = uuid.uuid5(uuid.NAMESPACE_OID, "rel-chat-direct-3")
+
+
+@pytest.mark.integration
+async def test_direct_counterpart_named_with_id(chat_db, allow_all_groups):
+    """正常私聊：对方恰好 1 个，id / 展示名都对（渠道约定 p2p 一对一）。"""
+    await _seed_conversation(_CHAT_DIRECT, scope="direct", name=None)
+    await _seed_user_message(
+        _CHAT_DIRECT, event_time=1000, text="赤尾在吗", scope="direct",
+        user_id=_USER_1, username="田申",
+    )
+    await _seed_bot_message(
+        _CHAT_DIRECT, event_time=2000, text="在的", persona_id="akao", scope="direct"
+    )
+
+    got = await find_persona_related_chats_recent(
+        persona_id="akao", since_ms=0, max_conversations=10, per_chat_limit=50
+    )
+
+    assert len(got) == 1
+    cps = got[0].counterparts
+    assert len(cps) == 1, "正常 p2p 私聊对方恰好 1 个"
+    assert cps[0].user_id == str(_USER_1)
+    assert cps[0].display_name == "田申"
+
+
+@pytest.mark.integration
+async def test_counterpart_resolved_from_full_history_outside_window(
+    chat_db, allow_all_groups
+):
+    """对方最后发言早于 since 窗口（窗口内只剩她自己独白）也要能具名（spec 决策 3）。
+
+    身份是会话的稳定事实、与内容增量窗口解耦——正是"她刚主动发过话、对方还没回"
+    这种最需要知道对面是谁的场景。
+    """
+    await _seed_conversation(_CHAT_DIRECT, scope="direct", name=None)
+    # 对方在窗口前说过话；窗口内只有她自己的消息
+    await _seed_user_message(
+        _CHAT_DIRECT, event_time=100, text="早安", scope="direct",
+        user_id=_USER_1, username="田申",
+    )
+    await _seed_bot_message(
+        _CHAT_DIRECT, event_time=2000, text="在想你", persona_id="akao", scope="direct"
+    )
+
+    got = await find_persona_related_chats_recent(
+        persona_id="akao", since_ms=1000, max_conversations=10, per_chat_limit=50
+    )
+
+    assert len(got) == 1
+    convo = got[0]
+    assert [m.is_self for m in convo.messages] == [True], "窗口内只剩她自己的独白"
+    assert len(convo.counterparts) == 1, "对方身份按全历史解析、不受窗口影响"
+    assert convo.counterparts[0].user_id == str(_USER_1)
+    assert convo.counterparts[0].display_name == "田申"
+
+
+@pytest.mark.integration
+async def test_proactive_outbound_row_not_mistaken_as_counterpart(chat_db, monkeypatch):
+    """proactive 出站 assistant 行的 common_user_id 是 bot 自己的（非 NULL）——
+    绝不能被误认成对方；对方只按 role='user' 行锚定。"""
+    _patch_whitelist(monkeypatch)
+    await _seed_conversation(_CHAT_DIRECT, scope="direct", name=None)
+    await _seed_bot_config("chiwei", "akao")
+    await _seed_user_message(
+        _CHAT_DIRECT, event_time=1000, text="在吗", scope="direct",
+        user_id=_USER_1, username="田申",
+    )
+    await _seed_proactive_bot_message(
+        _CHAT_DIRECT, event_time=2000, text_="我刚在想你", bot_name="chiwei"
+    )
+
+    got = await find_persona_related_chats_recent(
+        persona_id="akao", since_ms=0, max_conversations=10, per_chat_limit=50
+    )
+
+    assert len(got) == 1
+    cps = got[0].counterparts
+    assert [c.user_id for c in cps] == [str(_USER_1)], (
+        "proactive 出站行（bot 自己的 common_user_id）不进对方列表"
+    )
+
+
+@pytest.mark.integration
+async def test_no_human_row_in_full_history_means_no_counterpart(chat_db, monkeypatch):
+    """全历史都没有真人 user 行（她只发过 proactive、对方从没回）→ 对象为空，
+    渲染层保持匿名兜底。"""
+    _patch_whitelist(monkeypatch)
+    await _seed_conversation(_CHAT_DIRECT, scope="direct", name=None)
+    await _seed_bot_config("chiwei", "akao")
+    await _seed_proactive_bot_message(
+        _CHAT_DIRECT, event_time=2000, text_="我刚在想你", bot_name="chiwei"
+    )
+
+    got = await find_persona_related_chats_recent(
+        persona_id="akao", since_ms=0, max_conversations=10, per_chat_limit=50
+    )
+
+    assert len(got) == 1
+    assert got[0].counterparts == []
+
+
+@pytest.mark.integration
+async def test_group_conversation_counterparts_empty(chat_db, allow_all_groups):
+    """群会话不聚合对象：counterparts 恒为空（具名化只针对私聊段）。"""
+    await _seed_conversation(_CHAT_GROUP, scope="group", name="一家人")
+    await _seed_bot_message(_CHAT_GROUP, event_time=1000, text="我在", persona_id="akao")
+    await _seed_user_message(_CHAT_GROUP, event_time=2000, text="哈喽")
+
+    got = await find_persona_related_chats_recent(
+        persona_id="akao", since_ms=0, max_conversations=10, per_chat_limit=50
+    )
+
+    assert len(got) == 1
+    assert got[0].counterparts == []
+
+
+@pytest.mark.integration
+async def test_dirty_direct_chat_lists_all_humans(chat_db, allow_all_groups):
+    """约定外脏数据：一个 direct 会话里出现 >1 个真人 → 如实全列（忠实呈现，
+    不替她挑"主对象"），最近发言的在前（稳定输出）。"""
+    await _seed_conversation(_CHAT_DIRECT, scope="direct", name=None)
+    await _seed_user_message(
+        _CHAT_DIRECT, event_time=1000, text="我先说", scope="direct",
+        user_id=_USER_1, username="田申",
+    )
+    await _seed_user_message(
+        _CHAT_DIRECT, event_time=2000, text="我后说", scope="direct",
+        user_id=_USER_2, username="原智鸿",
+    )
+    await _seed_bot_message(
+        _CHAT_DIRECT, event_time=3000, text="都在啊", persona_id="akao", scope="direct"
+    )
+
+    got = await find_persona_related_chats_recent(
+        persona_id="akao", since_ms=0, max_conversations=10, per_chat_limit=50
+    )
+
+    cps = got[0].counterparts
+    assert [(c.user_id, c.display_name) for c in cps] == [
+        (str(_USER_2), "原智鸿"),
+        (str(_USER_1), "田申"),
+    ], "多真人如实全列、最近发言的在前"
+
+
+@pytest.mark.integration
+async def test_counterpart_display_name_prefers_named_row(chat_db, allow_all_groups):
+    """展示名取该真人**有名字**的最近一行：最新一行 sender_display_name 为空时
+    不把名字弄丢；全部行都没名字才落展示名兜底（不暴露 raw user_id、不拼 None）。"""
+    await _seed_conversation(_CHAT_DIRECT, scope="direct", name=None)
+    await _seed_user_message(
+        _CHAT_DIRECT, event_time=1000, text="有名字的行", scope="direct",
+        user_id=_USER_1, username="田申",
+    )
+    await _seed_user_message(
+        _CHAT_DIRECT, event_time=2000, text="没名字的行", scope="direct",
+        user_id=_USER_1, username=None,
+    )
+    # 另一个真人：全历史都没写过展示名
+    await _seed_user_message(
+        _CHAT_DIRECT, event_time=1500, text="无名氏", scope="direct",
+        user_id=_USER_2, username=None,
+    )
+    await _seed_bot_message(
+        _CHAT_DIRECT, event_time=3000, text="嗯", persona_id="akao", scope="direct"
+    )
+
+    got = await find_persona_related_chats_recent(
+        persona_id="akao", since_ms=0, max_conversations=10, per_chat_limit=50
+    )
+
+    by_id = {c.user_id: c for c in got[0].counterparts}
+    assert by_id[str(_USER_1)].display_name == "田申", "有名字的行优先，不被空名行盖掉"
+    no_name = by_id[str(_USER_2)]
+    assert no_name.display_name, "全无名也给非空兜底展示名"
+    assert str(_USER_2) not in no_name.display_name, "兜底不暴露 raw user_id"
+    assert "None" not in no_name.display_name
+
+
+@pytest.mark.integration
+async def test_counterpart_aggregation_batched_not_per_chat(chat_db, allow_all_groups):
+    """身份聚合对选中会话批量一次查：**身份聚合的查询次数不随会话数增长**
+    （spec Task 1 验收）。只约束这一个不变式——消息查询自身的次数走向（比如
+    未来也批量化）不归这个测试管，不钉总查询量常数（codex T3 建议）。"""
+    from sqlalchemy import event as sa_event
+
+    captured: list[str] = []
+
+    def _capture(conn, cursor, statement, parameters, context, executemany):
+        if statement.lstrip().upper().startswith("SELECT"):
+            captured.append(statement)
+
+    async def _identity_query_count() -> int:
+        """跑一次查询，数可归类为**身份聚合**的 SELECT 条数。
+
+        归类特征：这条查询路径里只有身份聚合用 ``DISTINCT ON``（每 (会话, 真人)
+        取最近有名行）——候选查询走 GROUP BY、消息查询是普通 SELECT，都不含。
+        """
+        captured.clear()
+        sa_event.listen(chat_db.sync_engine, "before_cursor_execute", _capture)
+        try:
+            await find_persona_related_chats_recent(
+                persona_id="akao", since_ms=0, max_conversations=10, per_chat_limit=50
+            )
+        finally:
+            sa_event.remove(chat_db.sync_engine, "before_cursor_execute", _capture)
+        return sum("DISTINCT ON" in stmt for stmt in captured)
+
+    async def _seed_direct(chat_id, *, t):
+        await _seed_conversation(chat_id, scope="direct", name=None)
+        await _seed_user_message(
+            chat_id, event_time=t, text="hi", scope="direct", username="田申"
+        )
+        await _seed_bot_message(
+            chat_id, event_time=t + 1, text="在", persona_id="akao", scope="direct"
+        )
+
+    await _seed_direct(_CHAT_DIRECT, t=1000)
+    n_with_1 = await _identity_query_count()
+
+    await _seed_direct(_CHAT_DIRECT_2, t=2000)
+    await _seed_direct(_CHAT_DIRECT_3, t=3000)
+    n_with_3 = await _identity_query_count()
+
+    assert n_with_1 == 1, (
+        "归类器必须真逮到那条身份聚合查询（不许空转绿）；"
+        f"实际 1 会话时归类到 {n_with_1} 条"
+    )
+    assert n_with_3 == 1, (
+        "3 个会话仍只有 1 条身份聚合查询——身份聚合不随会话数 N+1；"
+        f"实际 3 会话时归类到 {n_with_3} 条"
+    )
+
+
 @pytest.mark.integration
 async def test_proactive_trigger_pseudo_messages_excluded(chat_db, allow_all_groups):
     """proactive_trigger 伪消息不进结果（它是触发器记录、不是真实对话）。"""

--- a/apps/agent-service/tests/domain/test_recipient_directory.py
+++ b/apps/agent-service/tests/domain/test_recipient_directory.py
@@ -3,8 +3,10 @@
 这一层只做「解析」：把名字 / typed uid 翻成「该怎么把消息送到 ta」。它**不发送**
 （发送是 task 3 的事），只回答两个问题：
 
-  * ``search_recipients(query)`` —— 按名字模糊查到候选（typed uid + 一段简介帮认人 /
-    区分重名）。**只返回候选，绝不排序、不按亲密度 / 活跃度 / 兴趣筛、不自动取第一个**
+  * ``search_recipients(query, persona_id=...)`` —— 按名字模糊查到候选（typed uid +
+    一段简介帮认人 / 区分重名）。persona 感知：真人候选的简介附「调用 persona 此刻
+    有没有能直接发过去的私聊线 + 最近一次时间」的事实（帮她区分重名，别编 uid）。
+    **只返回候选，绝不排序、不按亲密度 / 活跃度 / 兴趣筛、不自动取第一个**
     （赤尾设计宪法：选谁是 life 自己的决定，代码不替她决定跟谁说话）。
   * ``resolve_delivery(uid)`` —— 把一个 typed uid 解析成投递目标：
       - ``persona:<id>`` → 信箱投递目标（对接 mailbox.deliver_event）；
@@ -26,6 +28,7 @@ Postgres 集成测试（``test_db`` fixture，对齐 test_persona_spoken_chats.p
 from __future__ import annotations
 
 import uuid
+from datetime import UTC, datetime
 
 import pytest
 from sqlalchemy import text
@@ -287,7 +290,7 @@ def test_user_uid_format():
 async def test_search_sister_by_name_returns_uid_and_intro(directory_db):
     await _seed_three_sisters()
 
-    got = await search_recipients("千凪")
+    got = await search_recipients("千凪", persona_id="akao")
 
     assert len(got) == 1
     cand = got[0]
@@ -300,7 +303,7 @@ async def test_search_sister_by_name_returns_uid_and_intro(directory_db):
 async def test_search_real_person_by_name_returns_user_uid_and_intro(directory_db):
     await _seed_bezhai_with_p2p()
 
-    got = await search_recipients("原智鸿")
+    got = await search_recipients("原智鸿", persona_id="akao")
 
     assert len(got) == 1
     cand = got[0]
@@ -313,7 +316,7 @@ async def test_search_partial_name_matches_substring(directory_db):
     await _seed_three_sisters()
     await _seed_bezhai_with_p2p()
 
-    got = await search_recipients("智鸿")
+    got = await search_recipients("智鸿", persona_id="akao")
 
     uids = {c.uid for c in got}
     assert f"user:{_BEZHAI}" in uids
@@ -329,7 +332,7 @@ async def test_search_returns_all_candidates_for_ambiguous_name(directory_db):
         _OTHER_P2P, user_id=_OTHER, bot_name="chiwei", scope="direct", event_time=1
     )
 
-    got = await search_recipients("小尾")
+    got = await search_recipients("小尾", persona_id="akao")
 
     uids = {c.uid for c in got}
     assert "persona:akao" in uids
@@ -341,7 +344,7 @@ async def test_search_returns_all_candidates_for_ambiguous_name(directory_db):
 async def test_search_no_match_returns_empty(directory_db):
     await _seed_three_sisters()
 
-    got = await search_recipients("查无此人")
+    got = await search_recipients("查无此人", persona_id="akao")
 
     assert got == []
 
@@ -357,12 +360,239 @@ async def test_search_does_not_rank_by_activity_or_intimacy(directory_db):
     await _seed_persona("akao", "赤尾同学", "二姐。")
     await _seed_persona("ayana", "绫奈同学", "小妹。")
 
-    got = await search_recipients("同学")
+    got = await search_recipients("同学", persona_id="akao")
 
     ids = [c.uid for c in got if c.uid.startswith("persona:")]
     assert ids == ["persona:akao", "persona:ayana", "persona:chinagi"], (
         f"同类候选按 persona_id 稳定升序，不按播种序 / 亲密度 / 活跃度，实际 {ids}"
     )
+
+
+# ---------------------------------------------------------------------------
+# search_recipients — persona 感知的私聊线事实（Task 3）
+#
+# 真人候选 intro 附「调用 persona 此刻有没有能直接发过去的私聊线 + 最近一次时间」，
+# 口径复用 _resolve_user 的可投递判定（direct + lark + bot_config(persona_id,
+# is_active)）。**措辞只陈述"此刻有没有能发过去的线"**，不做"历史上从没私聊过"的
+# 断言（spec 决策 5：线不存在可能是 bot 下线 / 归属别的姐妹，不代表没聊过）。
+# ---------------------------------------------------------------------------
+
+# 一个确定的私聊最近活跃时刻：UTC 2026-06-03 16:30 = CST 2026-06-04 00:30 ——
+# 故意选跨日的时刻，钉死「日期按 CST 显示」（按 UTC 算日期会错报成 6 月 3 日）。
+_LAST_DM_MS = int(datetime(2026, 6, 3, 16, 30, tzinfo=UTC).timestamp() * 1000)
+
+# 更早的一个时刻（UTC 2026-06-01 02:00 = CST 10:00 → 2026年6月1日），给「入站旧、
+# 出站新」的双向时间测试当旧端。
+_OLD_DM_MS = int(datetime(2026, 6, 1, 2, 0, tzinfo=UTC).timestamp() * 1000)
+
+
+@pytest.mark.integration
+async def test_search_same_name_users_intro_distinguishes_dm_line(directory_db):
+    """同名两真人一个有私聊线一个没有 → intro 可区分且日期正确（CST 自然中文日期）。"""
+    with_line = uuid.uuid5(uuid.NAMESPACE_OID, "user-samename-with-line")
+    without_line = uuid.uuid5(uuid.NAMESPACE_OID, "user-samename-without-line")
+    conv = uuid.uuid5(uuid.NAMESPACE_OID, "conv-samename-with-line")
+    await _seed_user(with_line, "原智鸿")
+    await _seed_user(without_line, "原智鸿")
+    await _seed_conversation(conv, scope="direct", name="原智鸿")
+    await _seed_message(
+        conv, user_id=with_line, bot_name="chiwei", scope="direct",
+        event_time=_LAST_DM_MS,
+    )
+    await _seed_bot_config("chiwei", "akao", is_active=True)
+
+    got = await search_recipients("原智鸿", persona_id="akao")
+
+    by_uid = {c.uid: c for c in got}
+    has = by_uid[f"user:{with_line}"]
+    lacks = by_uid[f"user:{without_line}"]
+    assert has.intro != lacks.intro, "同名两真人的 intro 必须可区分"
+    assert "能直接发过去的私聊" in has.intro
+    assert "2026年6月4日" in has.intro, f"日期按 CST 显示，实际 intro：{has.intro}"
+    assert "没有能直接发过去的私聊线" in lacks.intro
+    for cand in (has, lacks):
+        # 措辞红线（spec 决策 5）：只陈述"此刻有没有线"，不做历史断言。
+        assert "从没" not in cand.intro
+        assert "没私聊过" not in cand.intro
+
+
+@pytest.mark.integration
+async def test_search_user_with_inactive_bot_line_not_claimed_sendable(directory_db):
+    """历史聊过、但那条线的 bot 已 inactive → intro 不得声称可发（此刻没有能发的线）。"""
+    user = uuid.uuid5(uuid.NAMESPACE_OID, "user-retired-bot-line")
+    conv = uuid.uuid5(uuid.NAMESPACE_OID, "conv-retired-bot-line")
+    await _seed_user(user, "退役线的人")
+    await _seed_conversation(conv, scope="direct", name="退役线")
+    await _seed_message(
+        conv, user_id=user, bot_name="chiwei-retired", scope="direct",
+        event_time=_LAST_DM_MS,
+    )
+    await _seed_bot_config("chiwei-retired", "akao", is_active=False)
+
+    got = await search_recipients("退役线的人", persona_id="akao")
+
+    assert len(got) == 1
+    intro = got[0].intro
+    assert "没有能直接发过去的私聊线" in intro
+    assert "最近一次" not in intro, "bot 已下线的线不得带'最近一次'的可发陈述"
+
+
+@pytest.mark.integration
+async def test_search_user_with_other_persona_line_not_claimed_sendable(directory_db):
+    """只跟**别的 persona** 的 bot 私聊过 → 对调用 persona 而言没有能发的线（persona 感知）。"""
+    user = uuid.uuid5(uuid.NAMESPACE_OID, "user-only-chinagi-line")
+    conv = uuid.uuid5(uuid.NAMESPACE_OID, "conv-only-chinagi-line-search")
+    await _seed_user(user, "只跟千凪聊过的人")
+    await _seed_conversation(conv, scope="direct", name="千凪线")
+    await _seed_message(
+        conv, user_id=user, bot_name="chinagi-bot", scope="direct",
+        event_time=_LAST_DM_MS,
+    )
+    await _seed_bot_config("chinagi-bot", "chinagi", is_active=True)
+
+    got = await search_recipients("只跟千凪聊过的人", persona_id="akao")
+
+    assert len(got) == 1
+    assert "没有能直接发过去的私聊线" in got[0].intro
+
+
+@pytest.mark.integration
+async def test_search_order_not_changed_by_dm_line_facts(directory_db):
+    """候选顺序仍是纯机制序（common_user_id 升序）——私聊线活跃度不影响排序。
+
+    把私聊线（且最近活跃）给排序靠**后**的那个 user：若实现偷偷按活跃度排，顺序会
+    翻转，本测试即红。
+    """
+    ua = uuid.uuid5(uuid.NAMESPACE_OID, "user-order-a")
+    ub = uuid.uuid5(uuid.NAMESPACE_OID, "user-order-b")
+    first, second = sorted([ua, ub])
+    conv = uuid.uuid5(uuid.NAMESPACE_OID, "conv-order-second-line")
+    await _seed_user(ua, "重名排序人")
+    await _seed_user(ub, "重名排序人")
+    # 私聊线给排序靠后的 second。
+    await _seed_conversation(conv, scope="direct", name="排序线")
+    await _seed_message(
+        conv, user_id=second, bot_name="chiwei", scope="direct",
+        event_time=_LAST_DM_MS,
+    )
+    await _seed_bot_config("chiwei", "akao", is_active=True)
+
+    got = await search_recipients("重名排序人", persona_id="akao")
+
+    user_uids = [c.uid for c in got if c.uid.startswith("user:")]
+    assert user_uids == [f"user:{first}", f"user:{second}"], (
+        f"顺序必须仍按 common_user_id 升序、与私聊活跃无关，实际 {user_uids}"
+    )
+
+
+@pytest.mark.integration
+async def test_search_dm_line_date_counts_bot_outbound_rows(directory_db):
+    """「最近一次」取可投递会话内最近一条消息——**双向、不限 role**（codex T3 必改 1）。
+
+    proactive 出站 assistant 行的 common_user_id 是 bot **自己**的（prod 查实口径），
+    只按「该真人自己的发言行」聚合会漏掉它：赤尾昨天刚主动私聊过 ta、ta 没回时，
+    intro 日期停在 ta 上次发言——恰好在主动私聊场景失真。必须算上 bot 出站行。
+    """
+    user = uuid.uuid5(uuid.NAMESPACE_OID, "user-bot-outbound-newer")
+    bot_user = uuid.uuid5(uuid.NAMESPACE_OID, "user-of-bot-itself")
+    conv = uuid.uuid5(uuid.NAMESPACE_OID, "conv-bot-outbound-newer")
+    await _seed_user(user, "被主动私聊的人")
+    await _seed_conversation(conv, scope="direct", name="主动线")
+    # 真人入站行（旧时间）。
+    await _seed_message(
+        conv, user_id=user, bot_name="chiwei", scope="direct", event_time=_OLD_DM_MS
+    )
+    # bot proactive 出站行（新时间）：role=assistant、common_user_id 写 bot **自己的**
+    # user id（不是收件真人的）——模拟 prod 出站行口径。
+    await _seed_message(
+        conv, user_id=bot_user, bot_name="chiwei", scope="direct", role="assistant",
+        event_time=_LAST_DM_MS,
+    )
+    await _seed_bot_config("chiwei", "akao", is_active=True)
+
+    got = await search_recipients("被主动私聊的人", persona_id="akao")
+
+    assert len(got) == 1
+    intro = got[0].intro
+    assert "2026年6月4日" in intro, (
+        f"最近一次要算会话内双向消息（含 bot 出站行），实际 intro：{intro}"
+    )
+    assert "2026年6月1日" not in intro
+
+
+@pytest.mark.integration
+async def test_search_intro_claim_consistent_with_resolve_delivery(directory_db):
+    """不变量守卫（codex T3 建议）：intro 的"可发"声称必须与投递口径同源。
+
+    同一份 seed 下，凡 intro 声称「有能直接发过去的私聊」的 user uid，对同 persona
+    调 resolve_delivery 必须成功返回目标；声称「没有线」的必须抛
+    UndeliverableRecipient——防止未来 _resolve_user 加安全闸时 intro 仍声称可发
+    （口径漂移在这里红）。
+    """
+    u_ok = uuid.uuid5(uuid.NAMESPACE_OID, "user-invariant-ok")
+    u_inactive = uuid.uuid5(uuid.NAMESPACE_OID, "user-invariant-inactive")
+    u_other = uuid.uuid5(uuid.NAMESPACE_OID, "user-invariant-other-persona")
+    u_none = uuid.uuid5(uuid.NAMESPACE_OID, "user-invariant-no-line")
+    conv_ok = uuid.uuid5(uuid.NAMESPACE_OID, "conv-invariant-ok")
+    conv_inactive = uuid.uuid5(uuid.NAMESPACE_OID, "conv-invariant-inactive")
+    conv_other = uuid.uuid5(uuid.NAMESPACE_OID, "conv-invariant-other")
+    # 同名四账号覆盖四种线况：有 active 线 / bot 已 inactive / 线归属别的 persona / 全无线。
+    for u in (u_ok, u_inactive, u_other, u_none):
+        await _seed_user(u, "口径守卫人")
+    await _seed_conversation(conv_ok, scope="direct", name="active 线")
+    await _seed_message(
+        conv_ok, user_id=u_ok, bot_name="chiwei", scope="direct", event_time=_LAST_DM_MS
+    )
+    await _seed_bot_config("chiwei", "akao", is_active=True)
+    await _seed_conversation(conv_inactive, scope="direct", name="退役线")
+    await _seed_message(
+        conv_inactive, user_id=u_inactive, bot_name="chiwei-retired", scope="direct",
+        event_time=_LAST_DM_MS,
+    )
+    await _seed_bot_config("chiwei-retired", "akao", is_active=False)
+    await _seed_conversation(conv_other, scope="direct", name="千凪线")
+    await _seed_message(
+        conv_other, user_id=u_other, bot_name="chinagi-bot", scope="direct",
+        event_time=_LAST_DM_MS,
+    )
+    await _seed_bot_config("chinagi-bot", "chinagi", is_active=True)
+
+    got = await search_recipients("口径守卫人", persona_id="akao")
+    user_cands = [c for c in got if c.uid.startswith("user:")]
+    assert len(user_cands) == 4
+
+    claimers = {
+        c.uid for c in user_cands if "没有能直接发过去的私聊线" not in c.intro
+    }
+    assert claimers == {f"user:{u_ok}"}, "只有 active 线的账号可声称能发"
+
+    for cand in user_cands:
+        if cand.uid in claimers:
+            assert "有能直接发过去的私聊" in cand.intro
+            target = await resolve_delivery(cand.uid, persona_id="akao")
+            assert isinstance(target, LarkP2PTarget), (
+                f"intro 声称可发的 uid 必须真的可投递：{cand.uid}"
+            )
+        else:
+            with pytest.raises(UndeliverableRecipient):
+                await resolve_delivery(cand.uid, persona_id="akao")
+
+
+@pytest.mark.integration
+async def test_search_sister_and_group_intro_carry_no_dm_line_fact(
+    directory_db, monkeypatch
+):
+    """姐妹 / 群候选的 intro 不受私聊线事实影响（事实只加在真人候选上）。"""
+    group = uuid.uuid5(uuid.NAMESPACE_OID, "conv-group-intro-unaffected")
+    await _seed_persona("akao", "小尾", "你是赤尾（小尾），18 岁。")
+    await _seed_conversation(group, scope="group", name="小尾粉丝群")
+    _patch_whitelist(monkeypatch, str(group))
+
+    got = await search_recipients("小尾", persona_id="akao")
+
+    by_uid = {c.uid: c for c in got}
+    assert "私聊" not in by_uid["persona:akao"].intro, "姐妹 intro 不带私聊线事实"
+    assert "私聊" not in by_uid[group_uid(group)].intro, "群 intro 不带私聊线事实"
 
 
 # ---------------------------------------------------------------------------
@@ -819,7 +1049,7 @@ async def test_search_recipients_includes_whitelisted_group(directory_db, monkey
     await _seed_conversation(_SOME_GROUP, scope="group", name="🐢🐢群（飞书版）")
     _patch_whitelist(monkeypatch, str(_SOME_GROUP))
 
-    got = await search_recipients("🐢🐢群")
+    got = await search_recipients("🐢🐢群", persona_id="akao")
 
     uids = {c.uid for c in got}
     assert group_uid(_SOME_GROUP) in uids, "白名单群应作为候选混进来"
@@ -836,7 +1066,7 @@ async def test_search_recipients_excludes_non_whitelisted_group(
     await _seed_conversation(out_wl, scope="group", name="海龟群B")
     _patch_whitelist(monkeypatch, str(in_wl))
 
-    got = await search_recipients("海龟群")
+    got = await search_recipients("海龟群", persona_id="akao")
 
     uids = {c.uid for c in got}
     assert group_uid(in_wl) in uids
@@ -852,7 +1082,7 @@ async def test_search_recipients_excludes_direct_conversation_as_group(
     await _seed_conversation(direct_conv, scope="direct", name="像群名的私聊")
     _patch_whitelist(monkeypatch, str(direct_conv))
 
-    got = await search_recipients("像群名的私聊")
+    got = await search_recipients("像群名的私聊", persona_id="akao")
 
     uids = {c.uid for c in got}
     assert group_uid(direct_conv) not in uids, "direct 会话不作群候选"

--- a/apps/agent-service/tests/integration/test_world_life_closed_loop.py
+++ b/apps/agent-service/tests/integration/test_world_life_closed_loop.py
@@ -479,7 +479,9 @@ async def test_life_wake_includes_realtime_recent_chat_context(
 
     stimulus = _agent_run.life_calls[-1]["messages_text"]
     assert "最近聊过的对话" in stimulus
-    assert "一段私聊" in stimulus
+    # 主动私聊具名化 Task 2：私聊段头部具名 + user:<uuid> 句柄（不再是匿名「一段私聊」），
+    # 让她主动发消息时首发 uid 即合法。
+    assert f"和 贝壳（user:{user_id}）的私聊里" in stimulus
     assert "贝壳：赤尾刚才还记得我吗" in stimulus
     assert "我：当然记得，刚刚才聊过。" in stimulus
     assert "窗边有风吹进来" in stimulus

--- a/apps/agent-service/tests/nodes/test_life_tools.py
+++ b/apps/agent-service/tests/nodes/test_life_tools.py
@@ -2396,6 +2396,7 @@ def stub_directory(monkeypatch):
 
     state: dict = {
         "search_calls": [],
+        "search_kwargs": [],
         "resolve_calls": [],
         "resolve_kwargs": [],
         "emitted": [],
@@ -2411,8 +2412,11 @@ def stub_directory(monkeypatch):
         "render_args": [],
     }
 
-    async def fake_search_recipients(query):
+    async def fake_search_recipients(query, *, persona_id=None):
+        # persona 感知（Task 3）：look_up_contact 必须把调用 persona 透传进来（真人
+        # 候选的私聊线事实按它算）；记下 kwargs 供断言透传正确。
         state["search_calls"].append(query)
+        state["search_kwargs"].append({"query": query, "persona_id": persona_id})
         return state["candidates"]
 
     async def fake_resolve_delivery(uid, *, persona_id=None):
@@ -2532,6 +2536,11 @@ async def test_look_up_contact_returns_all_candidates_with_uid_and_intro(stub_di
     out = await tools["look_up_contact"].invoke({"query": "赤尾"})
 
     assert stub_directory["search_calls"] == ["赤尾"]
+    # persona 透传（Task 3）：真人候选的私聊线事实按**调用 persona**算，look_up_contact
+    # 必须把闭包里的 persona_id 传给 search_recipients。
+    assert stub_directory["search_kwargs"] == [
+        {"query": "赤尾", "persona_id": "chinagi"}
+    ]
     assert isinstance(out, str)
     # 两个重名候选都列出来交给她挑（不替她取第一个）。
     assert "persona:akao" in out and "user:u-1" in out

--- a/apps/agent-service/tests/nodes/test_life_wake_recent_chats.py
+++ b/apps/agent-service/tests/nodes/test_life_wake_recent_chats.py
@@ -3,11 +3,19 @@
 把 T1 查询返回的 ``LifeChatConversation`` 列表渲染成按会话分组的消息列表：
 私聊 / 群分清（群带群名）、她自己的回复显示「我」、每条 ``（时间）发言人：内容``
 忠实呈现，不加工成「某人对你说 X」、不截断单条内容。
+
+主动私聊具名化 Task 2：私聊头部标注对面是谁 + ``user:<uuid>`` 句柄（有 counterparts
+才具名，没有保持匿名兜底）；群头部在群名之外带 ``group:<uuid>`` 句柄——让她主动
+发消息时首发 uid 即合法，不用编。句柄标注只在会话头部，不进 speaker 名。
 """
 
 from __future__ import annotations
 
-from app.data.message_record import LifeChatConversation, LifeChatMessage
+from app.data.message_record import (
+    LifeChatConversation,
+    LifeChatCounterpart,
+    LifeChatMessage,
+)
 from app.nodes.life_wake import _format_recent_chats
 
 
@@ -101,6 +109,93 @@ def test_group_without_name_falls_back():
     ]
     out = _format_recent_chats(convs)
     assert "某人：在吗" in out
+    assert "None" not in out
+
+
+def test_direct_chat_header_names_counterpart_with_handle():
+    """私聊具名（Task 2）：头部标对象名 + user:<uuid> 句柄；句柄只在头部、不进 speaker 名。"""
+    convs = [
+        LifeChatConversation(
+            chat_id="c1",
+            scope="direct",
+            display_name=None,
+            messages=[
+                _msg("田申", False, "赤尾在吗", "08:30 CST"),
+                _msg("akao", True, "在的在的", "08:31 CST"),
+            ],
+            counterparts=[LifeChatCounterpart(user_id="u-1", display_name="田申")],
+        )
+    ]
+    out = _format_recent_chats(convs)
+    assert "· 和 田申（user:u-1）的私聊里：" in out
+    assert "一段私聊里" not in out, "具名了就不再用匿名兜底头"
+    # 句柄标注在会话头部，不进 speaker 名：消息行仍是「田申：」原样
+    assert "田申：赤尾在吗" in out
+    assert "user:u-1）：赤尾在吗" not in out
+
+
+def test_direct_chat_multiple_counterparts_all_listed():
+    """约定外脏数据多对象：如实全列在头部（不替她挑「主对象」），各带各的句柄。"""
+    convs = [
+        LifeChatConversation(
+            chat_id="c1",
+            scope="direct",
+            display_name=None,
+            messages=[_msg("原智鸿", False, "在吗", "09:00 CST")],
+            counterparts=[
+                LifeChatCounterpart(user_id="u-2", display_name="原智鸿"),
+                LifeChatCounterpart(user_id="u-1", display_name="田申"),
+            ],
+        )
+    ]
+    out = _format_recent_chats(convs)
+    assert "· 和 原智鸿（user:u-2）、田申（user:u-1）的私聊里：" in out
+
+
+def test_direct_chat_without_counterpart_keeps_anonymous_header():
+    """全历史无真人行（对方从没回过）：保持现状匿名兜底，不硬造名字、不拼 None。"""
+    convs = [
+        LifeChatConversation(
+            chat_id="c1",
+            scope="direct",
+            display_name=None,
+            messages=[_msg("akao", True, "在想你", "10:00 CST")],
+            counterparts=[],
+        )
+    ]
+    out = _format_recent_chats(convs)
+    assert "· 一段私聊里：" in out
+    assert "user:" not in out, "没有对象就没有句柄，不硬造"
+    assert "None" not in out
+
+
+def test_group_header_carries_group_handle():
+    """群头部（Task 2）：群名之外带 group:<uuid> 句柄（口吻同历史动静的群句柄标注）。"""
+    convs = [
+        LifeChatConversation(
+            chat_id="g1",
+            scope="group",
+            display_name="赤尾应援团",
+            messages=[_msg("路人A", False, "今晚直播吗", "09:00 CST")],
+        )
+    ]
+    out = _format_recent_chats(convs)
+    assert "群「赤尾应援团」" in out
+    assert "群句柄 group:g1" in out
+
+
+def test_group_without_name_still_carries_handle_no_none():
+    """群名缺失：兜底头也带群句柄，绝不把 None 拼进文案。"""
+    convs = [
+        LifeChatConversation(
+            chat_id="g1",
+            scope="group",
+            display_name=None,
+            messages=[_msg("某人", False, "在吗", "10:00 CST")],
+        )
+    ]
+    out = _format_recent_chats(convs)
+    assert "群句柄 group:g1" in out
     assert "None" not in out
 
 


### PR DESCRIPTION
Life engine kept fabricating send_message uids (pinyin usernames, raw
display names, full group titles — 5-10 UndeliverableRecipient per day
all week) because the recent-chats stimulus section rendered DMs as an
anonymous "一段私聊里" with no counterpart identity, and no user:<uuid>
handle appeared anywhere in the stimulus. Same-name contact candidates
from look_up_contact were also indistinguishable (identical intros),
leading to blind first-pick misdelivery.

- Resolve DM counterparts (id + display name) from full conversation
  history, decoupled from the since window — anchored on role='user'
  rows to dodge two traps: human rows also carry bot_name, and
  proactive outbound rows carry the bot's own common_user_id. Batched
  per selected chats, no N+1.
- Render DM headers named with user:<uuid> handles and group headers
  with group:<uuid> handles (inline, following _group_handle_suffix
  precedent). Handles ground identity only; deliverability still
  fail-louds at resolve_delivery.
- search_recipients now requires the calling persona and annotates
  human candidates with deliverable-DM-line facts (existence + last
  activity across both directions), worded strictly to the query's
  semantics — no "never chatted" historical claims. Candidate ordering
  untouched (no ranking, per design constitution).
- Guard test pins intro claims to resolve_delivery outcomes so the two
  SQL criteria cannot drift apart.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
