### PR TITLE
feat(monitoring): alert on lark inbound going silent, not just on errors

### DIFF
--- a/infra/k8s/monitoring/kube-prometheus-stack-values.yaml
+++ b/infra/k8s/monitoring/kube-prometheus-stack-values.yaml
@@ -135,6 +135,18 @@ alertmanager:
   config:
     global:
       resolve_timeout: 5m
+    # 夜间静音窗口，供 LarkInboundEventsSilent 使用。
+    #
+    # 时间**刻意用 UTC 表示**：16:00-24:00 UTC = 次日 00:00-08:00 北京时间。
+    # 不写 location: Asia/Shanghai，因为一旦镜像里缺 tzdata，未知时区会让整份
+    # Alertmanager 配置加载失败——那是所有告警全哑，比夜间误报严重得多。
+    # 中国不实行夏令时，UTC+8 恒定，这个换算不会漂。
+    time_intervals:
+      - name: night-cn
+        time_intervals:
+          - times:
+              - start_time: '16:00'
+                end_time: '24:00'
     route:
       receiver: feishu
       group_by: ['alertname', 'namespace']
@@ -145,6 +157,21 @@ alertmanager:
         - matchers:
             - alertname =~ "InfoInhibitor|Watchdog"
           receiver: "null"
+        # 入站断流告警夜里不吵：0-8 点本来就可能真的没人说话，
+        # 45m 窗口在低峰期必然误报。连接类告警（ConnectFailure /
+        # ReconnectStorm）是确定性信号，不静音、全天有效。
+        #
+        # mute 的语义要清楚：它只抑制**通知**，不清除 firing 状态。所以
+        #   - 夜里一直没恢复的故障，08:00 后一个 group_interval 内会补发（符合预期）
+        #   - 夜里发生又自行恢复的故障，不会补报，早上什么都看不到
+        #   - 若告警在静音前已通知，其 resolved 落在静音窗口内会被吞掉，
+        #     群里可能留下一条永不消解的告警
+        # 这是拿「夜间不被误报吵醒」换来的，接受。
+        - matchers:
+            - alertname = "LarkInboundEventsSilent"
+          receiver: feishu
+          mute_time_intervals:
+            - night-cn
     receivers:
       - name: feishu
         webhook_configs:

--- a/infra/k8s/monitoring/loki-alert-rules.yaml
+++ b/infra/k8s/monitoring/loki-alert-rules.yaml
@@ -17,3 +17,71 @@ data:
             annotations:
               summary: "飞书消息发送失败"
               description: "chat-response-worker 在过去 5 分钟内有消息发送失败，请检查日志。"
+
+      # 飞书入站链路告警。
+      #
+      # 背景：2026-07-28 事故——飞书事件订阅填的是裸内网 IP，飞书推送端到该网段丢了
+      # 路由，请求在 connect() 阶段就 ENETUNREACH，成功率跌到 50% 以下。当时 33 条告警
+      # 规则一条都没响，因为失败的请求**根本没到达我们**：Pod 健康、到达的请求 100% 是
+      # 200、blackbox 从集群内探测也通。所有基于「错误率」的告警对这类故障天生失明。
+      #
+      # 事故后入站改成 WSClient 长连接（我们主动连出去），所以这组规则盯两件事：
+      # 连接本身是否建得起来，以及事件是否真的还在进来。
+      #
+      # 选择器为什么是 pod=~ 而不是 lane=：Loki 的 stream label 只有
+      # namespace / app / pod 等，**没有 lane**——promtail 没把 Pod 的 lane label
+      # 提上来。实测 {app="channel-server"} 有日志、加上 lane="prod" 返回 0 行。
+      # 写 lane= 会让两条计数规则永远为空（静默失效），并让 absent_over_time
+      # 永远为真（上线即持续误报）。pod 名带泳道后缀，用它区分 prod 与泳道。
+      #
+      # 已知盲区（本组规则抓不到，需要按 bot 维度的 metric 才能覆盖）：
+      #   - 单个 bot 掉线：6 个 bot 的事件混在一起，其余 bot 的流量会盖住它
+      #   - 部分丢事件：同一 app_id 有多个长连接客户端时飞书是**随机投递**而非
+      #     广播，所以泳道抢连接只会分走一部分事件，prod 不会彻底断流
+      #   - WS 假活：连接还在但不再收包，且不打任何日志
+      - name: lark-inbound-alerts
+        rules:
+          # 长连接建不起来。飞书 SDK 在 connect 失败时打 error 级 [ws] 日志。
+          # 注意这是日志脉冲不是连接状态：单次失败会 critical 并因 [5m] 窗口保持
+          # 约五分钟，即便下一次重试已经成功。
+          - alert: LarkWebSocketConnectFailure
+            expr: |
+              sum(count_over_time({namespace="prod", app="channel-server", pod=~"channel-server-prod-.*"} |~ `\[ws\].*(connect failed|ws error|new WebSocket error)` [5m])) > 0
+            for: 0m
+            labels:
+              severity: critical
+            annotations:
+              summary: "飞书长连接建立失败"
+              description: "channel-server 的飞书 WebSocket 连接报错，事件可能收不到。查 make logs APP=channel-server KEYWORD='[ws]'。"
+
+          # 重连风暴。单次重连是正常的网络抖动，SDK 会无限重试；但它的重连间隔是
+          # 120s + 随机 0-30s，15 分钟内超过 3 次说明是持续连不上而不是抖动。
+          - alert: LarkWebSocketReconnectStorm
+            expr: |
+              sum(count_over_time({namespace="prod", app="channel-server", pod=~"channel-server-prod-.*"} |= "[ws]" |= "reconnect" [15m])) > 3
+            for: 0m
+            labels:
+              severity: warning
+            annotations:
+              summary: "飞书长连接反复重连"
+              description: "channel-server 15 分钟内重连超过 3 次，长连接不稳定。"
+
+          # 入站事件断流——唯一能抓到 2026-07-28 那类故障的信号：不是错误变多，
+          # 而是流量消失。
+          #
+          # 必须用 absent_over_time，不能写 sum(count_over_time(...)) == 0：完全没有
+          # 日志时 count_over_time 返回空向量而非 0，`== 0` 永远不会触发，恰好在该
+          # 告警的时候静默。
+          #
+          # 45m 这个窗口是初值，缺乏夜间流量基线支撑，上线后按实际误报情况收紧；
+          # 真要定准应该按 bot、按时段统计事件间隔分布。0-8 点（北京时间）由
+          # Alertmanager 的 mute_time_intervals 静音。
+          - alert: LarkInboundEventsSilent
+            expr: |
+              absent_over_time({namespace="prod", app="channel-server", pod=~"channel-server-prod-.*"} |= "[inbound]" [45m])
+            for: 0m
+            labels:
+              severity: critical
+            annotations:
+              summary: "飞书入站事件断流"
+              description: "channel-server 已连续 45 分钟没有收到任何飞书事件。检查长连接状态和飞书开放平台事件订阅配置。"


