### PR TITLE
fix(channel-server): fall back to OSS for daily photos

### DIFF
--- a/apps/channel-server/src/infrastructure/crontab/services/daily-photo.ts
+++ b/apps/channel-server/src/infrastructure/crontab/services/daily-photo.ts
@@ -49,6 +49,7 @@ export class DailyPhotoService {
             await sendCard('oc_a79ce7cc8cc4afdcfd519532d0a917f5', card);
         } catch (e) {
             console.error('daily send new photo error:', e);
+            throw e;
         }
     }
 }
@@ -58,4 +59,3 @@ export const dailyPhotoService = new DailyPhotoService();
 
 // 注册定时任务
 registerCrontabService(dailyPhotoService);
-

--- a/apps/channel-server/src/plugins/lark/services/photo/local-source.test.ts
+++ b/apps/channel-server/src/plugins/lark/services/photo/local-source.test.ts
@@ -6,6 +6,7 @@ import {
     buildLocalPixivImageFilter,
     dedupePixivAddrs,
     getLocalPixivImageCandidates,
+    getLocalPixivImageContentWith,
     mapLocalPixivImageDoc,
     minioObjectName,
 } from './local-source';
@@ -151,6 +152,22 @@ describe('local pixiv image source', () => {
     it('uses basename as the local MinIO object name', () => {
         expect(minioObjectName('pixiv_img_v2/20260604/12345678_p0.png')).toBe('12345678_p0.png');
         expect(minioObjectName('12345678_p0.png')).toBe('12345678_p0.png');
+    });
+
+    it('falls back to the full OSS key when MinIO cannot read the image', async () => {
+        const readMinio = mock(async () => {
+            throw new Error('InvalidAccessKeyId');
+        });
+        const readOss = mock(async () => Buffer.from('image-from-oss'));
+
+        const content = await getLocalPixivImageContentWith(
+            'pixiv_img_v2/20260604/12345678_p0.png',
+            { readMinio, readOss },
+        );
+
+        expect(content.toString()).toBe('image-from-oss');
+        expect(readMinio).toHaveBeenCalledWith('pixiv_img_v2/20260604/12345678_p0.png');
+        expect(readOss).toHaveBeenCalledWith('pixiv_img_v2/20260604/12345678_p0.png');
     });
 
     it('maps local Mongo docs to ImageForLark fields', () => {

--- a/apps/channel-server/src/plugins/lark/services/photo/local-source.ts
+++ b/apps/channel-server/src/plugins/lark/services/photo/local-source.ts
@@ -1,5 +1,6 @@
 import * as Minio from 'minio';
 import { MongoClient, type Collection, type Document, type Filter } from 'mongodb';
+import { getOss } from '@aliyun/oss';
 import { StatusMode } from 'types/pixiv';
 import type { ImageForLark, ListPixivImageDto, ReportLarkUploadDto } from 'types/pixiv';
 
@@ -46,6 +47,11 @@ export interface LocalPixivCandidatePage {
 
 interface LocalPixivCandidateDependencies {
     collection?: LocalPixivCandidateCollection;
+}
+
+interface LocalPixivImageContentDependencies {
+    readMinio(tosFileName: string): Promise<Buffer>;
+    readOss(tosFileName: string): Promise<Buffer>;
 }
 
 let mongoClient: MongoClient | null = null;
@@ -214,8 +220,28 @@ export function buildLocalPixivCandidatePipeline(request: LocalPixivCandidateReq
 }
 
 export async function getLocalPixivImageContent(tosFileName: string): Promise<Buffer> {
-    const stream = await getMinioClient().getObject(getMinioBucket(), minioObjectName(tosFileName));
-    return streamToBuffer(stream);
+    return getLocalPixivImageContentWith(tosFileName, {
+        async readMinio(key) {
+            const stream = await getMinioClient().getObject(getMinioBucket(), minioObjectName(key));
+            return streamToBuffer(stream);
+        },
+        async readOss(key) {
+            const object = await getOss().getFile(key);
+            return Buffer.isBuffer(object.content) ? object.content : Buffer.from(object.content);
+        },
+    });
+}
+
+export async function getLocalPixivImageContentWith(
+    tosFileName: string,
+    dependencies: LocalPixivImageContentDependencies,
+): Promise<Buffer> {
+    try {
+        return await dependencies.readMinio(tosFileName);
+    } catch {
+        console.warn(`MinIO image read failed; falling back to OSS: ${tosFileName}`);
+        return dependencies.readOss(tosFileName);
+    }
 }
 
 export async function reportLocalLarkUpload(params: ReportLarkUploadDto): Promise<void> {


### PR DESCRIPTION
## Summary

- Fall back to OSS with the full object key when MinIO image reads fail.
- Propagate daily photo cron failures so they are not logged as successful.

## Testing

- 375 channel-server tests passed.
- Bun production compile passed.