### PR TITLE
fix: pin builds to app nodes, restore monitoring on an offline node

### DIFF
--- a/apps/paas-engine/internal/adapter/kubernetes/kaniko.go
+++ b/apps/paas-engine/internal/adapter/kubernetes/kaniko.go
@@ -61,6 +61,10 @@ func (e *KanikoBuildExecutor) Submit(ctx context.Context, sub *port.BuildSubmiss
 	jobName := fmt.Sprintf("kaniko-%s", strings.ReplaceAll(sub.BuildID, "-", ""))
 	ttl := int32(3600)
 	backoff := int32(0)
+	// 从 Job 创建时刻起算，排不上队的时间也算在内 —— 这正是要的：
+	// 没有期限时，调度不上的构建会永远停在 running（build 记录在 Submit 成功即写 running），
+	// Makefile 的轮询只认终态，于是卡死。观测到最慢的真实构建 425s，给 4 倍余量。
+	deadline := int64(1800)
 
 	gitContext := "git://github.com/" + sub.GitRepo
 	gitRef := sub.GitRef
@@ -112,6 +116,7 @@ func (e *KanikoBuildExecutor) Submit(ctx context.Context, sub *port.BuildSubmiss
 		Spec: batchv1.JobSpec{
 			BackoffLimit:            &backoff,
 			TTLSecondsAfterFinished: &ttl,
+			ActiveDeadlineSeconds:   &deadline,
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{labelBuildID: sub.BuildID},
@@ -130,6 +135,9 @@ func (e *KanikoBuildExecutor) Submit(ctx context.Context, sub *port.BuildSubmiss
 func (e *KanikoBuildExecutor) podSpec(args []string) corev1.PodSpec {
 	spec := corev1.PodSpec{
 		RestartPolicy: corev1.RestartPolicyNever,
+		// 构建需要外网（git clone + base 镜像），只有 app 节点有可用出口。
+		// 与 deployer.go 对齐，别让 Job 漂到 proxy 节点上去。
+		NodeSelector: map[string]string{"node-role": "app"},
 		Containers: []corev1.Container{
 			{
 				Name:  "kaniko",

--- a/apps/paas-engine/internal/adapter/kubernetes/kaniko_test.go
+++ b/apps/paas-engine/internal/adapter/kubernetes/kaniko_test.go
@@ -135,6 +135,79 @@ func TestJobToStatus(t *testing.T) {
 	}
 }
 
+// 构建 Pod 必须落在 app 节点上：只有它有能拉 git 仓库和 base 镜像的外网出口。
+// proxy1（node-role=proxy）虽然直连外网，但到不了公司代理，落上去构建必失败。
+func TestSubmit_PinsBuildToAppNode(t *testing.T) {
+	client := fake.NewSimpleClientset()
+	executor := NewKanikoBuildExecutor(client, KanikoBuildConfig{
+		Namespace:   "paas-builds",
+		KanikoImage: "gcr.io/kaniko-project/executor:latest",
+	})
+
+	_, err := executor.Submit(context.Background(), &port.BuildSubmission{
+		BuildID:  "test-build-id",
+		GitRepo:  "https://github.com/example/repo",
+		GitRef:   "main",
+		ImageTag: "registry.example.com/app:latest",
+	})
+	if err != nil {
+		t.Fatalf("Submit() error = %v", err)
+	}
+
+	jobs, err := client.BatchV1().Jobs("paas-builds").List(context.Background(), metav1.ListOptions{})
+	if err != nil {
+		t.Fatalf("List jobs error = %v", err)
+	}
+	if len(jobs.Items) != 1 {
+		t.Fatalf("expected 1 job, got %d", len(jobs.Items))
+	}
+
+	got := jobs.Items[0].Spec.Template.Spec.NodeSelector
+	if got["node-role"] != "app" {
+		t.Errorf("NodeSelector = %v, want node-role=app", got)
+	}
+}
+
+// 构建必须有执行期限。没有的话，Job 排不上（app 节点被 cordon / label 改了 / 资源不够）
+// 就永远停在 Pending，而 build 记录在 Submit 成功那一刻就写成了 running
+// （build_service.go:120），Makefile 的轮询只认 succeeded/failed/cancelled，
+// 于是表现成「构建永远 running、日志为空」。activeDeadlineSeconds 从 Job 创建时刻起算、
+// 不管 Pod 有没有跑起来，所以排不上的 Job 也会到点变 Failed，轮询才有终点。
+func TestSubmit_HasExecutionDeadline(t *testing.T) {
+	client := fake.NewSimpleClientset()
+	executor := NewKanikoBuildExecutor(client, KanikoBuildConfig{
+		Namespace:   "paas-builds",
+		KanikoImage: "gcr.io/kaniko-project/executor:latest",
+	})
+
+	_, err := executor.Submit(context.Background(), &port.BuildSubmission{
+		BuildID:  "test-build-id",
+		GitRepo:  "https://github.com/example/repo",
+		GitRef:   "main",
+		ImageTag: "registry.example.com/app:latest",
+	})
+	if err != nil {
+		t.Fatalf("Submit() error = %v", err)
+	}
+
+	jobs, err := client.BatchV1().Jobs("paas-builds").List(context.Background(), metav1.ListOptions{})
+	if err != nil {
+		t.Fatalf("List jobs error = %v", err)
+	}
+	if len(jobs.Items) != 1 {
+		t.Fatalf("expected 1 job, got %d", len(jobs.Items))
+	}
+
+	got := jobs.Items[0].Spec.ActiveDeadlineSeconds
+	if got == nil {
+		t.Fatal("ActiveDeadlineSeconds is nil: 排不上的构建会永远停在 running")
+	}
+	// 观测到的最慢一次真实构建 425s，留 4 倍余量
+	if *got != 1800 {
+		t.Errorf("ActiveDeadlineSeconds = %d, want 1800", *got)
+	}
+}
+
 func containsArg(args []string, target string) bool {
 	for _, a := range args {
 		if a == target {

--- a/infra/k8s/monitoring/kube-prometheus-stack-values.yaml
+++ b/infra/k8s/monitoring/kube-prometheus-stack-values.yaml
@@ -1,5 +1,23 @@
+# cpu1 (node-role: infra) 没有外网，所有镜像必须从内网 Harbor 拉。
+# Harbor 里镜像名被拍平成 library/<短名>，所以 registry 和 repository 都要覆盖。
+# 节点 containerd 已配 robot 拉取凭据，无需 imagePullSecrets。
+
 grafana:
   # adminPassword set via --set grafana.adminPassword=... at install time
+  image:
+    registry: harbor.local:30002
+    repository: library/grafana
+    tag: "12.4.0"
+  initChownData:
+    image:
+      registry: harbor.local:30002
+      repository: library/busybox
+      tag: "1.37.0"
+  sidecar:
+    image:
+      registry: harbor.local:30002
+      repository: library/k8s-sidecar
+      tag: "2.5.0"
   grafana.ini:
     security:
       allow_embedding: true
@@ -19,8 +37,33 @@ grafana:
       access: proxy
       isDefault: false
 
+prometheusOperator:
+  image:
+    registry: harbor.local:30002
+    repository: library/prometheus-operator
+    tag: "v0.89.0"
+  # 注入成 operator 的 --prometheus-config-reloader= 参数，
+  # operator 用它给每个 Prometheus/Alertmanager Pod 挂 config-reloader sidecar
+  prometheusConfigReloader:
+    image:
+      registry: harbor.local:30002
+      repository: library/prometheus-config-reloader
+      tag: "v0.89.0"
+  admissionWebhooks:
+    # 装 ValidatingWebhookConfiguration 证书的一次性 Job。
+    # 镜像目前还没镜像到 Harbor（原始出处 ghcr.io/jkroepke/kube-webhook-certgen:1.7.8）
+    patch:
+      image:
+        registry: harbor.local:30002
+        repository: library/kube-webhook-certgen
+        tag: "1.7.8"
+
 prometheus:
   prometheusSpec:
+    image:
+      registry: harbor.local:30002
+      repository: library/prometheus
+      tag: "v3.10.0"
     nodeSelector:
       node-role: infra
     securityContext:
@@ -55,12 +98,30 @@ defaultRules:
 nodeExporter:
   enabled: true
 
+# nodeExporter.enabled 的 subchart，镜像 key 在 subchart 命名空间下
+prometheus-node-exporter:
+  image:
+    registry: harbor.local:30002
+    repository: library/node-exporter
+    tag: "v1.10.2"
+
 kubeStateMetrics:
   enabled: true
+
+# kubeStateMetrics.enabled 的 subchart，镜像 key 在 subchart 命名空间下
+kube-state-metrics:
+  image:
+    registry: harbor.local:30002
+    repository: library/kube-state-metrics
+    tag: "v2.18.0"
 
 alertmanager:
   enabled: true
   alertmanagerSpec:
+    image:
+      registry: harbor.local:30002
+      repository: library/alertmanager
+      tag: "v0.31.1"
     nodeSelector:
       node-role: infra
     storage:

--- a/infra/k8s/monitoring/loki-values.yaml
+++ b/infra/k8s/monitoring/loki-values.yaml
@@ -1,6 +1,14 @@
 deploymentMode: SingleBinary
 
+# cpu1 (node-role: infra) 没有外网，所有镜像必须从内网 Harbor 拉。
+# Harbor 里镜像名被拍平成 library/<短名>，所以 registry 和 repository 都要覆盖。
+# 节点 containerd 已配 robot 拉取凭据，无需 imagePullSecrets。
+
 loki:
+  image:
+    registry: harbor.local:30002
+    repository: library/loki
+    tag: "3.6.5"
   auth_enabled: false
   commonConfig:
     replication_factor: 1
@@ -23,14 +31,60 @@ loki:
         directory: /var/loki/rules
     enable_api: true
 
+# nginx 反代（loki-gateway），promtail / grafana 都走它
+gateway:
+  image:
+    registry: harbor.local:30002
+    repository: library/nginx-unprivileged
+    tag: "1.29-alpine"
+
+# k8s-sidecar，把 loki-alert-rules ConfigMap 同步进 singleBinary Pod
+sidecar:
+  image:
+    registry: harbor.local:30002
+    repository: library/k8s-sidecar
+    tag: "1.30.9"
+
+lokiCanary:
+  image:
+    registry: harbor.local:30002
+    repository: library/loki-canary
+    tag: "3.6.5"
+
+# chunks-cache / results-cache 的 memcached + exporter
+memcached:
+  image:
+    registry: harbor.local:30002
+    repository: library/memcached
+    tag: "1.6.39-alpine"
+
+memcachedExporter:
+  image:
+    registry: harbor.local:30002
+    repository: library/memcached-exporter
+    tag: "v0.15.4"
+
+# `helm test` 用的一次性 Pod，我们不跑 helm test。关掉而不是把镜像指向 Harbor——
+# loki-helm-test 没镜像进来，留着只会在渲染结果里留一条拉不动的悬空引用。
+test:
+  enabled: false
+
 singleBinary:
   replicas: 1
   nodeSelector:
     node-role: infra
   persistence:
     enabled: true
-    storageClass: ""
+    # 必须写 "-" 不能写 ""：chart 用 `{{- with .persistence.storageClass }}` 判断，
+    # 空字符串是 falsy，整个 storageClassName 键会被省掉，PVC 就落到默认 SC
+    # （local-path）走动态供给 —— 拿到一块空盘，pv-loki 里的历史日志白恢复。
+    # "-" 是 chart 约定的「显式无 class」写法，会渲染成 storageClassName: ""。
+    storageClass: "-"
     size: 10Gi
+    # 精确认领 pv-loki。pv-prometheus 同样是 10Gi/RWO/无 class，不用 selector 就是碰运气。
+    selector:
+      matchLabels:
+        chiwei.io/volume: loki
   extraVolumes:
     - name: loki-alert-rules
       configMap:

--- a/infra/k8s/monitoring/namespace.yaml
+++ b/infra/k8s/monitoring/namespace.yaml
@@ -1,0 +1,21 @@
+# monitoring namespace 的 Pod Security 例外。
+#
+# 集群默认（/etc/rancher/k3s/psa-config.yaml，2026-07-23 入侵后重建时加的硬化）是
+# enforce=baseline / audit=restricted / warn=restricted，只豁免 kube-system。
+#
+# node-exporter 在 baseline 下**装不上**，而且不是配置问题、绕不过去：它要
+# hostNetwork + hostPID + hostPath(/proc,/sys,/) + hostPort 9100，这几样 baseline 全禁。
+# 采集宿主机指标本身就需要看见宿主机，这是它的本职而不是过度授权。
+#
+# 所以只放宽 enforce，audit 和 warn 仍然钉在 restricted ——
+# 以后若有别的特权 Pod 混进这个 ns，enforce 不拦，但审计日志里跑不掉。
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: monitoring
+  labels:
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/audit-version: latest
+    pod-security.kubernetes.io/warn: restricted
+    pod-security.kubernetes.io/warn-version: latest

--- a/infra/k8s/monitoring/promtail-values.yaml
+++ b/infra/k8s/monitoring/promtail-values.yaml
@@ -1,3 +1,10 @@
 config:
   clients:
     - url: http://loki-gateway.monitoring.svc.cluster.local/loki/api/v1/push
+
+# cpu1 (node-role: infra) 没有外网，所有镜像必须从内网 Harbor 拉。
+# Harbor 里镜像名被拍平成 library/<短名>，所以 registry 和 repository 都要覆盖。
+image:
+  registry: harbor.local:30002
+  repository: library/promtail
+  tag: "3.5.1"

--- a/infra/k8s/monitoring/pvs.yaml
+++ b/infra/k8s/monitoring/pvs.yaml
@@ -1,0 +1,110 @@
+# monitoring 栈的四个 hostPath PV。全部落在 infra 节点（cpu1）的 /data00/k8s-volumes/ 下。
+#
+# 为什么进仓库：2026-07-23 入侵后重建集群时，这四个 PV 只存在于集群里、仓库里没有定义，
+# 只能从 etcd 备份反推。hostPath PV 是集群拓扑的一部分，跟 values 一样该版本化。
+#
+# 为什么写 nodeAffinity：hostPath 本身不带节点约束。Pod 调度到别的节点时不会失败，
+# 而是挂上一个**空目录**——数据看起来"丢了"，实际是挂错了机器。nodeAffinity 让它响亮地失败。
+#
+# 为什么 type: Directory 而不是 DirectoryOrCreate：路径不存在时宁可 Pod 起不来，
+# 也不要静默创建一个空目录然后让 Loki/Prometheus 以为自己是新装的。
+#
+# 属主必须手工设好——kubelet 不会给 hostPath 卷应用 fsGroup：
+#   grafana      472:472      (grafana chart securityContext)
+#   loki         10001:10001  (loki chart podSecurityContext)
+#   prometheus   0:0          (kube-prometheus-stack-values.yaml 显式覆盖成 root)
+#   alertmanager 1000:2000    (kube-prometheus-stack alertmanagerSpec 默认值)
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: pv-grafana
+spec:
+  capacity:
+    storage: 1Gi
+  accessModes:
+    - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: ""
+  hostPath:
+    path: /data00/k8s-volumes/grafana
+    type: Directory
+  nodeAffinity:
+    required:
+      nodeSelectorTerms:
+        - matchExpressions:
+            - key: node-role
+              operator: In
+              values: [infra]
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: pv-loki
+  # loki chart 的 volumeClaimTemplate 不支持 volumeName，只支持 selector，
+  # 所以靠这个标签让 storage-loki-0 精确认领这一个 PV。
+  # 不打标签而指望"刚好只剩它可选"是脆的：pv-prometheus 同样是 10Gi/RWO/sc=""，
+  # 谁先绑就看运气。
+  labels:
+    chiwei.io/volume: loki
+spec:
+  capacity:
+    storage: 10Gi
+  accessModes:
+    - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: ""
+  hostPath:
+    path: /data00/k8s-volumes/loki
+    type: Directory
+  nodeAffinity:
+    required:
+      nodeSelectorTerms:
+        - matchExpressions:
+            - key: node-role
+              operator: In
+              values: [infra]
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: pv-prometheus
+spec:
+  capacity:
+    storage: 10Gi
+  accessModes:
+    - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: ""
+  hostPath:
+    path: /data00/k8s-volumes/prometheus
+    type: Directory
+  nodeAffinity:
+    required:
+      nodeSelectorTerms:
+        - matchExpressions:
+            - key: node-role
+              operator: In
+              values: [infra]
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: pv-alertmanager
+spec:
+  capacity:
+    storage: 2Gi
+  accessModes:
+    - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: ""
+  hostPath:
+    path: /data00/k8s-volumes/alertmanager
+    type: Directory
+  nodeAffinity:
+    required:
+      nodeSelectorTerms:
+        - matchExpressions:
+            - key: node-role
+              operator: In
+              values: [infra]


### PR DESCRIPTION
Two things the k3s rebuild dragged into the light. Both were latent before the
incident; the rebuild just removed the accidents that were hiding them.

**Builds had no node constraint.** Business Deployments have carried
`node-role: app` for as long as `deployer.go` has existed; Kaniko Jobs never
did. Two of three nodes cannot build — infra has no internet, proxy has direct
internet but no route to the relay `BUILD_HTTP_PROXY` names — so the scheduler
had a 1-in-3 chance of producing `proxyconnect ... i/o timeout`. The proxy node
has been cordoned as a stopgap since; this lets it come back.

Pinning to a single node makes "never schedules" likelier, and that path had no
terminal state: the build row goes `running` when Submit returns, the watcher
only reads Job status so it never sees the Pod's `FailedScheduling`, and
`make deploy` loops `while true` on succeeded/failed/cancelled. Symptom was a
build stuck running with an empty log, indefinitely. `activeDeadlineSeconds`
runs from Job creation regardless of whether a Pod started, so it catches the
unschedulable case too.

**The monitoring values assumed internet on a node that has none.** Chart
defaults point at docker.io / quay.io / registry.k8s.io; the infra node cannot
reach any of them, so this was not a slow install but a stalled one. Every
image now resolves to Harbor, per-component rather than via
`global.imageRegistry` — our mirror flattens names to `library/<short>`, and a
global rewrite would synthesize paths that do not exist.

Two findings worth calling out, because both fail quietly rather than loudly:

- `singleBinary.persistence.storageClass: ""` is dropped by the chart's
  `{{- with }}` guard, so the claim fell to the default StorageClass and got a
  new empty volume. The 9G of restored logs stayed in `pv-loki`, unmounted.
  Loki came up healthy and simply looked like a fresh install. Fixed with the
  chart's `"-"` idiom plus a label selector, since `pv-prometheus` is also a
  10Gi RWO classless volume and binding was otherwise a race.
- The four hostPath PVs existed only in etcd, so this rebuild had to
  reconstruct them from a backup. They are defined here now, with nodeAffinity —
  hostPath carries no node constraint, and a pod landing on the wrong node
  mounts an empty directory instead of failing.

The namespace takes a Pod Security exception: cluster default is
`enforce=baseline`, and node-exporter cannot run under it. hostNetwork /
hostPID / hostPath / hostPort are what reading host metrics requires, not
over-permission. Only `enforce` is relaxed — `audit` and `warn` stay at
`restricted`, so any other privileged pod landing in monitoring still surfaces.

## Verification

- `make test` green in paas-engine, `go vet` clean. Both new tests fail before
  their fix (nodeSelector empty; deadline nil).
- All three charts render with zero non-Harbor image references; 16 unique
  images, each pre-pulled on every node that will run it (17/17 on infra, 2/2
  of the DaemonSet images on the other two).
- `storage-loki-0` now `Bound` to `pv-loki`; Loki logs
  `get or create table found=true table=loki_index_20661`, i.e. it is reading
  the restored index rather than starting empty.
- 35/35 Prometheus scrape targets up. 24 Grafana dashboards and all three
  datasources restored.
- `make logs APP=channel-server` returns live lines, which is the thing that
  was broken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)