### PR TITLE
fix: harden Pixiv daily download liveness

### DIFF
--- a/apps/media-sync-worker/.env.example
+++ b/apps/media-sync-worker/.env.example
@@ -9,6 +9,8 @@ MONGO_CONNECT_TIMEOUT_MS=10000
 REDIS_HOST=localhost
 REDIS_PORT=6379
 REDIS_PASSWORD=your_redis_password_here
+# 单条 Redis 命令硬超时，防止半开连接永久阻塞每日作者发现。
+REDIS_COMMAND_TIMEOUT_MS=30000
 
 # 飞书开放平台配置
 APP_ID=cli_xxxxxxxxxxxxxxxxxxxx
@@ -26,6 +28,8 @@ BANGUMI_ACCESS_TOKEN=your_bangumi_access_token_here
 # 定时任务配置
 # Pixiv 下载任务 cron 表达式，默认每天 10:12
 DOWNLOAD_CRON="12 10 * * *"
+# 单个作者发现/入队的最终 watchdog；超时后记录并继续下一个作者。
+DOWNLOAD_AUTHOR_TIMEOUT_MS=600000
 # 下载等待参数：默认均为旧硬编码等待的一半；需要进一步提速可按压测结果降到 0。
 DOWNLOAD_AFTER_ILLUST_INFO_DELAY_MS=1500
 DOWNLOAD_BEFORE_PAGE_DOWNLOAD_DELAY_MS=1000

--- a/apps/media-sync-worker/README.md
+++ b/apps/media-sync-worker/README.md
@@ -39,6 +39,8 @@ Pixiv 图片元数据本地镜像例外：下载成功后，worker 会在 `PIXIV
 ## 可选环境变量
 
 - `DOWNLOAD_CRON`：Pixiv 下载任务 cron 表达式，默认 `12 10 * * *`（每天 10:12）。
+- `DOWNLOAD_AUTHOR_TIMEOUT_MS`：单个关注作者发现与入队的硬超时，默认 `600000`；超时后发出协作中止信号、记录失败并继续下一个作者。冷却时间戳在 watchdog 清除后才提交。
+- `REDIS_COMMAND_TIMEOUT_MS`：media-sync-worker 单条 Redis 命令硬超时，默认 `30000`。
 - `DOWNLOAD_AFTER_ILLUST_INFO_DELAY_MS`：取作品信息后的等待时间，默认 `1500`（旧值减半）。
 - `DOWNLOAD_BEFORE_PAGE_DOWNLOAD_DELAY_MS`：单页图片代理下载前等待时间，默认 `1000`（旧值减半）。
 - `DOWNLOAD_AFTER_TASK_DELAY_MS`：每个下载任务完成后的等待时间，默认 `2500`（旧值减半）。
@@ -62,6 +64,10 @@ Pixiv 图片元数据本地镜像例外：下载成功后，worker 会在 `PIXIV
 - `TAGGER_PROJECTION_*`：结果投影的 batch、轮询、重试和 processing 超时配置。
 - `TAGGER_CALLBACK_URL` / `TAGGER_CALLBACK_AUTH_TOKEN`：tagger-service 回调地址和回调鉴权 token。
 - `TAGGER_CALLBACK_SERVER_ENABLED` / `TAGGER_CALLBACK_PORT`：开启 worker 内部 HTTP callback 入口及端口。
+
+每日作者发现启动前会验证源 Mongo 的 `download_task.illust_id` 唯一索引，并使用原子 upsert 入队。若存量存在重复 `illust_id`，索引创建会失败并终止本轮发现；上线前必须先只读检查重复数据，不能由应用自动删除。作者失败或超时会让整批以错误结束并交给 cron 的现有重试，而不是只打印成功。
+
+本链路的飞书状态通知另有固定 30 秒等待上限，避免 Lark SDK 的无界请求卡住每日任务。
 
 ## 部署验证开关
 

--- a/apps/media-sync-worker/src/env.d.ts
+++ b/apps/media-sync-worker/src/env.d.ts
@@ -10,11 +10,13 @@ declare namespace NodeJS {
     PROXY_HTTP_SECRET: string;
     REDIS_HOST: string;
     REDIS_PORT: string;
+    REDIS_COMMAND_TIMEOUT_MS: string;
     BANGUMI_ACCESS_TOKEN: string;
     MONGO_HOST: string;
     MONGO_PORT: string;
     MONGO_CONNECT_TIMEOUT_MS: string;
     DOWNLOAD_CRON: string;
+    DOWNLOAD_AUTHOR_TIMEOUT_MS: string;
     DOWNLOAD_AFTER_ILLUST_INFO_DELAY_MS: string;
     DOWNLOAD_BEFORE_PAGE_DOWNLOAD_DELAY_MS: string;
     DOWNLOAD_AFTER_TASK_DELAY_MS: string;

--- a/apps/media-sync-worker/src/mongo/client.ts
+++ b/apps/media-sync-worker/src/mongo/client.ts
@@ -2,6 +2,7 @@ import { Collection } from "mongodb";
 import { MongoService, MongoCollection, getMongoService } from "@inner/shared/mongo";
 import { loadMongoConfigFromEnv } from "./config";
 import { DownloadTask, PixivImageInfo, TranslateWord } from "./types";
+import { ensureDownloadTaskUniqueIndex } from "./downloadTaskRepository";
 
 // MongoDB 服务实例
 let mongoService: MongoService;
@@ -10,6 +11,7 @@ let mongoService: MongoService;
 export let ImgCollection: MongoCollection<PixivImageInfo>;
 export let DownloadTaskMap: MongoCollection<DownloadTask>;
 export let TranslateWordMap: MongoCollection<TranslateWord>;
+let downloadTaskUniqueIndexPromise: Promise<void> | undefined;
 
 // Bangumi Archive 集合实例（使用原生 Collection）
 export let BangumiSubjectCollection: Collection;
@@ -94,3 +96,18 @@ export const mongoInitPromise = (async () => {
     throw err;
   }
 })();
+
+export async function ensureDownloadTaskRepositoryReady(): Promise<void> {
+  await mongoInitPromise;
+  downloadTaskUniqueIndexPromise ??=
+    ensureDownloadTaskUniqueIndex(DownloadTaskMap);
+  const currentAttempt = downloadTaskUniqueIndexPromise;
+  try {
+    await currentAttempt;
+  } catch (error) {
+    if (downloadTaskUniqueIndexPromise === currentAttempt) {
+      downloadTaskUniqueIndexPromise = undefined;
+    }
+    throw error;
+  }
+}

