### PR TITLE
fix(lane): carry lane in AMQP headers so it survives cross-service hops

### DIFF
--- a/apps/agent-service/app/runtime/debounce.py
+++ b/apps/agent-service/app/runtime/debounce.py
@@ -51,7 +51,12 @@ from app.runtime.data import Data
 from app.runtime.naming import to_snake
 from app.runtime.node import inputs_of
 from app.runtime.placement import nodes_for_app
-from app.runtime.propagation import bind_context, extract_context, inject_context
+from app.runtime.propagation import (
+    bind_context,
+    extract_context,
+    inject_context,
+    outbound_context,
+)
 from app.runtime.wire import WireSpec
 
 logger = logging.getLogger(__name__)
@@ -209,9 +214,17 @@ async def publish_debounce(w: WireSpec, consumer: Callable, data: Data) -> None:
         "key": key,
         "fire_now": bool(fire_now_flag),
     }
-    headers = inject_context({"data_type": type(data).__name__})
+    # One lane value for both the header and the queue: debounce routes are
+    # lane_fallback=False, so a message published to a lane queue is never
+    # seen by prod — but the handler restores context from the header alone,
+    # so a header/queue mismatch would run the fire under the wrong lane.
+    ctx = outbound_context()
+    headers = inject_context({"data_type": type(data).__name__}, ctx)
     delay_ms = 0 if body["fire_now"] else seconds * 1000
-    await mq.publish(_route_for(w, consumer), body, headers=headers, delay_ms=delay_ms)
+    await mq.publish(
+        _route_for(w, consumer), body,
+        headers=headers, delay_ms=delay_ms, lane=ctx.lane,
+    )
     logger.debug(
         "debounce publish: %s key=%s count=%d fire_now=%s",
         w.data_type.__name__, key, new_count, body["fire_now"],
@@ -256,9 +269,10 @@ async def _do_reschedule(
         "key": key,
         "fire_now": False,
     }
-    headers = inject_context({"data_type": type(data).__name__})
+    ctx = outbound_context()
+    headers = inject_context({"data_type": type(data).__name__}, ctx)
     await mq.publish(_route_for(w, consumer), body, headers=headers,
-                     delay_ms=seconds * 1000)
+                     delay_ms=seconds * 1000, lane=ctx.lane)
     logger.info(
         "debounce reschedule: %s key=%s new_trigger_id=%s",
         type(data).__name__, key, new_trigger_id,

--- a/apps/agent-service/app/runtime/emit.py
+++ b/apps/agent-service/app/runtime/emit.py
@@ -276,9 +276,25 @@ async def _mq_publish_for_source(src, data: Data) -> None:
     Looks up the Route in ALL_ROUTES by queue name (queue must be a known
     route — compile_graph rejects unknown queues at startup). Body is
     ``data.model_dump(mode='json')`` to mirror Source.mq consumer-side
-    decoding. Lane resolution happens inside ``mq.publish``.
+    decoding.
+
+    trace_id / lane also ride the message *header* (``inject_context``),
+    same as every other publish in the runtime. The consuming end
+    (``Runtime._source_loop_mq``) rebuilds contextvars from headers only —
+    it deliberately has no env fallback, because a prod pod also drains
+    lane messages that TTL'd back from a lane queue. Publishing without
+    headers therefore drops the lane at the process boundary and every
+    outbound HTTP call in the consuming process goes to prod.
+
+    The lane is resolved ONCE via ``outbound_context`` and handed to both
+    the header and ``mq.publish(lane=...)``. Letting ``mq.publish`` resolve
+    the queue lane on its own would reintroduce the mismatch: it reads
+    ``current_lane()`` (contextvar → ``LANE`` env) while the header would
+    carry the bare contextvar, so a background emit on a lane pod would
+    land in ``xxx_ppe-x`` stamped ``lane: ""``.
     """
     from app.infra.rabbitmq import mq
+    from app.runtime.propagation import inject_context, outbound_context
     from app.runtime.sink_dispatch import _route_by_queue
 
     queue_name = src.params["queue"]
@@ -290,7 +306,9 @@ async def _mq_publish_for_source(src, data: Data) -> None:
             f"Add it to app/infra/rabbitmq.py."
         )
     body = data.model_dump(mode="json")
-    await mq.publish(route, body)
+    ctx = outbound_context()
+    headers = inject_context({"data_type": type(data).__name__}, ctx)
+    await mq.publish(route, body, headers=headers, lane=ctx.lane)
 
 
 # ---------------------------------------------------------------------------

--- a/apps/agent-service/app/runtime/propagation.py
+++ b/apps/agent-service/app/runtime/propagation.py
@@ -4,11 +4,13 @@ The runtime moves messages across processes via RabbitMQ. Every transport hop
 reads inbound headers into contextvars before invoking business code, and
 writes contextvars back into outbound headers before publishing.
 
-Three primitives:
+Four primitives:
 
 * ``extract_context(headers)`` — defensive parse of inbound headers.
 * ``inject_context(headers, ctx=None)`` — write outbound headers (defaults to
   reading current contextvars).
+* ``outbound_context(fallback_lane=None)`` — the Context a *producer* should
+  inject, with the lane resolved the same way ``mq.publish`` picks the queue.
 * ``bind_context(ctx)`` — async context manager that sets contextvars on enter,
   restores on exit (works on success and exception paths).
 
@@ -70,6 +72,29 @@ def inject_context(
     out["trace_id"] = ctx.trace_id or ""
     out["lane"] = ctx.lane or ""
     return out
+
+
+def outbound_context(*, fallback_lane: str | None = None) -> Context:
+    """Build the Context for an outbound publish.
+
+    Lane resolution order: contextvar → ``fallback_lane`` (a lane the Data
+    itself carries, used by sink dispatch) → ``current_lane()``, which is the
+    ``LANE`` env of the running Deployment. That last step is the whole point:
+    ``mq.publish`` picks the queue with ``current_lane()``, so a producer that
+    injected the bare contextvar would stamp ``lane: ""`` on a message it just
+    routed to ``xxx_ppe-x``. Callers MUST feed ``ctx.lane`` back into
+    ``mq.publish(lane=...)`` so the two can never drift apart again.
+
+    The env fallback is producer-only. Consumers stay header-only on purpose:
+    a prod pod also drains messages that TTL'd back from a lane queue, so
+    reading its own ``LANE`` there would relabel foreign messages.
+    """
+    from app.infra.rabbitmq import current_lane
+
+    return Context(
+        trace_id=trace_id_var.get(),
+        lane=lane_var.get() or fallback_lane or current_lane(),
+    )
 
 
 @contextlib.asynccontextmanager

--- a/apps/agent-service/app/runtime/review_queue.py
+++ b/apps/agent-service/app/runtime/review_queue.py
@@ -18,7 +18,7 @@ from collections.abc import Callable
 from app.infra.rabbitmq import Route, mq
 from app.runtime.data import Data
 from app.runtime.naming import to_snake
-from app.runtime.propagation import inject_context
+from app.runtime.propagation import inject_context, outbound_context
 from app.runtime.wire import WireSpec
 
 logger = logging.getLogger(__name__)
@@ -63,12 +63,17 @@ async def publish_to_review_queue(
         "last_error": last_error,
         "attempts": attempts,
     }
-    headers = inject_context({"data_type": "manual_review_envelope"})
-    # lane defaults to ... sentinel which calls current_lane() internally.
+    # Resolve the lane once and pass it explicitly. Leaving it to the ...
+    # sentinel would have publish_with_confirm call current_lane() (contextvar
+    # → LANE env) while the header carried only the contextvar — an operator
+    # inspecting a lane's review queue would see prod-labelled envelopes.
+    ctx = outbound_context()
+    headers = inject_context({"data_type": "manual_review_envelope"}, ctx)
     confirmed = await mq.publish_with_confirm(
         route,
         body,
         headers=headers,
+        lane=ctx.lane,
     )
     if not confirmed:
         logger.warning(

--- a/apps/agent-service/app/runtime/sink_dispatch.py
+++ b/apps/agent-service/app/runtime/sink_dispatch.py
@@ -3,8 +3,8 @@
 Phase 2 把 ``Sink.mq("queue")`` 真正跑起来：emit 一个 Data 时，对每条
 ``wire(Data).to(Sink.mq(name))`` 通过 ``ALL_ROUTES`` 查到对应的 ``Route``
 (queue + routing_key)，然后用现有 ``mq.publish(route, body)`` 发出去。
-``mq.publish`` 内部会按 ``current_lane()`` 做 lane 队列 + routing key
-后缀，这部分行为对 sink dispatch 透明。
+lane 由 ``outbound_context`` 解析一次，同时喂给 header 和
+``mq.publish(lane=...)``——header 的 lane 跟队列的 lane 必须同源。
 
 Phase 7a (Gap 11): trace_id / lane 写入 header（与 durable / debounce 一致），
 同时保留 body 字段中的 ``lane``（chat-response-worker.ts 仍按 body 读）。
@@ -16,10 +16,9 @@ queue 直接 raise GraphError，所以这里 ``_route_by_queue`` 返回 None
 """
 from __future__ import annotations
 
-from app.api.middleware import lane_var, trace_id_var
 from app.infra.rabbitmq import ALL_ROUTES, Route, mq
 from app.runtime.data import Data
-from app.runtime.propagation import Context, inject_context
+from app.runtime.propagation import inject_context, outbound_context
 from app.runtime.sink import SinkSpec
 
 
@@ -32,22 +31,18 @@ async def _dispatch_mq_sink(sink: SinkSpec, data: Data) -> None:
     )
     body = data.model_dump(mode="json")
     # Lane source priority: contextvar > body.lane field (carried by some
-    # Data classes for body-level routing, e.g. ChatResponseSegment).
+    # Data classes for body-level routing, e.g. ChatResponseSegment) >
+    # LANE env. ``outbound_context`` owns that order; passing ctx.lane back
+    # into publish keeps the header and the queue on one value — omitting it
+    # would let publish re-resolve via current_lane() and, on a lane pod with
+    # no contextvar, route to the lane queue while the header said prod.
     raw_body_lane = body.get("lane")
     body_lane = (
         raw_body_lane if isinstance(raw_body_lane, str) and raw_body_lane else None
     )
-    ctx_lane = lane_var.get() or body_lane
-    headers = inject_context(
-        {"data_type": type(data).__name__},
-        Context(trace_id=trace_id_var.get(), lane=ctx_lane),
-    )
-    if ctx_lane:
-        await mq.publish(route, body, headers=headers, lane=ctx_lane)
-    else:
-        # Fall through to mq.publish's default lane resolution
-        # (current_lane() -> lane_var or LANE env), preserving prior behavior.
-        await mq.publish(route, body, headers=headers)
+    ctx = outbound_context(fallback_lane=body_lane)
+    headers = inject_context({"data_type": type(data).__name__}, ctx)
+    await mq.publish(route, body, headers=headers, lane=ctx.lane)
 
 
 def _route_by_queue(queue_name: str) -> Route | None:

--- a/apps/agent-service/tests/integration/test_phase3_e2e.py
+++ b/apps/agent-service/tests/integration/test_phase3_e2e.py
@@ -117,13 +117,19 @@ class _FakeRedis:
 
 
 class _FakeMq:
-    """In-memory mq stub: stores published bodies in a list."""
+    """In-memory mq stub: stores published bodies in a list.
+
+    Signature mirrors the real ``_RabbitMQ.publish`` — including the ``lane``
+    sentinel — so a producer that resolves the lane itself (every runtime
+    publish does, to keep the header and the queue on one value) is exercised
+    here instead of blowing up on an unexpected kwarg.
+    """
 
     def __init__(self):
-        self.published: list[tuple] = []  # list of (route, body, headers, delay_ms)
+        self.published: list[tuple] = []  # (route, body, headers, delay_ms, lane)
 
-    async def publish(self, route, body, headers=None, delay_ms=None):
-        self.published.append((route, body, headers, delay_ms))
+    async def publish(self, route, body, delay_ms=None, headers=None, lane=...):
+        self.published.append((route, body, headers, delay_ms, lane))
 
 
 class _FakeMessage:
@@ -188,7 +194,7 @@ async def test_e2e_single_emit_one_fire(monkeypatch):
     assert mq_fake.published[0][3] == 60_000
 
     handler = _build_handler(w, consumer)
-    _route, body, headers, _delay = mq_fake.published[0]
+    _route, body, headers, _delay, _lane = mq_fake.published[0]
     msg = _FakeMessage(body, headers or {})
     await handler(msg)
 
@@ -223,13 +229,13 @@ async def test_e2e_multiple_emits_one_fire(monkeypatch):
     handler = _build_handler(w, consumer)
 
     # 前 2 条 message 被新 publish 作废，atomic claim fail → drop
-    for _route, body, headers, _delay in mq_fake.published[:2]:
+    for _route, body, headers, _delay, _lane in mq_fake.published[:2]:
         msg = _FakeMessage(body, headers or {})
         await handler(msg)
     assert len(fired) == 0
 
     # 最后一条 latest 匹配 → fire
-    _route, body, headers, _delay = mq_fake.published[2]
+    _route, body, headers, _delay, _lane = mq_fake.published[2]
     msg = _FakeMessage(body, headers or {})
     await handler(msg)
     assert len(fired) == 1
@@ -336,7 +342,7 @@ async def test_e2e_per_key_isolation(monkeypatch):
     await publish_debounce(w, consumer, SampleTrigger(chat_id="c2", persona_id="p2"))
 
     handler = _build_handler(w, consumer)
-    for _route, body, headers, _delay in mq_fake.published:
+    for _route, body, headers, _delay, _lane in mq_fake.published:
         await handler(_FakeMessage(body, headers or {}))
 
     assert sorted(fired) == [("c1", "p1"), ("c2", "p2")]

--- a/apps/agent-service/tests/runtime/test_emit_cross_process.py
+++ b/apps/agent-service/tests/runtime/test_emit_cross_process.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from typing import Annotated
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
@@ -22,6 +22,16 @@ def _isolate(monkeypatch):
 
 class _XReq(Data):
     x_id: Annotated[str, Key]
+
+    class Meta:
+        transient = True
+
+
+class _ChatReqProbe(Data):
+    """Uses a queue that really exists in ALL_ROUTES so the publish path
+    (``_mq_publish_for_source`` -> ``_route_by_queue``) resolves a Route."""
+
+    chat_id: Annotated[str, Key]
 
     class Meta:
         transient = True
@@ -110,3 +120,81 @@ async def test_emit_raises_when_no_mq_source_and_consumer_other_app(monkeypatch)
         await emit(_XReq(x_id="x3"))
 
     fake_publish.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_emit_mq_publish_injects_trace_and_lane_headers(monkeypatch):