### PR DESCRIPTION
## Why

Today roughly half of all Lark events were being dropped for about an hour, and **not one of the 33 existing alert rules fired**.

The event subscription pointed at a bare internal IP. Feishu's push fleet had lost its route to that subnet, so `connect()` failed with `ENETUNREACH` on their side — the failing requests never reached us at all. Everything we could see looked perfect: pods healthy with zero restarts, every request that did arrive returned 200 in 1–4ms, blackbox probes passing from inside the cluster. The one Lark-flavoured rule we had, `LarkApiHighErrorRate`, watches our outbound calls to Feishu, not their inbound calls to us.

That is the lesson worth encoding: an alert built on an error rate is structurally blind to a failure whose only symptom is traffic disappearing. No amount of threshold tuning on the existing rules would have caught this.

The ingress has since been switched to a WSClient persistent connection that we open outbound, which removes the dependency on Feishu being able to reach into our network. These rules watch the two things that can still break: whether the connection can be established, and whether events are actually still arriving.

## What

Three Loki rules plus an Alertmanager night-mute window. Pure addition — no existing line is modified.

| Alert | Fires when | Severity |
|---|---|---|
| `LarkWebSocketConnectFailure` | SDK logs a `[ws]` connect error within 5m | critical |
| `LarkWebSocketReconnectStorm` | more than 3 reconnects in 15m (SDK retries every 120s + jitter, so this means persistently failing, not jitter) | warning |
| `LarkInboundEventsSilent` | no inbound event for 45m | critical |

## Three decisions that are easy to get wrong

**The selector filters on `pod`, not `lane`.** Loki's stream labels here are `namespace` / `app` / `pod` only — promtail never promotes the Pod's `lane` label. Measured directly: `{app="channel-server"}` returns rows, adding `lane="prod"` returns zero. Shipping that would have left the two counting rules permanently silent and `absent_over_time` permanently true, paging from the moment it loaded. Pod names carry the lane suffix, so `pod=~"channel-server-prod-.*"` draws the same line correctly.

**`absent_over_time`, not `sum(count_over_time(...)) == 0`.** With no matching lines at all, `count_over_time` returns an empty vector rather than zero, so the `== 0` form never fires — it would go quiet at exactly the moment it is supposed to alert.

**The mute window is written in UTC**, `16:00-24:00` = `00:00-08:00` CST, rather than using `location: Asia/Shanghai`. If the Alertmanager image lacks tzdata, an unknown timezone rejects the entire config, silencing every alert we have — far worse than one nighttime false positive. China observes no DST, so the offset is fixed.

## Known gaps, documented inline rather than papered over

- A single bot going dark is masked by the other five; all six share one event stream.
- Partial loss is invisible: Feishu load-balances rather than broadcasts across clients sharing an `app_id`, so a lane stealing the connection diverts only some events instead of stopping them.
- A connection that stays open but stops delivering logs nothing at all.
- The 45m window has no traffic baseline behind it and should be tightened once a week of overnight data exists.

Closing the first three needs per-bot metrics, not log counting. That is deliberately out of scope here.

## Verification

The SDK serialises its logger args to JSON, so lines read `[info]: [ "[ws]", "ws connect failed" ]`. Checked the regex against 4 failure samples (match) and 4 healthy samples — ready / reconnect / manual close / self-build notice — (no match). Confirmed both `[inbound]` and `[ws]` filters return rows under the new pod selector against live Loki.

## Deploying

The two files activate differently:

- `loki-alert-rules.yaml` is a ConfigMap mounted at `/var/loki/rules/fake`. Applying the manifest is enough; the ruler picks it up on its own without a restart.
- `kube-prometheus-stack-values.yaml` is helm values and needs a chart upgrade.

Afterwards, confirm all four Loki rules load healthy — including the pre-existing `ChatResponseSendFailure`, which shares the same `rules.yaml` — and that Alertmanager accepted the config. Alertmanager loads its config as a whole, so a problem there would take the existing 33 alerts down with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