--- a/apps/media-sync-worker/src/mongo/downloadTaskRepository.test.ts
+++ b/apps/media-sync-worker/src/mongo/downloadTaskRepository.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it, mock } from 'bun:test';
+import { MongoServerError } from 'mongodb';
+import {
+    ensureDownloadTaskUniqueIndex,
+    insertDownloadTaskOnce,
+} from './downloadTaskRepository';
+import { DownloadTaskStatus } from './types';
+
+describe('ensureDownloadTaskUniqueIndex', () => {
+    it('declares illust_id as a unique repository invariant', async () => {
+        const createIndex = mock(async () => 'uniq_download_task_illust_id');
+
+        await ensureDownloadTaskUniqueIndex({ createIndex } as any);
+
+        expect(createIndex).toHaveBeenCalledWith(
+            { illust_id: 1 },
+            {
+                unique: true,
+                background: true,
+                name: 'uniq_download_task_illust_id',
+            }
+        );
+    });
+});
+
+describe('insertDownloadTaskOnce', () => {
+    const now = new Date('2026-07-24T12:00:00.000Z');
+
+    it('uses one atomic upsert and reports a new task', async () => {
+        const findOneAndUpdate = mock(async () => null);
+
+        const inserted = await insertDownloadTaskOnce(
+            { findOneAndUpdate } as any,
+            '123',
+            now
+        );
+
+        expect(inserted).toBe(true);
+        expect(findOneAndUpdate).toHaveBeenCalledWith(
+            { illust_id: '123' },
+            {
+                $setOnInsert: {
+                    illust_id: '123',
+                    status: DownloadTaskStatus.Pending,
+                    create_time: now,
+                    update_time: now,
+                    retry_time: 0,
+                    last_run_time: undefined,
+                    last_run_error: undefined,
+                },
+            },
+            { upsert: true, returnDocument: 'before' }
+        );
+    });
+
+    it('reports an existing task without replacing its state', async () => {
+        const findOneAndUpdate = mock(async () => ({
+            illust_id: '123',
+            status: DownloadTaskStatus.Success,
+        }));
+
+        expect(
+            await insertDownloadTaskOnce({ findOneAndUpdate } as any, '123', now)
+        ).toBe(false);
+    });
+
+    it('treats a duplicate-key race as an existing task', async () => {
+        const findOneAndUpdate = mock(async () => {
+            throw new MongoServerError({
+                message: 'duplicate key',
+                code: 11000,
+                keyPattern: { illust_id: 1 },
+            });
+        });
+
+        expect(
+            await insertDownloadTaskOnce({ findOneAndUpdate } as any, '123', now)
+        ).toBe(false);
+    });
+
+    it('does not hide a duplicate-key error for an unrelated constraint', async () => {
+        const failure = new MongoServerError({
+            message: 'duplicate key',
+            code: 11000,
+            keyPattern: { other_key: 1 },
+        });
+        const findOneAndUpdate = mock(async () => {
+            throw failure;
+        });
+
+        const promise = insertDownloadTaskOnce(
+            { findOneAndUpdate } as any,
+            '123',
+            now
+        );
+
+        expect(promise).rejects.toBe(failure);
+        await promise.catch(() => {});
+    });
+
+    it('preserves non-duplicate database errors', async () => {
+        const failure = new Error('mongo unavailable');
+        const findOneAndUpdate = mock(async () => {
+            throw failure;
+        });
+
+        const promise = insertDownloadTaskOnce(
+            { findOneAndUpdate } as any,
+            '123',
+            now
+        );
+
+        expect(promise).rejects.toBe(failure);
+        await promise.catch(() => {});
+    });
+});

--- a/apps/media-sync-worker/src/mongo/downloadTaskRepository.ts
+++ b/apps/media-sync-worker/src/mongo/downloadTaskRepository.ts
@@ -1,0 +1,58 @@
+import type { MongoCollection } from '@inner/shared/mongo';
+import { MongoServerError, type UpdateFilter } from 'mongodb';
+import { DownloadTask, DownloadTaskStatus } from './types';
+
+type DownloadTaskIndexCollection = Pick<
+    MongoCollection<DownloadTask>,
+    'createIndex'
+>;
+
+type DownloadTaskWriteCollection = Pick<
+    MongoCollection<DownloadTask>,
+    'findOneAndUpdate'
+>;
+
+export async function ensureDownloadTaskUniqueIndex(
+    collection: DownloadTaskIndexCollection
+): Promise<void> {
+    await collection.createIndex(
+        { illust_id: 1 },
+        {
+            unique: true,
+            background: true,
+            name: 'uniq_download_task_illust_id',
+        }
+    );
+}
+
+export async function insertDownloadTaskOnce(
+    collection: DownloadTaskWriteCollection,
+    illustId: string,
+    now: Date = new Date()
+): Promise<boolean> {
+    const task = new DownloadTask({
+        illust_id: illustId,
+        status: DownloadTaskStatus.Pending,
+        create_time: now,
+        update_time: now,
+        retry_time: 0,
+    });
+
+    try {
+        const existing = await collection.findOneAndUpdate(
+            { illust_id: illustId },
+            { $setOnInsert: task } as UpdateFilter<DownloadTask>,
+            { upsert: true, returnDocument: 'before' }
+        );
+        return existing === null;
+    } catch (error) {
+        if (
+            error instanceof MongoServerError &&
+            error.code === 11000 &&
+            error.keyPattern?.illust_id === 1
+        ) {
+            return false;
+        }
+        throw error;
+    }
+}

--- a/apps/media-sync-worker/src/mongo/service.ts
+++ b/apps/media-sync-worker/src/mongo/service.ts
@@ -16,7 +16,13 @@ import {
   TranslateWord,
     UploadImgV2Req,
 } from "./types";