+    """Cross-process emit over Source.mq must write trace/lane into the
+    message header.
+
+    The consumer end (``Runtime._source_loop_mq``) rebuilds contextvars from
+    headers *only* — there is deliberately no body / env fallback, because a
+    prod pod also drains lane messages that TTL'd back from a lane queue.
+    So a publish without headers means the consuming process runs the whole
+    downstream chain with ``lane=None`` and ``lane_router`` sends every
+    outbound HTTP call to the prod service.
+    """
+    from app.runtime.propagation import Context, bind_context
+
+    @node
+    async def chat_handler(r: _ChatReqProbe) -> None:
+        pass
+
+    wire(_ChatReqProbe).to(chat_handler).from_(Source.mq("chat_request"))
+    bind(chat_handler).to_app("vectorize-worker")
+
+    monkeypatch.setenv("APP_NAME", "agent-service")
+
+    import sys
+
+    emit_mod = sys.modules["app.runtime.emit"]
+    emit_mod.reset_emit_runtime()
+
+    fake_publish = AsyncMock()
+    with patch("app.infra.rabbitmq.mq.publish", fake_publish):
+        async with bind_context(Context(trace_id="t-emit", lane="ppe-emit")):
+            await emit(_ChatReqProbe(chat_id="c9"))
+
+    fake_publish.assert_awaited_once()
+    args, kwargs = fake_publish.await_args
+    assert args[0].queue == "chat_request"
+    assert args[1]["chat_id"] == "c9"
+    headers = kwargs.get("headers")
+    assert headers is not None, (
+        "emit() published to Source.mq without headers — trace/lane are lost "
+        "at the process boundary"
+    )
+    assert headers["lane"] == "ppe-emit"
+    assert headers["trace_id"] == "t-emit"
+
+
+@pytest.mark.asyncio
+async def test_emit_mq_publish_writes_empty_lane_header_outside_a_lane(monkeypatch):
+    """No lane in context -> header still present, written as "" (the
+    on-wire shape ``inject_context`` guarantees and ``extract_context``
+    coerces back to None)."""
+
+    @node
+    async def chat_handler(r: _ChatReqProbe) -> None:
+        pass
+
+    wire(_ChatReqProbe).to(chat_handler).from_(Source.mq("chat_request"))
+    bind(chat_handler).to_app("vectorize-worker")
+
+    monkeypatch.setenv("APP_NAME", "agent-service")
+
+    import sys
+
+    emit_mod = sys.modules["app.runtime.emit"]
+    emit_mod.reset_emit_runtime()
+
+    fake_publish = AsyncMock()
+    with patch("app.infra.rabbitmq.mq.publish", fake_publish):
+        await emit(_ChatReqProbe(chat_id="c10"))
+
+    fake_publish.assert_awaited_once()
+    _args, kwargs = fake_publish.await_args
+    headers = kwargs.get("headers")
+    assert headers is not None
+    assert headers["lane"] == ""
+    assert headers["data_type"] == "_ChatReqProbe"

--- a/apps/agent-service/tests/runtime/test_propagation.py
+++ b/apps/agent-service/tests/runtime/test_propagation.py
@@ -10,6 +10,7 @@ from app.runtime.propagation import (
     bind_context,
     extract_context,
     inject_context,
+    outbound_context,
 )
 
 
@@ -69,6 +70,58 @@ class TestInjectContext:
         # contextvars default to None when not set in this scope
         h = inject_context(None)
         assert h == {"trace_id": "", "lane": ""}
+
+
+class TestOutboundContext:
+    """Producer-side lane must be resolved the way ``mq.publish`` picks the
+    queue — ``current_lane()``: contextvar first, ``LANE`` env second.
+
+    This is deliberately NOT symmetric with the consuming side, which is
+    header-only: a prod pod drains lane messages that TTL'd back from a lane
+    queue, so consuming with an env fallback would relabel them as prod.
+    A producer has no such ambiguity — the process publishes to its own lane.
+    """
+
+    def test_contextvar_wins(self, monkeypatch) -> None:
+        monkeypatch.setenv("LANE", "ppe-env")
+        l_tok = lane_var.set("ppe-ctx")
+        t_tok = trace_id_var.set("t1")
+        try:
+            ctx = outbound_context()
+        finally:
+            lane_var.reset(l_tok)
+            trace_id_var.reset(t_tok)
+        assert ctx == Context(trace_id="t1", lane="ppe-ctx")
+
+    def test_falls_back_to_lane_env_when_contextvar_is_empty(
+        self, monkeypatch
+    ) -> None:
+        monkeypatch.setenv("LANE", "ppe-env")
+        ctx = outbound_context()
+        assert ctx.lane == "ppe-env"
+
+    def test_prod_and_missing_lane_are_none(self, monkeypatch) -> None:
+        monkeypatch.setenv("LANE", "prod")
+        assert outbound_context().lane is None
+        monkeypatch.delenv("LANE")
+        assert outbound_context().lane is None
+
+    def test_fallback_lane_beats_env_but_not_contextvar(
+        self, monkeypatch
+    ) -> None:
+        """``fallback_lane`` is the Data-carried lane used by sink dispatch;
+        it ranks between the contextvar and the process env."""
+        monkeypatch.setenv("LANE", "ppe-env")
+        assert outbound_context(fallback_lane="ppe-body").lane == "ppe-body"
+        l_tok = lane_var.set("ppe-ctx")
+        try:
+            assert outbound_context(fallback_lane="ppe-body").lane == "ppe-ctx"
+        finally:
+            lane_var.reset(l_tok)
+
+    def test_fallback_lane_used_when_nothing_else_set(self, monkeypatch) -> None:
+        monkeypatch.delenv("LANE", raising=False)
+        assert outbound_context(fallback_lane="ppe-body").lane == "ppe-body"
 
 
 class TestBindContext:

