### PR TITLE
chore(monitoring): drop the ServiceMonitor for a deleted service

### DIFF
--- a/infra/k8s/monitoring/servicemonitors.yaml
+++ b/infra/k8s/monitoring/servicemonitors.yaml
@@ -200,31 +200,6 @@ spec:
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: qdrant
-  namespace: monitoring
-  labels:
-    release: kube-prometheus-stack
-spec:
-  namespaceSelector:
-    matchNames:
-      - prod
-  selector:
-    matchLabels:
-      app: qdrant
-      tier: infra
-  endpoints:
-    - port: http
-      path: /metrics
-      interval: 15s
-      authorization:
-        type: Bearer
-        credentials:
-          name: qdrant-metrics-token
-          key: token
----
-apiVersion: monitoring.coreos.com/v1
-kind: ServiceMonitor
-metadata:
   name: chat-response-worker
   namespace: monitoring
   labels:


### PR DESCRIPTION
qdrant went away with the k3s rebuild; its ServiceMonitor did not. The operator
rejects it — the Bearer secret it names is gone too — and that rejection keeps
`PrometheusOperatorRejectedResources` firing.

Found by the monitoring stack the moment it came back up, which is the point of
having it. An alert nobody can act on trains you to ignore the channel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)