### PR TITLE
fix(agent-service): anchor life in time so she stops living at the wrong hour

### DIFF
--- a/apps/agent-service/app/data/queries/messages.py
+++ b/apps/agent-service/app/data/queries/messages.py
@@ -7,6 +7,7 @@ agent-service payload names, where ``message_id`` is the common message id.
 from __future__ import annotations
 
 import json
+from datetime import datetime
 from uuid import UUID
 
 from sqlalchemy import func, or_, text, update
@@ -608,7 +609,10 @@ async def find_persona_spoken_chats_in_window(
 
 
 def _life_chat_message(
-    record: CommonMessageRecord, msg_persona: str | None, persona_id: str
+    record: CommonMessageRecord,
+    msg_persona: str | None,
+    persona_id: str,
+    now: datetime,
 ) -> LifeChatMessage:
     """把一条 common 消息 + 它的发言 persona 折成 life 读对话用的可读形态。
 
@@ -617,7 +621,9 @@ def _life_chat_message(
     ``COALESCE(agent_response, bot_config 兜底)`` 取、含 proactive 出站行归属）。
     展示名：她自己用 persona_id；别的 persona 用它的 persona_id；真人用
     ``sender_display_name`` 兜底（不暴露 raw user_id）。CST 时间走项目 cst_time 归一
-    （``event_time`` 毫秒整数 → ``str`` 喂 ``to_cst_hm``，与历史毫秒口径一致）。
+    （``event_time`` 毫秒整数 → ``str`` 喂 ``to_cst_dated``，与历史毫秒口径一致）：
+    当天的只给时分，**跨天的补上 MM-DD**——回看窗口冷启时回退 6 小时、经常跨夜，
+    只给 ``23:41 CST`` 她分不清那是昨晚还是刚才（线上事故 2026-08-03）。
     """
     is_self = record.role == "assistant" and msg_persona == persona_id
     if is_self:
@@ -631,7 +637,9 @@ def _life_chat_message(
         speaker_display_name=speaker,
         is_self=is_self,
         text=json.loads(record.content).get("text", "") if record.content else "",
-        cst_time=cst_time.to_cst_hm(str(record.create_time)),
+        cst_time=cst_time.to_cst_dated(
+            str(record.create_time), now=now, seconds=False
+        ),
     )
 
 
@@ -716,6 +724,7 @@ async def find_persona_related_chats_recent(
     since_ms: int,
     max_conversations: int,
     per_chat_limit: int,
+    now: datetime,
 ) -> list[LifeChatConversation]:
     """她相关会话（真人私聊 + 白名单内的群）的最近一段消息 —— life 醒来实时拉对话。
 
@@ -734,6 +743,10 @@ async def find_persona_related_chats_recent(
     量控制不字符截断**：超 ``per_chat_limit`` 只保最近 N 条、仍按发生先后升序。每条折成
     ``LifeChatMessage``（发言者展示名 / 是否她自己 / 文本 / CST 时间），返回
     ``LifeChatConversation`` 列表（chat_id + scope + 群名 + 消息列表 + 私聊对面真人）。
+
+    ``now`` 由调用方给、不在这里现取：消息时间戳「同一天省日期、跨天补 MM-DD」要拿
+    调用方那一轮的同一个「今天」去比。自己现取会和调用方的 now 差开——跨午夜那一瞬
+    两边落在不同日历日，同一屏 stimulus 里的日期口径就自相矛盾。
 
     私聊会话额外聚合「对面是谁」（主动私聊具名化 Task 1）：对选中的私聊**批量一次**
     经 :func:`_direct_counterparts_by_chat` 解析对方真人（口径见该函数——按全历史
@@ -824,7 +837,7 @@ async def find_persona_related_chats_recent(
         # 一批 (record, 发言 persona)：消息渲染与文件候选都从这同一批派生（同一边界）。
         record_pairs = [(_record(msg), msg_persona) for msg, msg_persona in rows]
         messages = [
-            _life_chat_message(record, msg_persona, persona_id)
+            _life_chat_message(record, msg_persona, persona_id, now)
             for record, msg_persona in record_pairs
         ]
         messages.reverse()

--- a/apps/agent-service/app/infra/cst_time.py
+++ b/apps/agent-service/app/infra/cst_time.py
@@ -95,6 +95,32 @@ def to_cst_hms(raw: str | None) -> str:
     return f"{dt.strftime('%H:%M:%S')} CST"
 
 
+def to_cst_dated(raw: str | None, *, now: datetime, seconds: bool = True) -> str:
+    """同一个 CST 日历日给 ``HH:MM:SS CST``，跨天补上 ``MM-DD``；无法解析则原样回显。
+
+    喂给 agent 的历史条目（信箱未读、聊天记录）必须用它，不能用只给时分秒的
+    :func:`to_cst_hms`：信箱既没有时间窗也没有 TTL，昨晚积压的未读会原样进 stimulus，
+    而 ``20:47:12 CST`` 这个形状昨晚和今晚长得一模一样——她无从分辨那是几小时前还是
+    一整天前（线上事故 2026-08-03：中午 13:18 往群里发「大半夜的发什么疯、赶紧滚去
+    睡觉」）。
+
+    同一天的**刻意不带**日期：绝大多数条目都是当天的，全带上既费 token 又让她每读
+    一行都要过滤一次冗余信息，反而稀释掉「这条是昨天的」这个真正需要被注意到的信号。
+
+    跨天判定按 **CST 日历日**（不是 UTC，也不是「差了 24 小时」）：CST 次日 00:30 的
+    UTC 还停在前一天 16:30，按 UTC 比会把刚过午夜的事错标成昨天。
+
+    ``seconds=False`` 给到分钟就停（聊天记录用：秒对读对话没有意义）。
+    """
+    dt = to_cst(raw)
+    if dt is None:
+        return f"{raw}" if raw else ""
+    clock = dt.strftime("%H:%M:%S" if seconds else "%H:%M")
+    if dt.astimezone(CST).date() == now.astimezone(CST).date():
+        return f"{clock} CST"
+    return f"{dt.strftime('%m-%d')} {clock} CST"
+
+
 # 中文星期（周一=0 … 周日=6，对齐 ``datetime.weekday()``），给完整时间口径用。
 _WEEKDAYS_CN = ("周一", "周二", "周三", "周四", "周五", "周六", "周日")
 

--- a/apps/agent-service/app/infra/daylight.py
+++ b/apps/agent-service/app/infra/daylight.py
@@ -1,4 +1,10 @@
-"""今天几点天亮、几点天黑——喂给 world 的日照锚点（idle-deadlock spec Task 2）。
+"""今天几点天亮、几点天黑——喂给 world 和三姐妹 life 的日照锚点。
+
+**为什么在 infra 而不在 world**：日出日落是客观天文事实，不是 world 的私有快照。
+最初（idle-deadlock spec Task 2）只有 world 用，就近放在了 ``app/world/``；后来
+life 也需要同一个锚（线上事故 2026-08-03，见下），而 ``life_wake`` 有「绝不 import
+app.world」的信息差命门。锚点本身两边都够得着，归属挪到中立的 infra，两边共用同一
+份定义（不复制、不留 re-export）。
 
 **为什么要有这个模块**：prod 实证 2026-07-24，广州当天真实日落约 19:13，但 world
 17:01 就写「傍晚前段」、17:56 写「傍晚后段的自然光继续退下去」、18:30 写「更深的
@@ -110,7 +116,7 @@ def compute_daylight(
 
 
 async def today_daylight_text(day: date) -> str:
-    """拼给 world 的日照锚点；坐标没配 / 配脏 / 算不出 → 空串（如实不拼）。
+    """拼给 world / life 的日照锚点；坐标没配 / 配脏 / 算不出 → 空串（如实不拼）。
 
     Dynamic Config 的拉取是同步 httpx（10s 缓存），走 ``asyncio.to_thread`` 避免
     缓存刷新那一次阻塞事件循环（与 :mod:`app.life.feed_whitelist` 同口径）。

--- a/apps/agent-service/app/nodes/life_wake.py
+++ b/apps/agent-service/app/nodes/life_wake.py
@@ -97,6 +97,9 @@ from app.domain.world_events import (
     strip_npc_prefix,
 )
 from app.infra import cst_time
+from app.infra.daylight import (  # module-level so tests can monkeypatch
+    today_daylight_text,
+)
 from app.infra.redis import get_redis
 from app.life.living_day import living_day
 from app.life.pages import read_day_page_before  # module-level so tests can monkeypatch
@@ -228,11 +231,26 @@ def _derive_life_round_id(
 
 
 def _recent_chat_since_ms(*, now: datetime, snapshot: LifeState | None) -> int:
-    """最近聊天增量水位：优先从上一轮 observed_at 往后看，冷启退回固定窗口。"""
+    """最近聊天回看窗口：从上一轮 observed_at 往后看，但**不短于**一个回看下限。
+
+    冷启（没有快照 / 快照时间脏）退回固定的 :data:`_RECENT_CHAT_SINCE_MS` 窗口。
+
+    为什么要有下限（线上事故 2026-08-03 根因之一）：水位原先就是上一轮 observed_at，
+    而 life 被事件唤醒时 45s–2min 就跑一轮，窗口于是跟着轮次频率一起收缩到一两分钟。
+    她越活跃、窗口越窄——窄到那一屏群聊里只剩她自己刚发的两句话（3 条里 2 条是「我：」），
+    唯一的外部输入是一句「啊啊啊啊啊」。她读着自己的回声当外部现实，顺着自己上一句的
+    错误推断越滑越远：中午 13:13 有人开玩笑说「下班了」，她回「快点回家躺着」，这句
+    回流成她的上下文，5 分钟后就变成「大半夜的发什么疯、明天不上班啦」。
+
+    下限只保证**外部上下文进得来**，不改「增量」的本意：水位比下限更早时以水位为准
+    （该看到的旧聊天不会被下限砍掉）。规模不靠这里控——仍由每会话 10 条上限兜住，
+    窗口放宽不等于喂更多条（no_context_truncation：控条目数，不截断内容）。
+    """
+    floor_ms = int(now.timestamp() * 1000) - _RECENT_CHAT_MIN_LOOKBACK_MS
     if snapshot is not None:
         observed = cst_time.parse(snapshot.observed_at)
         if observed is not None:
-            return int(observed.timestamp() * 1000)
+            return min(int(observed.timestamp() * 1000), floor_ms)
     return int(now.timestamp() * 1000) - _RECENT_CHAT_SINCE_MS
 
 
@@ -371,7 +389,7 @@ def _format_surroundings(surroundings: list[EventEnvelope], now: datetime) -> st
     时降级（不带数字时间锚），留白仍由「上一次感知到的周遭」的框兜住。
     """
     body = "\n".join(
-        f"（{cst_time.to_cst_hms(ev.occurred_at)}）{ev.summary}"
+        f"（{cst_time.to_cst_dated(ev.occurred_at, now=now)}）{ev.summary}"
         for ev in surroundings
     )
     # 时间锚按最新那版（末尾）切片的感知时刻算——她对周遭的最近一次认知有多新。
@@ -409,7 +427,7 @@ def _format_idle_sense(idle_sense: list[EventEnvelope], now: datetime) -> str:
     """
     anchor = _humanize_elapsed(idle_sense[-1].occurred_at, now) if idle_sense else None
     body = "\n".join(
-        f"（{cst_time.to_cst_hms(ev.occurred_at)}）{ev.summary}"
+        f"（{cst_time.to_cst_dated(ev.occurred_at, now=now)}）{ev.summary}"
         for ev in idle_sense
     )
     if anchor is None:
@@ -436,7 +454,7 @@ def _group_handle_suffix(ev: EventEnvelope) -> str:
     return f"（来自群聊，群句柄 {handle}）"
 
 
-def _format_dynamics(dynamics: list[EventEnvelope]) -> str:
+def _format_dynamics(dynamics: list[EventEnvelope], now: datetime) -> str:
     """把离散动静拼成她"刚感知到的几件事"，按发生先后。
 
     放 event 的客观可感形态（summary）+ 类型 + 发生时间——都是投进她信箱的、她够得着
@@ -446,7 +464,7 @@ def _format_dynamics(dynamics: list[EventEnvelope]) -> str:
     UTC），显示时一律过 ``cst_time`` 归一到 CST，让她看到的所有时刻是同一个 CST 口径。
     """
     return "\n".join(
-        f"- [{ev.kind}] {cst_time.to_cst_hms(ev.occurred_at)} "
+        f"- [{ev.kind}] {cst_time.to_cst_dated(ev.occurred_at, now=now)} "
         f"{ev.summary}{_group_handle_suffix(ev)}"
         for ev in dynamics
     )
@@ -468,7 +486,7 @@ def _speaker_display(source: str) -> str:
     return strip_npc_prefix(source)
 
 
-def _format_speech(speech: list[EventEnvelope]) -> str:
+def _format_speech(speech: list[EventEnvelope], now: datetime) -> str:
     """把别人直接对她说的话（kind=speech）拼成「X 对你说：原话」，按发生先后（1C Task 3）。
 
     speech 有两类直投来源，都呈现成「X 对你说：原话」让她看清是谁对她说了什么——区别于
@@ -482,13 +500,13 @@ def _format_speech(speech: list[EventEnvelope]) -> str:
     transcript 天然承载，这里只如实呈现收到的每句。
     """
     return "\n".join(
-        f"（{cst_time.to_cst_hms(ev.occurred_at)}）"
+        f"（{cst_time.to_cst_dated(ev.occurred_at, now=now)}）"
         f"{_speaker_display(ev.source)} 对你说：{ev.summary}"
         for ev in speech
     )
 
 
-def _format_messages(messages: list[EventEnvelope]) -> str:
+def _format_messages(messages: list[EventEnvelope], now: datetime) -> str:
     """把别人隔手机发来的消息（kind=message）拼成「X 给你发消息：内容」，按发生先后（task 5）。
 
     通信介质维度（spec 决策 5 / 7）：这是**隔着手机/飞书**发来的消息——不在一起时发的，
@@ -500,13 +518,13 @@ def _format_messages(messages: list[EventEnvelope]) -> str:
     ``cst_time`` 归一到 CST（同其它各类）。
     """
     return "\n".join(
-        f"（{cst_time.to_cst_hms(ev.occurred_at)}）"
+        f"（{cst_time.to_cst_dated(ev.occurred_at, now=now)}）"
         f"{_speaker_display(ev.source)} 给你发消息：{ev.summary}"
         for ev in messages
     )
 
 
-def _format_own_chat_reply(own_replies: list[EventEnvelope]) -> str:
+def _format_own_chat_reply(own_replies: list[EventEnvelope], now: datetime) -> str:
     """把 chat 已发出的回复（kind=own_chat_reply）拼成"你自己刚说的话"，按发生先后。
 
     这是 chat/life 并发重复回复修复的核心呈现：chat_node 确认一段回复内容确实发给
@@ -521,7 +539,7 @@ def _format_own_chat_reply(own_replies: list[EventEnvelope]) -> str:
     模型把自己刚发的回复误当成"外部发生的一件事"又去回应一次。
     """
     return "\n".join(
-        f"（{cst_time.to_cst_hms(ev.occurred_at)}）你刚回复了：{ev.summary}"
+        f"（{cst_time.to_cst_dated(ev.occurred_at, now=now)}）你刚回复了：{ev.summary}"
         for ev in own_replies
     )
 
@@ -591,6 +609,10 @@ def _split_perception(
 #   * 每会话最多 10 条：每个会话只铺最近一段、不把整卷历史拉进来。
 # 这三个都是机制层的规模闸（同 inbox 上限那类），不替她判断哪些重要（赤尾宪法）。
 _RECENT_CHAT_SINCE_MS = 6 * 60 * 60 * 1000
+# 回看下限：她再活跃，群聊窗口也至少往回看这么久，保证读到的不只是自己刚说的话。
+# 30 分钟——够覆盖一段完整的群聊来回（谁挑的头、聊到哪了），又不至于把几小时前
+# 早已翻篇的话题重新拽回她眼前。见 :func:`_recent_chat_since_ms`。
+_RECENT_CHAT_MIN_LOOKBACK_MS = 30 * 60 * 1000
 _RECENT_CHAT_MAX_CONVERSATIONS = 5
 _RECENT_CHAT_PER_CHAT_LIMIT = 10
 
@@ -816,6 +838,9 @@ async def _run_life_round(
             since_ms=recent_chat_since_ms,
             max_conversations=_RECENT_CHAT_MAX_CONVERSATIONS,
             per_chat_limit=_RECENT_CHAT_PER_CHAT_LIMIT,
+            # 本轮的同一个 now：聊天时间戳的「今天」必须和 stimulus 顶部那行时刻、
+            # 以及事件时间戳用的是同一个快照，否则跨午夜时同一屏里日期口径打架。
+            now=now,
         )
     except Exception as e:
         logger.warning(
@@ -874,9 +899,13 @@ async def _run_life_round(
             e,
         )
         day_page = None
+    # 「写于」带日期（to_cst_dated 而不是只给时分的 to_cst_hm）：这段进 SYSTEM、每轮
+    # 都在，是她读到的第一批文字之一。一个裸的「23:40 CST」悬在那里会跟「现在几点」
+    # 争注意力（线上事故 2026-08-03：她把一屏夜间时间戳读成了「现在是晚上」）；带上
+    # 日期才跟前面的「{date} 那天」呼应上，这个时刻落回昨天。
     day_page_text = (
         f"【你睡前写下的上一页日子】（{day_page.date} 那天留下来的几笔，"
-        f"写于 {cst_time.to_cst_hm(day_page.written_at)}）：\n"
+        f"写于 {cst_time.to_cst_dated(day_page.written_at, now=now, seconds=False)}）：\n"
         f"{day_page.narrative}"
         if day_page is not None
         else ""
@@ -1013,6 +1042,37 @@ async def _run_life_round(
     # 本子（当天会变）/ 现在时间 / 五类感知 / 冷启状态恢复段，末尾印本轮 round marker。
     parts: list[str] = []
 
+    # 时刻行 + 当天日照锚，**必须是 stimulus 的第一段**（线上事故 2026-08-03 的直接修复）。
+    #
+    # 完整日期口径（#279：年月日 + 星期 + 时分），不是只给时分：她记日程 / 算 remind_at
+    # 时要把「5 分钟后」「周五」这类相对时间换算成绝对 ISO，没有今天的日期她只能瞎填
+    # 日期分量（线上 bug：remind_at 被填到过去，提醒永远不在该响的那一刻触发）。
+    #
+    # 位置为什么必须置顶：原先它排在本子 / 群聊之后，模型先读到一屏「下班了」「快点
+    # 回家躺着」，再读到「现在是 … 13:16」——语义氛围压过了数字锚，她在中午 13:18 往
+    # 群里发「大半夜的发什么疯、赶紧滚去睡觉」，还把「晚上八点」jot_down 进本子固化成
+    # 记忆。SYSTEM 里一个时间字都没有，这行是她唯一的时钟，不能埋在中段。
+    # （置顶不打散前缀缓存：整段 stimulus 是当轮追加到 messages 末尾的全新 token，
+    # 它之前的 system + 历史 turn 一字未动，缓存命中的是那一段。）
+    #
+    # 日照锚和 world 同一口径（#308 已在 world 验证有效：world 当时只看到一个裸时间戳，
+    # 就退回「傍晚≈天黑」的通用先验，把黄昏写早了 1.5–2 小时）。只给客观天文事实，不给
+    # 任何「几点之后算晚上」的判断——那是她自己看着现实此刻去推的事（赤尾宪法）。
+    # 算不出（坐标没配 / 配脏 / 极昼极夜）返回空串，如实不拼；抛错也只是少一个锚，
+    # 绝不带走时刻行本身、绝不炸整轮（照 notebook / day_page 的 fail-soft 姿势）。
+    try:
+        daylight_text = await today_daylight_text(now.date())
+    except Exception as e:
+        logger.warning(
+            "[life_wake] %s/%s failed to compute daylight anchor, "
+            "clock line keeps going without it: %s",
+            lane,
+            persona_id,
+            e,
+        )
+        daylight_text = ""
+    parts.append(f"现在是 {cst_time.to_cst_full(observed_at)}。{daylight_text}")
+
     # 她本子里还没了结的事（备忘录 & 日程 第二块）：每轮唤醒读她**还活着**的条目
     # （active_only=True：她自己没标 done / dropped 的），渲成一段塞进她的输入，让她
     # 带着自己记下惦记的事过日子。**只读、绝不改状态、不删任何东西**（spec 必改点）；
@@ -1098,11 +1158,6 @@ async def _run_life_round(
     if recent_chats:
         parts.append(_format_recent_chats(recent_chats))
 
-    # 完整日期口径（#279：年月日 + 星期 + 时分），不是只给时分：她记日程 / 算 remind_at
-    # 时要把「5 分钟后」「周五」这类相对时间换算成绝对 ISO，没有今天的日期她只能瞎填
-    # 日期分量（线上 bug：remind_at 被填到过去，提醒永远不在该响的那一刻触发）。
-    parts.append(f"现在是 {cst_time.to_cst_full(observed_at)}。")
-
     # 状态恢复段（spec 决策 5 核心）：上一刻状态正常靠当天连续意识流（transcript）延续，
     # 不每轮重塞。只有意识流断了（冷启 / Redis 24h 过期丢失 / 跨天新 session → transcript
     # 空）时，才从 PG 的 LifeState 兜底恢复，作"醒来记得之前在做什么"喂进当前 USER。
@@ -1169,7 +1224,7 @@ async def _run_life_round(
         if speech:
             parts.append(
                 "【有人当面对你说话】（就在你身边、直接冲你来的话，按发生先后）：\n"
-                f"{_format_speech(speech)}"
+                f"{_format_speech(speech, now)}"
             )
         if messages:
             # 通信介质维度（spec 决策 5 / 7）：隔着手机/飞书发来的消息，**不是当面**。
@@ -1178,7 +1233,7 @@ async def _run_life_round(
             parts.append(
                 "【有人隔着手机给你发消息】（你们这会儿不在一起、隔着手机/飞书发来的，"
                 "不是当面说的，按发生先后）：\n"
-                f"{_format_messages(messages)}"
+                f"{_format_messages(messages, now)}"
             )
         if own_replies:
             # chat/life 并发重复回复修复：这是她**自己**刚发出去的话，绝不能和「别人
@@ -1187,12 +1242,12 @@ async def _run_life_round(
             parts.append(
                 "【你刚对这次交流的回复】（这是你自己刚发出去的话，不是别人对你说的，"
                 "已经发过了、不用再回一遍）：\n"
-                f"{_format_own_chat_reply(own_replies)}"
+                f"{_format_own_chat_reply(own_replies, now)}"
             )
         if dynamics:
             parts.append(
                 "这会儿你还感知到这些客观动静（按发生先后）：\n"
-                f"{_format_dynamics(dynamics)}"
+                f"{_format_dynamics(dynamics, now)}"
             )
         parts.append("读懂此刻你周遭，过你自己的这一刻。")
 

--- a/apps/agent-service/app/world/engine.py
+++ b/apps/agent-service/app/world/engine.py
@@ -115,7 +115,7 @@ from app.runtime.lane_policy import current_deployment_lane
 from app.runtime.node import node
 from app.runtime.single_flight import SingleFlightConflict, single_flight
 from app.world.arc import read_world_arc  # module-level so tests can monkeypatch
-from app.world.daylight import (  # module-level so tests can monkeypatch
+from app.infra.daylight import (  # module-level so tests can monkeypatch
     today_daylight_text,
 )
 from app.world.npc_roster import (  # module-level so tests can monkeypatch
@@ -936,7 +936,7 @@ def _world_loop_messages(
     判断是这条规则划定清楚的唯一例外，靠 :func:`_sisters_section` 加回的 ``observed_at``
     做时间外推（见该函数 docstring）。
 
-    ``daylight_text``：今天的日照锚点（:func:`app.world.daylight.today_daylight_text`
+    ``daylight_text``：今天的日照锚点（:func:`app.infra.daylight.today_daylight_text`
     渲染的「（今天日出 HH:MM、日落 HH:MM）」），**直接贴在【现实此刻】那一行的时刻
     后面**——它跟时刻是同一件事（今天这个时刻处在昼夜的哪一段），拆成独立一段反而
     要模型自己去连。prod 实证 07-24：真实日落 19:13，world 17:01 就写「傍晚前段」、

--- a/apps/agent-service/tests/data/test_persona_related_chats.py
+++ b/apps/agent-service/tests/data/test_persona_related_chats.py
@@ -28,6 +28,7 @@ from app.data.models import (
     CommonMessage,
 )
 from app.data.queries.messages import find_persona_related_chats_recent
+from app.infra import cst_time
 from app.life import feed_whitelist as fw
 
 _CHAT_GROUP = uuid.uuid5(uuid.NAMESPACE_OID, "rel-chat-group")
@@ -241,7 +242,7 @@ async def test_private_chat_returned_with_self_and_other(chat_db, allow_all_grou
     )
 
     got = await find_persona_related_chats_recent(
-        persona_id="akao", since_ms=0, max_conversations=10, per_chat_limit=50
+        persona_id="akao", since_ms=0, max_conversations=10, per_chat_limit=50, now=cst_time.now_cst()
     )
 
     assert len(got) == 1
@@ -275,7 +276,7 @@ async def test_whitelisted_group_returned_non_whitelisted_excluded(chat_db, monk
     await _seed_bot_message(_CHAT_GROUP_2, event_time=1000, text="同学群我也说了", persona_id="akao")
 
     got = await find_persona_related_chats_recent(
-        persona_id="akao", since_ms=0, max_conversations=10, per_chat_limit=50
+        persona_id="akao", since_ms=0, max_conversations=10, per_chat_limit=50, now=cst_time.now_cst()
     )
 
     chat_ids = {c.chat_id for c in got}
@@ -290,7 +291,7 @@ async def test_passive_presence_chat_excluded(chat_db, allow_all_groups):
     await _seed_user_message(_CHAT_GROUP, event_time=1000, text="群里热闹但她没说话")
 
     got = await find_persona_related_chats_recent(
-        persona_id="akao", since_ms=0, max_conversations=10, per_chat_limit=50
+        persona_id="akao", since_ms=0, max_conversations=10, per_chat_limit=50, now=cst_time.now_cst()
     )
 
     assert got == []
@@ -303,7 +304,7 @@ async def test_recency_window_excludes_old_chats(chat_db, allow_all_groups):
     await _seed_bot_message(_CHAT_GROUP, event_time=100, text="很久以前说的", persona_id="akao")
 
     got = await find_persona_related_chats_recent(
-        persona_id="akao", since_ms=1000, max_conversations=10, per_chat_limit=50
+        persona_id="akao", since_ms=1000, max_conversations=10, per_chat_limit=50, now=cst_time.now_cst()
     )
 
     assert got == [], "她只在 since_ms 之前发过言的会话不算最近活跃"
@@ -318,7 +319,7 @@ async def test_per_chat_limit_keeps_most_recent_ascending(chat_db, allow_all_gro
         await _seed_user_message(_CHAT_GROUP, event_time=2000 + i, text=f"第{i}条")
 
     got = await find_persona_related_chats_recent(
-        persona_id="akao", since_ms=0, max_conversations=10, per_chat_limit=3
+        persona_id="akao", since_ms=0, max_conversations=10, per_chat_limit=3, now=cst_time.now_cst()
     )
 
     assert len(got) == 1
@@ -341,7 +342,7 @@ async def test_max_conversations_caps_number_of_chats(chat_db, allow_all_groups)
     await _seed_bot_message(_CHAT_DIRECT, event_time=3000, text="最新", persona_id="akao", scope="direct")
 
     got = await find_persona_related_chats_recent(
-        persona_id="akao", since_ms=0, max_conversations=2, per_chat_limit=50
+        persona_id="akao", since_ms=0, max_conversations=2, per_chat_limit=50, now=cst_time.now_cst()
     )
 
     assert len(got) == 2, "会话数上限=2"
@@ -359,7 +360,7 @@ async def test_other_persona_speech_does_not_make_chat_hers(chat_db, allow_all_g
     await _seed_bot_message(_CHAT_GROUP, event_time=2000, text="我在", persona_id="chinagi")
 
     got = await find_persona_related_chats_recent(
-        persona_id="akao", since_ms=0, max_conversations=10, per_chat_limit=50
+        persona_id="akao", since_ms=0, max_conversations=10, per_chat_limit=50, now=cst_time.now_cst()
     )
 
     assert got == []
@@ -381,7 +382,7 @@ async def test_proactive_only_private_chat_qualifies(chat_db, monkeypatch):
     )
 
     got = await find_persona_related_chats_recent(
-        persona_id="akao", since_ms=0, max_conversations=10, per_chat_limit=50
+        persona_id="akao", since_ms=0, max_conversations=10, per_chat_limit=50, now=cst_time.now_cst()
     )
 
     assert len(got) == 1, "她只发过 proactive 的私聊也算她相关会话"
@@ -403,7 +404,7 @@ async def test_user_row_with_bot_name_not_marked_self(chat_db, allow_all_groups)
     )
 
     got = await find_persona_related_chats_recent(
-        persona_id="akao", since_ms=0, max_conversations=10, per_chat_limit=50
+        persona_id="akao", since_ms=0, max_conversations=10, per_chat_limit=50, now=cst_time.now_cst()
     )
 
     assert len(got) == 1
@@ -439,7 +440,7 @@ async def test_file_candidates_from_same_boundary(chat_db, allow_all_groups):
     )
 
     got = await find_persona_related_chats_recent(
-        persona_id="akao", since_ms=0, max_conversations=10, per_chat_limit=50
+        persona_id="akao", since_ms=0, max_conversations=10, per_chat_limit=50, now=cst_time.now_cst()
     )
     assert len(got) == 1
     cands = got[0].file_candidates
@@ -470,7 +471,7 @@ async def test_file_candidate_tos_ref_derived_without_backfill(chat_db, allow_al
     )
 
     got = await find_persona_related_chats_recent(
-        persona_id="akao", since_ms=0, max_conversations=10, per_chat_limit=50
+        persona_id="akao", since_ms=0, max_conversations=10, per_chat_limit=50, now=cst_time.now_cst()
     )
     cands = got[0].file_candidates
     assert len(cands) == 1
@@ -498,7 +499,7 @@ async def test_media_video_excluded_from_file_candidates(chat_db, allow_all_grou
     )
 
     got = await find_persona_related_chats_recent(
-        persona_id="akao", since_ms=0, max_conversations=10, per_chat_limit=50
+        persona_id="akao", since_ms=0, max_conversations=10, per_chat_limit=50, now=cst_time.now_cst()
     )
     cands = got[0].file_candidates
     names = {c.file_name for c in cands}
@@ -513,7 +514,7 @@ async def test_no_file_messages_means_empty_candidates(chat_db, allow_all_groups
         _CHAT_DIRECT, event_time=2000, text="在的", persona_id="akao", scope="direct"
     )
     got = await find_persona_related_chats_recent(
-        persona_id="akao", since_ms=0, max_conversations=10, per_chat_limit=50
+        persona_id="akao", since_ms=0, max_conversations=10, per_chat_limit=50, now=cst_time.now_cst()
     )
     assert got[0].file_candidates == []
 
@@ -546,7 +547,7 @@ async def test_direct_counterpart_named_with_id(chat_db, allow_all_groups):
     )
 
     got = await find_persona_related_chats_recent(
-        persona_id="akao", since_ms=0, max_conversations=10, per_chat_limit=50
+        persona_id="akao", since_ms=0, max_conversations=10, per_chat_limit=50, now=cst_time.now_cst()
     )
 
     assert len(got) == 1
@@ -576,7 +577,7 @@ async def test_counterpart_resolved_from_full_history_outside_window(
     )
 
     got = await find_persona_related_chats_recent(
-        persona_id="akao", since_ms=1000, max_conversations=10, per_chat_limit=50
+        persona_id="akao", since_ms=1000, max_conversations=10, per_chat_limit=50, now=cst_time.now_cst()
     )
 
     assert len(got) == 1
@@ -603,7 +604,7 @@ async def test_proactive_outbound_row_not_mistaken_as_counterpart(chat_db, monke
     )
 
     got = await find_persona_related_chats_recent(
-        persona_id="akao", since_ms=0, max_conversations=10, per_chat_limit=50
+        persona_id="akao", since_ms=0, max_conversations=10, per_chat_limit=50, now=cst_time.now_cst()
     )
 
     assert len(got) == 1
@@ -625,7 +626,7 @@ async def test_no_human_row_in_full_history_means_no_counterpart(chat_db, monkey
     )
 
     got = await find_persona_related_chats_recent(
-        persona_id="akao", since_ms=0, max_conversations=10, per_chat_limit=50
+        persona_id="akao", since_ms=0, max_conversations=10, per_chat_limit=50, now=cst_time.now_cst()
     )
 
     assert len(got) == 1
@@ -640,7 +641,7 @@ async def test_group_conversation_counterparts_empty(chat_db, allow_all_groups):
     await _seed_user_message(_CHAT_GROUP, event_time=2000, text="哈喽")
 
     got = await find_persona_related_chats_recent(
-        persona_id="akao", since_ms=0, max_conversations=10, per_chat_limit=50
+        persona_id="akao", since_ms=0, max_conversations=10, per_chat_limit=50, now=cst_time.now_cst()
     )
 
     assert len(got) == 1
@@ -665,7 +666,7 @@ async def test_dirty_direct_chat_lists_all_humans(chat_db, allow_all_groups):
     )
 
     got = await find_persona_related_chats_recent(
-        persona_id="akao", since_ms=0, max_conversations=10, per_chat_limit=50
+        persona_id="akao", since_ms=0, max_conversations=10, per_chat_limit=50, now=cst_time.now_cst()
     )
 
     cps = got[0].counterparts
@@ -698,7 +699,7 @@ async def test_counterpart_display_name_prefers_named_row(chat_db, allow_all_gro
     )
 
     got = await find_persona_related_chats_recent(
-        persona_id="akao", since_ms=0, max_conversations=10, per_chat_limit=50
+        persona_id="akao", since_ms=0, max_conversations=10, per_chat_limit=50, now=cst_time.now_cst()
     )
 
     by_id = {c.user_id: c for c in got[0].counterparts}
@@ -732,7 +733,11 @@ async def test_counterpart_aggregation_batched_not_per_chat(chat_db, allow_all_g
         sa_event.listen(chat_db.sync_engine, "before_cursor_execute", _capture)
         try:
             await find_persona_related_chats_recent(
-                persona_id="akao", since_ms=0, max_conversations=10, per_chat_limit=50
+                persona_id="akao",
+                since_ms=0,
+                max_conversations=10,
+                per_chat_limit=50,
+                now=cst_time.now_cst(),
             )
         finally:
             sa_event.remove(chat_db.sync_engine, "before_cursor_execute", _capture)
@@ -775,8 +780,56 @@ async def test_proactive_trigger_pseudo_messages_excluded(chat_db, allow_all_gro
     )
 
     got = await find_persona_related_chats_recent(
-        persona_id="akao", since_ms=0, max_conversations=10, per_chat_limit=50
+        persona_id="akao", since_ms=0, max_conversations=10, per_chat_limit=50, now=cst_time.now_cst()
     )
 
     texts = [m.text for m in got[0].messages]
     assert not any("伪消息" in t for t in texts)
+
+
+@pytest.mark.integration
+async def test_cross_day_chat_message_carries_date(chat_db, allow_all_groups):
+    """不是今天发的群/私聊消息，时间戳要带日期。
+
+    线上事故 2026-08-03 的一条：喂给 life 的对话每条只标 ``23:41 CST``，冷启回退的
+    6 小时窗口经常跨夜，她读到一屏深夜时间戳却分不清那是昨晚还是刚才。当天的仍旧只
+    给时分（省 token、不干扰阅读），跨天的补上 ``MM-DD``。
+    """
+    import datetime as _dt
+
+    now = cst_time.now_cst()
+    yesterday = now - _dt.timedelta(days=1)
+    await _seed_conversation(_CHAT_DIRECT, scope="direct", name=None)
+    await _seed_user_message(
+        _CHAT_DIRECT,
+        event_time=int(yesterday.timestamp() * 1000),
+        text="昨晚说的话",
+        scope="direct",
+        username="贝壳",
+    )
+    await _seed_user_message(
+        _CHAT_DIRECT,
+        event_time=int(now.timestamp() * 1000),
+        text="刚才说的话",
+        scope="direct",
+        username="贝壳",
+    )
+    await _seed_bot_message(
+        _CHAT_DIRECT,
+        event_time=int(now.timestamp() * 1000) + 1,
+        text="在的",
+        persona_id="akao",
+        scope="direct",
+    )
+
+    got = await find_persona_related_chats_recent(
+        persona_id="akao", since_ms=0, max_conversations=10, per_chat_limit=50, now=cst_time.now_cst()
+    )
+
+    by_text = {m.text: m.cst_time for m in got[0].messages}
+    assert by_text["昨晚说的话"].startswith(yesterday.strftime("%m-%d")), (
+        f"跨天消息要带日期，实际 {by_text['昨晚说的话']!r}"
+    )
+    assert not by_text["刚才说的话"].startswith(now.strftime("%m-%d")), (
+        f"当天消息保持简洁不带日期，实际 {by_text['刚才说的话']!r}"
+    )

--- a/apps/agent-service/tests/nodes/test_life_wake.py
+++ b/apps/agent-service/tests/nodes/test_life_wake.py
@@ -243,6 +243,14 @@ def patched(monkeypatch):
     async def fake_read_day_page_before(*, lane, persona_id, before_date):
         return None
 
+    # 日照锚点默认桩成「算不出」（空串）：真实的 today_daylight_text 会读 Dynamic
+    # Config（缓存 miss 时是同步 httpx），节点测试不该碰网络、也不该被外部配置左右。
+    # 需要验日照的用例自己 monkeypatch 覆盖它。
+    async def fake_daylight(day):
+        return ""
+
+    monkeypatch.setattr(lw, "today_daylight_text", fake_daylight)
+
     monkeypatch.setattr(lw, "find_life_state", fake_find)
     monkeypatch.setattr(lw, "list_unread_events", fake_unread)
     monkeypatch.setattr(lw, "mark_events_read", fake_mark)
@@ -258,7 +266,7 @@ def patched(monkeypatch):
         return list(state["notebook"])
 
     async def fake_find_recent_chats(
-        *, persona_id, since_ms, max_conversations, per_chat_limit
+        *, persona_id, since_ms, max_conversations, per_chat_limit, now
     ):
         state["recent_chat_calls"].append(
             {
@@ -266,6 +274,7 @@ def patched(monkeypatch):
                 "since_ms": since_ms,
                 "max_conversations": max_conversations,
                 "per_chat_limit": per_chat_limit,
+                "now": now,
             }
         )
         if state["recent_chat_raises"] is not None:
@@ -4096,3 +4105,203 @@ def test_life_wake_cfg_uses_life_model_alias():
     assert lw._LIFE_WAKE_CFG.prompt_id == "life_wake"
     assert lw._LIFE_WAKE_CFG.model_id == "life-model"
     assert lw._LIFE_WAKE_CFG.trace_name == "life-wake"
+
+
+# ---------------------------------------------------------------------------
+# 时间锚加固（prod 事故 2026-08-03：akao 在中午 13:18 往群里发「大半夜的发什么疯、
+# 赶紧滚去睡觉」，并把「晚上八点」jot_down 进本子固化成记忆）。
+#
+# 事后从 langfuse trace 复盘出来的三条：
+#   1. SYSTEM 里一个时间字都没有，唯一的时钟夹在 USER stimulus 中段，后面还跟着
+#      一整片只有 HH:MM 没有日期的时间戳 —— 数字锚输给了「下班/回家/躺平」的语义氛围。
+#   2. world 在 #308 之后有两重锚（时刻置顶 + 当天日出日落），life 一重都没有。
+#   3. 群聊窗口用上一轮 observed_at 做水位，life 轮次越密窗口越窄，窄到只剩她自己
+#      刚说的那两句回声，她顺着自己的错误推断越滑越远。
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_current_time_is_first_thing_in_user_stimulus(patched, monkeypatch):
+    """时刻行必须是 USER stimulus 的第一段，不能被本子 / 群聊挤到中段。
+
+    prod 事故根因之一：唯一的时钟夹在本子和群聊之后，模型先读到一屏「下班了」
+    「快点回家躺着」，再读到「现在是 ... 13:16」，语义氛围压过了数字锚。world
+    的 ``【现实此刻】`` 是置顶的，life 也必须置顶。
+    """
+    patched["notebook"] = [
+        _notebook_entry("n1", "田申耳鸣：看了四家医院都没用，记得请他喝奶茶")
+    ]
+    patched["recent_chats"] = [
+        _life_chat_conversation(
+            messages=[
+                _life_chat_message(is_self=False, text="下班了", cst_time="13:13 CST"),
+                _life_chat_message(is_self=True, text="快点回家躺着啦", cst_time="13:14 CST"),
+            ]
+        )
+    ]
+    patched["unread"] = [_envelope("e1", "雨还在下")]
+    _FakeAgent.install(monkeypatch, script=None)
+
+    await lw.life_wake_node(EventArrived(lane="coe-t3", persona_id="akao"))
+
+    stimulus = _FakeAgent.last_run()["messages"][-1].text()
+    assert stimulus.lstrip().startswith("现在是 "), (
+        f"时刻行必须是 stimulus 第一段（否则语义氛围会压过数字锚），实际开头 "
+        f"{stimulus[:120]!r}"
+    )
+    assert stimulus.index("现在是 ") < stimulus.index("下班了"), (
+        "时刻行必须排在群聊之前"
+    )
+
+
+@pytest.mark.asyncio
+async def test_current_time_carries_daylight_anchor(patched, monkeypatch):
+    """时刻行后面贴当天日出日落，和 world 同一口径（#308 已在 world 验证有效）。
+
+    只给客观天文事实，不给「几点之后算晚上」的判断（赤尾宪法：不替她下结论）。
+    """
+    async def fake_daylight(day):
+        return "（今天日出 06:02、日落 19:13）"
+
+    monkeypatch.setattr(lw, "today_daylight_text", fake_daylight)
+    patched["unread"] = [_envelope("e1", "雨还在下")]
+    _FakeAgent.install(monkeypatch, script=None)
+
+    await lw.life_wake_node(EventArrived(lane="coe-t3", persona_id="akao"))
+
+    stimulus = _FakeAgent.last_run()["messages"][-1].text()
+    assert "日出 06:02" in stimulus and "日落 19:13" in stimulus, (
+        f"时刻行该带当天日照锚，实际 {stimulus[:200]!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_daylight_failure_does_not_kill_the_round(patched, monkeypatch):
+    """日照算不出来（坐标没配 / 极昼极夜 / 抛错）只是少一个锚，绝不炸整轮。"""
+    async def boom(day):
+        raise RuntimeError("dynamic config 挂了")
+
+    monkeypatch.setattr(lw, "today_daylight_text", boom)
+    patched["unread"] = [_envelope("e1", "雨还在下")]
+    _FakeAgent.install(monkeypatch, script=None)
+
+    await lw.life_wake_node(EventArrived(lane="coe-t3", persona_id="akao"))
+
+    stimulus = _FakeAgent.last_run()["messages"][-1].text()
+    assert "现在是 " in stimulus, "日照失败不该带走时刻行本身"
+    assert patched["marked"], "日照失败不该让整轮 early-return / 不标已读"
+
+
+@pytest.mark.asyncio
+async def test_recent_chat_window_has_minimum_lookback(patched, monkeypatch):
+    """群聊回看窗口有下限：life 轮次再密，也要看得到足够的外部对话。
+
+    prod 事故根因之三：水位 = 上一轮 observed_at，life 每 45s–2min 一轮，窗口就
+    只有一两分钟 —— 她读到的「群里正在发生什么」只剩自己刚说的两句回声，于是顺着
+    自己的错误推断自我加固。窗口下限保证外部上下文进得来（规模仍由每会话 10 条上限兜住）。
+    """
+    from datetime import datetime, timedelta
+
+    now = datetime(2026, 6, 3, 13, 16, tzinfo=lw.cst_time.CST)
+    monkeypatch.setattr(lw.cst_time, "now_cst", lambda: now)
+    # 上一轮就在 90 秒前 —— 典型的密集轮次
+    patched["snapshot"] = LifeState(
+        lane="coe-t3",
+        persona_id="akao",
+        current_state="在沙发上",
+        response_mood="平静",
+        activity_type="rest",
+        observed_at=(now - timedelta(seconds=90)).isoformat(),
+    )
+    patched["unread"] = [_envelope("e1", "门铃响了")]
+    _FakeAgent.install(monkeypatch, script=None)
+
+    await lw.life_wake_node(EventArrived(lane="coe-t3", persona_id="akao"))
+
+    since_ms = patched["recent_chat_calls"][0]["since_ms"]
+    floor_ms = int(now.timestamp() * 1000) - lw._RECENT_CHAT_MIN_LOOKBACK_MS
+    assert since_ms <= floor_ms, (
+        f"上一轮才过 90 秒，窗口不能跟着收缩到 90 秒 —— 至少要回看 "
+        f"{lw._RECENT_CHAT_MIN_LOOKBACK_MS // 60000} 分钟，实际 since_ms={since_ms} "
+        f"(floor={floor_ms})"
+    )
+
+
+@pytest.mark.asyncio
+async def test_recent_chat_window_never_shrinks_below_watermark(patched, monkeypatch):
+    """水位比下限更早时以水位为准（该看的旧聊天不能因为下限被砍掉）。"""
+    from datetime import datetime, timedelta
+
+    now = datetime(2026, 6, 3, 13, 16, tzinfo=lw.cst_time.CST)
+    monkeypatch.setattr(lw.cst_time, "now_cst", lambda: now)
+    observed_at = (now - timedelta(hours=3)).isoformat()
+    patched["snapshot"] = LifeState(
+        lane="coe-t3",
+        persona_id="akao",
+        current_state="在沙发上",
+        response_mood="平静",
+        activity_type="rest",
+        observed_at=observed_at,
+    )
+    patched["unread"] = [_envelope("e1", "门铃响了")]
+    _FakeAgent.install(monkeypatch, script=None)
+
+    await lw.life_wake_node(EventArrived(lane="coe-t3", persona_id="akao"))
+
+    expected = int(lw.cst_time.parse(observed_at).timestamp() * 1000)
+    assert patched["recent_chat_calls"][0]["since_ms"] == expected, (
+        "水位早于下限时以水位为准，不能被下限往后推"
+    )
+
+
+@pytest.mark.asyncio
+async def test_cross_day_event_timestamp_carries_date(patched, monkeypatch):
+    """不是今天发生的事件，时间戳要带日期 —— 否则昨晚 20:47 和今晚 20:47 长得一模一样。
+
+    信箱没有时间窗、也没有 TTL，昨晚积压的未读会原样进来。只给 ``20:47:12 CST``
+    她无从分辨那是几个小时前还是一天前。
+    """
+    from datetime import datetime
+
+    now = datetime(2026, 6, 3, 13, 16, tzinfo=lw.cst_time.CST)
+    monkeypatch.setattr(lw.cst_time, "now_cst", lambda: now)
+    patched["unread"] = [
+        _envelope("e-old", "昨晚的动静", occurred_at="2026-06-02T20:47:12+08:00"),
+        _envelope("e-new", "刚才的动静", occurred_at="2026-06-03T13:15:00+08:00"),
+    ]
+    _FakeAgent.install(monkeypatch, script=None)
+
+    await lw.life_wake_node(EventArrived(lane="coe-t3", persona_id="akao"))
+
+    stimulus = _FakeAgent.last_run()["messages"][-1].text()
+    old_line = next(l for l in stimulus.splitlines() if "昨晚的动静" in l)
+    new_line = next(l for l in stimulus.splitlines() if "刚才的动静" in l)
+    assert "06-02" in old_line, (
+        f"跨天事件必须带日期，实际 {old_line!r}"
+    )
+    assert "06-03" not in new_line, (
+        f"当天事件保持简洁不带日期（省 token、不干扰阅读），实际 {new_line!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_recent_chat_query_shares_the_round_now(patched, monkeypatch):
+    """聊天查询拿到的「现在」必须是本轮那一个 now，不能让查询层自己现取。
+
+    消息时间戳「同一天省日期、跨天补 MM-DD」要跟 stimulus 顶部那行时刻用同一个
+    「今天」去比。查询层自己 ``now_cst()`` 会和本轮的 now 差开，跨午夜那一瞬两边
+    落在不同日历日——同一屏 stimulus 里，顶部说今天是 6/4，聊天记录却把 00:10 的
+    消息标成「06-04」当跨天处理，日期口径自相矛盾。
+    """
+    from datetime import datetime
+
+    now = datetime(2026, 6, 3, 13, 16, tzinfo=lw.cst_time.CST)
+    monkeypatch.setattr(lw.cst_time, "now_cst", lambda: now)
+    patched["unread"] = [_envelope("e1", "门铃响了")]
+    _FakeAgent.install(monkeypatch, script=None)
+
+    await lw.life_wake_node(EventArrived(lane="coe-t3", persona_id="akao"))
+
+    assert patched["recent_chat_calls"][0]["now"] == now, (
+        "聊天查询必须收到本轮的 now，不能自己现取"
+    )

--- a/apps/agent-service/tests/nodes/test_life_wake_day_review.py
+++ b/apps/agent-service/tests/nodes/test_life_wake_day_review.py
@@ -172,6 +172,14 @@ def patched(monkeypatch):
 
     import app.domain.arc_awareness as arc_mod
 
+    # 日照锚点默认桩成「算不出」（空串）：真实的 today_daylight_text 会读 Dynamic
+    # Config（缓存 miss 时是同步 httpx），节点测试不该碰网络、也不该被外部配置左右。
+    # 需要验日照的用例自己 monkeypatch 覆盖它。
+    async def fake_daylight(day):
+        return ""
+
+    monkeypatch.setattr(lw, "today_daylight_text", fake_daylight)
+
     monkeypatch.setattr(arc_mod, "read_world_arc", fake_arc)
     monkeypatch.setattr(lw, "find_life_state", fake_find)
     monkeypatch.setattr(lw, "list_unread_events", fake_unread)
@@ -471,3 +479,29 @@ def test_update_life_state_doc_guides_sleep_marking():
     desc = update.definition.description
     assert "sleep" in desc
     assert "去睡" in desc, "工具说明要轻补一句去睡标 sleep 的引导（prompt 姿态）"
+
+
+@pytest.mark.asyncio
+async def test_day_page_written_at_carries_date_not_bare_clock(patched, monkeypatch):
+    """「写于」要带日期，不能只给一个裸的 ``23:40 CST``。
+
+    这一段进 SYSTEM、每轮都在，是她读到的第一批文字之一。只给时分的话，一个昨晚
+    23:40 的时刻就这么悬在她眼前，和「现在几点」争夺注意力——线上事故 2026-08-03 里
+    她正是把一屏夜间时间戳读成了「现在是晚上」。日期跟前面「{date} 那天」呼应上，
+    这个时刻才落回昨天。
+    """
+    patched["day_page"] = DayPage(
+        lane=_LANE,
+        persona_id=_PERSONA,
+        date="2026-06-09",
+        narrative="昨天最挂心的是那道没解出来的题。",
+        written_at="2026-06-09T23:40:00+08:00",
+    )
+    _FakeAgent.install(monkeypatch)
+
+    await _wake()
+
+    day_page = _FakeAgent.last_prompt_vars()["day_page"]
+    assert "06-09 23:40" in day_page, (
+        f"「写于」要带日期，实际 {day_page!r}"
+    )

--- a/apps/agent-service/tests/nodes/test_life_wake_fold.py
+++ b/apps/agent-service/tests/nodes/test_life_wake_fold.py
@@ -144,6 +144,14 @@ def patched(monkeypatch):
 
     import app.domain.arc_awareness as arc_mod
 
+    # 日照锚点默认桩成「算不出」（空串）：真实的 today_daylight_text 会读 Dynamic
+    # Config（缓存 miss 时是同步 httpx），节点测试不该碰网络、也不该被外部配置左右。
+    # 需要验日照的用例自己 monkeypatch 覆盖它。
+    async def fake_daylight(day):
+        return ""
+
+    monkeypatch.setattr(lw, "today_daylight_text", fake_daylight)
+
     monkeypatch.setattr(arc_mod, "read_world_arc", fake_arc)
     monkeypatch.setattr(lw, "find_life_state", fake_find)
     monkeypatch.setattr(lw, "list_unread_events", fake_unread)

--- a/apps/agent-service/tests/unit/infra/test_cst_time.py
+++ b/apps/agent-service/tests/unit/infra/test_cst_time.py
@@ -180,3 +180,51 @@ def test_now_cst_iso_roundtrips_close_to_now():
     parsed = cst_time.parse(cst_time.now_cst_iso())
     after = datetime.now(timezone.utc)
     assert before - timedelta(seconds=5) <= parsed <= after + timedelta(seconds=5)
+
+
+# ---------------------------------------------------------------------------
+# to_cst_dated —— 跨天的时刻要带日期
+#
+# prod 事故 2026-08-03：信箱没有时间窗也没有 TTL，昨晚积压的未读会原样进 stimulus，
+# 而渲染只给 ``20:47:12 CST`` —— 昨晚 20:47 和今晚 20:47 在 prompt 里长得一模一样，
+# agent 无从分辨。同一天的保持简洁（省 token、不干扰阅读），跨天的补上日期。
+# ---------------------------------------------------------------------------
+
+
+def test_to_cst_dated_same_day_omits_date():
+    now = datetime(2026, 6, 3, 13, 16, tzinfo=cst_time.CST)
+    assert cst_time.to_cst_dated("2026-06-03T09:05:07+08:00", now=now) == "09:05:07 CST"
+
+
+def test_to_cst_dated_other_day_carries_date():
+    now = datetime(2026, 6, 3, 13, 16, tzinfo=cst_time.CST)
+    assert (
+        cst_time.to_cst_dated("2026-06-02T20:47:12+08:00", now=now)
+        == "06-02 20:47:12 CST"
+    )
+
+
+def test_to_cst_dated_compares_in_cst_not_utc():
+    """跨天判定按 CST 日历日，不按 UTC —— CST 次日 00:30 的 UTC 还停在前一天 16:30。"""
+    now = datetime(2026, 6, 3, 13, 16, tzinfo=cst_time.CST)
+    # UTC 2026-06-02T16:30Z == CST 2026-06-03 00:30，跟 now 是同一个 CST 日历日
+    assert cst_time.to_cst_dated("2026-06-02T16:30:00Z", now=now) == "00:30:00 CST"
+
+
+def test_to_cst_dated_passthrough_on_unparseable():
+    """无法解析的脏串原样回显（同 to_cst_hm / to_cst_full 的兜底，不静默吞）。"""
+    now = datetime(2026, 6, 3, 13, 16, tzinfo=cst_time.CST)
+    assert "这不是时间" in cst_time.to_cst_dated("这不是时间", now=now)
+
+
+def test_to_cst_dated_without_seconds():
+    """聊天记录只到分钟（秒对读对话没有意义），跨天照样补日期。"""
+    now = datetime(2026, 6, 3, 13, 16, tzinfo=cst_time.CST)
+    assert (
+        cst_time.to_cst_dated("2026-06-03T09:05:07+08:00", now=now, seconds=False)
+        == "09:05 CST"
+    )
+    assert (
+        cst_time.to_cst_dated("2026-06-02T20:47:12+08:00", now=now, seconds=False)
+        == "06-02 20:47 CST"
+    )

--- a/apps/agent-service/tests/unit/infra/test_daylight.py
+++ b/apps/agent-service/tests/unit/infra/test_daylight.py
@@ -23,7 +23,7 @@ from datetime import date
 import pytest
 
 from app.infra.cst_time import CST
-from app.world import daylight as daylight_mod
+from app.infra import daylight as daylight_mod
 
 # 广州（越秀区一带）——prod 实证用的坐标，只在测试里写死当样本，生产走 Dynamic Config。
 _GZ_LAT = 23.1291

--- a/apps/agent-service/tests/world/conftest.py
+++ b/apps/agent-service/tests/world/conftest.py
@@ -19,13 +19,13 @@ def _no_daylight_coords(monkeypatch):
     """默认「日照坐标没配」——让 world 用例保持 hermetic（不真去拉 Dynamic Config）。
 
     每轮 world 推演都会读 ``world_daylight_coords``（见
-    :mod:`app.world.daylight`）。真实的 ``dynamic_config.get`` 是同步 httpx，测试里
+    :mod:`app.infra.daylight`）。真实的 ``dynamic_config.get`` 是同步 httpx，测试里
     会真发一次请求（失败被吞、返回默认值，但白等一次 DNS / 连接超时）。这里统一
     桩成「没配」，等于生产上还没配坐标时的状态——也正好是降级路径的默认口径。
 
     需要日照锚点的用例自己覆写这个桩（monkeypatch 同一个属性即可，后设的生效）。
     """
-    from app.world import daylight as daylight_mod
+    from app.infra import daylight as daylight_mod
 
     monkeypatch.setattr(
         daylight_mod.dynamic_config,

--- a/apps/agent-service/tests/world/test_world_engine.py
+++ b/apps/agent-service/tests/world/test_world_engine.py
@@ -3322,9 +3322,9 @@ async def test_world_round_carries_today_daylight_anchor(monkeypatch):
 
     从 Dynamic Config 的坐标一路走到 prompt（不桩中间的渲染函数）：坐标配上 → 时刻
     段里出现**当天真实**的日出 / 日落。期望值用同一个纯函数算（它本身由
-    ``tests/world/test_world_daylight.py`` 对着 prod 那天的真实日落钉死）。
+    ``tests/unit/infra/test_daylight.py`` 对着 prod 那天的真实日落钉死）。
     """
-    from app.world import daylight as daylight_mod
+    from app.infra import daylight as daylight_mod
 
     monkeypatch.setattr(
         daylight_mod.dynamic_config,


### PR DESCRIPTION
## What happened

On 2026-08-03 at 13:18 CST akao told a Feishu group *"it's the middle of the night, go to bed, don't you have work tomorrow"* — on a Monday afternoon. In the same breath she answered a remark nobody had made. By 13:18:59 she had written **"8pm"** into her own notebook, turning a guess into a memory. Her sister ayana, that same minute, knew perfectly well it was early afternoon and said so three times.

## Why

The trace says the inputs were clean. `现在是 … 13:16 CST` was right there, every event carried a CST stamp, and `world_time` was accurate. What failed was the *shape* of the round.

- **The SYSTEM prompt contains no time at all.** The single clock lived in the middle of the USER stimulus, behind the notebook and behind a screenful of group chat reading 下班了 / 快点回家躺着. Atmosphere beat the number.
- **world got two time anchors in #308; life got none.** `life_wake.py` wasn't in that commit. #308's own postmortem describes the identical failure mode: handed a bare timestamp, the model falls back on *"evening ≈ dark"* and wrote dusk two hours early.
- **The chat lookback watermark was the previous round's `observed_at`**, and an event-woken life round fires every 45s–2min. The window collapsed to ~90 seconds: three messages, two of them her own. She read her own echo as the outside world and compounded her own mistake.
- **Inbox entries render as bare `HH:MM:SS`**, so last night's 20:47 and tonight's 20:47 are indistinguishable — and the mailbox has neither a time window nor a TTL.

## What changed

Everything here is on the input side. The constitution forbids fixing agent behaviour with thresholds or guard clauses; you fix what she reads.

- **Clock line moves to the first thing in the stimulus** and carries the day's sunrise/sunset, same recipe as world. Facts only — no "after X it's night" rule. Reordering costs no prefix cache: the stimulus is fresh tokens appended after an untouched system + history.
- **`daylight` moves from `app/world/` to `app/infra/`.** `life_wake` may not import `app.world` (information-asymmetry guard), and sunrise is an astronomical fact, not a world snapshot. No re-export left behind.
- **`to_cst_dated()`** — same CST calendar day stays `HH:MM:SS`, other days get `MM-DD`. Same-day entries deliberately stay bare so *"this one is from yesterday"* keeps its signal. Applied to inbox events, chat lines and `day_page`.
- **30-minute floor on the chat lookback window**, so enough of the outside conversation survives however often she wakes. An earlier watermark still wins; volume is still bounded by the per-chat cap, not by the window.
- **`find_persona_related_chats_recent()` takes `now` from the caller** instead of reading the clock itself, so every timestamp in one stimulus is compared against the same "today" across midnight.

## Deliberately not fixed

`unread[:50]` over an ascending list still hands her the **oldest** fifty when the mailbox backs up. Taking the newest instead would strand the rest forever — only what she reads gets marked read — and dropping them on her behalf is exactly the *"code decides what she forgets"* the constitution rules out. That needs its own decision. akao had one unread event during the incident, so it played no part in it.

## Verification

```
$ uv run pytest tests/ -q
2792 passed, 3 skipped, 5 warnings in 109.28s
```

New tests pin each contract: clock line is first, daylight anchor present, daylight failure doesn't kill the round, lookback floor holds under dense rounds, an earlier watermark still wins, cross-day entries carry dates while same-day ones don't, and the chat query shares the round's `now`.

## Follow-up, not in this PR

The langfuse `life_wake` template (v17) only declares 3 of the 5 variables the code passes — `world_arc` and `day_page` are silently dropped, so life has no cross-day continuity anchor at all. Fixing that contract is a separate change, and it should land **after** this one is deployed: the template takes effect immediately against currently-running code, and `day_page` is night-flavoured prose that wants the time anchors in place first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