-import { DownloadTaskMap, ImgCollection, TranslateWordMap } from "./client";
+import {
+  DownloadTaskMap,
+  ImgCollection,
+  TranslateWordMap,
+  ensureDownloadTaskRepositoryReady,
+} from "./client";
+import { insertDownloadTaskOnce } from "./downloadTaskRepository";
 import { loadConsumerGuardConfig } from "../service/downloadRuntime";
 
 /**
@@ -60,25 +66,8 @@ export async function getMaxIllustId(illustIds: number[]): Promise<number> {
  * @throws 如果在数据库操作中发生错误，将抛出错误
  */
 export async function insertDownloadTask(illustId: string): Promise<boolean> {
-  // 查询是否已经存在相同 illustId 的任务
-  const filter: Filter<DownloadTask> = { illust_id: illustId };
-
-  // 使用封装的 find 方法查找是否已经存在此任务
-  const existingTasks = await DownloadTaskMap.find(filter);
-
-  // 如果找到了现有任务，返回 false 表示未插入
-  if (existingTasks.length > 0) {
-    return false;
-  }
-
-  // 创建新的下载任务
-  const newTask = DownloadTask.createTask(illustId);
-
-  // 插入新任务
-  await DownloadTaskMap.insertOne(newTask);
-
-  // 返回 true 表示成功插入
-  return true;
+  await ensureDownloadTaskRepositoryReady();
+  return insertDownloadTaskOnce(DownloadTaskMap, illustId);
 }
 
 /**

--- a/apps/media-sync-worker/src/redis/config.test.ts
+++ b/apps/media-sync-worker/src/redis/config.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'bun:test';
+import {
+    loadRedisCommandTimeoutMs,
+    withRedisCommandTimeout,
+} from './config';
+
+describe('loadRedisCommandTimeoutMs', () => {
+    it('defaults media-sync Redis commands to a 30 second hard timeout', () => {
+        expect(loadRedisCommandTimeoutMs({})).toBe(30_000);
+    });
+
+    it('accepts a positive override and rejects non-positive or invalid values', () => {
+        expect(loadRedisCommandTimeoutMs({ REDIS_COMMAND_TIMEOUT_MS: '45000' })).toBe(45_000);
+        expect(loadRedisCommandTimeoutMs({ REDIS_COMMAND_TIMEOUT_MS: '0' })).toBe(30_000);
+        expect(loadRedisCommandTimeoutMs({ REDIS_COMMAND_TIMEOUT_MS: '-1' })).toBe(30_000);
+        expect(loadRedisCommandTimeoutMs({ REDIS_COMMAND_TIMEOUT_MS: 'slow' })).toBe(30_000);
+        expect(loadRedisCommandTimeoutMs({ REDIS_COMMAND_TIMEOUT_MS: '30000ms' })).toBe(30_000);
+        expect(loadRedisCommandTimeoutMs({ REDIS_COMMAND_TIMEOUT_MS: '1.5' })).toBe(30_000);
+        expect(loadRedisCommandTimeoutMs({ REDIS_COMMAND_TIMEOUT_MS: '2147483648' })).toBe(30_000);
+    });
+});
+
+describe('withRedisCommandTimeout', () => {
+    it('wires the parsed timeout into the shared client config without dropping base fields', () => {
+        expect(
+            withRedisCommandTimeout(
+                {
+                    host: 'redis.internal',
+                    port: 6380,
+                    password: 'secret',
+                },
+                { REDIS_COMMAND_TIMEOUT_MS: '45000' }
+            )
+        ).toEqual({
+            host: 'redis.internal',
+            port: 6380,
+            password: 'secret',
+            commandTimeout: 45_000,
+        });
+    });
+});

--- a/apps/media-sync-worker/src/redis/config.ts
+++ b/apps/media-sync-worker/src/redis/config.ts
@@ -1,0 +1,31 @@
+import type { RedisConfig } from '@inner/shared/cache';
+
+const DEFAULT_REDIS_COMMAND_TIMEOUT_MS = 30_000;
+const MAX_TIMER_DELAY_MS = 2_147_483_647;
+
+export function loadRedisCommandTimeoutMs(
+    env: Record<string, string | undefined> = process.env
+): number {
+    const raw = env.REDIS_COMMAND_TIMEOUT_MS;
+    if (raw === undefined || raw === '') {
+        return DEFAULT_REDIS_COMMAND_TIMEOUT_MS;
+    }
+    const normalized = raw.trim();
+    if (!/^\d+$/.test(normalized)) {
+        return DEFAULT_REDIS_COMMAND_TIMEOUT_MS;
+    }
+    const parsed = Number(normalized);
+    return Number.isSafeInteger(parsed) && parsed > 0 && parsed <= MAX_TIMER_DELAY_MS
+        ? parsed
+        : DEFAULT_REDIS_COMMAND_TIMEOUT_MS;
+}
+
+export function withRedisCommandTimeout(
+    baseConfig: RedisConfig,
+    env: Record<string, string | undefined> = process.env
+): RedisConfig {
+    return {
+        ...baseConfig,
+        commandTimeout: loadRedisCommandTimeoutMs(env),
+    };
+}

--- a/apps/media-sync-worker/src/redis/redisClient.ts
+++ b/apps/media-sync-worker/src/redis/redisClient.ts
@@ -1,6 +1,13 @@
-import { getRedisClient, RedisClient } from '@inner/shared/cache';
+import {
+    createDefaultRedisConfig,
+    getRedisClient,
+    RedisClient,
+} from '@inner/shared/cache';
+import { withRedisCommandTimeout } from './config';
 
 // 使用共享的 Redis 客户端
-const redisClient: RedisClient = getRedisClient();
+const redisClient: RedisClient = getRedisClient(
+    withRedisCommandTimeout(createDefaultRedisConfig())
+);
 
 export default redisClient;

--- a/apps/media-sync-worker/src/service/dailyAuthorBatch.test.ts
+++ b/apps/media-sync-worker/src/service/dailyAuthorBatch.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it } from 'bun:test';
+import {
+    assertDailyAuthorBatchSucceeded,
+    runDailyAuthorBatch,
+} from './dailyAuthorBatch';
+
+const AUTHORS = [
+    { userId: 'stuck', userName: 'stuck author' },
+    { userId: 'healthy', userName: 'healthy author' },
+];
+
+describe('runDailyAuthorBatch', () => {
+    it('times out a permanently pending author and continues with the next author', async () => {
+        const started: string[] = [];
+        const committed: string[] = [];
+        const errors: string[] = [];
+        let stuckSignal: AbortSignal | undefined;
+
+        const summary = await runDailyAuthorBatch(AUTHORS, {
+            authorTimeoutMs: 10,
+            runAuthor: async (author, signal) => {
+                started.push(author.userId);
+                if (author.userId === 'stuck') {
+                    stuckSignal = signal;
+                    await new Promise<never>(() => {});
+                }
+            },
+            afterAuthor: async (author) => {
+                committed.push(author.userId);
+            },
+            logError: (message) => errors.push(message),
+        });
+
+        expect(started).toEqual(['stuck', 'healthy']);
+        expect(committed).toEqual(['healthy']);
+        expect(summary).toEqual({
+            status: 'completed_with_errors',
+            total: 2,
+            completed: 1,
+            failed: 0,
+            timed_out: 1,
+        });
+        expect(errors).toHaveLength(1);
+        expect(errors[0]).toContain('"author_id":"stuck"');
+        expect(errors[0]).toContain('"status":"timed_out"');
+        expect(errors[0]).toContain('"timeout_ms":10');
+        expect(stuckSignal?.aborted).toBe(true);
+    });
+
+    it('isolates an ordinary author failure and reports accurate batch counts', async () => {
+        const started: string[] = [];
+
+        const summary = await runDailyAuthorBatch(AUTHORS, {
+            authorTimeoutMs: 100,
+            runAuthor: async (author) => {
+                started.push(author.userId);
+                if (author.userId === 'stuck') {
+                    throw new Error('pixiv rejected request');
+                }
+            },
+            logError: () => {},
+        });
+
+        expect(started).toEqual(['stuck', 'healthy']);
+        expect(summary).toEqual({
+            status: 'completed_with_errors',
+            total: 2,
+            completed: 1,
+            failed: 1,
+            timed_out: 0,
+        });
+    });
+
+    it('isolates a post-watchdog cooldown commit failure and continues', async () => {
+        const committed: string[] = [];
+
+        const summary = await runDailyAuthorBatch(AUTHORS, {
+            authorTimeoutMs: 100,
+            runAuthor: async () => 'completed' as const,
+            afterAuthor: async (author) => {
+                committed.push(author.userId);
+                if (author.userId === 'stuck') {
+                    throw new Error('redis hset failed');
+                }
+            },
+            logError: () => {},
+        });
+
+        expect(committed).toEqual(['stuck', 'healthy']);
+        expect(summary).toEqual({
+            status: 'completed_with_errors',
+            total: 2,
+            completed: 1,
+            failed: 1,
+            timed_out: 0,
+        });
+    });
+
+    it('marks an all-settled batch as completed', async () => {
+        const summary = await runDailyAuthorBatch(AUTHORS, {
+            authorTimeoutMs: 100,
+            runAuthor: async () => {},
+            logError: () => {},
+        });
+
+        expect(summary).toEqual({
+            status: 'completed',
+            total: 2,
+            completed: 2,
+            failed: 0,
+            timed_out: 0,
+        });
+    });
+
+    it('turns a partial batch into a cron-visible failure after preserving its summary', () => {
+        const summary = {
+            status: 'completed_with_errors' as const,
+            total: 2,
+            completed: 1,
+            failed: 1,
+            timed_out: 0,
+        };
+
+        expect(() => assertDailyAuthorBatchSucceeded(summary)).toThrow(
+            `daily author batch incomplete: ${JSON.stringify(summary)}`
+        );
+    });
+
+    it('accepts a fully completed batch', () => {
+        expect(() =>
+            assertDailyAuthorBatchSucceeded({
+                status: 'completed',
+                total: 2,
+                completed: 2,
+                failed: 0,
+                timed_out: 0,
+            })
+        ).not.toThrow();
+    });
+});

--- a/apps/media-sync-worker/src/service/dailyAuthorBatch.ts
+++ b/apps/media-sync-worker/src/service/dailyAuthorBatch.ts
@@ -1,0 +1,118 @@
+export interface DailyAuthor {
+    userId: string;
+    userName: string;
+}
+
+export interface DailyAuthorBatchSummary {
+    status: 'completed' | 'completed_with_errors';
+    total: number;
+    completed: number;
+    failed: number;
+    timed_out: number;
+}
+
+interface DailyAuthorBatchOptions<T extends DailyAuthor, TResult> {
+    authorTimeoutMs: number;
+    runAuthor: (author: T, signal: AbortSignal) => Promise<TResult>;
+    afterAuthor?: (author: T, result: TResult) => Promise<void>;
+    logError?: (message: string) => void;
+}
+
+class DailyAuthorTimeoutError extends Error {
+    constructor(
+        readonly authorId: string,
+        readonly timeoutMs: number
+    ) {
+        super(`author ${authorId} did not settle within ${timeoutMs}ms`);
+        this.name = 'DailyAuthorTimeoutError';
+    }
+}
+
+export async function runDailyAuthorBatch<T extends DailyAuthor, TResult = void>(
+    authors: readonly T[],
+    options: DailyAuthorBatchOptions<T, TResult>
+): Promise<DailyAuthorBatchSummary> {
+    const counts = {
+        total: authors.length,
+        completed: 0,
+        failed: 0,
+        timed_out: 0,
+    };
+    const logError = options.logError ?? ((message: string) => console.error(message));
+
+    for (const author of authors) {
+        try {
+            const result = await runAuthorWithTimeout(
+                author,
+                options.authorTimeoutMs,
+                options.runAuthor
+            );
+            await options.afterAuthor?.(author, result);
+            counts.completed++;
+        } catch (error) {
+            const timedOut = error instanceof DailyAuthorTimeoutError;
+            if (timedOut) {
+                counts.timed_out++;
+            } else {
+                counts.failed++;
+            }
+            logError(
+                `daily_download_author_failed ${JSON.stringify({
+                    author_id: author.userId,
+                    author_name: author.userName,
+                    status: timedOut ? 'timed_out' : 'failed',
+                    ...(timedOut ? { timeout_ms: options.authorTimeoutMs } : {}),
+                    error: formatError(error),
+                })}`
+            );
+        }
+    }
+
+    return {
+        status:
+            counts.failed > 0 || counts.timed_out > 0
+                ? 'completed_with_errors'
+                : 'completed',
+        ...counts,
+    };
+}
+
+export function assertDailyAuthorBatchSucceeded(
+    summary: DailyAuthorBatchSummary
+): void {
+    if (summary.status === 'completed_with_errors') {
+        throw new Error(`daily author batch incomplete: ${JSON.stringify(summary)}`);
+    }
+}
+
+async function runAuthorWithTimeout<T extends DailyAuthor, TResult>(
+    author: T,
+    timeoutMs: number,
+    runAuthor: (author: T, signal: AbortSignal) => Promise<TResult>
+): Promise<TResult> {
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const controller = new AbortController();
+    try {
+        return await Promise.race([
+            Promise.resolve().then(() => runAuthor(author, controller.signal)),
+            new Promise<never>((_, reject) => {
+                timer = setTimeout(() => {
+                    const timeoutError = new DailyAuthorTimeoutError(
+                        author.userId,
+                        timeoutMs
+                    );
+                    controller.abort(timeoutError);
+                    reject(timeoutError);
+                }, timeoutMs);
+            }),
+        ]);
+    } finally {
+        if (timer !== undefined) {
+            clearTimeout(timer);
+        }
+    }
+}
+
+function formatError(error: unknown): string {
+    return error instanceof Error ? error.message : String(error);
+}

--- a/apps/media-sync-worker/src/service/dailyAuthorDiscovery.test.ts
+++ b/apps/media-sync-worker/src/service/dailyAuthorDiscovery.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it } from 'bun:test';
+import {
+    enqueueDownloadTasks,
+    runDailyAuthorDiscovery,
+} from './dailyAuthorDiscovery';
+
+const AUTHOR = { userId: '62922469', userName: 'test author' };
+
+describe('runDailyAuthorDiscovery', () => {
+    it('finishes discovery without committing cooldown state inside the watchdog', async () => {
+        const events: string[] = [];
+
+        const result = await runDailyAuthorDiscovery(
+            AUTHOR,
+            {
+                getLastDownloadTime: async () => {
+                    events.push('read_cooldown');
+                    return null;
+                },
+                discoverAuthor: async () => {
+                    events.push('discover');
+                },
+                waitAfterAuthor: async () => {
+                    events.push('wait');
+                },
+                getRandomDays: () => 2,
+                now: () => 1_700_000_000_000,
+            },
+            new AbortController().signal
+        );
+
+        expect(result).toBe('completed');
+        expect(events).toEqual(['read_cooldown', 'discover', 'wait']);
+    });
+
+    it('preserves the discovery error', async () => {
+        const failure = new Error('mongo insert failed');
+
+        const promise = runDailyAuthorDiscovery(
+            AUTHOR,
+            {
+                getLastDownloadTime: async () => null,
+                discoverAuthor: async () => {
+                    throw failure;
+                },
+                waitAfterAuthor: async () => {},
+                getRandomDays: () => 2,
+                now: () => 1_700_000_000_000,
+            },
+            new AbortController().signal
+        );
+
+        expect(promise).rejects.toBe(failure);
+        await promise.catch(() => {});
+    });
+
+    it('rejects when the watchdog aborts late work', async () => {
+        const controller = new AbortController();
+        const timeout = new Error('author timed out');
+
+        const promise = runDailyAuthorDiscovery(
+            AUTHOR,
+            {
+                getLastDownloadTime: async () => null,
+                discoverAuthor: async () => {
+                    controller.abort(timeout);
+                },
+                waitAfterAuthor: async () => {},
+                getRandomDays: () => 2,
+                now: () => 1_700_000_000_000,
+            },
+            controller.signal
+        );
+
+        expect(promise).rejects.toBe(timeout);
+        await promise.catch(() => {});
+    });
+
+    it('keeps an author inside its cooldown without rediscovering or rewriting it', async () => {
+        let discoveries = 0;
+
+        const result = await runDailyAuthorDiscovery(
+            AUTHOR,
+            {
+                getLastDownloadTime: async () => '1700000000',
+                discoverAuthor: async () => {
+                    discoveries++;
+                },
+                waitAfterAuthor: async () => {},
+                getRandomDays: () => 2,
+                now: () => 1_700_000_100_000,
+            },
+            new AbortController().signal
+        );
+
+        expect(result).toBe('skipped');
+        expect(discoveries).toBe(0);
+    });
+});
+
+describe('enqueueDownloadTasks', () => {
+    it('stops and preserves the original insertion error', async () => {
+        const failure = new Error('write concern timed out');
+        const inserted: string[] = [];
+
+        const promise = enqueueDownloadTasks(
+            ['101', '102', '103'],
+            async (illustId) => {
+                inserted.push(illustId);
+                if (illustId === '102') {
+                    throw failure;
+                }
+                return true;
+            },
+            new AbortController().signal
+        );
+
+        expect(promise).rejects.toBe(failure);
+        await promise.catch(() => {});
+        expect(inserted).toEqual(['101', '102']);
+    });
+
+    it('does not start another insertion after an in-flight write settles late', async () => {
+        const controller = new AbortController();
+        const timeout = new Error('author timed out');
+        const inserted: string[] = [];
+
+        const promise = enqueueDownloadTasks(
+            ['101', '102'],
+            async (illustId) => {
+                inserted.push(illustId);
+                controller.abort(timeout);
+                return true;
+            },
+            controller.signal
+        );
+
+        expect(promise).rejects.toBe(timeout);
+        await promise.catch(() => {});
+        expect(inserted).toEqual(['101']);
+    });
+});

--- a/apps/media-sync-worker/src/service/dailyAuthorDiscovery.ts
+++ b/apps/media-sync-worker/src/service/dailyAuthorDiscovery.ts
@@ -1,0 +1,72 @@
+import type { DailyAuthor } from './dailyAuthorBatch';
+
+export interface DailyAuthorDiscoveryDependencies {
+    getLastDownloadTime: (authorId: string) => Promise<string | null>;
+    discoverAuthor: (authorId: string, signal: AbortSignal) => Promise<void>;
+    waitAfterAuthor: () => Promise<void>;
+    getRandomDays: () => number;
+    now: () => number;
+}
+
+export type DailyAuthorDiscoveryResult = 'completed' | 'skipped';
+
+export async function runDailyAuthorDiscovery(
+    author: DailyAuthor,
+    dependencies: DailyAuthorDiscoveryDependencies,
+    signal: AbortSignal
+): Promise<DailyAuthorDiscoveryResult> {
+    throwIfAborted(signal);
+    const lastDownloadTime = await dependencies.getLastDownloadTime(author.userId);
+    throwIfAborted(signal);
+
+    if (
+        lastDownloadTime !== null &&
+        isInsideCooldown(
+            lastDownloadTime,
+            dependencies.getRandomDays(),
+            dependencies.now()
+        )
+    ) {
+        return 'skipped';
+    }
+
+    await dependencies.discoverAuthor(author.userId, signal);
+    throwIfAborted(signal);
+
+    await dependencies.waitAfterAuthor();
+    throwIfAborted(signal);
+    return 'completed';
+}
+
+export async function enqueueDownloadTasks(
+    illustIds: readonly string[],
+    insertTask: (illustId: string) => Promise<boolean>,
+    signal: AbortSignal
+): Promise<void> {
+    for (const illustId of illustIds) {
+        throwIfAborted(signal);
+        await insertTask(illustId);
+        throwIfAborted(signal);
+    }
+}
+
+export function throwIfAborted(signal: AbortSignal): void {
+    if (!signal.aborted) {
+        return;
+    }
+    throw signal.reason ?? new Error('daily author discovery aborted');
+}
+
+function isInsideCooldown(
+    lastDownloadTime: string,
+    cooldownDays: number,
+    nowMs: number
+): boolean {
+    const lastDownloadTimestamp = Number.parseInt(lastDownloadTime, 10);
+    if (!Number.isFinite(lastDownloadTimestamp)) {
+        return false;
+    }
+    const nextAllowedDownloadTime =
+        lastDownloadTimestamp * 1000 + cooldownDays * 24 * 60 * 60 * 1000;
+    return nextAllowedDownloadTime > nowMs;
+}

--- a/apps/media-sync-worker/src/service/dailyDownload.ts
+++ b/apps/media-sync-worker/src/service/dailyDownload.ts
@@ -7,9 +7,32 @@ import {
 } from "../pixiv/pixiv";
 import { FollowerInfo } from "../pixiv/types";
 import redisClient from "../redis/redisClient";
-import { loadDownloadDelayConfig, waitMs } from "./downloadRuntime";
+import { ensureDownloadTaskRepositoryReady } from "../mongo/client";
+import {
+  assertDailyAuthorBatchSucceeded,
+  runDailyAuthorBatch,
+} from "./dailyAuthorBatch";
+import {
+  enqueueDownloadTasks,
+  runDailyAuthorDiscovery,
+  throwIfAborted,
+  type DailyAuthorDiscoveryResult,
+} from "./dailyAuthorDiscovery";
+import {
+  loadDailyDownloadGuardConfig,
+  loadDownloadDelayConfig,
+  waitMs,
+} from "./downloadRuntime";
+import { sendDailyNotificationWithTimeout } from "./dailyNotification";
 
 const RedisDownloadUserDictKey = "download_user_dict";
+const DAILY_NOTIFICATION_TIMEOUT_MS = 30_000;
+
+const sendDailyDownloadNotification = (message: string): Promise<void> =>
+  sendDailyNotificationWithTimeout(
+    () => send_msg(process.env.SELF_CHAT_ID!, message),
+    DAILY_NOTIFICATION_TIMEOUT_MS
+  );
 
 const getRandomDays = (): number => {
   return Math.floor(Math.random() * 3) + 2;
@@ -19,91 +42,112 @@ const getRandomDays = (): number => {
 export const startDownload = async (): Promise<void> => {
   console.log("Download service started...");
   const delayConfig = loadDownloadDelayConfig();
+  const guardConfig = loadDailyDownloadGuardConfig();
 
   try {
+    await ensureDownloadTaskRepositoryReady();
+
     // 获取 "已上传" 标签下的关注者
     const authorArr = await getFollowersByTag("已上传");
 
     // 如果成功获取关注者
     if (authorArr && authorArr.length > 0) {
-      // console.log('Fetched authors:', authorArr);
-      // 这里放置你的下载逻辑
-      // 假设你需要对每个作者执行下载操作
-      for (const author of authorArr) {
-        await downloadEachUser(author, delayConfig);
+      const summary = await runDailyAuthorBatch(authorArr, {
+        authorTimeoutMs: guardConfig.authorTimeoutMs,
+        runAuthor: (author, signal) =>
+          downloadEachUser(author, delayConfig, signal),
+        afterAuthor: async (author, result) => {
+          if (result === "completed") {
+            await redisClient.hset(
+              RedisDownloadUserDictKey,
+              author.userId,
+              `${Math.floor(Date.now() / 1000)}`
+            );
+          }
+        },
+      });
+      const summaryLog = `daily_download_author_batch ${JSON.stringify(summary)}`;
+      if (summary.status === "completed_with_errors") {
+        console.warn(summaryLog);
+      } else {
+        console.info(summaryLog);
       }
+      assertDailyAuthorBatchSucceeded(summary);
     } else {
       // 如果没有关注者，发送消息
-      await send_msg(process.env.SELF_CHAT_ID!, "没有找到关注者");
+      await sendDailyDownloadNotification("没有找到关注者");
     }
   } catch (err) {
     // 如果获取关注者出错，发送错误消息
-    console.error("Error fetching followers:", err);
-    await send_msg(process.env.SELF_CHAT_ID!, "下载图片服务获取元信息失败");
+    console.error("Daily download failed:", err);
+    try {
+      await sendDailyDownloadNotification("下载图片服务执行失败");
+    } catch (notifyError) {
+      console.error("Failed to notify daily download failure:", notifyError);
+    }
+    throw err;
   }
 };
 
 const downloadEachUser = async (
   author: FollowerInfo,
-  delayConfig = loadDownloadDelayConfig()
-): Promise<void> => {
+  delayConfig: ReturnType<typeof loadDownloadDelayConfig>,
+  signal: AbortSignal
+): Promise<DailyAuthorDiscoveryResult> => {
   console.log(`Downloading images for author: ${author.userName}`);
-  // 执行下载逻辑...
   const authorId = author.userId;
 
   try {
-    // 从 Redis 获取对应作者的下载时间，使用封装的 hGetValue 函数
-    const lastDownloadTime = await redisClient.hget(
-      RedisDownloadUserDictKey,
-      authorId
+    const result = await runDailyAuthorDiscovery(
+      author,
+      {
+        getLastDownloadTime: async (currentAuthorId) => {
+          const lastDownloadTime = await redisClient.hget(
+            RedisDownloadUserDictKey,
+            currentAuthorId
+          );
+          if (!lastDownloadTime) {
+            console.log(
+              `Redis field is empty, starting download for author: ${currentAuthorId}`
+            );
+          }
+          return lastDownloadTime;
+        },
+        discoverAuthor: async (currentAuthorId, currentSignal) => {
+          await DownloadIllusts(
+            {
+              authorId: currentAuthorId,
+              authorLastFilter: true,
+            },
+            currentSignal
+          );
+        },
+        waitAfterAuthor: () => waitMs(delayConfig.afterAuthorMs),
+        getRandomDays,
+        now: Date.now,
+      },
+      signal
     );
 
-    if (!lastDownloadTime) {
-      console.log(
-        `Redis field is empty, starting download for author: ${authorId}`
-      );
-    } else {
-      const lastDownloadTimestamp = parseInt(lastDownloadTime, 10);
-      const randDay = getRandomDays(); // 随机生成 2 到 4 天
-      const nextAllowedDownloadTime =
-        new Date(lastDownloadTimestamp * 1000).getTime() +
-        randDay * 24 * 60 * 60 * 1000;
-
-      // 如果距离上次下载不足指定天数，则跳过该作者
-      if (nextAllowedDownloadTime > Date.now()) {
-        console.log(
-          `Skipping download for author: ${authorId}, within restricted time range`
-        );
-        return;
-      }
-    }
-
-    // 更新 Redis 中的下载时间，使用封装的 hSetValue 函数
-    await redisClient.hset(
-      RedisDownloadUserDictKey,
-      authorId,
-      `${Math.floor(Date.now() / 1000)}`
-    );
-
-    // 执行下载逻辑
-    const downloadRequest = {
-      authorId: authorId,
-      authorLastFilter: true,
-    };
-
-    const result = await DownloadIllusts(downloadRequest);
-
-    await waitMs(delayConfig.afterAuthorMs);
-
-    if (result) {
+    if (result === "completed") {
       console.log(`Download successful for author: ${authorId}`);
     } else {
-      throw new Error(`Download failed for author: ${authorId}`);
+      console.log(
+        `Skipping download for author: ${authorId}, within restricted time range`
+      );
     }
+    return result;
   } catch (err) {
     // 错误处理，如果下载失败则发送消息
     console.error(`Download failed for author: ${authorId}:`, err);
-    await send_msg(process.env.SELF_CHAT_ID!, `作者：${authorId} 图片下载失败`);
+    if (!signal.aborted) {
+      try {
+        await sendDailyDownloadNotification(`作者：${authorId} 图片下载失败`);
+      } catch (notifyError) {
+        console.error(`Failed to notify download failure for author: ${authorId}:`, notifyError);
+      }
+    }
+    throw err;
   }
 };
 
@@ -118,14 +162,18 @@ interface DownloadIllustsReq {
 }
 
 export const DownloadIllusts = async (
-  req: DownloadIllustsReq
-): Promise<boolean> => {
+  req: DownloadIllustsReq,
+  signal: AbortSignal
+): Promise<void> => {
   let illustIds: string[] = req.limitIllusts || [];
 
   try {
+    throwIfAborted(signal);
+
     // 1. 如果传入了 authorId，则获取该作者的作品
     if (req.authorId) {
       illustIds = await getAuthorArtwork(req.authorId);
+      throwIfAborted(signal);
       console.log(
         `作者：${req.authorId} 查询到 ${illustIds.length} 张图片`
       );
@@ -134,6 +182,7 @@ export const DownloadIllusts = async (
     // 2. 如果传递了 keyword，则获取与该关键词相关的作品
     if (req.keyword) {
       illustIds = await getTagArtwork(req.keyword, req.page || 1);
+      throwIfAborted(signal);
     }
 
     // 3. 对作品ID进行排序，按降序排列
@@ -156,7 +205,7 @@ export const DownloadIllusts = async (
     }
 
     if (illustIds.length === 0) {
-      return true; // 如果没有作品ID，直接返回
+      return;
     }
 
     // 如果需要过滤作者的最后作品
@@ -164,11 +213,12 @@ export const DownloadIllusts = async (
       const maxIllustId = await getMaxIllustId(
         illustIds.map((id) => parseInt(id, 10))
       );
+      throwIfAborted(signal);
       if (!maxIllustId) {
-        await send_msg(
-          process.env.SELF_CHAT_ID!,
+        await sendDailyDownloadNotification(
           `作者：${req.authorId} 历史没有数据，请注意`
         );
+        throwIfAborted(signal);
       } else {
         console.log(
           `作者：${req.authorId} 历史最大作品ID为 ${maxIllustId}, 过滤掉作者最后作品`
@@ -182,6 +232,7 @@ export const DownloadIllusts = async (
 
     // 从 Redis 获取 ban_illusts 列表
     const banIllusts = await redisClient.smembers("ban_illusts");
+    throwIfAborted(signal);
 
     // 过滤掉被禁止的作品
     if (banIllusts) {
@@ -194,41 +245,39 @@ export const DownloadIllusts = async (
       } else if (req.keyword) {
         console.log(`关键词：${req.keyword}跳过下载`);
       }
-      return true;
+      return;
     }
 
     // 记录开始下载日志
     if (req.authorId) {
       console.log(`作者：${req.authorId}开始下载${illustIds.length}张图片`);
-      await send_msg(
-        process.env.SELF_CHAT_ID!,
+      await sendDailyDownloadNotification(
         `作者：${req.authorId} 开始下载 ${illustIds.length} 张图片`
       );
+      throwIfAborted(signal);
     } else if (req.keyword) {
       console.log(`关键词：${req.keyword}开始下载${illustIds.length}张图片`);
-      await send_msg(
-        process.env.SELF_CHAT_ID!,
+      await sendDailyDownloadNotification(
         `关键词：${req.keyword} 开始下载 ${illustIds.length} 张图片`
       );
+      throwIfAborted(signal);
     }
 
-    // 遍历所有作品ID，插入下载任务
-    for (const illustId of illustIds) {
-      try {
+    await enqueueDownloadTasks(
+      illustIds,
+      async (illustId) => {
         const insertSuccess = await insertDownloadTask(illustId);
         if (insertSuccess) {
           console.log(`插入任务 ${illustId} 成功`);
         } else {
           console.log(`任务 ${illustId} 已存在`);
         }
-      } catch (err) {
-        console.error(`插入任务 ${illustId} 失败: ${err}`);
-      }
-    }
+        return insertSuccess;
+      },
+      signal
+    );
   } catch (err) {
     console.error("下载图片时发生错误: ", err);
-    return false;
+    throw err;
   }
-
-  return true;
 };

--- a/apps/media-sync-worker/src/service/dailyNotification.test.ts
+++ b/apps/media-sync-worker/src/service/dailyNotification.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'bun:test';
+import {
+    DailyNotificationTimeoutError,
+    sendDailyNotificationWithTimeout,
+} from './dailyNotification';
+
+describe('sendDailyNotificationWithTimeout', () => {
+    it('settles when the notification completes', async () => {
+        let sent = false;
+
+        await sendDailyNotificationWithTimeout(async () => {
+            sent = true;
+        }, 100);
+
+        expect(sent).toBe(true);
+    });
+
+    it('rejects a permanently pending notification within the configured bound', async () => {
+        const promise = sendDailyNotificationWithTimeout(
+            async () => new Promise<never>(() => {}),
+            10
+        );
+
+        expect(promise).rejects.toBeInstanceOf(DailyNotificationTimeoutError);
+        await promise.catch(() => {});
+    });
+});

--- a/apps/media-sync-worker/src/service/dailyNotification.ts
+++ b/apps/media-sync-worker/src/service/dailyNotification.ts
@@ -1,0 +1,28 @@
+export class DailyNotificationTimeoutError extends Error {
+    constructor(readonly timeoutMs: number) {
+        super(`daily download notification did not settle within ${timeoutMs}ms`);
+        this.name = 'DailyNotificationTimeoutError';
+    }
+}
+
+export async function sendDailyNotificationWithTimeout(
+    send: () => Promise<void>,
+    timeoutMs: number
+): Promise<void> {
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    try {
+        await Promise.race([
+            Promise.resolve().then(send),
+            new Promise<never>((_, reject) => {
+                timer = setTimeout(
+                    () => reject(new DailyNotificationTimeoutError(timeoutMs)),
+                    timeoutMs
+                );
+            }),
+        ]);
+    } finally {
+        if (timer !== undefined) {
+            clearTimeout(timer);
+        }
+    }
+}

--- a/apps/media-sync-worker/src/service/downloadRuntime.test.ts
+++ b/apps/media-sync-worker/src/service/downloadRuntime.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'bun:test';
-import { loadConsumerGuardConfig, loadDownloadDelayConfig } from './downloadRuntime';
+import {
+    loadConsumerGuardConfig,
+    loadDailyDownloadGuardConfig,
+    loadDownloadDelayConfig,
+} from './downloadRuntime';
 
 describe('loadDownloadDelayConfig', () => {
     it('defaults artificial waits to half of the old hard-coded values', () => {
@@ -106,6 +110,37 @@ describe('loadConsumerGuardConfig', () => {
         ).toEqual({
             cycleTimeoutMs: 1800000,
             runningTaskReclaimMs: 2700000,
+        });
+    });
+});
+
+describe('loadDailyDownloadGuardConfig', () => {
+    it('defaults the per-author watchdog to 10 minutes', () => {
+        expect(loadDailyDownloadGuardConfig({})).toEqual({
+            authorTimeoutMs: 10 * 60 * 1000,
+        });
+    });
+
+    it('accepts positive overrides and rejects zero, negative, or invalid values', () => {
+        expect(
+            loadDailyDownloadGuardConfig({
+                DOWNLOAD_AUTHOR_TIMEOUT_MS: '120000',
+            })
+        ).toEqual({ authorTimeoutMs: 120000 });
+        expect(loadDailyDownloadGuardConfig({ DOWNLOAD_AUTHOR_TIMEOUT_MS: '0' })).toEqual({
+            authorTimeoutMs: 10 * 60 * 1000,
+        });
+        expect(loadDailyDownloadGuardConfig({ DOWNLOAD_AUTHOR_TIMEOUT_MS: 'nope' })).toEqual({
+            authorTimeoutMs: 10 * 60 * 1000,
+        });
+        expect(loadDailyDownloadGuardConfig({ DOWNLOAD_AUTHOR_TIMEOUT_MS: '120000ms' })).toEqual({
+            authorTimeoutMs: 10 * 60 * 1000,
+        });
+        expect(loadDailyDownloadGuardConfig({ DOWNLOAD_AUTHOR_TIMEOUT_MS: '1.5' })).toEqual({
+            authorTimeoutMs: 10 * 60 * 1000,
+        });
+        expect(loadDailyDownloadGuardConfig({ DOWNLOAD_AUTHOR_TIMEOUT_MS: '2147483648' })).toEqual({
+            authorTimeoutMs: 10 * 60 * 1000,
         });
     });
 });

--- a/apps/media-sync-worker/src/service/downloadRuntime.ts
+++ b/apps/media-sync-worker/src/service/downloadRuntime.ts
@@ -48,6 +48,23 @@ export interface ConsumerGuardConfig {
     runningTaskReclaimMs: number;
 }
 
+export interface DailyDownloadGuardConfig {
+    authorTimeoutMs: number;
+}
+
+const DEFAULT_AUTHOR_TIMEOUT_MS = 10 * 60 * 1000;
+
+export function loadDailyDownloadGuardConfig(
+    env: Record<string, string | undefined> = process.env
+): DailyDownloadGuardConfig {
+    return {
+        authorTimeoutMs: readPositiveMs(
+            env.DOWNLOAD_AUTHOR_TIMEOUT_MS,
+            DEFAULT_AUTHOR_TIMEOUT_MS
+        ),
+    };
+}
+
 // 60 分钟：最坏合法单轮 ≈ 20 页/并发 2 的大任务，每页代理请求最坏顶满 180s（10 批 ×
 // 180s = 30min）+ 前置 info/pages 请求各最坏 180s + 限流冷却 120s + 翻译与 Mongo 杂项
 // ≈ 40min；留余量后凡超过 60min 必是挂死而非慢。
@@ -105,8 +122,8 @@ function readNonNegativeMs(value: string | undefined, fallback: number): number 
     if (value === undefined || value === '') {
         return fallback;
     }
-    const parsed = Number.parseInt(value, 10);
-    if (!Number.isFinite(parsed) || parsed < 0) {
+    const parsed = parseTimerMs(value);
+    if (parsed === null || parsed < 0) {
         return fallback;
     }
     return parsed;
@@ -118,9 +135,20 @@ function readPositiveMs(value: string | undefined, fallback: number): number {
     if (value === undefined || value === '') {
         return fallback;
     }
-    const parsed = Number.parseInt(value, 10);
-    if (!Number.isFinite(parsed) || parsed <= 0) {
+    const parsed = parseTimerMs(value);
+    if (parsed === null || parsed <= 0) {
         return fallback;
     }
     return parsed;
+}
+
+function parseTimerMs(value: string): number | null {
+    const normalized = value.trim();
+    if (!/^\d+$/.test(normalized)) {
+        return null;
+    }
+    const parsed = Number(normalized);
+    return Number.isSafeInteger(parsed) && parsed <= 2_147_483_647
+        ? parsed
+        : null;
 }

--- a/docs/specs/pixiv-image-flow-hardening.md
+++ b/docs/specs/pixiv-image-flow-hardening.md
@@ -2,9 +2,10 @@
 
 ## Problem
 
-当前 Pixiv 图片链路已经从作品发现贯通到本地 Mongo、MinIO、Tagger 和飞书发图，但五处状态边界会造成静默漏图或永久悬挂：
+当前 Pixiv 图片链路已经从作品发现贯通到本地 Mongo、MinIO、Tagger 和飞书发图，但六处状态边界会造成静默漏图或永久悬挂：
 
 - 关注作者分页会漏掉不足一整页的尾页。
+- 每日发现串行处理作者时，任一 Redis 或外部请求永久不 settle 都会阻塞剩余全部作者，而 Pod 仍保持 Ready。
 - 单页下载、元数据写入或下载后交接失败时，作品任务仍可能进入 Success。
 - 下载后镜像与 Tagger 入队是进程内后台任务，进程退出可丢失；已存在图片又绕过补偿。
 - channel-server 在抽中不可用本地候选后直接缩短结果，不继续补位。
@@ -15,6 +16,7 @@
 把 Pixiv 图片从发现到展示收敛为一条可重放、可观测、最终一致的链路：
 
 - 关注作者分页完整覆盖 Pixiv 返回的 total。
+- 单个作者或 Redis 命令超时后留下可定位日志并继续后续作者，整批不再因一个无界 await 永久悬挂。
 - 一个作品只有在所有选中页面都已下载或确认存在，并完成必要的耐久交接后，下载任务才进入 Success。
 - 下载后的本地镜像与 Tagger outbox 可幂等重放；进程在任意一步退出后，任务重试或有界对账都能继续推进。
 - 发图查询只选择具备展示入口的本地文档，并在候选处理失败时继续补位，直到达到请求数量或候选确实耗尽。
@@ -84,11 +86,16 @@
 
    每次在已有远端 task 失败后重新提交，图片 generation 单调增加；当前远端 `task_id` 是该 generation 的 owner token。task 记录其每张图片的 generation，callback、submitted 对账、重新入队、projection 完成和 lease 释放都必须同时匹配 generation、owner 与 lease fencing token。迟到 callback 可以保留为 task 事件，但只要不再拥有图片就标记为 stale，不得覆盖当前 result、重排当前图片或清除新 generation 的 pending projection。task commit marker 只在全部 row 已持久化或被 fencing 判定 stale 后写入。
 
+10. **每日作者发现以单作者故障隔离保证批次活性**
+
+   media-sync-worker 的 Redis 命令和单作者处理分别设置正数硬超时。单作者超时或普通异常都记录作者 ID、名称和错误并继续下一个作者。watchdog 超时会发出 `AbortSignal`，迟到 Promise 在后续外部 I/O 边界停止；已经发出的不可取消调用仍可能迟到完成，因此下载任务插入必须由 `download_task.illust_id` 唯一索引和原子 upsert 保证幂等。作者冷却时间只在作品发现与全部任务入队成功、watchdog 已清除后提交，失败和超时不能提前消费后续重试窗口。飞书通知必须有独立等待上限。超时只隔离作者，不把失败伪装成整批成功：批次结束日志必须带成功、失败和超时计数，部分失败还必须作为错误返回给 cron 重试。
+
 ## State and data impact
 
 继续使用现有数据库，不引入新基础设施：
 
 - 旧 `chiwei.img_map` 仍是图片源数据。
+- 旧 `chiwei.download_task` 增加 `illust_id` 唯一索引，发现阶段以原子 upsert 创建任务。
 - 本地 `chiwei_pixiv.pixiv_images` 增加 Tagger 原始结果、任务状态、独立更新时间和检索词；不改图片创建/更新时间来伪造“今日新图”。
 - `chiwei_tagger.tagger_image_results` 在原有 trigger 状态之外增加独立 projection 状态、尝试次数、lease 和下次执行时间；历史完成结果可自动进入投影。
 - `chiwei_tagger.tagger_tasks` 增加 `registering` 可恢复过渡态、每图 generation/processing lease、submitted 对账 lease、下次对账时间和错误信息；callback 最后更新 task，作为整批结果持久化或 stale 判定完成的 commit marker。
@@ -100,6 +107,8 @@
 
 - 新增历史 post-download reconciler 的 enabled、batch size 和 idle delay 配置，默认关闭。
 - 新增 Tagger submitted 对账等待时间、投影 retry/processing timeout 和 projection 历史 backfill 开关等运行参数；历史 backfill 默认关闭，Tagger 功能关闭时不启动对应 worker。
+- 新增 media-sync-worker 专用 Redis 命令超时与单作者处理超时配置；非法值回退安全默认值。
+- 每日发现运行前验证 `download_task.illust_id` 唯一索引；若存量重复导致索引无法创建，本轮必须失败并在人工处理数据后再重试，不允许静默退回非原子插入。
 - 新索引先以后台方式创建并验证完成，再允许开启存量扫描；存量扫描与投影的 batch 上限必须可配置，不能与下载高峰争抢无界资源。
 - media-sync-worker 发布会中断当前下载、trigger、projection 和 reconcile 循环；上线前必须确认在途任务并走独立 `coe-*` 泳道。
 - 该 worker 的测试泳道若复用生产源 Mongo/OSS/MinIO，会产生真实状态竞争和写入；验证必须使用隔离数据，或关闭 schedules、download consumer、Tagger trigger、projection 和历史 reconciler，仅做无副作用启动检查。
@@ -147,6 +156,11 @@
    - Verification：原始 row 字段逐项保留；旧 generation 不能覆盖新结果；重复本地文档全部更新；零匹配退避并告警；只有开启授权后旧 completed 结果才补投影；搜索能命中真实 v1 tag、描述和 OCR 文本。
 
 7. **整体验证与运维交接**
-   - Goal：确认五项修复覆盖所有调用方，并给出安全的隔离验证和历史启用方式。
+   - Goal：确认六项修复覆盖所有调用方，并给出安全的隔离验证和历史启用方式。
    - Deliverable：分层测试结果、类型检查、调用方反查、配置/README 更新和回滚说明。
    - Verification：依赖可用环境中相关 Bun 测试与 TypeScript 检查通过；tagger-service 任务查询契约测试通过；未执行未经授权的部署或生产写入。
+
+8. **每日作者发现故障隔离**
+   - Goal：单个作者卡住或 Redis 命令无响应时，其余关注作者仍能继续进入发现流程。
+   - Deliverable：有界 Redis 命令与飞书通知、带协作中止的单作者 watchdog、watchdog 清除后的冷却提交、唯一索引保护的原子入队、结构化批次计数和运行参数说明。
+   - Verification：永久 pending、普通拒绝和正常完成三类作者混合时，后续作者仍执行且结果计数准确；失败/超时不写冷却，迟到链路不继续发起新副作用，入队错误保留原始原因，并发 upsert 不产生重复任务，部分失败由 cron 感知；非法超时配置回退默认值。

--- a/packages/ts-shared/src/cache/redis-client.ts
+++ b/packages/ts-shared/src/cache/redis-client.ts
@@ -8,6 +8,7 @@ export interface RedisConfig {
     port: number;
     password?: string;
     retryStrategy?: (times: number) => number;
+    commandTimeout?: number;
 }
 
 /**


### PR DESCRIPTION
## Summary

- Prevent one stuck Pixiv author, Redis command, or Lark notification from blocking the daily batch.
- Preserve enqueue failures, commit cooldowns only after successful discovery, and report partial batches to cron.
- Make download-task enqueue idempotent with a unique Mongo index and atomic upsert.

## Testing

- bun test apps/media-sync-worker (216 pass)
- bun run --cwd apps/media-sync-worker check
- bunx tsc --noEmit -p packages/ts-shared/tsconfig.json
- git diff --check