--- a/apps/agent-service/tests/runtime/test_publish_lane_consistency.py
+++ b/apps/agent-service/tests/runtime/test_publish_lane_consistency.py
@@ -1,0 +1,289 @@
+"""Cross-module invariant: header lane == queue lane, every publish.
+
+``mq.publish`` picks the queue with ``current_lane()`` — contextvar first,
+``LANE`` env second. ``inject_context`` (no explicit Context) reads the
+contextvar only. On a lane pod there is a window where those two disagree:
+a background task / startup-time emit has no contextvar, so the message
+lands in ``xxx_ppe-x`` while its header says ``lane: ""``.
+
+That combination is exactly the bug this module guards. The consuming side
+is header-only by design (a prod pod also drains messages that TTL'd back
+from a lane queue, so it cannot fall back to its own ``LANE``), so a
+lane-queue message carrying an empty lane header gets processed as prod and
+every outbound call in the consuming process goes to prod.
+
+The tests assert the invariant directly rather than the implementation:
+whatever lane ends up in the header, the routing key + lazily-declared
+queue that the broker actually saw must be the ones derived from THAT lane.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Annotated
+
+import pytest
+
+from app.infra.rabbitmq import Route
+from app.runtime import Data, Key, Sink, Source, bind, emit, node, wire
+from app.runtime.placement import clear_bindings
+from app.runtime.propagation import Context, bind_context
+from app.runtime.wire import WireSpec, clear_wiring
+
+LANE = "ppe-lanecheck"
+
+
+# ---------------------------------------------------------------------------
+# Probe Data classes (module level so @node's get_type_hints() resolves them)
+# ---------------------------------------------------------------------------
+
+
+class _SourceMqProbe(Data):
+    """Rides ``chat_request``, a queue that really exists in ALL_ROUTES."""
+
+    chat_id: Annotated[str, Key]
+
+    class Meta:
+        transient = True
+
+
+class _SinkProbe(Data):
+    session_id: Annotated[str, Key]
+
+    class Meta:
+        transient = True
+
+
+class _DebounceProbe(Data):
+    chat_id: Annotated[str, Key]
+
+    class Meta:
+        transient = True
+
+
+class _ReviewProbe(Data):
+    id: Annotated[str, Key]
+
+    class Meta:
+        transient = True
+
+
+async def _debounce_consumer(t: _DebounceProbe) -> None:
+    return None
+
+
+def _review_consumer() -> None:
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _isolate():
+    clear_wiring()
+    clear_bindings()
+    from app.runtime.emit import reset_emit_runtime
+
+    reset_emit_runtime()
+    yield
+    clear_wiring()
+    clear_bindings()
+    reset_emit_runtime()
+
+
+@pytest.fixture
+def broker(monkeypatch):
+    """Run the real ``mq.publish`` against a stubbed exchange / channel.
+
+    Patching ``mq.publish`` itself would hide the very thing under test —
+    the queue name is computed *inside* publish. So we stub one layer
+    lower and read the routing key + headers the broker would have seen.
+    """
+    from app.infra.rabbitmq import mq
+
+    declared: list[str] = []
+    published: list[tuple[str, object]] = []
+
+    class _FakeQueue:
+        async def bind(self, exchange, routing_key=None):
+            return None
+
+    class _FakeChannel:
+        async def declare_queue(self, name, durable=True, arguments=None):
+            declared.append(name)
+            return _FakeQueue()
+
+    class _FakeExchange:
+        async def publish(self, message, routing_key=None):
+            published.append((routing_key, message))
+
+    monkeypatch.setattr(mq, "_exchange", _FakeExchange())
+    monkeypatch.setattr(mq, "_channel", _FakeChannel())
+    monkeypatch.setattr(mq, "_declared_lane_queues", set())
+    return SimpleNamespace(declared=declared, published=published)
+
+
+@pytest.fixture
+def lane_env(monkeypatch):
+    """The broken combination: no contextvar lane, ``LANE`` env set."""
+    monkeypatch.setenv("LANE", LANE)
+    monkeypatch.setenv("APP_NAME", "agent-service")
+
+
+def assert_header_lane_drives_the_queue(broker, route: Route) -> str | None:
+    """Assert the routing key / queue the broker saw match the header lane.
+
+    Returns the header lane so callers can additionally pin its value.
+    """
+    assert len(broker.published) == 1, (
+        f"expected exactly one publish, got {len(broker.published)}"
+    )
+    rk, message = broker.published[0]
+    headers = dict(message.headers or {})
+    header_lane = headers.get("lane") or None
+
+    expected_rk = f"{route.rk}.{header_lane}" if header_lane else route.rk
+    assert rk == expected_rk, (
+        f"header says lane={header_lane!r} but the message was routed with "
+        f"{rk!r} (expected {expected_rk!r}) — the queue lane and the header "
+        f"lane come from different sources, so the consumer will treat this "
+        f"message as belonging to the wrong lane"
+    )
+    if header_lane:
+        assert f"{route.queue}_{header_lane}" in broker.declared, (
+            f"lane queue for {header_lane!r} was never declared; declared="
+            f"{broker.declared}"
+        )
+    return header_lane
+
+
+# ---------------------------------------------------------------------------
+# 1. emit() -> Source.mq cross-process publish
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_emit_source_mq_header_lane_matches_queue_lane(broker, lane_env):
+    from app.infra.rabbitmq import CHAT_REQUEST
+
+    @node
+    async def _remote_handler(r: _SourceMqProbe) -> None:
+        pass
+
+    wire(_SourceMqProbe).to(_remote_handler).from_(Source.mq("chat_request"))
+    bind(_remote_handler).to_app("some-other-app")
+
+    async with bind_context(Context(trace_id=None, lane=None)):
+        await emit(_SourceMqProbe(chat_id="c1"))
+
+    assert assert_header_lane_drives_the_queue(broker, CHAT_REQUEST) == LANE
+
+
+# ---------------------------------------------------------------------------
+# 2. emit() -> Sink.mq dispatch
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_sink_dispatch_header_lane_matches_queue_lane(broker, lane_env):
+    from app.infra.rabbitmq import RECALL
+
+    wire(_SinkProbe).to(Sink.mq("recall"))
+
+    async with bind_context(Context(trace_id=None, lane=None)):
+        await emit(_SinkProbe(session_id="s1"))
+
+    assert assert_header_lane_drives_the_queue(broker, RECALL) == LANE
+
+
+# ---------------------------------------------------------------------------
+# 3 + 4. debounce publish + reschedule
+# ---------------------------------------------------------------------------
+
+
+def _debounce_wire() -> WireSpec:
+    return WireSpec(
+        data_type=_DebounceProbe,
+        consumers=[_debounce_consumer],
+        debounce={"seconds": 60, "max_buffer": 3},
+        debounce_key_by=lambda e: f"probe:{e.chat_id}",
+    )
+
+
+@pytest.fixture
+def fake_redis(monkeypatch):
+    from unittest.mock import AsyncMock
+
+    redis = AsyncMock()
+    # publish path returns [count, fire_now]; CAS swap path returns 1
+    redis.eval = AsyncMock(return_value=[1, 0])
+    monkeypatch.setattr(
+        "app.runtime.debounce.get_redis", AsyncMock(return_value=redis)
+    )
+    return redis
+
+
+@pytest.mark.asyncio
+async def test_debounce_publish_header_lane_matches_queue_lane(
+    broker, lane_env, fake_redis
+):
+    from app.runtime.debounce import _route_for, publish_debounce
+
+    w = _debounce_wire()
+    await publish_debounce(w, _debounce_consumer, _DebounceProbe(chat_id="c1"))
+
+    route = _route_for(w, _debounce_consumer)
+    assert assert_header_lane_drives_the_queue(broker, route) == LANE
+
+
+@pytest.mark.asyncio
+async def test_debounce_reschedule_header_lane_matches_queue_lane(
+    broker, lane_env, fake_redis
+):
+    from app.runtime.debounce import _do_reschedule, _route_for
+
+    fake_redis.eval = type(fake_redis.eval)(return_value=1)  # CAS swap ok
+
+    w = _debounce_wire()
+    await _do_reschedule(
+        w, _debounce_consumer, _DebounceProbe(chat_id="c1"), "orig-trigger"
+    )
+
+    route = _route_for(w, _debounce_consumer)
+    assert assert_header_lane_drives_the_queue(broker, route) == LANE
+
+
+# ---------------------------------------------------------------------------
+# 5. manual-review queue
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_review_queue_header_lane_matches_queue_lane(broker, lane_env):
+    from app.runtime.review_queue import (
+        publish_to_review_queue,
+        review_queue_name_for,
+        route_for_review,
+    )
+
+    spec = WireSpec(
+        data_type=_ReviewProbe,
+        consumers=[_review_consumer],
+        durable=True,
+        on_error="manual-review",
+    )
+    confirmed = await publish_to_review_queue(
+        wire=spec,
+        consumer=_review_consumer,
+        data=_ReviewProbe(id="x"),
+        exc=RuntimeError("boom"),
+        attempts=2,
+        last_error="boom",
+    )
+    assert confirmed is True
+
+    route = route_for_review(review_queue_name_for(spec, _review_consumer))
+    assert assert_header_lane_drives_the_queue(broker, route) == LANE

--- a/apps/agent-service/tests/runtime/test_source_mq.py
+++ b/apps/agent-service/tests/runtime/test_source_mq.py
@@ -164,10 +164,103 @@ async def test_mq_source_generates_fallback_trace_id_when_header_missing(
         ok = await _wait_until(lambda: len(received) >= 1, timeout=5.0)
         assert ok, "expected 1 message processed"
 
-        trace, _lane = seen_ctx[0]
+        trace, lane = seen_ctx[0]
         assert trace is not None, "trace_id must be auto-generated; node saw None"
         assert re.fullmatch(r"mq:mqsrc_no_trace:[0-9a-f]{8}", trace), (
             f"expected mq:<queue>:<uuid8> shape, got {trace!r}"
+        )
+        # No lane header at all -> no lane. The trace_id fallback must not
+        # invent one (env LANE fallback here would mislabel TTL'd-back lane
+        # messages as prod).
+        assert lane is None
+    finally:
+        await _stop_runtime(rt, task)
+
+
+@pytest.mark.integration
+async def test_mq_source_binds_lane_from_header(rabbitmq):
+    """A real (non-empty) ``lane`` header lands in ``lane_var`` for the node
+    call.
+
+    This is the case the suite never covered: the existing basic test only
+    publishes ``lane: ""`` (-> None), so a consumer that dropped the lane
+    entirely would still pass. Lane must survive the hop because
+    ``lane_router.get_headers()`` reads ``lane_var`` — a None there sends
+    every outbound HTTP call from this node to the prod service.
+
+    Note the publish itself goes to the *prod* queue (no LANE env in this
+    process): header lane and queue lane are independent on purpose. That is
+    exactly the shape of a lane message that TTL'd back to prod, which is why
+    the header — not env — is the authority.
+    """
+    from app.infra.rabbitmq import Route, mq
+
+    @node
+    async def ingest(req: _Req) -> None:
+        received.append(req)
+        seen_ctx.append((trace_id_var.get(), lane_var.get()))
+
+    wire(_Req).to(ingest).from_(Source.mq("mqsrc_lane_hdr"))
+
+    route = Route("mqsrc_lane_hdr", "mqsrc_lane_hdr.rk")
+    await mq.declare_route(route)
+
+    rt, task = await _run_runtime()
+    try:
+        await mq.publish(
+            route,
+            {"message_id": "l1"},
+            headers={"trace_id": "t-lane", "lane": "ppe-x"},
+        )
+
+        ok = await _wait_until(lambda: len(received) >= 1, timeout=5.0)
+        assert ok, "expected 1 message processed"
+
+        trace, lane = seen_ctx[0]
+        assert trace == "t-lane"
+        assert lane == "ppe-x", (
+            f"lane header must reach lane_var inside the node; got {lane!r}"
+        )
+    finally:
+        await _stop_runtime(rt, task)
+
+
+@pytest.mark.integration
+async def test_mq_source_keeps_lane_when_trace_id_header_missing(rabbitmq):
+    """The trace_id auto-generation fallback must not clobber the lane.
+
+    Rebuilding the Context to fill in a synthetic trace_id is the one place
+    where the extracted lane could silently be dropped, and a producer that
+    injects lane but no trace_id is a realistic shape (channel-server injects
+    lane per request; trace_id is optional).
+    """
+    import re
+
+    from app.infra.rabbitmq import Route, mq
+
+    @node
+    async def ingest(req: _Req) -> None:
+        received.append(req)
+        seen_ctx.append((trace_id_var.get(), lane_var.get()))
+
+    wire(_Req).to(ingest).from_(Source.mq("mqsrc_lane_no_trace"))
+
+    route = Route("mqsrc_lane_no_trace", "mqsrc_lane_no_trace.rk")
+    await mq.declare_route(route)
+
+    rt, task = await _run_runtime()
+    try:
+        await mq.publish(route, {"message_id": "l2"}, headers={"lane": "ppe-y"})
+
+        ok = await _wait_until(lambda: len(received) >= 1, timeout=5.0)
+        assert ok, "expected 1 message processed"
+
+        trace, lane = seen_ctx[0]
+        assert re.fullmatch(r"mq:mqsrc_lane_no_trace:[0-9a-f]{8}", trace or ""), (
+            f"expected mq:<queue>:<uuid8> shape, got {trace!r}"
+        )
+        assert lane == "ppe-y", (
+            f"lane must survive the trace_id fallback rebuild; got {lane!r}"
         )
     finally:
         await _stop_runtime(rt, task)

--- a/apps/channel-server/src/infrastructure/integrations/amqp-context.test.ts
+++ b/apps/channel-server/src/infrastructure/integrations/amqp-context.test.ts
@@ -1,0 +1,73 @@
+// 消费侧从 AMQP header 还原跨进程上下文的口径单测。
+//
+// 这是 rabbitmq.ts::publish 注入侧（rabbitmq.test.ts 覆盖）的对侧：写入什么格式，
+// 这里就必须按同样的格式读回来。归一规则必须与 agent-service
+// app/runtime/propagation.py 的 _coerce 完全一致，否则同一条消息在 TS worker 和
+// Python 服务里会解出两个不同的 lane。
+
+import { describe, it, expect } from 'bun:test';
+import type { ConsumeMessage } from 'amqplib';
+
+import { laneFromMessage, traceIdFromMessage } from './amqp-context';
+
+function msgWithHeaders(headers: Record<string, unknown> | undefined): ConsumeMessage {
+    return {
+        content: Buffer.from('{}'),
+        fields: {} as ConsumeMessage['fields'],
+        properties: { headers } as unknown as ConsumeMessage['properties'],
+    } as ConsumeMessage;
+}
+
+describe('laneFromMessage', () => {
+    it('header 带非空字符串 lane：原样返回', () => {
+        expect(laneFromMessage(msgWithHeaders({ lane: 'ppe-taskb' }))).toBe('ppe-taskb');
+        expect(laneFromMessage(msgWithHeaders({ lane: 'coe-x' }))).toBe('coe-x');
+        // 'prod' 不在这里被特殊处理：publish 侧对 prod 写的是空串，真出现字面
+        // 'prod' 说明上游另有约定，如实透出而不是偷偷归一。
+        expect(laneFromMessage(msgWithHeaders({ lane: 'prod' }))).toBe('prod');
+    });
+
+    it('header lane 是空串：无 lane（inject_context 对「无 lane」写的就是空串）', () => {
+        expect(laneFromMessage(msgWithHeaders({ lane: '' }))).toBeUndefined();
+    });
+
+    it('headers 里没有 lane key：无 lane', () => {
+        expect(laneFromMessage(msgWithHeaders({ trace_id: 't-1' }))).toBeUndefined();
+    });
+
+    it('整个 headers 缺失：无 lane（部署窗口内的在途旧消息走这条）', () => {
+        expect(laneFromMessage(msgWithHeaders(undefined))).toBeUndefined();
+    });
+
+    it('lane 不是字符串：无 lane（与 Python _coerce 对齐，不做 String() 强转）', () => {
+        expect(laneFromMessage(msgWithHeaders({ lane: 42 }))).toBeUndefined();
+        expect(laneFromMessage(msgWithHeaders({ lane: null }))).toBeUndefined();
+        expect(laneFromMessage(msgWithHeaders({ lane: true }))).toBeUndefined();
+        expect(laneFromMessage(msgWithHeaders({ lane: ['ppe-taskb'] }))).toBeUndefined();
+        expect(laneFromMessage(msgWithHeaders({ lane: { v: 'ppe-taskb' } }))).toBeUndefined();
+        // amqplib 会把 longstr header 解成 Buffer；Buffer 不是 string，同样按无 lane 处理。
+        expect(laneFromMessage(msgWithHeaders({ lane: Buffer.from('ppe-taskb') }))).toBeUndefined();
+    });
+});
+
+describe('traceIdFromMessage', () => {
+    it('header 带非空字符串 trace_id：原样返回', () => {
+        expect(traceIdFromMessage(msgWithHeaders({ trace_id: 't-1' }))).toBe('t-1');
+    });
+
+    it('空串 / 缺 key / 无 headers / 非字符串：都当没有 trace（与 lane 同一套归一规则）', () => {
+        expect(traceIdFromMessage(msgWithHeaders({ trace_id: '' }))).toBeUndefined();
+        expect(traceIdFromMessage(msgWithHeaders({ lane: 'ppe-taskb' }))).toBeUndefined();
+        expect(traceIdFromMessage(msgWithHeaders(undefined))).toBeUndefined();
+        expect(traceIdFromMessage(msgWithHeaders({ trace_id: 42 }))).toBeUndefined();
+        expect(
+            traceIdFromMessage(msgWithHeaders({ trace_id: Buffer.from('t-1') })),
+        ).toBeUndefined();
+    });
+
+    it('lane 和 trace_id 各读各的 key，互不串味', () => {
+        const msg = msgWithHeaders({ lane: 'ppe-taskb', trace_id: 't-1' });
+        expect(laneFromMessage(msg)).toBe('ppe-taskb');
+        expect(traceIdFromMessage(msg)).toBe('t-1');
+    });
+});

--- a/apps/channel-server/src/infrastructure/integrations/amqp-context.ts
+++ b/apps/channel-server/src/infrastructure/integrations/amqp-context.ts
@@ -1,0 +1,60 @@
+// 一条 AMQP 消息随身携带的跨进程上下文（lane + trace_id），消费侧的读出口径。
+//
+// 这一头和 rabbitmq.ts::publish 的写入是同一份约定的两侧，也和 agent-service 的
+// app/runtime/propagation.py（inject_context / extract_context）是同一份跨语言约定：
+// key 固定 `lane` / `trace_id`，空值写空串而不是省略 key，读回来时空串和非字符串
+// 都归一成「无」。三处必须同时改，改一处就是让同一条消息在 TS worker 和 Python
+// 服务里解出两个不同的 lane。
+//
+// 为什么单独一个模块而不是挂在 rabbitmq.ts 上：读出是不碰连接的纯函数，而
+// rabbitmq.ts 是有连接状态的单例，被多个测试文件用 bun 的 mock.module 整体替换成
+// 桩（mock.module 是进程级的，mock.restore() 不撤销）。纯函数挂上去，跨文件跑测试
+// 时会跟着被桩掉、变成 undefined。同理 @infrastructure/lane-policy 也是因为这个
+// 原因独立出去的——但那个回答的是另一个问题（本进程是不是 prod 部署），和这里
+// 「这条入站消息属于哪个泳道」不是一回事。
+
+import type { ConsumeMessage } from 'amqplib';
+
+/**
+ * header 归一：空串 / 缺失 / 非字符串（amqplib 会把 longstr 解成 Buffer）都 →
+ * undefined，与 propagation.py 的 `_coerce` 同口径。lane 和 trace_id 共用这一份规则，
+ * 免得两个 key 的归一慢慢漂成两套。
+ */
+function headerString(msg: ConsumeMessage, key: string): string | undefined {
+    const raw = msg.properties.headers?.[key];
+    return typeof raw === 'string' && raw ? raw : undefined;
+}
+
+/**
+ * 从入站消息的 AMQP header 取 lane。空串 / 缺失 / 非字符串都 → undefined（无 lane，
+ * 等价 prod）。
+ *
+ * 为什么只认 header：泳道队列（chat_response_{lane} / recall_{lane}）带 10s TTL +
+ * DLX，下游没部泳道时消息会降级回 prod 队列由 prod worker 接手，但它**仍然属于那个
+ * 泳道**——header 是唯一能穿过 TTL/DLX 降级还保持原样的载体。
+ *
+ * 为什么不回落 body.lane：Python 侧把「header 明确写空」和「header 压根没写」都归一
+ * 成 None，消费侧无从区分；回落 body 会把上游已判定为 prod 的消息错误复活成泳道消息。
+ *
+ * 为什么不回落 env LANE：prod worker 收到的很可能正是降级回来的泳道消息，env 兜底
+ * 会把它错判成 prod，恰好毁掉这个机制要修的能力。
+ *
+ * 部署窗口内的在途旧消息没有 header，按无 lane 处理、当 prod 走——已接受的降级。
+ */
+export function laneFromMessage(msg: ConsumeMessage): string | undefined {
+    return headerString(msg, 'lane');
+}
+
+/**
+ * 从入站消息的 AMQP header 取 trace_id，归一规则同 lane。
+ *
+ * 消费侧据此把整条处理跑在同一条 trace 下：worker 自己再 publish 时，publish 会从
+ * AsyncLocalStorage 取 trace_id 写回 header（见 rabbitmq.ts::publish）。不恢复就是
+ * 每跳一次换一条 trace，重投 / 降级这些最需要追的路径反而追不了。
+ *
+ * 取不到时返回 undefined 而不是空串：调用方拿它去 createContext，undefined 会生成
+ * 一个新 traceId，本次处理内部至少是自洽的一条链；空串会让下游的 trace 字段全空。
+ */
+export function traceIdFromMessage(msg: ConsumeMessage): string | undefined {
+    return headerString(msg, 'trace_id');
+}

--- a/apps/channel-server/src/infrastructure/integrations/rabbitmq.test.ts
+++ b/apps/channel-server/src/infrastructure/integrations/rabbitmq.test.ts
@@ -1,0 +1,189 @@
+// publish 的 AMQP header 上下文注入单测。
+//
+// 背景：泳道信息此前只编码进队列名（chat_request_{lane}）和消息体，没有写进 AMQP
+// header。下游 agent-service 的 runtime/propagation.py::extract_context 只读 header
+// 的 "lane" / "trace_id" 两个 key，读不到就当 lane=None —— 处理泳道消息时所有出站
+// HTTP 不带 x-ctx-lane，被 sidecar 打回 prod。泳道队列 TTL 到期 DLX 降级回 prod 后
+// 同理：prod 服务不知道这条消息原本属于哪个泳道。
+//
+// 约定对齐 propagation.py::inject_context：key 固定 "lane" / "trace_id"，空值写空
+// 字符串而不是省略 key。
+
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+// 走 @inner/shared 的基座 context（与 @middleware/context 共用同一个
+// AsyncLocalStorage）：inbound-lane-consumer.test.ts 把 @middleware/context 整个
+// mock 成了没有 getTraceId 的桩，而 bun 的 mock.module 是进程级全局。
+import { context } from '@inner/shared';
+import type * as RabbitMQModule from './rabbitmq';
+
+// 同目录的 inbound-lane-consumer.test.ts 和 plugins 下若干测试都 mock.module 掉了本
+// 模块，而 bun 的 mock.module 是进程级全局：整套 bun test 跑起来时，直接
+// `import './rabbitmq'` 拿到的是别人的桩（publish 变成空实现，断言全落空）。带 query
+// 的 specifier 是另一个模块 key，拿得到未被替换的真实实现和一个干净的单例。
+const { rabbitmqClient, CHAT_REQUEST } = (await import(
+    // @ts-expect-error 带 query 的 specifier 只有 bun 运行时认，tsc 解析不到；类型由下面的断言给出
+    './rabbitmq.ts?real'
+)) as typeof RabbitMQModule;
+
+interface PublishCall {
+    exchange: string;
+    rk: string;
+    content: Buffer;
+    headers: Record<string, unknown> | undefined;
+}
+
+const calls: PublishCall[] = [];
+
+const fakeChannel = {
+    publish: (
+        exchange: string,
+        rk: string,
+        content: Buffer,
+        options: { headers?: Record<string, unknown> },
+    ): boolean => {
+        calls.push({ exchange, rk, content, headers: options.headers });
+        return true;
+    },
+    assertQueue: async () => ({}),
+    bindQueue: async () => ({}),
+};
+
+// publish 依赖已连接的 channel。这里直接注入假 channel，避免 mock.module('amqplib')
+// 污染同进程其他测试（bun 的 mock.module 是进程级全局）。
+function injectFakeChannel(): void {
+    (rabbitmqClient as unknown as { channel: unknown }).channel = fakeChannel;
+}
+
+function clearChannel(): void {
+    (rabbitmqClient as unknown as { channel: unknown }).channel = null;
+}
+
+function lastHeaders(): Record<string, unknown> {
+    expect(calls.length).toBe(1);
+    const headers = calls[0]!.headers;
+    if (!headers) throw new Error('expected publish options.headers to be present');
+    return headers;
+}
+
+const originalLane = process.env.LANE;
+
+beforeEach(() => {
+    calls.length = 0;
+    injectFakeChannel();
+});
+
+afterEach(() => {
+    clearChannel();
+    if (originalLane === undefined) {
+        delete process.env.LANE;
+    } else {
+        process.env.LANE = originalLane;
+    }
+});
+
+describe('publish 注入 lane / trace_id header', () => {
+    it('泳道进程：header 带上当前泳道和 trace_id', async () => {
+        process.env.LANE = 'ppe-foo';
+
+        await context.run(context.createContext('trace-lane-1'), async () => {
+            await rabbitmqClient.publish(CHAT_REQUEST, { hello: 'world' });
+        });
+
+        expect(lastHeaders()).toEqual({ lane: 'ppe-foo', trace_id: 'trace-lane-1' });
+    });
+
+    it('prod 进程：lane 写空串而不是省略 key（对齐 inject_context）', async () => {
+        delete process.env.LANE;
+
+        await context.run(context.createContext('trace-prod-1'), async () => {
+            await rabbitmqClient.publish(CHAT_REQUEST, { hello: 'world' });
+        });
+
+        expect(lastHeaders()).toEqual({ lane: '', trace_id: 'trace-prod-1' });
+    });
+
+    it('无 context 时 trace_id 写空串', async () => {
+        delete process.env.LANE;
+
+        await rabbitmqClient.publish(CHAT_REQUEST, { hello: 'world' });
+
+        expect(lastHeaders()).toEqual({ lane: '', trace_id: '' });
+    });
+
+    it('显式传 lane 参数：header 用传入的泳道，而不是进程泳道', async () => {
+        process.env.LANE = 'ppe-foo';
+
+        await context.run(context.createContext('trace-explicit'), async () => {
+            await rabbitmqClient.publish(CHAT_REQUEST, {}, undefined, undefined, 'ppe-bar');
+        });
+
+        const headers = lastHeaders();
+        expect(headers.lane).toBe('ppe-bar');
+        expect(calls[0]!.rk).toBe('chat.request.ppe-bar');
+    });
+
+    it("显式传 lane='prod'：header lane 写空串，走 prod 队列", async () => {
+        process.env.LANE = 'ppe-foo';
+
+        await context.run(context.createContext('trace-explicit-prod'), async () => {
+            await rabbitmqClient.publish(CHAT_REQUEST, {}, undefined, undefined, 'prod');
+        });
+
+        const headers = lastHeaders();
+        expect(headers.lane).toBe('');
+        expect(calls[0]!.rk).toBe('chat.request');
+    });
+
+    it('调用方自带 header（x-retry-count）不被覆盖，且同样带上 lane / trace_id', async () => {
+        process.env.LANE = 'ppe-foo';
+
+        await context.run(context.createContext('trace-retry'), async () => {
+            await rabbitmqClient.publish(CHAT_REQUEST, {}, undefined, { 'x-retry-count': 3 });
+        });
+
+        expect(lastHeaders()).toEqual({
+            'x-retry-count': 3,
+            lane: 'ppe-foo',
+            trace_id: 'trace-retry',
+        });
+    });
+
+    it('调用方给的 lane / trace_id header 被 publish 的权威值盖掉，自定义 header 留着', async () => {
+        process.env.LANE = 'ppe-foo';
+
+        await context.run(context.createContext('trace-authoritative'), async () => {
+            await rabbitmqClient.publish(
+                CHAT_REQUEST,
+                {},
+                undefined,
+                { lane: 'ppe-caller', trace_id: 'trace-caller', 'x-retry-count': 3 },
+                'ppe-bar',
+            );
+        });
+
+        // lane header 必须跟 routing key 同源：routing key 用的是 publish 内部算出的
+        // effectiveLane，header 让调用方改写就会出现「消息进 chat_request_ppe-bar
+        // 队列、header 却写着 ppe-caller」，下游按 header 判 lane 直接判错——这正是
+        // header 注入要消灭的那类不一致。trace_id 同理，只认当前 context。
+        expect(lastHeaders()).toEqual({
+            lane: 'ppe-bar',
+            trace_id: 'trace-authoritative',
+            'x-retry-count': 3,
+        });
+        expect(calls[0]!.rk).toBe('chat.request.ppe-bar');
+    });
+
+    it('delayMs 与上下文 header 并存', async () => {
+        process.env.LANE = 'ppe-foo';
+
+        await context.run(context.createContext('trace-delay'), async () => {
+            await rabbitmqClient.publish(CHAT_REQUEST, {}, 5000);
+        });
+
+        expect(lastHeaders()).toEqual({
+            'x-delay': 5000,
+            lane: 'ppe-foo',
+            trace_id: 'trace-delay',
+        });
+    });
+});

--- a/apps/channel-server/src/infrastructure/integrations/rabbitmq.ts
+++ b/apps/channel-server/src/infrastructure/integrations/rabbitmq.ts
@@ -1,4 +1,7 @@
 import amqplib, { Channel, ChannelModel, ConsumeMessage } from 'amqplib';
+// traceId 属于 base context（@middleware/context 的 context 就是 spread 了它、共用同
+// 一个 AsyncLocalStorage），这里只需要 traceId，取基座这层即可。
+import { context } from '@inner/shared';
 
 const EXCHANGE_NAME = 'post_processing';
 const DLX_NAME = 'post_processing_dlx';
@@ -150,7 +153,21 @@ class RabbitMQClient {
 
         const actualRK = laneRK(route.rk, effectiveLane);
 
-        const msgHeaders: Record<string, unknown> = { ...headers };
+        // 泳道和 trace 必须落在 AMQP header 上：下游 agent-service 的
+        // runtime/propagation.py::extract_context 只认 header 的 "lane" / "trace_id"，
+        // 队列名和消息体里的泳道它读不到。空值写空串而不是省略 key，与 Python 侧
+        // inject_context 的线上格式一致。
+        //
+        // 调用方 header 先展开、lane / trace_id 后写：这两个是 publish 内部定的权威
+        // 值，调用方覆盖不了。lane 尤其不能让：routing key 用的就是上面这个
+        // effectiveLane，header 被改写就会出现「消息进 queue_Y、header 却写着 X」，
+        // 下游按 header 判 lane 直接判错。调用方自己的 header（x-retry-count 之类）
+        // 不在这两个 key 上，照常保留。
+        const msgHeaders: Record<string, unknown> = {
+            ...headers,
+            trace_id: context.getTraceId() || '',
+            lane: effectiveLane || '',
+        };
         if (delayMs !== undefined) {
             msgHeaders['x-delay'] = delayMs;
         }
@@ -158,7 +175,7 @@ class RabbitMQClient {
         ch.publish(EXCHANGE_NAME, actualRK, Buffer.from(JSON.stringify(body)), {
             persistent: true,
             contentType: 'application/json',
-            headers: Object.keys(msgHeaders).length > 0 ? msgHeaders : undefined,
+            headers: msgHeaders,
         });
     }
 

--- a/apps/channel-server/src/infrastructure/lane-policy.test.ts
+++ b/apps/channel-server/src/infrastructure/lane-policy.test.ts
@@ -1,0 +1,35 @@
+import { afterEach, describe, expect, it } from 'bun:test';
+import { isProdDeployment } from './lane-policy';
+
+describe('isProdDeployment', () => {
+    it('LANE 未注入 / 空 / prod → prod 部署', () => {
+        expect(isProdDeployment(undefined)).toBe(true);
+        expect(isProdDeployment('')).toBe(true);
+        expect(isProdDeployment('prod')).toBe(true);
+    });
+
+    it('任何泳道值 → 非 prod 部署', () => {
+        expect(isProdDeployment('ppe-x')).toBe(false);
+        expect(isProdDeployment('coe-y')).toBe(false);
+        expect(isProdDeployment('blue')).toBe(false);
+        expect(isProdDeployment('prod-2')).toBe(false);
+    });
+
+    describe('默认读 process.env.LANE', () => {
+        const originalLane = process.env.LANE;
+
+        afterEach(() => {
+            if (originalLane === undefined) delete process.env.LANE;
+            else process.env.LANE = originalLane;
+        });
+
+        it('LANE=prod → true，LANE=ppe-x → false，LANE 删掉 → true', () => {
+            process.env.LANE = 'prod';
+            expect(isProdDeployment()).toBe(true);
+            process.env.LANE = 'ppe-x';
+            expect(isProdDeployment()).toBe(false);
+            delete process.env.LANE;
+            expect(isProdDeployment()).toBe(true);
+        });
+    });
+});

--- a/apps/channel-server/src/infrastructure/lane-policy.ts
+++ b/apps/channel-server/src/infrastructure/lane-policy.ts
@@ -1,0 +1,20 @@
+// 本进程的部署身份：prod 还是泳道。LANE 由 PaaS 部署时自动注入（值 = 本 release
+// 的 lane），prod 部署注入 'prod' 或压根不注入，所以两者都算 prod 部署。
+//
+// 「是不是 prod 部署」是一批全局副作用的准入条件。这些副作用作用在共享资源上、
+// 没有按泳道隔离的口径，只能 prod 独占：
+//   - crontab：daily-photo 往写死的真实飞书群发消息、emoji 每小时全量覆写共享表，
+//     泳道跑起来就是重复发群消息 + 写脏 prod 数据；
+//   - 飞书 WS 长连：飞书对同一 app_id 的多个长连客户端是随机投递而非广播，泳道建
+//     连会静默分走一部分线上事件，prod 不断流、告警也抓不到。
+// 判定写在代码里而不是再加环境变量：这类准入条件一旦挂在 env / Release 配置上，
+// 配置被覆盖就会静默失效。
+//
+// 对位 agent-service 的 app/runtime/lane_policy.py（Python 侧同一套判断）。
+//
+// 注：@integrations/rabbitmq 的 getLane() 读同一个 LANE，但答的是另一个问题——
+// 本进程的队列 / 路由后缀是什么。准入判断不挂在它上面，也就不会被别处对那个模块
+// 的整体 mock 顺带改写。
+export function isProdDeployment(laneEnv: string | undefined = process.env.LANE): boolean {
+    return !laneEnv || laneEnv === 'prod';
+}

--- a/apps/channel-server/src/plugins/lark/webhook/ingress-gate.test.ts
+++ b/apps/channel-server/src/plugins/lark/webhook/ingress-gate.test.ts
@@ -1,18 +1,56 @@
-import { describe, it, expect } from 'bun:test';
-import { shouldEnableDirectIngress } from './ingress-gate';
+import { afterEach, describe, it, expect } from 'bun:test';
+import { isDirectIngressEnabled } from './ingress-gate';
 
-// 飞书直连入口（webhook + ws）的 env gate 纯逻辑。默认 off 是双跑红线：
-// WSClient 是主动长连，只有 LARK_DIRECT_INGRESS 显式 'true' 才开。
-describe('shouldEnableDirectIngress', () => {
-    it('未设置 → off（默认不启动 WS 长连）', () => {
-        expect(shouldEnableDirectIngress(undefined)).toBe(false);
+// 飞书直连长连（WSClient）的开关是「prod 部署 AND env」：
+//   - 泳道：飞书对共享 app_id 的多个长连客户端是随机投递而非广播，任何非 prod
+//     泳道建长连都会静默分走线上事件，所以泳道一律 off，且不给 env 后门；
+//   - env：prod 内部保留 LARK_DIRECT_INGRESS 作为「入站走不走长连」的开关。
+describe('isDirectIngressEnabled（LANE + LARK_DIRECT_INGRESS）', () => {
+    const originalLane = process.env.LANE;
+    const originalFlag = process.env.LARK_DIRECT_INGRESS;
+
+    function setEnv(lane: string | undefined, flag: string | undefined): void {
+        if (lane === undefined) delete process.env.LANE;
+        else process.env.LANE = lane;
+        if (flag === undefined) delete process.env.LARK_DIRECT_INGRESS;
+        else process.env.LARK_DIRECT_INGRESS = flag;
+    }
+
+    afterEach(() => {
+        setEnv(originalLane, originalFlag);
     });
-    it("'false' / 其它值 → off", () => {
-        expect(shouldEnableDirectIngress('false')).toBe(false);
-        expect(shouldEnableDirectIngress('1')).toBe(false);
-        expect(shouldEnableDirectIngress('')).toBe(false);
+
+    it("LANE 未注入 + flag 'true' → on（空等价于 prod）", () => {
+        setEnv(undefined, 'true');
+        expect(isDirectIngressEnabled()).toBe(true);
     });
-    it("'true' → on（③ cutover 在场才开）", () => {
-        expect(shouldEnableDirectIngress('true')).toBe(true);
+
+    it("LANE=prod + flag 'true' → on", () => {
+        setEnv('prod', 'true');
+        expect(isDirectIngressEnabled()).toBe(true);
+    });
+
+    it("LANE=prod 但 flag 未开 / 非 'true' → off（与关系）", () => {
+        setEnv('prod', undefined);
+        expect(isDirectIngressEnabled()).toBe(false);
+        setEnv('prod', 'false');
+        expect(isDirectIngressEnabled()).toBe(false);
+        setEnv('prod', '1');
+        expect(isDirectIngressEnabled()).toBe(false);
+    });
+
+    it("LANE=ppe-x + flag 'true' → off（泳道不抢线上长连）", () => {
+        setEnv('ppe-x', 'true');
+        expect(isDirectIngressEnabled()).toBe(false);
+    });
+
+    it("LANE=coe-y + flag 'true' → off", () => {
+        setEnv('coe-y', 'true');
+        expect(isDirectIngressEnabled()).toBe(false);
+    });
+
+    it('泳道 + flag 未开 → off', () => {
+        setEnv('ppe-x', undefined);
+        expect(isDirectIngressEnabled()).toBe(false);
     });
 });

--- a/apps/channel-server/src/plugins/lark/webhook/ingress-gate.ts
+++ b/apps/channel-server/src/plugins/lark/webhook/ingress-gate.ts
@@ -1,17 +1,19 @@
-// 飞书 WS 直连入口的 env gate。
+// 飞书 WS 直连入口的 gate：prod 部署 AND env 打开，两个条件同时满足才建长连。
 //
-// HTTP webhook 已经由 channel-server 注册被动路由；WSClient 是主动长连，
-// 仍需要显式打开，避免未准备好的 websocket bot 被当前进程接管。
+// 泳道维度是硬约束（见 @infrastructure/lane-policy）：飞书对同一 app_id 的多个长
+// 连客户端是随机投递而非广播，泳道建连会静默分走线上事件。它不给 env 后门——
+// LARK_DIRECT_INGRESS 挂在 app env 上、所有泳道天然继承，只靠 env 挡不住。
 //
-// 入口是部署属性（这个进程要不要当飞书入口），不是业务行为参数，所以走环境变量
-// （部署期决定）而非 dynamic config（运行时）。
+// env 维度语义收窄为「prod 内部入站走不走长连」的回退开关：HTTP webhook 是被动
+// 路由，channel-server 起来就注册；WSClient 是主动长连，仍要显式打开。
+//
+// 两个维度都是部署属性（这个进程要不要当飞书入口），所以读环境变量（部署期决定）
+// 而不是 dynamic config（运行时）。
 
-export const LARK_DIRECT_INGRESS_ENV = 'LARK_DIRECT_INGRESS';
+import { isProdDeployment } from '@infrastructure/lane-policy';
 
-export function shouldEnableDirectIngress(envValue: string | undefined): boolean {
-    return envValue === 'true';
-}
+const LARK_DIRECT_INGRESS_ENV = 'LARK_DIRECT_INGRESS';
 
 export function isDirectIngressEnabled(): boolean {
-    return shouldEnableDirectIngress(process.env[LARK_DIRECT_INGRESS_ENV]);
+    return isProdDeployment() && process.env[LARK_DIRECT_INGRESS_ENV] === 'true';
 }

--- a/apps/channel-server/src/startup/application.test.ts
+++ b/apps/channel-server/src/startup/application.test.ts
@@ -1,0 +1,102 @@
+import { afterAll, beforeEach, describe, expect, mock, test } from 'bun:test';
+
+// crontab 的副作用是全局的（daily-photo 往写死的真实飞书群发消息、emoji 每小时
+// 全量覆写共享表），所以 initialize() 只在 prod 部署起 crontab，泳道部署跳过。
+// 这里跑真实的 initialize()，只把它够不着的重依赖（DB / MQ 连接 / channel runtime
+// 初始化）换成 stub，lane 判定走真实代码（读 process.env.LANE）。
+//
+// mock.module 在 bun 里是全局的，且 mock.restore() 不会撤销它：别的测试文件也在
+// 用的模块（@plugins/runtime、@integrations/*），先把真身抓下来，afterAll 再注回
+// 去，避免污染同一轮里后跑的测试文件。
+
+const initializeCrontabs = mock(() => {});
+const startInboundLaneConsumer = mock(async () => {});
+const startChannelDirectIngresses = mock(async () => {});
+
+// application.ts 独占的依赖：直接 mock，不必还原（也就不会真的连 PG / Mongo，
+// 不会把 crontab 的一堆服务模块拖进来）。
+mock.module('./database', () => ({
+    DatabaseManager: {
+        initialize: async () => {},
+        close: async () => {},
+    },
+}));
+mock.module('@crontab/index', () => ({ initializeCrontabs }));
+
+const realRabbitmq = { ...(await import('@integrations/rabbitmq')) };
+mock.module('@integrations/rabbitmq', () => ({
+    ...realRabbitmq,
+    rabbitmqClient: {
+        connect: async () => {},
+        declareTopology: async () => {},
+        close: async () => {},
+    },
+}));
+
+const realInboundLaneConsumer = { ...(await import('@integrations/inbound-lane-consumer')) };
+mock.module('@integrations/inbound-lane-consumer', () => ({
+    ...realInboundLaneConsumer,
+    startInboundLaneConsumer,
+}));
+
+const realPluginRuntime = { ...(await import('@plugins/runtime')) };
+mock.module('@plugins/runtime', () => ({
+    ...realPluginRuntime,
+    initializeChannelRuntimes: async () => {},
+    runChannelInitializers: async () => {},
+    startChannelDirectIngresses,
+}));
+
+const { multiBotManager } = await import('@core/services/bot/multi-bot-manager');
+const botManagerInitialize = multiBotManager.initialize;
+multiBotManager.initialize = async () => {};
+
+const { ApplicationManager, createDefaultConfig } = await import('./application');
+
+afterAll(() => {
+    multiBotManager.initialize = botManagerInitialize;
+    mock.module('@integrations/rabbitmq', () => realRabbitmq);
+    mock.module('@integrations/inbound-lane-consumer', () => realInboundLaneConsumer);
+    mock.module('@plugins/runtime', () => realPluginRuntime);
+});
+
+describe('ApplicationManager.initialize：crontab 只在 prod 部署起', () => {
+    const originalLane = process.env.LANE;
+
+    function initializeWithLane(lane: string | undefined): Promise<void> {
+        if (lane === undefined) delete process.env.LANE;
+        else process.env.LANE = lane;
+        return new ApplicationManager(createDefaultConfig()).initialize();
+    }
+
+    beforeEach(() => {
+        initializeCrontabs.mockClear();
+        startChannelDirectIngresses.mockClear();
+    });
+
+    afterAll(() => {
+        if (originalLane === undefined) delete process.env.LANE;
+        else process.env.LANE = originalLane;
+    });
+
+    test('LANE 未注入（等价 prod）→ 起 crontab', async () => {
+        await initializeWithLane(undefined);
+        expect(initializeCrontabs).toHaveBeenCalledTimes(1);
+    });
+
+    test('LANE=prod → 起 crontab', async () => {
+        await initializeWithLane('prod');
+        expect(initializeCrontabs).toHaveBeenCalledTimes(1);
+    });
+
+    test('LANE=ppe-x → 不起 crontab（其余启动步骤照跑）', async () => {
+        await initializeWithLane('ppe-x');
+        expect(initializeCrontabs).not.toHaveBeenCalled();
+        expect(startChannelDirectIngresses).toHaveBeenCalledTimes(1);
+    });
+
+    test('LANE=coe-y → 不起 crontab', async () => {
+        await initializeWithLane('coe-y');
+        expect(initializeCrontabs).not.toHaveBeenCalled();
+    });
+});

--- a/apps/channel-server/src/startup/application.ts
+++ b/apps/channel-server/src/startup/application.ts
@@ -2,6 +2,7 @@ import { DatabaseManager } from './database';
 import { HttpServerManager, ServerConfig } from './server';
 import { multiBotManager } from '@core/services/bot/multi-bot-manager';
 import { initializeCrontabs } from '@crontab/index';
+import { isProdDeployment } from '@infrastructure/lane-policy';
 import { rabbitmqClient, getLane } from '@integrations/rabbitmq';
 import { startInboundLaneConsumer } from '@integrations/inbound-lane-consumer';
 import '@plugins/index';
@@ -72,9 +73,15 @@ export class ApplicationManager {
         // 5.6 各 channel runtime 自己决定是否启动主动入口（如平台 WS）。
         await startChannelDirectIngresses(multiBotManager.getBotsByInitType('websocket'));
 
-        // 6. 启动所有定时任务
-        initializeCrontabs();
-        console.info('All crontab tasks initialized!');
+        // 6. 启动所有定时任务：仅 prod 部署。crontab 的副作用是全局的（daily-photo
+        // 往写死的真实飞书群发消息、emoji 每小时全量覆写共享表），没有按泳道隔离
+        // 的口径，泳道部署跑起来就是重复发群消息 + 写脏 prod 数据。
+        if (isProdDeployment()) {
+            initializeCrontabs();
+            console.info('All crontab tasks initialized!');
+        } else {
+            console.info(`[crontab] skipped on lane=${lane} (prod only)`);
+        }
 
         // 7. 显示当前加载的机器人配置
         this.logBotConfigurations();

--- a/apps/channel-server/src/workers/chat-response-handler.lane-header.test.ts
+++ b/apps/channel-server/src/workers/chat-response-handler.lane-header.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect } from 'bun:test';
+
+import { handleChatResponse } from './chat-response-handler';
+import type { ChatResponseHandlerDeps } from './chat-response-handler';
+import { context } from '@middleware/context';
+import type { OutboundCapabilities, MessageRef } from '@core/ports/channel-plugin';
+import type { ConsumeMessage } from 'amqplib';
+
+// chat-response-worker 的 lane 恢复口径。
+//
+// 背景：泳道队列（chat_response_{lane}）带 10s TTL + DLX，下游没部泳道时消息会
+// 降级回 prod 队列，由 prod 的 chat-response-worker 接手。降级后这条消息**仍然
+// 属于那个泳道**——出站要用泳道的下游，不能当成 prod 自己的活。AMQP header 是
+// 唯一能穿过 TTL/DLX 降级还保持原样的载体（body 里的 lane 是 agent-service 写给
+// 别的用途的字段，判 lane 不看它）。
+//
+// 口径（与 agent-service app/runtime/propagation.py 的 inject/extract 对齐）：
+//   * header key 是 `lane`；
+//   * 空串 / 非字符串 = 无 lane（等价 prod），因为 Python 侧 inject_context 对
+//     「没有 lane」写的就是空串，两端必须同样归一；
+//   * 不回落 body.lane：Python 的 _coerce 把「明确写空」和「压根没写」都归一成
+//     None，消费侧无从区分，回落 body 会把上游已判定为 prod 的消息错误复活；
+//   * 不回落 env LANE：prod worker 收到的很可能正是降级回来的泳道消息，env 兜底
+//     会把它错判成 prod，恰好毁掉这里要修的能力。
+
+function makeMsg(
+    payload: Record<string, unknown>,
+    headers?: Record<string, unknown>,
+): ConsumeMessage {
+    return {
+        content: Buffer.from(JSON.stringify(payload)),
+        fields: {} as ConsumeMessage['fields'],
+        properties: { headers } as unknown as ConsumeMessage['properties'],
+    } as ConsumeMessage;
+}
+
+// session_id=null 的主动发 payload：不碰 DB（handler 跳过 agent_response 查询），
+// 用最小依赖把整条链跑到 context.run 内部。
+function payloadWithBodyLane(bodyLane?: string) {
+    return {
+        channel: 'lark',
+        is_proactive: true,
+        message_id: 'proactive:550e8400-e29b-41d4-a716-446655440000',
+        chat_id: '018f-conversation',
+        bot_name: 'akao',
+        session_id: null,
+        root_id: null,
+        is_p2p: true,
+        content: '在吗',
+        status: 'success',
+        part_index: 0,
+        is_last: true,
+        ...(bodyLane === undefined ? {} : { lane: bodyLane }),
+    };
+}
+
+// 在 context.run 内部观测 handler 实际取到的 lane。
+// getCapabilities / 各 capability 方法都在 context.run 里被调用，随便挑一个都能
+// 读到当时的 AsyncLocalStorage 内容，这里用 getCapabilities（最早的一个）。
+function makeDeps(): { deps: ChatResponseHandlerDeps; observed: Array<string | undefined> } {
+    const observed: Array<string | undefined> = [];
+    const cap: OutboundCapabilities = {
+        async resolveOutboundTarget() {
+            throw new Error('must not resolve source message for proactive payload');
+        },
+        async resolveMessageRef() {
+            throw new Error('must not resolve source message for proactive payload');
+        },
+        async resolveConversationRef(commonConversationId) {
+            return { channelId: `oc_for_${commonConversationId}` };
+        },
+        async recordOutboundMessage() {
+            return 'common_assistant_msg_id';
+        },
+        async sendText(): Promise<MessageRef> {
+            return { channelId: 'om_new_msg' };
+        },
+        async reply(): Promise<MessageRef> {
+            return { channelId: 'om_reply_msg' };
+        },
+    };
+    const repo = {
+        findOneBy: async () => null,
+        update: async () => ({ affected: 0 }),
+    } as unknown as ChatResponseHandlerDeps['repo'];
+
+    return {
+        observed,
+        deps: {
+            repo,
+            getCapabilities: () => {
+                observed.push(context.getAll().lane);
+                return cap;
+            },
+            ack: () => {},
+            nack: () => {},
+            observeDuration: () => {},
+            observeQueueDelay: () => {},
+        },
+    };
+}
+
+describe('handleChatResponse — lane 从 AMQP header 恢复', () => {
+    it('header 带真实 lane：handler 在该 lane 的 context 下出站', async () => {
+        const { deps, observed } = makeDeps();
+
+        await handleChatResponse(deps, makeMsg(payloadWithBodyLane(), { lane: 'ppe-taskb' }));
+
+        expect(observed).toEqual(['ppe-taskb']);
+    });
+
+    it('header lane 为空串：视为无 lane（prod），不回落 body.lane', async () => {
+        const { deps, observed } = makeDeps();
+
+        // agent-service inject_context 对「无 lane」写的就是空串，且 body 里可能
+        // 仍带着 lane 字段——空串 header 必须压过 body。
+        await handleChatResponse(deps, makeMsg(payloadWithBodyLane('ppe-taskb'), { lane: '' }));
+
+        expect(observed).toEqual([undefined]);
+    });
+
+    it('完全没有 header：视为无 lane（prod），不回落 body.lane', async () => {
+        const { deps, observed } = makeDeps();
+
+        // 部署窗口内的在途旧消息（上游还没开始写 header）走这条路：按 lane 缺失
+        // 处理、当 prod 走，这是已接受的降级，不是回落 body。
+        await handleChatResponse(deps, makeMsg(payloadWithBodyLane('ppe-taskb'), undefined));
+
+        expect(observed).toEqual([undefined]);
+    });
+
+    it('header 与 body 的 lane 不一致：header 是唯一权威', async () => {
+        const { deps, observed } = makeDeps();
+
+        await handleChatResponse(
+            deps,
+            makeMsg(payloadWithBodyLane('ppe-stale'), { lane: 'ppe-taskb' }),
+        );
+
+        expect(observed).toEqual(['ppe-taskb']);
+    });
+
+    it('header lane 不是字符串：视为无 lane（与 Python _coerce 对齐）', async () => {
+        const { deps, observed } = makeDeps();
+
+        await handleChatResponse(deps, makeMsg(payloadWithBodyLane('ppe-taskb'), { lane: 42 }));
+
+        expect(observed).toEqual([undefined]);
+    });
+});

--- a/apps/channel-server/src/workers/chat-response-handler.ts
+++ b/apps/channel-server/src/workers/chat-response-handler.ts
@@ -12,6 +12,7 @@ import type { ConsumeMessage } from 'amqplib';
 import dayjs from 'dayjs';
 
 import { context } from '@middleware/context';
+import { laneFromMessage } from '@integrations/amqp-context';
 import type { OutboundCapabilities } from '@core/ports/channel-plugin';
 import { imageRegistryLookupId } from './image-registry-key';
 import { dispatchChatResponseOutbound } from './chat-response-outbound';
@@ -37,6 +38,9 @@ export interface ChatResponsePayload {
     full_content?: string;
     status: 'success' | 'failed';
     error?: string;
+    // agent-service 仍在 body 里回填 lane（它自己按 body 字段做别的事），但
+    // **判 lane 不看这里**：lane 只认 AMQP header，口径见
+    // @integrations/amqp-context 的 laneFromMessage（连同「为什么不回落 body」）。
     lane?: string;
     part_index?: number;
     is_last?: boolean;
@@ -134,7 +138,11 @@ export async function handleChatResponse(
     }
 
     // 设置 bot context — ack 统一在 context.run 之后，callback 内部禁止 ack/nack
-    const contextData = context.createContext(botName || undefined, undefined, payload.lane);
+    const contextData = context.createContext(
+        botName || undefined,
+        undefined,
+        laneFromMessage(msg),
+    );
 
     await context.run(contextData, async () => {
         if (status === 'failed') {

--- a/apps/channel-server/src/workers/recall-worker.lane-header.test.ts
+++ b/apps/channel-server/src/workers/recall-worker.lane-header.test.ts
@@ -1,0 +1,183 @@
+import { describe, it, expect } from 'bun:test';
+
+import { handleRecall } from './recall-worker';
+import type { RecallHandlerDeps } from './recall-worker';
+import { context } from '@middleware/context';
+import type { OutboundCapabilities, MessageRef } from '@core/ports/channel-plugin';
+import type { ConsumeMessage } from 'amqplib';
+
+// recall-worker 的 lane 恢复口径，与 chat-response-handler 同源（见那边的长注释）：
+// lane 只认 AMQP header `lane`，空串 / 非字符串 = 无 lane（prod），不回落 body.lane、
+// 不回落 env LANE。recall 队列同样带 10s TTL + DLX，泳道消息会降级回 prod 队列由
+// prod worker 接手，撤回必须发生在原泳道的 context 下。
+//
+// 这里额外钉住重投路径：replies 还没落库时 worker 会延时重投一条 recall，重投必须
+// 沿用入站 header 解析出的 lane，否则一次重投就把 lane 丢干净（下一跳再也无从恢复）。
+//
+// 但 handler 只负责把 lane 作为 republish 的**第四个参数**传对——lane header 本身由
+// rabbitmq.ts::publish 内部按这个参数统一注入（rabbitmq.test.ts 覆盖：显式 lane 参数
+// → header，'prod' → 空串，调用方自带的 x-retry-count 不被覆盖）。所以下面断言
+// headers 里**没有** lane：两处都写 lane header 会让「谁负责注入」变模糊，且两份口径
+// 迟早漂移。
+
+function makeMsg(
+    payload: Record<string, unknown>,
+    headers?: Record<string, unknown>,
+): ConsumeMessage {
+    return {
+        content: Buffer.from(JSON.stringify(payload)),
+        fields: {} as ConsumeMessage['fields'],
+        properties: { headers } as unknown as ConsumeMessage['properties'],
+    } as ConsumeMessage;
+}
+
+function recallPayload(bodyLane?: string) {
+    return {
+        channel: 'lark',
+        session_id: 'sess-1',
+        reason: 'unsafe',
+        detail: 'test',
+        ...(bodyLane === undefined ? {} : { lane: bodyLane }),
+    };
+}
+
+interface Harness {
+    deps: RecallHandlerDeps;
+    observedLanes: Array<string | undefined>;
+    republishes: Array<{
+        payload: Record<string, unknown>;
+        delayMs: number;
+        headers: Record<string, unknown>;
+        lane: string;
+    }>;
+}
+
+// hasReplies=false 模拟「replies 还没落库」→ 走延时重投分支。
+function makeHarness(hasReplies: boolean): Harness {
+    const observedLanes: Array<string | undefined> = [];
+    const republishes: Harness['republishes'] = [];
+
+    const cap: OutboundCapabilities = {
+        async resolveOutboundTarget() {
+            throw new Error('not used');
+        },
+        async resolveMessageRef(): Promise<MessageRef> {
+            return { channelId: 'om_to_recall' };
+        },
+        async resolveConversationRef() {
+            return { channelId: 'oc_x' };
+        },
+        async recordOutboundMessage() {
+            return 'ignored';
+        },
+        async sendText(): Promise<MessageRef> {
+            return { channelId: 'ignored' };
+        },
+        async reply(): Promise<MessageRef> {
+            return { channelId: 'ignored' };
+        },
+        // 撤回在 context.run 内部执行：这里观测 handler 实际取到的 lane。
+        async recall() {
+            observedLanes.push(context.getAll().lane);
+        },
+    };
+
+    const repo = {
+        findOneBy: async () =>
+            hasReplies
+                ? {
+                      session_id: 'sess-1',
+                      bot_name: 'akao',
+                      safety_status: 'pending',
+                      replies: [{ common_message_id: 'cm-1' }],
+                  }
+                : null,
+        update: async () => ({ affected: 1 }),
+    } as unknown as RecallHandlerDeps['repo'];
+
+    return {
+        observedLanes,
+        republishes,
+        deps: {
+            repo,
+            getCapabilities: () => cap,
+            republish: async (payload, delayMs, headers, lane) => {
+                republishes.push({ payload, delayMs, headers, lane });
+            },
+            ack: () => {},
+            nack: () => {},
+        },
+    };
+}
+
+describe('handleRecall — lane 从 AMQP header 恢复', () => {
+    it('header 带真实 lane：撤回发生在该 lane 的 context 下', async () => {
+        const h = makeHarness(true);
+
+        await handleRecall(h.deps, makeMsg(recallPayload(), { lane: 'ppe-taskb' }));
+
+        expect(h.observedLanes).toEqual(['ppe-taskb']);
+    });
+
+    it('header lane 为空串：视为无 lane（prod），不回落 body.lane', async () => {
+        const h = makeHarness(true);
+
+        await handleRecall(h.deps, makeMsg(recallPayload('ppe-taskb'), { lane: '' }));
+
+        expect(h.observedLanes).toEqual([undefined]);
+    });
+
+    it('完全没有 header：视为无 lane（prod），不回落 body.lane', async () => {
+        const h = makeHarness(true);
+
+        await handleRecall(h.deps, makeMsg(recallPayload('ppe-taskb'), undefined));
+
+        expect(h.observedLanes).toEqual([undefined]);
+    });
+
+    it('header 与 body 的 lane 不一致：header 是唯一权威', async () => {
+        const h = makeHarness(true);
+
+        await handleRecall(h.deps, makeMsg(recallPayload('ppe-stale'), { lane: 'ppe-taskb' }));
+
+        expect(h.observedLanes).toEqual(['ppe-taskb']);
+    });
+});
+
+describe('handleRecall — 重投沿用 header lane', () => {
+    it('replies 未落库重投：目标 lane 用入站 header 的 lane，lane header 交给 publish 注入', async () => {
+        const h = makeHarness(false);
+
+        await handleRecall(h.deps, makeMsg(recallPayload('ppe-stale'), { lane: 'ppe-taskb' }));
+
+        expect(h.republishes.length).toBe(1);
+        expect(h.republishes[0].lane).toBe('ppe-taskb');
+        // headers 只带重试计数：lane header 由 publish 按上面这个 lane 参数注入，
+        // handler 不重复写一份。toEqual 全量比对，防止 lane 被重新塞回来。
+        expect(h.republishes[0].headers).toEqual({ 'x-retry-count': 1 });
+    });
+
+    it('无 header 的重投：显式投回 prod（publish 据此把 lane header 写成空串）', async () => {
+        const h = makeHarness(false);
+
+        await handleRecall(h.deps, makeMsg(recallPayload('ppe-stale'), undefined));
+
+        expect(h.republishes.length).toBe(1);
+        // 'prod' 是显式值而非 undefined：publish 对 undefined 会回落 env LANE，
+        // 那正是这里绝不能发生的事。
+        expect(h.republishes[0].lane).toBe('prod');
+        expect(h.republishes[0].headers).toEqual({ 'x-retry-count': 1 });
+    });
+
+    it('重投沿用入站的 x-retry-count（第 2 次重投计数为 2）', async () => {
+        const h = makeHarness(false);
+
+        await handleRecall(
+            h.deps,
+            makeMsg(recallPayload(), { lane: 'ppe-taskb', 'x-retry-count': 1 }),
+        );
+
+        expect(h.republishes[0].headers).toEqual({ 'x-retry-count': 2 });
+        expect(h.republishes[0].lane).toBe('ppe-taskb');
+    });
+});

--- a/apps/channel-server/src/workers/recall-worker.republish-trace.test.ts
+++ b/apps/channel-server/src/workers/recall-worker.republish-trace.test.ts
@@ -1,0 +1,137 @@
+// 重投（republish）必须把入站消息的 trace_id 带下去。
+//
+// replies 还没落库时 handleRecall 会延时重投一条 recall —— 这是 recall 链路上唯一
+// 由 worker 自己发起的出站消息。重投走 rabbitmq.ts::publish，而 publish 的 trace_id
+// 取自 AsyncLocalStorage：重投分支若发生在 context 之外，写进 header 的就是空串，
+// 真实重试路径上 trace 链断掉（lane 不受影响——它是显式算出来当参数传的）。
+//
+// 这里刻意**不 stub publish**：把真实 publish 接进 deps.republish（和 recall-worker
+// main() 里的接法一致），断言最终落到 AMQP header 上的值。stub 掉只能验「handler
+// 传了什么参数」，验不到「header 上最终是什么」，而后者才是下游
+// propagation.py::extract_context 真正读的东西。同理它也顺带钉住 publish 的权威
+// 字段不被调用方 header 覆盖（x-retry-count 这类自定义 header 则必须留着）。
+//
+// handler 侧「重投用哪个 lane 参数」的口径由 recall-worker.lane-header.test.ts 覆盖。
+
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import type { ConsumeMessage } from 'amqplib';
+
+import { handleRecall } from './recall-worker';
+import type { RecallHandlerDeps } from './recall-worker';
+import type * as RabbitMQModule from '@integrations/rabbitmq';
+
+// 同 rabbitmq.test.ts：多个测试文件用 mock.module 把 @integrations/rabbitmq 整体换成
+// 桩，而 bun 的 mock.module 是进程级全局。带 query 的 specifier 是另一个模块 key，
+// 拿得到未被替换的真实 publish 和一个干净的单例。
+const { rabbitmqClient, RECALL } = (await import(
+    // @ts-expect-error 带 query 的 specifier 只有 bun 运行时认，tsc 解析不到；类型由下面的断言给出
+    '../infrastructure/integrations/rabbitmq.ts?real'
+)) as typeof RabbitMQModule;
+
+interface PublishCall {
+    rk: string;
+    headers: Record<string, unknown> | undefined;
+}
+
+const published: PublishCall[] = [];
+
+const fakeChannel = {
+    publish: (
+        _exchange: string,
+        rk: string,
+        _content: Buffer,
+        options: { headers?: Record<string, unknown> },
+    ): boolean => {
+        published.push({ rk, headers: options.headers });
+        return true;
+    },
+    assertQueue: async () => ({}),
+    bindQueue: async () => ({}),
+};
+
+const originalLane = process.env.LANE;
+
+beforeEach(() => {
+    published.length = 0;
+    (rabbitmqClient as unknown as { channel: unknown }).channel = fakeChannel;
+    // 进程泳道故意设成第三个值：重投的 lane 必须来自入站 header，任何一步回落到
+    // 进程 env 都会在断言里露出来。
+    process.env.LANE = 'ppe-worker-env';
+});
+
+afterEach(() => {
+    (rabbitmqClient as unknown as { channel: unknown }).channel = null;
+    if (originalLane === undefined) {
+        delete process.env.LANE;
+    } else {
+        process.env.LANE = originalLane;
+    }
+});
+
+function makeMsg(headers?: Record<string, unknown>): ConsumeMessage {
+    return {
+        content: Buffer.from(
+            JSON.stringify({
+                channel: 'lark',
+                session_id: 'sess-1',
+                reason: 'unsafe',
+                detail: 'test',
+            }),
+        ),
+        fields: {} as ConsumeMessage['fields'],
+        properties: { headers } as unknown as ConsumeMessage['properties'],
+    } as ConsumeMessage;
+}
+
+// replies 还没落库（findOneBy → null）→ 走延时重投分支。republish 接真实 publish。
+function makeDeps(): RecallHandlerDeps {
+    return {
+        repo: {
+            findOneBy: async () => null,
+            update: async () => ({ affected: 1 }),
+        } as unknown as RecallHandlerDeps['repo'],
+        getCapabilities: () => {
+            throw new Error('重投分支不应该取 channel capabilities');
+        },
+        republish: (payload, delayMs, headers, lane) =>
+            rabbitmqClient.publish(RECALL, payload, delayMs, headers, lane),
+        ack: () => {},
+        nack: () => {},
+    };
+}
+
+describe('handleRecall 重投：AMQP header 上的 trace_id / lane', () => {
+    it('泳道消息重投：header 的 trace_id 就是入站的 trace_id，lane 与 routing key 同源', async () => {
+        await handleRecall(makeDeps(), makeMsg({ lane: 'ppe-taskb', trace_id: 'trace-inbound-1' }));
+
+        expect(published.length).toBe(1);
+        expect(published[0]!.rk).toBe('action.recall.ppe-taskb');
+        expect(published[0]!.headers).toEqual({
+            trace_id: 'trace-inbound-1',
+            lane: 'ppe-taskb',
+            'x-retry-count': 1,
+            'x-delay': 5000,
+        });
+    });
+
+    it('降级回 prod 的消息重投：trace 照样接上，lane 显式写空串（不回落进程 LANE）', async () => {
+        await handleRecall(makeDeps(), makeMsg({ trace_id: 'trace-inbound-2' }));
+
+        expect(published.length).toBe(1);
+        expect(published[0]!.rk).toBe('action.recall');
+        expect(published[0]!.headers).toEqual({
+            trace_id: 'trace-inbound-2',
+            lane: '',
+            'x-retry-count': 1,
+            'x-delay': 5000,
+        });
+    });
+
+    it('入站没有 trace_id：不写空串，起一条新 trace（后续重试仍能串起来）', async () => {
+        await handleRecall(makeDeps(), makeMsg({ lane: 'ppe-taskb' }));
+
+        expect(published.length).toBe(1);
+        expect(published[0]!.headers?.trace_id).toBeString();
+        expect(published[0]!.headers?.trace_id).not.toBe('');
+    });
+});

--- a/apps/channel-server/src/workers/recall-worker.ts
+++ b/apps/channel-server/src/workers/recall-worker.ts
@@ -3,20 +3,15 @@
  *
  * 消费 RabbitMQ recall queue，根据 session_id 查找 common_agent_response，
  * 调用对应 channel 插件撤回消息，更新 safety_status。
+ *
+ * 模块结构：handleRecall（纯业务、依赖注入）+ main（进程装配）。进程级副作用
+ * （文件日志 / console 接管、DB 连接、MQ 连接、信号处理）全部收在 main 与
+ * import.meta.main 守卫里，模块本身 import 安全，测试可以直接喂 payload + header
+ * 跑整条 handleRecall。
  */
 
-
-import { LoggerFactory } from '@inner/shared';
-
-// Initialize file logging before any other imports that use console.*
-LoggerFactory.createLogger({
-    enableFileLogging: true,
-    logDir: process.env.LOG_DIR || '/var/log/channel-server',
-    logFileName: 'recall-worker.log',
-    enableConsoleOverride: true,
-});
-
 import AppDataSource from 'ormconfig';
+import { LoggerFactory } from '@inner/shared';
 import { CommonAgentResponse } from '@entities/common-agent-response';
 import {
     rabbitmqClient,
@@ -24,12 +19,15 @@ import {
     getLane,
     laneQueue,
 } from '@integrations/rabbitmq';
+import { laneFromMessage, traceIdFromMessage } from '@integrations/amqp-context';
 import { multiBotManager } from '@core/services/bot/multi-bot-manager';
 import { context } from '@middleware/context';
 import { getChannelRegistry } from '@core/registry/channel-registry';
 import '@plugins/index';
 import { initializeChannelPlugins } from '@plugins/initialize';
 import { recallReplies } from './recall-outbound';
+import type { Repository } from 'typeorm';
+import type { OutboundCapabilities } from '@core/ports/channel-plugin';
 import type { ConsumeMessage } from 'amqplib';
 
 // 撤回走渠道能力端口：worker 只按 payload.channel 取插件，common id 反查和
@@ -47,16 +45,60 @@ interface RecallPayload {
     trigger_message_id?: string;
     reason: string;
     detail?: string;
+    // 上游仍在 body 里带 lane，但**判 lane 不看这里**：lane 只认 AMQP header，
+    // 口径见 @integrations/amqp-context 的 laneFromMessage。
     lane?: string;
 }
 
-async function handleRecall(msg: ConsumeMessage): Promise<void> {
+// handler 的可注入依赖。main 灌真实实现，测试灌 spy。
+export interface RecallHandlerDeps {
+    repo: Repository<CommonAgentResponse>;
+    getCapabilities: (channel: string) => OutboundCapabilities;
+    // replies 还没落库时延时重投一条 recall。lane 由 handler 按入站 header 决定，
+    // 'prod' 表示投回 prod 队列。
+    republish: (
+        payload: Record<string, unknown>,
+        delayMs: number,
+        headers: Record<string, unknown>,
+        lane: string,
+    ) => Promise<void>;
+    ack: (msg: ConsumeMessage) => void;
+    nack: (msg: ConsumeMessage, requeue?: boolean) => void;
+}
+
+export async function handleRecall(deps: RecallHandlerDeps, msg: ConsumeMessage): Promise<void> {
+    // 整条处理都跑在入站消息的上下文里：lane 和 trace_id 都从 AMQP header 恢复
+    // （口径见 @integrations/amqp-context）。
+    //
+    // 为什么必须是整条、而不是只包住撤回那一段：重投走 rabbitmq.ts::publish，而
+    // publish 的 trace_id 取自 AsyncLocalStorage —— 重投分支跑在 context 之外时写进
+    // header 的就是空串，真实重试路径上 trace 链断掉。显式往 headers 里塞 trace_id
+    // 也没用：publish 内部的权威值会盖掉调用方给的。
+    //
+    // bot_name 要查库才知道，撤回前再开一层带 botName 的内层 context（沿用同一个
+    // traceId / lane）。
+    const lane = laneFromMessage(msg);
+    // 入站没带 trace_id 时 createContext 生成一个，内层复用它这个**生成后**的值，
+    // 否则内外两层会是两条不同的 trace。
+    const inbound = context.createContext(undefined, traceIdFromMessage(msg), lane);
+    return context.run(inbound, () => runRecall(deps, msg, lane, inbound.traceId));
+}
+
+async function runRecall(
+    deps: RecallHandlerDeps,
+    msg: ConsumeMessage,
+    lane: string | undefined,
+    traceId: string,
+): Promise<void> {
+    const { repo, getCapabilities, republish, ack, nack } = deps;
+
     const payload: RecallPayload = JSON.parse(msg.content.toString());
     const { session_id, reason, detail, channel = DEFAULT_CHANNEL } = payload;
 
-    console.info(`[RecallWorker] Processing recall: session_id=${session_id}, channel=${channel}, reason=${reason}`);
+    console.info(
+        `[RecallWorker] Processing recall: session_id=${session_id}, channel=${channel}, lane=${lane ?? 'prod'}, reason=${reason}`,
+    );
 
-    const repo = AppDataSource.getRepository(CommonAgentResponse);
     const agentResponse = await repo.findOneBy({ session_id });
 
     // Phase 2: 终态短路，防止重复 Recall 把 recalled 覆盖成 recall_failed。
@@ -69,7 +111,7 @@ async function handleRecall(msg: ConsumeMessage): Promise<void> {
         console.info(
             `[RecallWorker] short-circuit: session_id=${session_id} already ${agentResponse.safety_status}`,
         );
-        rabbitmqClient.ack(msg);
+        ack(msg);
         return;
     }
 
@@ -82,14 +124,19 @@ async function handleRecall(msg: ConsumeMessage): Promise<void> {
                 `[RecallWorker] No replies yet for session_id=${session_id}, ` +
                     `retrying (${retryCount + 1}/${MAX_RETRY}) with delay ${delayMs}ms`,
             );
-            await rabbitmqClient.publish(
-                RECALL,
+            // 重投沿用入站 header 解析出的 lane：目标队列要回原泳道，没有 lane 就
+            // **显式**投回 prod——lane 参数传 undefined 会让 publish 回落进程 env
+            // LANE，prod worker 接手降级消息时那正是要命的误判。
+            //
+            // 随行 header 只写重试计数：lane header 由 publish 按上面这个 lane 参数
+            // 统一注入（连同 trace_id），调用点不重复写一份。
+            await republish(
                 payload as unknown as Record<string, unknown>,
                 delayMs,
                 { 'x-retry-count': retryCount + 1 },
-                payload.lane,
+                lane ?? 'prod',
             );
-            rabbitmqClient.ack(msg);
+            ack(msg);
             return;
         }
         // 达到最大重试次数：在进 DLQ 之前写 recall_failed 终态，
@@ -114,20 +161,21 @@ async function handleRecall(msg: ConsumeMessage): Promise<void> {
         } catch (e) {
             console.error(`[RecallWorker] Failed to write recall_failed status:`, e);
         }
-        rabbitmqClient.nack(msg, false);
+        nack(msg, false);
         return;
     }
 
-    // 设置 bot context 以使用正确的 Lark client
+    // 设置 bot context 以使用正确的 Lark client；traceId / lane 沿用入站那条，
+    // 撤回打出去的平台请求和上面的日志才在同一条 trace 上。
     const botName = agentResponse.bot_name;
-    const contextData = context.createContext(botName || undefined, undefined, payload.lane);
+    const contextData = context.createContext(botName || undefined, traceId, lane);
     let recalledCount = 0;
     let failedCount = 0;
 
     await context.run(contextData, async () => {
         // 逐条撤回走渠道能力端口。common_message_id → 渠道裸 message id 的反查
         // 在插件内完成，worker 不碰任何平台私有映射表。
-        const capabilities = getChannelRegistry().get(channel).capabilities;
+        const capabilities = getCapabilities(channel);
         const result = await recallReplies(capabilities, agentResponse.replies);
         recalledCount = result.recalled;
         failedCount = result.failed;
@@ -156,11 +204,20 @@ async function handleRecall(msg: ConsumeMessage): Promise<void> {
         );
     }
 
-    rabbitmqClient.ack(msg);
+    ack(msg);
     console.info(`[RecallWorker] Recall completed: session_id=${session_id}`);
 }
 
 async function main(): Promise<void> {
+    // 文件日志 + console 接管：进程入口独占的副作用。ESM 的 import 本来就在模块
+    // 体之前求值，放这里和放模块顶层的实际时机一致，但模块变成 import 安全的。
+    LoggerFactory.createLogger({
+        enableFileLogging: true,
+        logDir: process.env.LOG_DIR || '/var/log/channel-server',
+        logFileName: 'recall-worker.log',
+        enableConsoleOverride: true,
+    });
+
     console.info('[RecallWorker] Starting...');
 
     // 1. 初始化数据库
@@ -178,26 +235,39 @@ async function main(): Promise<void> {
     console.info('[RecallWorker] RabbitMQ connected');
 
     // 4. 开始消费（按泳道）
+    const deps: RecallHandlerDeps = {
+        repo: AppDataSource.getRepository(CommonAgentResponse),
+        getCapabilities: (channel) => getChannelRegistry().get(channel).capabilities,
+        republish: (payload, delayMs, headers, lane) =>
+            rabbitmqClient.publish(RECALL, payload, delayMs, headers, lane),
+        ack: (msg) => rabbitmqClient.ack(msg),
+        nack: (msg, requeue) => rabbitmqClient.nack(msg, requeue),
+    };
+
     const lane = getLane();
     const queue = laneQueue(RECALL.queue, lane);
-    await rabbitmqClient.consume(queue, handleRecall);
+    await rabbitmqClient.consume(queue, (msg) => handleRecall(deps, msg));
     console.info(`[RecallWorker] Consuming queue: ${queue}, waiting for messages...`);
 }
 
-main().catch((err) => {
-    console.error('[RecallWorker] Fatal error:', err);
-    process.exit(1);
-});
+// 只有作为进程入口（bun src/workers/recall-worker.ts / 编译产物 recall-worker）
+// 时才启动；被 import（测试）时模块零副作用。
+if (import.meta.main) {
+    main().catch((err) => {
+        console.error('[RecallWorker] Fatal error:', err);
+        process.exit(1);
+    });
 
-// 优雅关闭
-process.on('SIGINT', async () => {
-    await rabbitmqClient.close();
-    await AppDataSource.destroy();
-    process.exit(0);
-});
+    // 优雅关闭
+    process.on('SIGINT', async () => {
+        await rabbitmqClient.close();
+        await AppDataSource.destroy();
+        process.exit(0);
+    });
 
-process.on('SIGTERM', async () => {
-    await rabbitmqClient.close();
-    await AppDataSource.destroy();
-    process.exit(0);
-});
+    process.on('SIGTERM', async () => {
+        await rabbitmqClient.close();
+        await AppDataSource.destroy();
+        process.exit(0);
+    });
+}

--- a/docs/plan/lane-propagation-fix-spec.md
+++ b/docs/plan/lane-propagation-fix-spec.md
@@ -1,0 +1,105 @@
+# 修复 lane 跨服务传递，解锁 channel-server 泳道部署
+
+## Problem
+
+lane 由 channel-server 根据 `lane_routing` 绑定产生，但发 MQ 时只编码进队列名和消息 body，**没有写进 AMQP header**。下游 agent-service 的 `extract_context` 只读 header，读不到就 `lane=None`，导致处理泳道消息时所有出站 HTTP 不带 `x-ctx-lane`、被 sidecar 打到 prod。泳道队列本有 10s TTL + DLX 降级回 prod 的设计（意图是"下游没部泳道就让 prod 接手"），但降级后 prod 服务不知道消息属于哪个泳道，泳道性彻底丢失。结果只能靠全链路 pod 的 `env LANE` 相同来掩盖——这就是"必须上下游一起部署"。
+
+另一半问题是 channel-server 泳道会产生全局副作用：飞书 WS 长连接开关 `LARK_DIRECT_INGRESS` 挂在 app 级 env、所有泳道继承，而飞书对共享 app_id 随机投递，泳道一起来就静默分走线上消息；`initializeCrontabs()` 也无 lane gate，泳道会照跑 daily-photo（硬编码真实群 id）和 emoji-sync（全量覆写 `lark_emoji`）。
+
+## Goal
+
+- lane 随消息在 AMQP header 中跨服务传递，header 是唯一权威来源。
+- prod agent-service 收到从泳道队列降级回来的消息时，能带着原 lane 继续处理，出站正确路由。
+- 只部署 channel-server 一个 Deployment 到泳道，即可完成飞书链路验证，不需要同步部署 agent-service 和两个 worker。
+- channel-server 部署到泳道不再产生任何全局副作用：不抢飞书长连接、不跑 cron。
+
+## Non-goals
+
+- 不拆 lark-service（阶段二，另出 spec）。
+- 不动 QQ 渠道的结构。
+- 不统一 `ctx:lane` 与 `lane` 两套 AsyncLocalStorage store key。`context-propagation.ts` 存 `ctx:lane`、`bot-context.ts` 存 `lane`、laneRouter 只读 `lane`，两套并存且 `getContextHeaders()` 无生产调用方。改它要动 ts-shared 公共中间件并波及 monitor-dashboard，本次不碰。
+- 不给 laneRouter 加 env LANE 兜底。见决策三。
+- 不修 paas-engine 的 `POST /api/paas/releases/` envs replace 语义。它与 `PUT` 的 merge 语义不一致、且无测试覆盖，是真实隐患（见决策五），但影响所有 app 的部署行为，应单独立项。
+- 不动 `runChannelInitializers` 的 `NEED_INIT` gate（是 env gate 不是 lane gate，同类隐患；当前该变量未配置，泳道不会触发）。
+- 不改 cron/interval source 的 `lane=None`（`engine.py:486/540`）。实现过程中确认了它的实际后果比预想的大：泳道 pod 上所有 cron 驱动的 durable publish 和 `emit_delayed` 都会投进 **prod 队列**并带 prod header——header 与队列一致，所以不是本次修的那类 bug，但整个工作逃出了泳道。尤其 `DELAYED_TRIGGER_ROUTES` 特意设了 `lane_fallback=False` 来防"泳道信封溢出到 prod"，而这条路径压根没把信封放进泳道队列。改它会改变路由行为，需要单独立项。当前非 prod 泳道默认关闭 time source，所以暂无实际影响。
+- 不清理 `outbox_dispatcher.py` 的 `_Bound` 重复实现。与本缺陷无关，属于顺手扩 scope。
+
+## Key design decisions
+
+**一、lane 注入放在 `publish` 内部，不改调用点。** `rabbitmq.ts` 的 `publish` 已经算好了 `effectiveLane`，在组装 header 处无条件写入即可，三个调用点一行都不用改，未来新增调用点自动正确。选它而非"逐个调用点显式传 header"，因为后者正是当前 bug 的成因——漏一处就静默降级，没有任何报错。
+
+**二、header key 对齐 Python 既有约定：`lane` 和 `trace_id`。** agent-service 的 `propagation.py` 已经用这两个 key 收发了大半年（durable / debounce / sink_dispatch 六条路径），TS 侧必须复用同一套。空值写空字符串而不是省略 key，与 `inject_context` 现有行为一致。
+
+**三、消费侧 header-only，不读 body.lane，更不回落 env LANE。** 两个理由。其一，Python 的 `_coerce` 把"header 明确写空"和"header 缺失"都归一成 `None`，无法区分，回落 body 会错误复活已被上游判定为 prod 的消息。其二，env 兜底会毁掉本次要修的核心能力——prod agent-service 消费 prod 队列时，收到的既可能是真 prod 消息、也可能是从泳道队列降级回来的泳道消息，用 env 兜底会把后者错判成 prod。部署窗口内的在途旧消息（无 header）按 lane 缺失处理，即当 prod 走，这是可接受的降级而非错误。env LANE 只用于没有上游的自发工作负载：worker 决定消费哪个队列、启动期拓扑声明、lane gate 判定。
+
+**四、TS 侧的 MQ header 读取收敛成一个模块，写入留在 `publish` 内。** 起初判断不需要抽（注入一处、消费两处），实现后两个 worker 各自出现了一份同样的 header 解析逻辑，违反单一定义，于是收敛进 `amqp-context.ts`。它只管"从入站 AMQP 消息读出 lane / trace_id"，是 `publish` 写入侧的对侧，也是 `propagation.py` 跨语言约定的 TS 消费端。**不放进 `rabbitmq.ts`**——那个模块被多个测试文件用 bun 的 `mock.module` 全局 mock（进程级、`mock.restore()` 不撤销），桩里缺新导出会让跨文件测试炸成 `not a function`。同理 `lane-policy.ts` 也独立成模块、直接读 `process.env.LANE` 而不复用 `getLane()`。
+
+**五、全局副作用的 lane gate 写在代码里，不靠环境变量。** 原方案是把 `LARK_DIRECT_INGRESS` 从 App envs 下沉到 prod Release envs，已验证**不可行**：`make deploy` 走 `POST /api/paas/releases/`，body 不带 `envs`，而 `release_service.go:146` 是无条件 `existing.Envs = req.Envs`，于是下一次例行发版就会静默清空 Release envs、prod 飞书 WS 入站整个挂掉且无告警。改为在代码里按 lane 判定：非 prod lane 一律不启动飞书长连接、不启动 crontab。这与 `startInboundLaneConsumer` 已有的 `if (lane)` gate 同构，也与 Python 侧 `lane_policy.time_sources_enabled_by_default`（prod 才默认开 cron）对齐。`LARK_DIRECT_INGRESS` 保留在 App envs 不动，语义收窄为"prod 是否用长连接"的回退开关，与 lane gate 是与关系。
+
+**六、生产侧 header 与队列必须同源，为此新增 Python 原语 `outbound_context()`。** 原实现里 `inject_context` 默认从 contextvar 读 lane，而 `mq.publish` 用带 env 兜底的 `current_lane()` 决定队列。泳道 pod 上 contextvar 为空时，消息会进 `xxx_ppe-x` 队列却带 `lane: ""` 的 header——在 header-only 的消费口径下正好重现本次要修的 bug。`outbound_context()` 把 lane 解析一次（contextvar → 显式 fallback → `current_lane()`），同一个值同时喂给 header 和队列，物理上无法漂移。**env 兜底只存在于这个生产侧原语里，消费侧仍是 header-only**，两者不矛盾：进程要往哪发由自己的 lane 决定，而收到什么消息不由自己决定。
+
+## Caller coverage
+
+**TS publish（3 处，全部不传 lane header）** —— 改 `publish` 内部即可覆盖全部：
+
+| 调用点 | 现状 | 改后 |
+|---|---|---|
+| `plugins/lark/events/handlers.ts:286` | headers 传 `undefined` | 自动带 lane/trace header |
+| `plugins/qq/events/handlers.ts:183` | headers 传 `undefined` | 同上 |
+| `workers/recall-worker.ts:85` | 只传 `x-retry-count` | 保留 retry，追加 lane/trace |
+
+`PROACTIVE_EVAL` 是死 route，全仓无 publish 调用，不涉及。
+
+**TS consume（3 处，lane 均来自 body）**：
+
+| 调用点 | 现状 | 改后 |
+|---|---|---|
+| `workers/chat-response-handler.ts:137` | `createContext(botName, undefined, payload.lane)` | 改读 header。Python `sink_dispatch.py:41-50` 早已注入 header，其第 9-11 行注释明确在等这个改动 |
+| `workers/recall-worker.ts:123` | 同上 | 同上 |
+| `infrastructure/integrations/inbound-lane-consumer.ts:76-77` | 从信封 body 读 `e.lane` | **不改**。信封是 channel-server 内部的跨 lane 投递格式，body 就是权威，不存在降级回 prod 的语义 |
+
+**Python consume**：`runtime/engine.py:678-682` 经实测**本来就是对的**——`extract_context` 读了两个字段，补 trace_id 时原样传递 `lane=ctx.lane`，`bind_context` 两个 contextvar 都设。用变异测试确认过（人为把 lane 置 None 后新测试转红）。所以入站缺口纯粹在上游不注入 header，engine.py 未改，只补了覆盖缺口的测试（原测试只发过 `lane: ""`，一个丢掉 lane 的消费者也能保持绿）。`durable.py` / `debounce.py` / `delayed_trigger.py` 已正确 extract+bind，不改。
+
+**Python publish**：`runtime/emit.py` 的 `_mq_publish_for_source` 完全没有 `inject_context`，是本缺陷在 Python 侧的对称形态（`emit()` → `Source.mq` 跨进程时 lane 同样丢）。另有四处（`sink_dispatch` 的 else 分支、`debounce` 两处、`review_queue`）虽然注了 header，但 header 走 contextvar、队列走 `current_lane()`，泳道 pod 无 context 时两者漂移——一并改用 `outbound_context()`。**队列选择逐值不变**，只改 header，无路由影响。`durable.py` 的三处（publish_durable、retry republish、emit_delayed）本来就把同一个 lane 值同时给 header 和队列，不改。`nodes/dlq_admin.py` 原封透传入站 header 但 lane 参数取 `current_lane()`，有同样的漂移形态，但它在 `nodes/` 下且信封契约需要单独审视，不在本次范围。
+
+**启动期全局副作用（`startup/application.ts`）**：`initializeCrontabs()` 无 lane gate，需加；`startChannelDirectIngresses` 现有 gate 只看 env，需追加 lane 条件。同文件的 `startInboundLaneConsumer`（`if (lane)`）和 `declareTopology`（按 lane 声明队列）已正确，不改。`multiBotManager.initialize()` 启动即 upsert `common_user` 并回写 `bot_config`，是幂等写、泳道跑起来本就需要 bot 身份，不改。
+
+**下游受害端（不需要改）**：tool-service 和 sandbox-worker 全目录 `lane` 零命中，纯靠 sidecar 按 header 分流，header 没了就落 prod。
+
+## Data & deployment impact
+
+- **无 DB schema 变更，无新表，无 prompt 变更，无 PaaS 配置变更。**
+- **消息格式向后兼容**：header 是新增字段，body 的 `lane` 字段保留不变（仍被 agent-service 用于回填 `chat_response.lane`），只是消费侧不再读它判 lane。旧消费者忽略未知 header。**部署顺序无约束**，两侧可独立上线。部署窗口内的在途旧消息会按 lane 缺失处理（当 prod 走），不会失败。
+- **DLX 降级保留 header**：RabbitMQ 的 dead-letter 只改路由元数据并追加 `x-death`，不删自定义 header，所以 10s TTL 降级回 prod 的消息仍带 lane。这是本次核心能力的前提，必须在真实 broker 上验收，不能只靠单测。
+- **触发跨服务部署**：channel-server 及其两个同镜像 Deployment（recall-worker、chat-response-worker）prod 必须同步 release；agent-service 独立部署。
+- **部署会中断在途后台任务**：agent-service 部署会杀掉正在跑的 rebuild / afterthought / world / life。部署前需确认无正在运行的任务。
+- **`make deploy` 会连带部署 sibling**：Makefile 的 sibling 循环会把两个 worker 一起部到同一泳道。Task E 要求泳道只跑 channel-server 一个 Deployment，需绕开该循环或事后清理。
+
+## Tasks
+
+A、B、C 三个任务文件不重叠，可并行。D 与 A/B/C 无文件冲突也可并行。**E 依赖 A–D 全部完成**，且是受控的线上验证，不可并行。
+
+**Task A — publish 侧注入 lane 与 trace_id**
+- **Goal**: channel-server 发出的每条 MQ 消息，AMQP header 都携带 lane 和 trace_id。
+- **Deliverable**: `apps/channel-server/src/infrastructure/integrations/rabbitmq.ts` 的 `publish`；配套单测。
+- **Verification**: 单测断言三种场景（泳道、prod、显式传 lane）下 amqplib 收到的 header 内容正确，且原有 `x-retry-count` 等自定义 header 不被覆盖；`bun test` 全绿。
+
+**Task B — 两个 worker 消费侧改读 header**
+- **Goal**: chat-response-worker 和 recall-worker 从 header 恢复 lane，使 prod worker 能正确处理降级回来的泳道消息。
+- **Deliverable**: `apps/channel-server/src/workers/chat-response-handler.ts`、`workers/recall-worker.ts`；配套单测。
+- **Verification**: 单测覆盖三种入站消息（header 有 lane、header 为空、无 header），断言 handler 内取到的 lane 正确且不再读 body 字段；`bun test` 全绿。不改 `inbound-lane-consumer.ts`。
+
+**Task C — agent-service 生产侧 header 与队列同源，消费侧补测试**
+- **Goal**: `emit()` 等跨进程投递注入 header，且 header 里的 lane 与实际投递队列永远同源；MQSource 消费侧的 lane 恢复有测试掩护。
+- **Deliverable**: `apps/agent-service/app/runtime/` 下的 `propagation.py`（新增生产侧原语）、`emit.py`、`sink_dispatch.py`、`debounce.py`、`review_queue.py`；`tests/runtime/` 补用例。
+- **Verification**: 消费侧断言 header 带真实 lane 时 node 内 `lane_var` 等于该 lane（原用例只发过空字符串，一个丢 lane 的消费者也能保持绿）；生产侧对每个 publish 点断言"contextvar 为空 + env LANE 有值"这个组合下，header 的 lane 与 broker 实际看到的 routing key 可互相推导。`uv run pytest` 全绿，且队列选择逐值不变。
+
+**Task D — 非 prod 泳道禁用全局副作用**
+- **Goal**: channel-server 部署到任何非 prod 泳道时，不启动飞书 WS 长连接、不启动 crontab，因而不会抢占线上飞书事件、不会重复发群消息或覆写共享表。
+- **Deliverable**: `apps/channel-server/src/startup/application.ts` 及飞书 ingress gate 所在模块；配套单测。
+- **Verification**: 单测断言 lane 为 prod/空时两者都启动、lane 为任意泳道值时都不启动，且飞书长连接同时受原 env 开关约束（两者是与关系）。`bun test` 全绿。不引入任何新的环境变量或 PaaS 配置。
+
+**Task E — 泳道端到端验证**
+- **Goal**: 证明只部 channel-server 一个 Deployment 到泳道，飞书链路能完整跑通，且 lane 在降级路径上不丢。
+- **Deliverable**: 验证记录（命令 + 实际输出）。
+- **Verification**: 泳道只运行 channel-server 这一个 Deployment（不部 agent-service、不部两个 worker），绑定 dev bot 后发消息，确认：泳道 channel-server 收到并处理；chat_request 消息 header 带正确 lane；prod agent-service 接手降级消息且处理时 lane 正确（不是 None、不是 prod）；回复正常送达飞书。同时确认泳道 pod 日志中没有飞书长连接启动和 cron 调度记录。全程不部署任何其他服务的泳道。


### PR DESCRIPTION
Framework-Layer-Spec: docs/plan/lane-propagation-fix-spec.md

Lane was modeled as a per-hop parameter, not as ambient context. channel-server
*creates* the lane (from `lane_routing` bindings — the inbound Feishu event has
none) but only ever encoded it into the queue name and the message body. The
downstream `extract_context` in agent-service reads AMQP headers and nothing
else, so every cross-service hop landed with `lane=None`, `lane_router` emitted
no `x-ctx-lane`, and the sidecar sent everything to prod.

That also made the existing degradation path dead on arrival. Lane queues carry
a 10s TTL plus a DLX back to the prod routing key precisely so an undeployed
downstream falls back to prod — but the prod consumer had no way to tell which
lane a demoted message came from. "You must deploy the whole chain to one lane"
was really "keep `env LANE` identical everywhere so nobody notices the missing
hop."

## Carrying the lane

`publish` already computed `effectiveLane` to build the routing key; it now also
stamps it onto the header. Caller headers spread first so `lane`/`trace_id`
stay authoritative — a caller override would produce a message sitting in queue
Y while claiming header X, and the consumer trusts the header.

Consumers read the header only. Not the body, and explicitly not their own
`env LANE`: a prod worker legitimately drains messages that TTL'd back from a
lane queue, and stamping its own identity on those would relabel them. The
parsing lived in both workers; it now lives once in `amqp-context.ts`.

On the Python side `outbound_context()` closes a matching gap. The header lane
came from a contextvar while `mq.publish` picked the queue from `current_lane()`
— two sources. On a lane pod with no bound context that produces a message
routed to `xxx_ppe-x` carrying `lane: ""`, reproducing the exact bug being
fixed here. Five publish sites now resolve both from one place.

## Unblocking lane deployment for channel-server

channel-server could not be deployed to a lane at all, which is why this path
had never been verified end to end.

`LARK_DIRECT_INGRESS=true` sits at app level, so every lane inherited it and
opened its own Feishu long connection. Feishu round-robins among clients sharing
an `app_id` rather than broadcasting, so a lane would silently siphon off part
of production traffic with no drop in prod throughput and nothing for an alert
to catch. Crontab was unguarded too: `daily-photo` posts to hardcoded group IDs
and `emoji` rewrites a shared table hourly.

Both are now gated on `isProdDeployment()`. The gate is code, not configuration:
`make deploy` POSTs to `/api/paas/releases/` without an `envs` field and
paas-engine assigns `existing.Envs = req.Envs` unconditionally, so a Release env
holding this switch would be wiped by the next routine deploy — silently, taking
prod Feishu ingress down with it.

`recall-worker` picked up dependency injection along the way. Its module top
level did `mkdir /var/log/...` and called `main()` bare, so importing it in a
test hit EACCES before any assertion ran. Republishing also happened outside
`context.run`, blanking the `trace_id` on every retry.

## Verification

Deployed channel-server alone to `ppe-lane-header` with agent-service left on
prod — the configuration that could not work before. Round trip completed:

- lane pod published with `lane=ppe-lane-header` into `chat_request_ppe-lane-header`
- the message took 10.06s from publish to pickup against a prod baseline of
  0.04-0.10s, the TTL/DLX signature
- `agent-service-prod` logged `route_chat_node received: lane=ppe-lane-header`
  while logging `lane=None` for concurrent prod traffic on the same pod, and
  declared `chat_response_ppe-lane-header` off the recovered value
- the reply came from `chat-response-worker-ppe-lane-header`;
  `chat-response-worker-prod` had nothing for that session
- the lane pod opened no Feishu websocket

Suites: 610 pass / 0 fail (channel-server), 1122 pass / 0 fail (agent-service).
